### PR TITLE
fix: use human-readable labels in homework generation prompt

### DIFF
--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -161,6 +161,7 @@ public class PromptService : IPromptService
         return $$"""
         Generate homework tasks for the lesson on "{{topic}}". Return JSON:
         {"tasks":[{"type":"","instructions":"","examples":[""]}]}
+        Use human-readable type labels such as "Fill in the Blanks", "Sentence Writing", "Vocabulary in Context", "Matching", "Translation", or "Short Answer".
         {{lessonSummaryLine}}Include 3-5 varied tasks the student can complete independently.
         """;
     }


### PR DESCRIPTION
## Summary
- The AI homework generator was producing machine identifiers (e.g. `gap_fill`, `writing`) for task type labels instead of human-readable text
- Added explicit example labels ("Fill in the Blanks", "Sentence Writing", "Vocabulary in Context", etc.) to the homework prompt in `PromptService.cs`

## Test plan
- [ ] Generate a homework block via the lesson editor and verify task types are human-readable labels
- [ ] Backend build passes with zero warnings
- [ ] All 93 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Homework tasks now display with human-readable type labels (e.g., "Fill in the Blanks", "Matching", "Translation") for improved clarity and better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->