### PR TITLE
refactor: add CancellationToken to ILessonService and IStudentService

### DIFF
--- a/backend/LangTeach.Api/Controllers/LessonsController.cs
+++ b/backend/LangTeach.Api/Controllers/LessonsController.cs
@@ -29,11 +29,11 @@ public class LessonsController : ControllerBase
     private string? Email => User.FindFirstValue(ClaimTypes.Email);
 
     [HttpGet]
-    public async Task<IActionResult> List([FromQuery] LessonListQuery query)
+    public async Task<IActionResult> List([FromQuery] LessonListQuery query, CancellationToken cancellationToken)
     {
         if (Auth0Id is null || string.IsNullOrEmpty(Email)) return Unauthorized();
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email!);
-        var result = await _lessonService.ListAsync(teacherId, query);
+        var result = await _lessonService.ListAsync(teacherId, query, cancellationToken);
         _logger.LogInformation(
             "GET /api/lessons. TeacherId={TeacherId} Status={Status} Search={Search} TotalCount={TotalCount}",
             teacherId, query.Status, query.Search, result.TotalCount);
@@ -41,7 +41,7 @@ public class LessonsController : ControllerBase
     }
 
     [HttpPost]
-    public async Task<IActionResult> Create([FromBody] CreateLessonRequest request)
+    public async Task<IActionResult> Create([FromBody] CreateLessonRequest request, CancellationToken cancellationToken)
     {
         if (Auth0Id is null || string.IsNullOrEmpty(Email)) return Unauthorized();
         if (!ModelState.IsValid)
@@ -52,7 +52,7 @@ public class LessonsController : ControllerBase
         }
 
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
-        var lesson = await _lessonService.CreateAsync(teacherId, request);
+        var lesson = await _lessonService.CreateAsync(teacherId, request, cancellationToken);
 
         if (lesson is null)
         {
@@ -64,11 +64,11 @@ public class LessonsController : ControllerBase
     }
 
     [HttpGet("{id:guid}")]
-    public async Task<IActionResult> GetById(Guid id)
+    public async Task<IActionResult> GetById(Guid id, CancellationToken cancellationToken)
     {
         if (Auth0Id is null || string.IsNullOrEmpty(Email)) return Unauthorized();
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email!);
-        var lesson = await _lessonService.GetByIdAsync(teacherId, id);
+        var lesson = await _lessonService.GetByIdAsync(teacherId, id, cancellationToken);
 
         if (lesson is null)
         {
@@ -81,7 +81,7 @@ public class LessonsController : ControllerBase
     }
 
     [HttpPut("{id:guid}")]
-    public async Task<IActionResult> Update(Guid id, [FromBody] UpdateLessonRequest request)
+    public async Task<IActionResult> Update(Guid id, [FromBody] UpdateLessonRequest request, CancellationToken cancellationToken)
     {
         if (Auth0Id is null || string.IsNullOrEmpty(Email)) return Unauthorized();
         if (!ModelState.IsValid)
@@ -92,7 +92,7 @@ public class LessonsController : ControllerBase
         }
 
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
-        var result = await _lessonService.UpdateAsync(teacherId, id, request);
+        var result = await _lessonService.UpdateAsync(teacherId, id, request, cancellationToken);
 
         return result switch
         {
@@ -104,7 +104,7 @@ public class LessonsController : ControllerBase
     }
 
     [HttpPut("{id:guid}/sections")]
-    public async Task<IActionResult> UpdateSections(Guid id, [FromBody] UpdateLessonSectionsRequest request)
+    public async Task<IActionResult> UpdateSections(Guid id, [FromBody] UpdateLessonSectionsRequest request, CancellationToken cancellationToken)
     {
         if (Auth0Id is null || string.IsNullOrEmpty(Email)) return Unauthorized();
         if (!ModelState.IsValid)
@@ -115,7 +115,7 @@ public class LessonsController : ControllerBase
         }
 
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
-        var updated = await _lessonService.UpdateSectionsAsync(teacherId, id, request);
+        var updated = await _lessonService.UpdateSectionsAsync(teacherId, id, request, cancellationToken);
 
         if (updated is null)
         {
@@ -128,11 +128,11 @@ public class LessonsController : ControllerBase
     }
 
     [HttpDelete("{id:guid}")]
