### PR TITLE
fix: remove translation column from vocabulary

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/GenerateControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/GenerateControllerTests.cs
@@ -13,7 +13,7 @@ namespace LangTeach.Api.Tests.Controllers;
 
 internal sealed class FakeClaudeClient : IClaudeClient
 {
-    public string FixedContent { get; set; } = """{"items":[{"word":"hello","definition":"greeting","exampleSentence":"Hello!","translation":"hola"}]}""";
+    public string FixedContent { get; set; } = """{"items":[{"word":"hello","definition":"greeting","exampleSentence":"Hello!"}]}""";
 
     public Task<ClaudeResponse> CompleteAsync(ClaudeRequest request, CancellationToken ct = default) =>
         Task.FromResult(new ClaudeResponse(FixedContent, "claude-haiku", 10, 20));

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -73,7 +73,6 @@ public class PromptService : IPromptService
             if (ctx.StudentNativeLanguage is not null)
             {
                 sb.AppendLine($"The student's native language is {nativeLang}.");
-                sb.AppendLine($"- Provide translations in {nativeLang} for vocabulary items.");
                 sb.AppendLine($"- For grammar explanations, note where {language} differs from {nativeLang}.");
                 sb.AppendLine($"- Flag false cognates between {nativeLang} and {language} when relevant.");
                 sb.AppendLine($"- Be aware of common errors {nativeLang} speakers make in {language}.");
@@ -103,7 +102,7 @@ public class PromptService : IPromptService
         var seed = Guid.NewGuid().ToString("N")[..8];
         return $$"""
         Generate a vocabulary list for the lesson on "{{topic}}". Return JSON:
-        {"items":[{"word":"","definition":"","exampleSentence":"","translation":""}]}
+        {"items":[{"word":"","definition":"","exampleSentence":""}]}
         Limit to 10-15 items appropriate for {{level}}.
         Choose a varied and unexpected selection — avoid the most obvious or common words for this topic (seed: {{seed}}).
         """;

--- a/e2e/helpers/mock-ai-stream.ts
+++ b/e2e/helpers/mock-ai-stream.ts
@@ -100,19 +100,16 @@ export const VOCABULARY_FIXTURE = {
       word: 'departure',
       definition: 'The act of leaving a place, especially to start a journey.',
       exampleSentence: 'The departure of the train was delayed by thirty minutes.',
-      translation: 'salida',
     },
     {
       word: 'itinerary',
       definition: 'A planned route or journey, including a list of places to visit.',
       exampleSentence: 'She prepared a detailed itinerary for the trip to Spain.',
-      translation: 'itinerario',
     },
     {
       word: 'accommodation',
       definition: 'A place where travelers can sleep and stay, such as a hotel or hostel.',
       exampleSentence: 'We booked accommodation near the city center.',
-      translation: 'alojamiento',
     },
   ],
 }

