### PR TITLE
fix: add SPA navigation fallback for Azure Static Web Apps

### DIFF
--- a/frontend/public/staticwebapp.config.json
+++ b/frontend/public/staticwebapp.config.json
@@ -1,6 +1,6 @@
 {
   "navigationFallback": {
     "rewrite": "/index.html",
-    "exclude": ["/assets/*", "/favicon.svg", "/logo.svg"]
+    "exclude": ["/assets/*", "/favicon.svg", "/icons.svg"]
   }
 }


### PR DESCRIPTION
## Summary
- Adds `staticwebapp.config.json` with navigation fallback so all routes rewrite to `index.html`
- Without this, Azure SWA returns 404 for any client-side route (e.g. `/dashboard`, `/lessons`), breaking Auth0 callback redirects and in-app navigation
- Excludes static assets (`/assets/*`, `/favicon.svg`, `/icons.svg`) from the fallback

## Test plan
- [ ] Deploy to Azure SWA and verify the site loads at the root URL
- [ ] Verify Auth0 login flow completes (redirect back to app works)
- [ ] Verify deep links (e.g. `/lessons`, `/students`) serve the SPA instead of 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added deployment configuration to optimize application routing and asset handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->