-    public async Task<IActionResult> Delete(Guid id)
+    public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
         if (Auth0Id is null || string.IsNullOrEmpty(Email)) return Unauthorized();
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email!);
-        var deleted = await _lessonService.DeleteAsync(teacherId, id);
+        var deleted = await _lessonService.DeleteAsync(teacherId, id, cancellationToken);
 
         if (!deleted)
         {
@@ -145,11 +145,11 @@ public class LessonsController : ControllerBase
     }
 
     [HttpPost("{id:guid}/duplicate")]
-    public async Task<IActionResult> Duplicate(Guid id)
+    public async Task<IActionResult> Duplicate(Guid id, CancellationToken cancellationToken)
     {
         if (Auth0Id is null || string.IsNullOrEmpty(Email)) return Unauthorized();
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email!);
-        var copy = await _lessonService.DuplicateAsync(teacherId, id);
+        var copy = await _lessonService.DuplicateAsync(teacherId, id, cancellationToken);
 
         if (copy is null)
         {

--- a/backend/LangTeach.Api/Controllers/StudentsController.cs
+++ b/backend/LangTeach.Api/Controllers/StudentsController.cs
@@ -29,11 +29,11 @@ public class StudentsController : ControllerBase
     private string Email => User.FindFirstValue(ClaimTypes.Email) ?? "";
 
     [HttpGet]
-    public async Task<IActionResult> List([FromQuery] StudentListQuery query)
+    public async Task<IActionResult> List([FromQuery] StudentListQuery query, CancellationToken cancellationToken)
     {
         if (Auth0Id is null) return Unauthorized();
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
-        var result = await _studentService.ListAsync(teacherId, query);
+        var result = await _studentService.ListAsync(teacherId, query, cancellationToken);
         _logger.LogInformation(
             "GET /api/students. TeacherId={TeacherId} Language={Language} CefrLevel={CefrLevel} TotalCount={TotalCount}",
             teacherId, query.Language, query.CefrLevel, result.TotalCount);
@@ -41,7 +41,7 @@ public class StudentsController : ControllerBase
     }
 
     [HttpPost]
-    public async Task<IActionResult> Create([FromBody] CreateStudentRequest request)
+    public async Task<IActionResult> Create([FromBody] CreateStudentRequest request, CancellationToken cancellationToken)
     {
         if (Auth0Id is null) return Unauthorized();
         if (!ModelState.IsValid)
@@ -52,16 +52,16 @@ public class StudentsController : ControllerBase
         }
 
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
-        var student = await _studentService.CreateAsync(teacherId, request);
+        var student = await _studentService.CreateAsync(teacherId, request, cancellationToken);
         return CreatedAtAction(nameof(GetById), new { id = student.Id }, student);
     }
 
     [HttpGet("{id:guid}")]