--- a/frontend/src/components/lesson/renderers/VocabularyRenderer.test.tsx
+++ b/frontend/src/components/lesson/renderers/VocabularyRenderer.test.tsx
@@ -7,8 +7,8 @@ import type { VocabularyContent } from '../../../types/contentTypes'
 function makeContent(overrides?: Partial<VocabularyContent>): VocabularyContent {
   return {
     items: [
-      { word: 'departure', definition: 'The act of leaving', exampleSentence: 'The departure was delayed.', translation: 'salida' },
-      { word: 'arrival', definition: 'The act of arriving', exampleSentence: 'We celebrated her arrival.', translation: 'llegada' },
+      { word: 'departure', definition: 'The act of leaving', exampleSentence: 'The departure was delayed.' },
+      { word: 'arrival', definition: 'The act of arriving', exampleSentence: 'We celebrated her arrival.' },
     ],
     ...overrides,
   }
@@ -24,7 +24,6 @@ describe('VocabularyRenderer.Preview', () => {
     expect(screen.getByTestId('vocabulary-table')).toBeInTheDocument()
     expect(screen.getByText('departure')).toBeInTheDocument()
     expect(screen.getByText('The act of leaving')).toBeInTheDocument()
-    expect(screen.getByText('salida')).toBeInTheDocument()
     expect(screen.getByText('arrival')).toBeInTheDocument()
   })
 
@@ -41,7 +40,7 @@ describe('VocabularyRenderer.Editor', () => {
 
     expect(screen.getByDisplayValue('departure')).toBeInTheDocument()
     expect(screen.getByDisplayValue('The act of leaving')).toBeInTheDocument()
-    expect(screen.getByDisplayValue('salida')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('The departure was delayed.')).toBeInTheDocument()
   })
 
   it('calls onChange when a word is edited', async () => {

--- a/frontend/src/components/lesson/renderers/VocabularyRenderer.tsx
+++ b/frontend/src/components/lesson/renderers/VocabularyRenderer.tsx
@@ -3,7 +3,7 @@ import { isVocabularyContent } from '../../../types/contentTypes'
 import type { VocabularyItem } from '../../../types/contentTypes'
 import type { EditorProps, PreviewProps, StudentProps } from '../contentRegistry'
 
-const TABLE_HEADERS = ['Word', 'Definition', 'Example', 'Translation']
+const TABLE_HEADERS = ['Word', 'Definition', 'Example']
 
 function VocabTable({ children }: { children: React.ReactNode }) {
   return (
@@ -56,7 +56,7 @@ function Editor({ parsedContent, rawContent, onChange }: EditorProps) {
 
   const handleAdd = () => {
     rowIdsRef.current.push(nextRowId++)
-    emit([...items, { word: '', definition: '', exampleSentence: '', translation: '' }])
+    emit([...items, { word: '', definition: '', exampleSentence: '' }])
   }
 
   const handleRemove = (index: number) => {
@@ -89,9 +89,6 @@ function Editor({ parsedContent, rawContent, onChange }: EditorProps) {
                 </td>
                 <td className="border border-zinc-200 p-1">
                   <input value={item.exampleSentence ?? ''} onChange={(e) => handleCellChange(i, 'exampleSentence', e.target.value)} className={inputClass} />
-                </td>
-                <td className="border border-zinc-200 p-1">
-                  <input value={item.translation ?? ''} onChange={(e) => handleCellChange(i, 'translation', e.target.value)} className={inputClass} />
                 </td>
                 <td className="border border-zinc-200 p-1 text-center">
                   <button
@@ -134,7 +131,6 @@ function Preview({ parsedContent, rawContent }: PreviewProps) {
           <td className="border border-zinc-200 px-3 py-2 font-medium">{item.word}</td>
           <td className="border border-zinc-200 px-3 py-2">{item.definition}</td>
           <td className="border border-zinc-200 px-3 py-2 italic text-zinc-600">{item.exampleSentence}</td>
-          <td className="border border-zinc-200 px-3 py-2 text-zinc-500">{item.translation}</td>
         </tr>
       ))}
     </VocabTable>
@@ -215,9 +211,6 @@ function Student({ parsedContent, rawContent }: StudentProps) {
             </p>
             {item.exampleSentence && (
               <p className="text-sm italic text-zinc-600">"{item.exampleSentence}"</p>
-            )}
-            {item.translation && (
-              <p className="text-sm text-indigo-600 font-medium">{item.translation}</p>
             )}
           </div>
         </div>

--- a/frontend/src/types/contentTypes.ts
+++ b/frontend/src/types/contentTypes.ts
@@ -11,7 +11,6 @@ export interface VocabularyItem {
   word: string
   definition: string
   exampleSentence?: string
-  translation?: string
 }
 
 export interface VocabularyContent {


### PR DESCRIPTION
## Summary
- Removed the translation field from vocabulary content across the full stack
- The AI was generating translations in arbitrary languages (e.g. Italian) when no student was linked, and even with a student the teacher cannot verify translations in languages they don't speak
- Translation may return later as a student-side feature (AI-generated study aid), not in the teacher's lesson editor

## Changes
- **Backend prompt** (`PromptService.cs`): removed `translation` from vocabulary JSON schema and system prompt
- **Frontend type** (`contentTypes.ts`): removed `translation?` from `VocabularyItem`
- **Renderer** (`VocabularyRenderer.tsx`): removed Translation column from editor, preview, and student flashcard
- **Tests**: updated unit tests and e2e mock fixture

## Test plan
- [x] Backend build: 0 warnings, 0 errors
- [x] Backend tests: 87 passed, 5 skipped (integration)
- [x] Frontend build: 0 errors
- [x] Frontend unit tests: 85 passed
- [x] Existing DB content with `translation` field is harmlessly ignored (field was optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated vocabulary item data structure across the application by removing the translation field. Vocabulary items in lessons now display word, definition, and example sentence only. This streamlines both the vocabulary editor interface for instructors and student preview displays, reducing overall complexity and keeping focus on essential language learning elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->