-    public async Task<IActionResult> GetById(Guid id)
+    public async Task<IActionResult> GetById(Guid id, CancellationToken cancellationToken)
     {
         if (Auth0Id is null) return Unauthorized();
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
-        var student = await _studentService.GetByIdAsync(teacherId, id);
+        var student = await _studentService.GetByIdAsync(teacherId, id, cancellationToken);
 
         if (student is null)
         {
@@ -74,7 +74,7 @@ public class StudentsController : ControllerBase
     }
 
     [HttpPut("{id:guid}")]
-    public async Task<IActionResult> Update(Guid id, [FromBody] UpdateStudentRequest request)
+    public async Task<IActionResult> Update(Guid id, [FromBody] UpdateStudentRequest request, CancellationToken cancellationToken)
     {
         if (Auth0Id is null) return Unauthorized();
         if (!ModelState.IsValid)
@@ -85,7 +85,7 @@ public class StudentsController : ControllerBase
         }
 
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
-        var updated = await _studentService.UpdateAsync(teacherId, id, request);
+        var updated = await _studentService.UpdateAsync(teacherId, id, request, cancellationToken);
 
         if (updated is null)
         {
@@ -98,11 +98,11 @@ public class StudentsController : ControllerBase
     }
 
     [HttpDelete("{id:guid}")]
-    public async Task<IActionResult> Delete(Guid id)
+    public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
         if (Auth0Id is null) return Unauthorized();
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
-        var deleted = await _studentService.DeleteAsync(teacherId, id);
+        var deleted = await _studentService.DeleteAsync(teacherId, id, cancellationToken);
 
         if (!deleted)
         {

--- a/backend/LangTeach.Api/Services/ILessonService.cs
+++ b/backend/LangTeach.Api/Services/ILessonService.cs
@@ -4,11 +4,11 @@ namespace LangTeach.Api.Services;
 
 public interface ILessonService
 {
-    Task<PagedResult<LessonDto>> ListAsync(Guid teacherId, LessonListQuery query);
-    Task<LessonDto?> GetByIdAsync(Guid teacherId, Guid lessonId);
-    Task<LessonDto?> CreateAsync(Guid teacherId, CreateLessonRequest request);
-    Task<LessonUpdateResult> UpdateAsync(Guid teacherId, Guid lessonId, UpdateLessonRequest request);
-    Task<LessonDto?> UpdateSectionsAsync(Guid teacherId, Guid lessonId, UpdateLessonSectionsRequest request);
-    Task<bool> DeleteAsync(Guid teacherId, Guid lessonId);
-    Task<LessonDto?> DuplicateAsync(Guid teacherId, Guid lessonId);
+    Task<PagedResult<LessonDto>> ListAsync(Guid teacherId, LessonListQuery query, CancellationToken cancellationToken = default);
+    Task<LessonDto?> GetByIdAsync(Guid teacherId, Guid lessonId, CancellationToken cancellationToken = default);
+    Task<LessonDto?> CreateAsync(Guid teacherId, CreateLessonRequest request, CancellationToken cancellationToken = default);
+    Task<LessonUpdateResult> UpdateAsync(Guid teacherId, Guid lessonId, UpdateLessonRequest request, CancellationToken cancellationToken = default);
+    Task<LessonDto?> UpdateSectionsAsync(Guid teacherId, Guid lessonId, UpdateLessonSectionsRequest request, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(Guid teacherId, Guid lessonId, CancellationToken cancellationToken = default);
+    Task<LessonDto?> DuplicateAsync(Guid teacherId, Guid lessonId, CancellationToken cancellationToken = default);
 }

--- a/backend/LangTeach.Api/Services/IStudentService.cs
+++ b/backend/LangTeach.Api/Services/IStudentService.cs
@@ -4,9 +4,9 @@ namespace LangTeach.Api.Services;
 
 public interface IStudentService
 {
-    Task<PagedResult<StudentDto>> ListAsync(Guid teacherId, StudentListQuery query);
-    Task<StudentDto?> GetByIdAsync(Guid teacherId, Guid studentId);
-    Task<StudentDto> CreateAsync(Guid teacherId, CreateStudentRequest request);
-    Task<StudentDto?> UpdateAsync(Guid teacherId, Guid studentId, UpdateStudentRequest request);
-    Task<bool> DeleteAsync(Guid teacherId, Guid studentId);
+    Task<PagedResult<StudentDto>> ListAsync(Guid teacherId, StudentListQuery query, CancellationToken cancellationToken = default);
+    Task<StudentDto?> GetByIdAsync(Guid teacherId, Guid studentId, CancellationToken cancellationToken = default);
+    Task<StudentDto> CreateAsync(Guid teacherId, CreateStudentRequest request, CancellationToken cancellationToken = default);
+    Task<StudentDto?> UpdateAsync(Guid teacherId, Guid studentId, UpdateStudentRequest request, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(Guid teacherId, Guid studentId, CancellationToken cancellationToken = default);
 }

--- a/backend/LangTeach.Api/Services/LessonService.cs
+++ b/backend/LangTeach.Api/Services/LessonService.cs
@@ -17,7 +17,7 @@ public class LessonService : ILessonService
         _logger = logger;
     }
 
-    public async Task<PagedResult<LessonDto>> ListAsync(Guid teacherId, LessonListQuery query)
+    public async Task<PagedResult<LessonDto>> ListAsync(Guid teacherId, LessonListQuery query, CancellationToken cancellationToken = default)
     {
         var page = Math.Max(query.Page, 1);
         var pageSize = query.PageSize;
@@ -41,13 +41,13 @@ public class LessonService : ILessonService
             q = q.Where(l => EF.Functions.Like(l.Title, term) || EF.Functions.Like(l.Topic, term));
         }
 
-        var totalCount = await q.CountAsync();
+        var totalCount = await q.CountAsync(cancellationToken);
 
         var items = await q
             .OrderByDescending(l => l.UpdatedAt)
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
 
         return new PagedResult<LessonDto>(
             items.Select(MapToDto).ToList(),
@@ -57,21 +57,21 @@ public class LessonService : ILessonService
         );
     }
 
-    public async Task<LessonDto?> GetByIdAsync(Guid teacherId, Guid lessonId)
+    public async Task<LessonDto?> GetByIdAsync(Guid teacherId, Guid lessonId, CancellationToken cancellationToken = default)
     {
         var lesson = await _db.Lessons
             .Include(l => l.Sections)
-            .FirstOrDefaultAsync(l => l.Id == lessonId && l.TeacherId == teacherId && !l.IsDeleted);
+            .FirstOrDefaultAsync(l => l.Id == lessonId && l.TeacherId == teacherId && !l.IsDeleted, cancellationToken);
 
         return lesson is null ? null : MapToDto(lesson);
     }
 
-    public async Task<LessonDto?> CreateAsync(Guid teacherId, CreateLessonRequest request)
+    public async Task<LessonDto?> CreateAsync(Guid teacherId, CreateLessonRequest request, CancellationToken cancellationToken = default)
     {
         if (request.StudentId.HasValue)
         {
             var studentExists = await _db.Students
-                .AnyAsync(s => s.Id == request.StudentId.Value && s.TeacherId == teacherId && !s.IsDeleted);
+                .AnyAsync(s => s.Id == request.StudentId.Value && s.TeacherId == teacherId && !s.IsDeleted, cancellationToken);
 
             if (!studentExists)
             {
@@ -103,7 +103,7 @@ public class LessonService : ILessonService
         if (request.TemplateId.HasValue)
         {
             var template = await _db.LessonTemplates
-                .FirstOrDefaultAsync(t => t.Id == request.TemplateId.Value);
+                .FirstOrDefaultAsync(t => t.Id == request.TemplateId.Value, cancellationToken);
 
             if (template is null)
             {
@@ -127,17 +127,17 @@ public class LessonService : ILessonService
         }
 
         _db.Lessons.Add(lesson);
-        await _db.SaveChangesAsync();
+        await _db.SaveChangesAsync(cancellationToken);
         _logger.LogInformation("Lesson created. TeacherId={TeacherId} LessonId={LessonId}", teacherId, lesson.Id);
 
         return MapToDto(lesson);
     }
 
-    public async Task<LessonUpdateResult> UpdateAsync(Guid teacherId, Guid lessonId, UpdateLessonRequest request)
+    public async Task<LessonUpdateResult> UpdateAsync(Guid teacherId, Guid lessonId, UpdateLessonRequest request, CancellationToken cancellationToken = default)
     {
         var lesson = await _db.Lessons
             .Include(l => l.Sections)
-            .FirstOrDefaultAsync(l => l.Id == lessonId && l.TeacherId == teacherId && !l.IsDeleted);
+            .FirstOrDefaultAsync(l => l.Id == lessonId && l.TeacherId == teacherId && !l.IsDeleted, cancellationToken);
 
         if (lesson is null)
             return new LessonUpdateResult.NotFound();
@@ -145,7 +145,7 @@ public class LessonService : ILessonService
         if (request.StudentId.HasValue)
         {
             var studentExists = await _db.Students
-                .AnyAsync(s => s.Id == request.StudentId.Value && s.TeacherId == teacherId && !s.IsDeleted);
+                .AnyAsync(s => s.Id == request.StudentId.Value && s.TeacherId == teacherId && !s.IsDeleted, cancellationToken);
 
             if (!studentExists)
             {
@@ -166,17 +166,17 @@ public class LessonService : ILessonService
         lesson.StudentId = request.StudentId;
         lesson.UpdatedAt = DateTime.UtcNow;
 
-        await _db.SaveChangesAsync();
+        await _db.SaveChangesAsync(cancellationToken);
         _logger.LogInformation("Lesson updated. TeacherId={TeacherId} LessonId={LessonId}", teacherId, lesson.Id);
 
         return new LessonUpdateResult.Success(MapToDto(lesson));
     }
 
-    public async Task<LessonDto?> UpdateSectionsAsync(Guid teacherId, Guid lessonId, UpdateLessonSectionsRequest request)
+    public async Task<LessonDto?> UpdateSectionsAsync(Guid teacherId, Guid lessonId, UpdateLessonSectionsRequest request, CancellationToken cancellationToken = default)
     {
         var lesson = await _db.Lessons
             .Include(l => l.Sections)
-            .FirstOrDefaultAsync(l => l.Id == lessonId && l.TeacherId == teacherId && !l.IsDeleted);
+            .FirstOrDefaultAsync(l => l.Id == lessonId && l.TeacherId == teacherId && !l.IsDeleted, cancellationToken);
 
         if (lesson is null)
             return null;
@@ -198,7 +198,7 @@ public class LessonService : ILessonService
         _db.LessonSections.AddRange(newSections);
         lesson.UpdatedAt = now;
 
-        await _db.SaveChangesAsync();
+        await _db.SaveChangesAsync(cancellationToken);
         _logger.LogInformation("Lesson sections updated. TeacherId={TeacherId} LessonId={LessonId} SectionCount={Count}",
             teacherId, lessonId, newSections.Count);
 
@@ -206,27 +206,27 @@ public class LessonService : ILessonService
         return MapToDto(lesson);
     }
 
-    public async Task<bool> DeleteAsync(Guid teacherId, Guid lessonId)
+    public async Task<bool> DeleteAsync(Guid teacherId, Guid lessonId, CancellationToken cancellationToken = default)
     {
         var lesson = await _db.Lessons
-            .FirstOrDefaultAsync(l => l.Id == lessonId && l.TeacherId == teacherId && !l.IsDeleted);
+            .FirstOrDefaultAsync(l => l.Id == lessonId && l.TeacherId == teacherId && !l.IsDeleted, cancellationToken);
 
         if (lesson is null)
             return false;
 
         lesson.IsDeleted = true;
         lesson.UpdatedAt = DateTime.UtcNow;
-        await _db.SaveChangesAsync();
+        await _db.SaveChangesAsync(cancellationToken);
         _logger.LogInformation("Lesson deleted. TeacherId={TeacherId} LessonId={LessonId}", teacherId, lesson.Id);
 
         return true;
     }
 
-    public async Task<LessonDto?> DuplicateAsync(Guid teacherId, Guid lessonId)
+    public async Task<LessonDto?> DuplicateAsync(Guid teacherId, Guid lessonId, CancellationToken cancellationToken = default)
     {
         var original = await _db.Lessons
             .Include(l => l.Sections)
-            .FirstOrDefaultAsync(l => l.Id == lessonId && l.TeacherId == teacherId && !l.IsDeleted);
+            .FirstOrDefaultAsync(l => l.Id == lessonId && l.TeacherId == teacherId && !l.IsDeleted, cancellationToken);
 
         if (original is null)
             return null;
@@ -259,7 +259,7 @@ public class LessonService : ILessonService
         };
 
         _db.Lessons.Add(copy);
-        await _db.SaveChangesAsync();
+        await _db.SaveChangesAsync(cancellationToken);
         _logger.LogInformation("Lesson duplicated. TeacherId={TeacherId} OriginalId={OriginalId} CopyId={CopyId}",
             teacherId, lessonId, copy.Id);
 

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -17,7 +17,7 @@ public class StudentService : IStudentService
         _logger = logger;
     }
 
-    public async Task<PagedResult<StudentDto>> ListAsync(Guid teacherId, StudentListQuery query)
+    public async Task<PagedResult<StudentDto>> ListAsync(Guid teacherId, StudentListQuery query, CancellationToken cancellationToken = default)
     {
         var page = Math.Max(query.Page, 1);
         var pageSize = query.PageSize;
@@ -30,13 +30,13 @@ public class StudentService : IStudentService
         if (!string.IsNullOrWhiteSpace(query.CefrLevel))
             q = q.Where(s => s.CefrLevel == query.CefrLevel);
 
-        var totalCount = await q.CountAsync();
+        var totalCount = await q.CountAsync(cancellationToken);
 
         var items = await q
             .OrderBy(s => s.Name)
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
 
         return new PagedResult<StudentDto>(
             items.Select(MapToDto).ToList(),
@@ -46,15 +46,15 @@ public class StudentService : IStudentService
         );
     }
 
-    public async Task<StudentDto?> GetByIdAsync(Guid teacherId, Guid studentId)
+    public async Task<StudentDto?> GetByIdAsync(Guid teacherId, Guid studentId, CancellationToken cancellationToken = default)
     {
         var student = await _db.Students
-            .FirstOrDefaultAsync(s => s.Id == studentId && s.TeacherId == teacherId && !s.IsDeleted);
+            .FirstOrDefaultAsync(s => s.Id == studentId && s.TeacherId == teacherId && !s.IsDeleted, cancellationToken);
 
         return student is null ? null : MapToDto(student);
     }
 
-    public async Task<StudentDto> CreateAsync(Guid teacherId, CreateStudentRequest request)
+    public async Task<StudentDto> CreateAsync(Guid teacherId, CreateStudentRequest request, CancellationToken cancellationToken = default)
     {
         var student = new Student
         {
@@ -70,17 +70,17 @@ public class StudentService : IStudentService
         };
 
         _db.Students.Add(student);
-        await _db.SaveChangesAsync();
+        await _db.SaveChangesAsync(cancellationToken);
         _logger.LogInformation("Student created. TeacherId={TeacherId} StudentId={StudentId}",
             teacherId, student.Id);
 
         return MapToDto(student);
     }
 
-    public async Task<StudentDto?> UpdateAsync(Guid teacherId, Guid studentId, UpdateStudentRequest request)
+    public async Task<StudentDto?> UpdateAsync(Guid teacherId, Guid studentId, UpdateStudentRequest request, CancellationToken cancellationToken = default)
     {
         var student = await _db.Students
-            .FirstOrDefaultAsync(s => s.Id == studentId && s.TeacherId == teacherId && !s.IsDeleted);
+            .FirstOrDefaultAsync(s => s.Id == studentId && s.TeacherId == teacherId && !s.IsDeleted, cancellationToken);
 
         if (student is null)
             return null;
@@ -92,24 +92,24 @@ public class StudentService : IStudentService
         student.Notes = request.Notes;
         student.UpdatedAt = DateTime.UtcNow;
 
-        await _db.SaveChangesAsync();
+        await _db.SaveChangesAsync(cancellationToken);
         _logger.LogInformation("Student updated. TeacherId={TeacherId} StudentId={StudentId}",
             teacherId, student.Id);
 
         return MapToDto(student);
     }
 
-    public async Task<bool> DeleteAsync(Guid teacherId, Guid studentId)
+    public async Task<bool> DeleteAsync(Guid teacherId, Guid studentId, CancellationToken cancellationToken = default)
     {
         var student = await _db.Students
-            .FirstOrDefaultAsync(s => s.Id == studentId && s.TeacherId == teacherId && !s.IsDeleted);
+            .FirstOrDefaultAsync(s => s.Id == studentId && s.TeacherId == teacherId && !s.IsDeleted, cancellationToken);
 
         if (student is null)
             return false;
 
         student.IsDeleted = true;
         student.UpdatedAt = DateTime.UtcNow;
-        await _db.SaveChangesAsync();
+        await _db.SaveChangesAsync(cancellationToken);
         _logger.LogInformation("Student deleted. TeacherId={TeacherId} StudentId={StudentId}",
             teacherId, student.Id);
 


### PR DESCRIPTION
Closes #21.

## What changed

- Added `CancellationToken cancellationToken = default` to all async methods on `ILessonService` and `IStudentService`
- Passed the token into every EF Core async call (`FirstOrDefaultAsync`, `AnyAsync`, `CountAsync`, `ToListAsync`, `SaveChangesAsync`) in both service implementations
- Controller actions now accept `CancellationToken` as a parameter (ASP.NET Core binds it from `HttpContext.RequestAborted` automatically)

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 18/18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced cancellation handling across lesson and student API endpoints. The system now gracefully manages request interruptions and timeouts, improving resource efficiency and responsiveness when operations are cancelled or clients disconnect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->