### PR TITLE
feat: desktop design polish across all pages (T20.5b)

### DIFF
--- a/.claude/memory/project_langteach_task_status.md
+++ b/.claude/memory/project_langteach_task_status.md
@@ -53,6 +53,7 @@ Phase 1 tasks are T1-T9 (defined in `plan/langteach-phase1/plan.md`).
 | T20 | Brand & Visual Polish (icon, favicon, loading states — replaces T9.1) | DONE — PR #67 merged |
 | T20.5 | Mobile & Tablet Responsive Polish (hamburger drawer, responsive layouts) | DONE — PR #69 merged |
 | T21 | Regenerate with Direction (make easier/harder/shorter/longer modifiers) | DONE — PR #65 merged |
+| T23-e2e | E2E Tests: Grammar, Reading, Exercises (ReadingRenderer, mock-auth e2e) | DONE — PR #70 merged |
 | T23 | Beta Demo Preparation (seed data, demo script, talking points) | pending (always last) |
 
 ## Key T2 Deviations (important for future tasks)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useAuth0 } from '@auth0/auth0-react'
 import { setupAuthInterceptor } from './lib/apiClient'
 import { ProtectedRoute } from './components/ProtectedRoute'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import AppShell from './components/AppShell'
 import Dashboard from './pages/Dashboard'
 import Settings from './pages/Settings'
@@ -32,23 +33,25 @@ function AuthSetup({ children }: { children: React.ReactNode }) {
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <AuthSetup>
-          <Routes>
-            <Route element={<ProtectedRoute><AppShell /></ProtectedRoute>}>
-              <Route path="/" element={<Dashboard />} />
-              <Route path="/settings" element={<Settings />} />
-              <Route path="/students" element={<Students />} />
-              <Route path="/students/new" element={<StudentForm />} />
-              <Route path="/students/:id/edit" element={<StudentForm />} />
-              <Route path="/lessons" element={<Lessons />} />
-              <Route path="/lessons/new" element={<LessonNew />} />
-              <Route path="/lessons/:id" element={<LessonEditor />} />
-              <Route path="/lessons/:id/study" element={<StudyView />} />
-            </Route>
-          </Routes>
-        </AuthSetup>
-      </BrowserRouter>
+      <TooltipProvider>
+        <BrowserRouter>
+          <AuthSetup>
+            <Routes>
+              <Route element={<ProtectedRoute><AppShell /></ProtectedRoute>}>
+                <Route path="/" element={<Dashboard />} />
+                <Route path="/settings" element={<Settings />} />
+                <Route path="/students" element={<Students />} />
+                <Route path="/students/new" element={<StudentForm />} />
+                <Route path="/students/:id/edit" element={<StudentForm />} />
+                <Route path="/lessons" element={<Lessons />} />
+                <Route path="/lessons/new" element={<LessonNew />} />
+                <Route path="/lessons/:id" element={<LessonEditor />} />
+                <Route path="/lessons/:id/study" element={<StudyView />} />
+              </Route>
+            </Routes>
+          </AuthSetup>
+        </BrowserRouter>
+      </TooltipProvider>
     </QueryClientProvider>
   )
 }

--- a/frontend/src/components/dashboard/QuickActions.test.tsx
+++ b/frontend/src/components/dashboard/QuickActions.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { QuickActions } from './QuickActions'
+
+function renderComponent(props = {}) {
+  return render(
+    <MemoryRouter>
+      <QuickActions studentCount={5} weekLessonCount={3} totalLessonCount={12} {...props} />
+    </MemoryRouter>,
+  )
+}
+
+describe('QuickActions', () => {
+  it('displays stat values', () => {
+    renderComponent()
+    expect(screen.getByTestId('stat-students')).toHaveTextContent('5')
+    expect(screen.getByTestId('stat-week-lessons')).toHaveTextContent('3')
+    expect(screen.getByTestId('stat-total-lessons')).toHaveTextContent('12')
+  })
+
+  it('renders stat boxes with brand accent colors', () => {
+    const { container } = renderComponent()
+    const statBoxes = container.querySelectorAll('.border-l-indigo-400')
+    expect(statBoxes.length).toBe(3)
+  })
+
+  it('renders stat icons with indigo color', () => {
+    const { container } = renderComponent()
+    const icons = container.querySelectorAll('.text-indigo-500')
+    expect(icons.length).toBe(3)
+  })
+
+  it('renders New Lesson button', () => {
+    renderComponent()
+    expect(screen.getByTestId('new-lesson-btn')).toHaveTextContent('New Lesson')
+  })
+})

--- a/frontend/src/components/dashboard/QuickActions.tsx
+++ b/frontend/src/components/dashboard/QuickActions.tsx
@@ -24,18 +24,18 @@ export function QuickActions({ studentCount, weekLessonCount, totalLessonCount }
         </Link>
 
         <div className="grid grid-cols-3 gap-2 text-center">
-          <div className="rounded-lg border border-zinc-100 p-2">
-            <Users className="h-4 w-4 text-zinc-400 mx-auto mb-1" />
+          <div className="rounded-lg border border-zinc-100 border-l-2 border-l-indigo-400 bg-indigo-50/50 p-2">
+            <Users className="h-4 w-4 text-indigo-500 mx-auto mb-1" />
             <p className="text-lg font-semibold text-zinc-900" data-testid="stat-students">{studentCount}</p>
             <p className="text-[10px] text-zinc-400">Students</p>
           </div>
-          <div className="rounded-lg border border-zinc-100 p-2">
-            <CalendarDays className="h-4 w-4 text-zinc-400 mx-auto mb-1" />
+          <div className="rounded-lg border border-zinc-100 border-l-2 border-l-indigo-400 bg-indigo-50/50 p-2">
+            <CalendarDays className="h-4 w-4 text-indigo-500 mx-auto mb-1" />
             <p className="text-lg font-semibold text-zinc-900" data-testid="stat-week-lessons">{weekLessonCount}</p>
             <p className="text-[10px] text-zinc-400">This Week</p>
           </div>
-          <div className="rounded-lg border border-zinc-100 p-2">
-            <BookOpen className="h-4 w-4 text-zinc-400 mx-auto mb-1" />
+          <div className="rounded-lg border border-zinc-100 border-l-2 border-l-indigo-400 bg-indigo-50/50 p-2">
+            <BookOpen className="h-4 w-4 text-indigo-500 mx-auto mb-1" />
             <p className="text-lg font-semibold text-zinc-900" data-testid="stat-total-lessons">{totalLessonCount}</p>
             <p className="text-[10px] text-zinc-400">Total</p>
           </div>

--- a/frontend/src/components/dashboard/UnscheduledDrafts.test.tsx
+++ b/frontend/src/components/dashboard/UnscheduledDrafts.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { UnscheduledDrafts } from './UnscheduledDrafts'
+import type { Lesson } from '../../api/lessons'
+
+function makeDraft(overrides: Partial<Lesson> = {}, idx = 0): Lesson {
+  return {
+    id: overrides.id ?? `d${idx}`,
+    title: overrides.title ?? `Draft ${idx}`,
+    language: 'English',
+    cefrLevel: overrides.cefrLevel ?? 'B1',
+    topic: 'Test',
+    durationMinutes: 60,
+    objectives: null,
+    status: 'Draft',
+    studentId: null,
+    templateId: null,
+    sections: [],
+    createdAt: '2026-03-10T10:00:00Z',
+    updatedAt: '2026-03-10T10:00:00Z',
+    scheduledAt: null,
+    studentName: null,
+    ...overrides,
+  }
+}
+
+function renderComponent(lessons: Lesson[]) {
+  return render(
+    <MemoryRouter>
+      <UnscheduledDrafts lessons={lessons} />
+    </MemoryRouter>,
+  )
+}
+
+describe('UnscheduledDrafts', () => {
+  it('renders nothing when no unscheduled drafts exist', () => {
+    const { container } = renderComponent([])
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows draft count in header', () => {
+    const drafts = Array.from({ length: 3 }, (_, i) => makeDraft({}, i))
+    renderComponent(drafts)
+    expect(screen.getByText('Unscheduled Drafts (3)')).toBeInTheDocument()
+  })
+
+  it('does not show "Open" text in rows', () => {
+    renderComponent([makeDraft()])
+    expect(screen.queryByText('Open')).not.toBeInTheDocument()
+  })
+
+  it('applies CEFR color classes to badges', () => {
+    renderComponent([makeDraft({ cefrLevel: 'A1' })])
+    const badge = screen.getByText('A1')
+    expect(badge.className).toContain('emerald')
+  })
+
+  it('shows only first 5 items and a "Show all" button when more than 5 drafts', () => {
+    const drafts = Array.from({ length: 8 }, (_, i) => makeDraft({ id: `d${i}`, title: `Draft ${i}` }, i))
+    renderComponent(drafts)
+
+    // Should show 5 visible items
+    for (let i = 0; i < 5; i++) {
+      expect(screen.getByTestId(`unscheduled-d${i}`)).toBeInTheDocument()
+    }
+    // 6th item should not be visible
+    expect(screen.queryByTestId('unscheduled-d5')).not.toBeInTheDocument()
+
+    // Show all button present
+    expect(screen.getByTestId('show-all-drafts')).toBeInTheDocument()
+    expect(screen.getByText('Show all (8)')).toBeInTheDocument()
+  })
+
+  it('shows all items after clicking "Show all"', async () => {
+    const user = userEvent.setup()
+    const drafts = Array.from({ length: 8 }, (_, i) => makeDraft({ id: `d${i}` }, i))
+    renderComponent(drafts)
+
+    await user.click(screen.getByTestId('show-all-drafts'))
+
+    // All 8 items should now be visible
+    for (let i = 0; i < 8; i++) {
+      expect(screen.getByTestId(`unscheduled-d${i}`)).toBeInTheDocument()
+    }
+    // Show all button should be gone
+    expect(screen.queryByTestId('show-all-drafts')).not.toBeInTheDocument()
+  })
+
+  it('shows all items directly when 5 or fewer drafts', () => {
+    const drafts = Array.from({ length: 4 }, (_, i) => makeDraft({ id: `d${i}` }, i))
+    renderComponent(drafts)
+
+    for (let i = 0; i < 4; i++) {
+      expect(screen.getByTestId(`unscheduled-d${i}`)).toBeInTheDocument()
+    }
+    expect(screen.queryByTestId('show-all-drafts')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/dashboard/UnscheduledDrafts.tsx
+++ b/frontend/src/components/dashboard/UnscheduledDrafts.tsx
@@ -2,8 +2,12 @@ import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { ChevronDown, ChevronUp } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { getCefrBadgeClasses } from '@/lib/cefr-colors'
 import type { Lesson } from '../../api/lessons'
+
+const COLLAPSED_LIMIT = 5
 
 interface UnscheduledDraftsProps {
   lessons: Lesson[]
@@ -12,6 +16,7 @@ interface UnscheduledDraftsProps {
 export function UnscheduledDrafts({ lessons }: UnscheduledDraftsProps) {
   const unscheduled = lessons.filter(l => l.status === 'Draft' && !l.scheduledAt)
   const [expanded, setExpanded] = useState(false)
+  const [showAll, setShowAll] = useState(false)
 
   // Auto-expand when unscheduled drafts first appear
   useEffect(() => {
@@ -19,6 +24,9 @@ export function UnscheduledDrafts({ lessons }: UnscheduledDraftsProps) {
   }, [unscheduled.length])
 
   if (unscheduled.length === 0) return null
+
+  const visibleItems = showAll ? unscheduled : unscheduled.slice(0, COLLAPSED_LIMIT)
+  const hasMore = unscheduled.length > COLLAPSED_LIMIT
 
   return (
     <Card className="bg-white border border-zinc-200" data-testid="unscheduled-drafts">
@@ -39,7 +47,7 @@ export function UnscheduledDrafts({ lessons }: UnscheduledDraftsProps) {
       {expanded && (
         <CardContent className="pt-0">
           <div className="space-y-2">
-            {unscheduled.map(lesson => (
+            {visibleItems.map(lesson => (
               <Link
                 key={lesson.id}
                 to={`/lessons/${lesson.id}`}
@@ -49,13 +57,23 @@ export function UnscheduledDrafts({ lessons }: UnscheduledDraftsProps) {
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-medium text-zinc-800 truncate">{lesson.title}</span>
-                    <Badge variant="outline" className="text-xs">{lesson.cefrLevel}</Badge>
+                    <Badge variant="outline" className={`text-xs ${getCefrBadgeClasses(lesson.cefrLevel)}`}>{lesson.cefrLevel}</Badge>
                   </div>
                   <p className="text-xs text-zinc-500">{lesson.studentName ?? 'No student'}</p>
                 </div>
-                <span className="text-xs text-indigo-600 shrink-0 ml-2">Open</span>
               </Link>
             ))}
+            {hasMore && !showAll && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={(e) => { e.stopPropagation(); setShowAll(true) }}
+                className="w-full text-xs text-indigo-600 hover:text-indigo-700 hover:bg-indigo-50"
+                data-testid="show-all-drafts"
+              >
+                Show all ({unscheduled.length})
+              </Button>
+            )}
           </div>
         </CardContent>
       )}

--- a/frontend/src/components/dashboard/WeekStrip.tsx
+++ b/frontend/src/components/dashboard/WeekStrip.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
+import { getCefrBadgeClasses } from '@/lib/cefr-colors'
 import { Button } from '@/components/ui/button'
 import type { Lesson } from '../../api/lessons'
 import type { Student } from '../../api/students'
@@ -56,7 +57,7 @@ export function WeekStrip({ weekOffset, onPrev, onNext, lessons, students, unsch
             <div
               key={idx}
               className={`min-w-[120px] shrink-0 snap-start md:min-w-0 md:shrink min-h-[100px] rounded-lg border p-2 ${
-                today ? 'bg-indigo-50 border-indigo-200' : 'bg-white border-zinc-200'
+                today ? 'bg-indigo-50 border-indigo-200 border-t-2 border-t-indigo-500' : 'bg-white border-zinc-200'
               }`}
               data-testid={`week-day-${idx}`}
             >
@@ -77,7 +78,7 @@ export function WeekStrip({ weekOffset, onPrev, onNext, lessons, students, unsch
                     data-testid={`lesson-pill-${lesson.id}`}
                   >
                     <div className="font-medium truncate">{lesson.studentName ?? 'No student'}</div>
-                    <Badge variant="outline" className="text-[10px] px-1 py-0 mt-0.5">{lesson.cefrLevel}</Badge>
+                    <Badge variant="outline" className={`text-[10px] px-1 py-0 mt-0.5 ${getCefrBadgeClasses(lesson.cefrLevel)}`}>{lesson.cefrLevel}</Badge>
                   </button>
                 ))}
               </div>

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -1,0 +1,64 @@
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delay = 0,
+  ...props
+}: TooltipPrimitive.Provider.Props) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delay={delay}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  side = "top",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/frontend/src/lib/cefr-colors.test.ts
+++ b/frontend/src/lib/cefr-colors.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { getCefrBadgeClasses } from './cefr-colors'
+
+describe('getCefrBadgeClasses', () => {
+  it('returns emerald classes for A1', () => {
+    expect(getCefrBadgeClasses('A1')).toContain('emerald')
+  })
+
+  it('returns emerald classes for A2', () => {
+    expect(getCefrBadgeClasses('A2')).toContain('emerald')
+  })
+
+  it('returns indigo classes for B1', () => {
+    expect(getCefrBadgeClasses('B1')).toContain('indigo')
+  })
+
+  it('returns indigo classes for B2', () => {
+    expect(getCefrBadgeClasses('B2')).toContain('indigo')
+  })
+
+  it('returns purple classes for C1', () => {
+    expect(getCefrBadgeClasses('C1')).toContain('purple')
+  })
+
+  it('returns purple classes for C2', () => {
+    expect(getCefrBadgeClasses('C2')).toContain('purple')
+  })
+
+  it('returns indigo as default for unknown levels', () => {
+    expect(getCefrBadgeClasses('X9')).toContain('indigo')
+  })
+})

--- a/frontend/src/lib/cefr-colors.ts
+++ b/frontend/src/lib/cefr-colors.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns Tailwind classes for CEFR level badges, color-coded by proficiency group.
+ */
+export function getCefrBadgeClasses(level: string): string {
+  switch (level) {
+    case 'A1':
+    case 'A2':
+      return 'text-emerald-700 border-emerald-200 bg-emerald-50'
+    case 'B1':
+    case 'B2':
+      return 'text-indigo-700 border-indigo-200 bg-indigo-50'
+    case 'C1':
+    case 'C2':
+      return 'text-purple-700 border-purple-200 bg-purple-50'
+    default:
+      return 'text-indigo-700 border-indigo-200 bg-indigo-50'
+  }
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -48,7 +48,7 @@ export default function Dashboard() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-semibold text-zinc-900">Dashboard</h1>
+        <h1 className="text-2xl font-bold text-zinc-900">Dashboard</h1>
         <p className="text-sm text-zinc-500 mt-1">Your teaching command center.</p>
       </div>
 

--- a/frontend/src/pages/LessonEditor.tsx
+++ b/frontend/src/pages/LessonEditor.tsx
@@ -34,6 +34,8 @@ import {
 import { GeneratePanel } from '@/components/lesson/GeneratePanel'
 import { ContentBlock } from '@/components/lesson/ContentBlock'
 import { ExportButton } from '@/components/lesson/ExportButton'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { getCefrBadgeClasses } from '@/lib/cefr-colors'
 import { FullLessonGenerateButton } from '@/components/lesson/FullLessonGenerateButton'
 import { LessonNotesCard } from '@/components/lesson/LessonNotesCard'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -303,7 +305,7 @@ export default function LessonEditor() {
 
   if (isLoading) {
     return (
-      <div className="space-y-6 max-w-3xl">
+      <div className="space-y-6 max-w-4xl">
         <div className="flex items-center gap-3">
           <Skeleton className="h-8 flex-1" />
           <Skeleton className="h-8 w-20 rounded-full" />
@@ -340,7 +342,7 @@ export default function LessonEditor() {
   }
 
   return (
-    <div className="space-y-6 max-w-3xl">
+    <div className="space-y-6 max-w-4xl">
       {/* Top bar */}
       <div className="flex items-center gap-2 md:gap-3 flex-wrap">
         {editingTitle ? (
@@ -355,7 +357,7 @@ export default function LessonEditor() {
           />
         ) : (
           <h1
-            className="text-2xl font-semibold text-zinc-900 flex-1 truncate cursor-pointer hover:text-indigo-700 transition-colors"
+            className="text-2xl font-bold text-zinc-900 flex-1 cursor-pointer hover:text-indigo-700 transition-colors"
             onClick={() => setEditingTitle(true)}
             onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && setEditingTitle(true)}
             role="button"
@@ -379,26 +381,36 @@ export default function LessonEditor() {
             {lesson.status}
           </button>
 
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => doDuplicate()}
-            disabled={isDuplicating}
-            aria-label="Duplicate lesson"
-            data-testid="duplicate-btn"
-          >
-            <Copy className="h-4 w-4 text-zinc-500" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger render={<span />}>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => doDuplicate()}
+                disabled={isDuplicating}
+                aria-label="Duplicate lesson"
+                data-testid="duplicate-btn"
+              >
+                <Copy className="h-4 w-4 text-zinc-500" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Duplicate</TooltipContent>
+          </Tooltip>
 
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => setConfirmDelete(true)}
-            aria-label="Delete lesson"
-            data-testid="delete-btn"
-          >
-            <Trash2 className="h-4 w-4 text-zinc-500" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger render={<span />}>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setConfirmDelete(true)}
+                aria-label="Delete lesson"
+                data-testid="delete-btn"
+              >
+                <Trash2 className="h-4 w-4 text-zinc-500" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Delete</TooltipContent>
+          </Tooltip>
 
           <ExportButton lessonId={id!} />
 
@@ -444,7 +456,7 @@ export default function LessonEditor() {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2 flex-wrap">
               <Badge variant="outline" className="text-xs text-zinc-500 border-zinc-200">{lesson.language}</Badge>
-              <Badge variant="outline" className="text-xs text-indigo-600 border-indigo-200 bg-indigo-50">{lesson.cefrLevel}</Badge>
+              <Badge variant="outline" className={`text-xs ${getCefrBadgeClasses(lesson.cefrLevel)}`}>{lesson.cefrLevel}</Badge>
               <span className="text-xs text-zinc-500">{lesson.topic}</span>
               <span className="text-xs text-zinc-400">{lesson.durationMinutes} min</span>
               {lesson.scheduledAt && (
@@ -615,6 +627,10 @@ export default function LessonEditor() {
                   className="resize-none text-sm"
                   data-testid={`section-${type.toLowerCase()}`}
                 />
+
+                {!sectionNotes[type] && blocks.length === 0 && (
+                  <p className="text-xs text-zinc-400 italic">Use Generate to create content, or type your notes above.</p>
+                )}
 
                 {blocks.map(block => (
                   <ContentBlock

--- a/frontend/src/pages/LessonNew.tsx
+++ b/frontend/src/pages/LessonNew.tsx
@@ -84,7 +84,7 @@ export default function LessonNew() {
     return (
       <div className="space-y-6 max-w-3xl">
         <div>
-          <h1 className="text-2xl font-semibold text-zinc-900">New Lesson</h1>
+          <h1 className="text-2xl font-bold text-zinc-900">New Lesson</h1>
           <p className="text-sm text-zinc-500 mt-1">Choose a template to get started, or start from blank.</p>
         </div>
 
@@ -153,7 +153,7 @@ export default function LessonNew() {
           <ArrowLeft className="h-4 w-4" />
         </button>
         <div>
-          <h1 className="text-2xl font-semibold text-zinc-900">Lesson Details</h1>
+          <h1 className="text-2xl font-bold text-zinc-900">Lesson Details</h1>
           <p className="text-sm text-zinc-500 mt-1">
             {selectedTemplateId
               ? `Using template: ${templates?.find(t => t.id === selectedTemplateId)?.name ?? ''}`

--- a/frontend/src/pages/Lessons.tsx
+++ b/frontend/src/pages/Lessons.tsx
@@ -10,6 +10,8 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { getCefrBadgeClasses } from '@/lib/cefr-colors'
 import { cn } from '@/lib/utils'
 import {
   AlertDialog,
@@ -150,7 +152,7 @@ export default function Lessons() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-zinc-900">Lessons</h1>
+          <h1 className="text-2xl font-bold text-zinc-900">Lessons</h1>
           <p className="text-sm text-zinc-500 mt-1">Create and manage your lesson plans.</p>
         </div>
         <Link
@@ -177,7 +179,7 @@ export default function Lessons() {
             <SelectValue placeholder="Language" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">All languages</SelectItem>
+            <SelectItem value="all">Language: All</SelectItem>
             {LANGUAGES.map((l) => <SelectItem key={l} value={l}>{l}</SelectItem>)}
           </SelectContent>
         </Select>
@@ -186,7 +188,7 @@ export default function Lessons() {
             <SelectValue placeholder="Level" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">All levels</SelectItem>
+            <SelectItem value="all">Level: All</SelectItem>
             {CEFR_LEVELS.map((l) => <SelectItem key={l} value={l}>{l}</SelectItem>)}
           </SelectContent>
         </Select>
@@ -195,7 +197,7 @@ export default function Lessons() {
             <SelectValue placeholder="Status" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">All statuses</SelectItem>
+            <SelectItem value="all">Status: All</SelectItem>
             <SelectItem value="Draft">Draft</SelectItem>
             <SelectItem value="Published">Published</SelectItem>
           </SelectContent>
@@ -226,7 +228,7 @@ export default function Lessons() {
       {lessons.length > 0 && (
         <div className="space-y-3">
           {lessons.map((lesson) => (
-            <Card key={lesson.id} className="bg-white border border-zinc-200 transition-all hover:shadow-sm hover:border-zinc-300" data-testid={`lesson-row-${lesson.id}`}>
+            <Card key={lesson.id} className="bg-white border border-zinc-200 shadow-sm transition-all hover:shadow-md hover:border-zinc-300" data-testid={`lesson-row-${lesson.id}`}>
               <CardContent className="flex items-center justify-between py-4 px-4 sm:px-6">
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-3 flex-wrap">
@@ -236,7 +238,7 @@ export default function Lessons() {
                     <Badge variant="outline" className="text-xs text-zinc-500 border-zinc-200">
                       {lesson.language}
                     </Badge>
-                    <Badge variant="outline" className="text-xs text-indigo-600 border-indigo-200 bg-indigo-50">
+                    <Badge variant="outline" className={`text-xs ${getCefrBadgeClasses(lesson.cefrLevel)}`}>
                       {lesson.cefrLevel}
                     </Badge>
                     <Badge variant="outline" className={cn('text-xs', statusBadgeClass(lesson.status))} data-testid="lesson-status">
@@ -248,36 +250,48 @@ export default function Lessons() {
                   </p>
                 </div>
                 <div className="flex items-center gap-1 ml-2 sm:ml-4 shrink-0">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => doDuplicate(lesson.id)}
-                    disabled={isDuplicating}
-                    aria-label={`Duplicate ${lesson.title}`}
-                    title="Clone"
-                    data-testid="duplicate-lesson"
-                  >
-                    <Copy className="h-4 w-4 text-zinc-400" />
-                  </Button>
-                  <Link
-                    to={`/lessons/${lesson.id}`}
-                    aria-label={`Edit ${lesson.title}`}
-                    title="Edit"
-                    className={cn(buttonVariants({ variant: 'ghost', size: 'icon' }))}
-                    data-testid="edit-lesson"
-                  >
-                    <Pencil className="h-4 w-4 text-zinc-400" />
-                  </Link>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => setLessonToDelete(lesson)}
-                    aria-label={`Delete ${lesson.title}`}
-                    title="Delete"
-                    data-testid="delete-lesson"
-                  >
-                    <Trash2 className="h-4 w-4 text-zinc-400" />
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger render={<span />}>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => doDuplicate(lesson.id)}
+                        disabled={isDuplicating}
+                        aria-label={`Duplicate ${lesson.title}`}
+                        data-testid="duplicate-lesson"
+                      >
+                        <Copy className="h-4 w-4 text-zinc-400" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Clone</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger render={<span />}>
+                      <Link
+                        to={`/lessons/${lesson.id}`}
+                        aria-label={`Edit ${lesson.title}`}
+                        className={cn(buttonVariants({ variant: 'ghost', size: 'icon' }))}
+                        data-testid="edit-lesson"
+                      >
+                        <Pencil className="h-4 w-4 text-zinc-400" />
+                      </Link>
+                    </TooltipTrigger>
+                    <TooltipContent>Edit</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger render={<span />}>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setLessonToDelete(lesson)}
+                        aria-label={`Delete ${lesson.title}`}
+                        data-testid="delete-lesson"
+                      >
+                        <Trash2 className="h-4 w-4 text-zinc-400" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Delete</TooltipContent>
+                  </Tooltip>
                 </div>
               </CardContent>
             </Card>

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -258,7 +258,7 @@ export default function StudentForm() {
   return (
     <div className="max-w-2xl space-y-6">
       <div>
-        <h1 className="text-2xl font-semibold text-zinc-900">
+        <h1 className="text-2xl font-bold text-zinc-900">
           {isEdit ? 'Edit Student' : 'Add Student'}
         </h1>
         <p className="text-sm text-zinc-500 mt-1">

--- a/frontend/src/pages/Students.tsx
+++ b/frontend/src/pages/Students.tsx
@@ -8,6 +8,8 @@ import { Button, buttonVariants } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+import { getCefrBadgeClasses } from '@/lib/cefr-colors'
 import { cn } from '@/lib/utils'
 import {
   AlertDialog,
@@ -95,7 +97,7 @@ export default function Students() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-zinc-900">Students</h1>
+          <h1 className="text-2xl font-bold text-zinc-900">Students</h1>
           <p className="text-sm text-zinc-500 mt-1">Manage your student profiles.</p>
         </div>
         <Link
@@ -131,7 +133,7 @@ export default function Students() {
       {students.length > 0 && (
         <div className="space-y-3">
           {students.map((student) => (
-            <Card key={student.id} className="bg-white border border-zinc-200" data-testid={`student-row-${student.id}`}>
+            <Card key={student.id} className="bg-white border border-zinc-200 shadow-sm transition-all hover:shadow-md hover:border-zinc-300" data-testid={`student-row-${student.id}`}>
               <CardContent className="flex items-center justify-between py-4 px-4 sm:px-6">
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-3 flex-wrap">
@@ -141,7 +143,7 @@ export default function Students() {
                     <Badge variant="outline" className="text-xs text-zinc-500 border-zinc-200">
                       {student.learningLanguage}
                     </Badge>
-                    <Badge variant="outline" className="text-xs text-indigo-600 border-indigo-200 bg-indigo-50" data-testid="student-level">
+                    <Badge variant="outline" className={`text-xs ${getCefrBadgeClasses(student.cefrLevel)}`} data-testid="student-level">
                       {student.cefrLevel}
                     </Badge>
                     {student.nativeLanguage && (
@@ -168,23 +170,33 @@ export default function Students() {
                   )}
                 </div>
                 <div className="flex items-center gap-1 ml-2 sm:ml-4 shrink-0">
-                  <Link
-                    to={`/students/${student.id}/edit`}
-                    aria-label={`Edit ${student.name}`}
-                    className={cn(buttonVariants({ variant: 'ghost', size: 'icon' }))}
-                    data-testid="edit-student"
-                  >
-                    <Pencil className="h-4 w-4 text-zinc-400" />
-                  </Link>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => setStudentToDelete(student)}
-                    aria-label={`Delete ${student.name}`}
-                    data-testid="delete-student"
-                  >
-                    <Trash2 className="h-4 w-4 text-zinc-400" />
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger render={<span />}>
+                      <Link
+                        to={`/students/${student.id}/edit`}
+                        aria-label={`Edit ${student.name}`}
+                        className={cn(buttonVariants({ variant: 'ghost', size: 'icon' }))}
+                        data-testid="edit-student"
+                      >
+                        <Pencil className="h-4 w-4 text-zinc-400" />
+                      </Link>
+                    </TooltipTrigger>
+                    <TooltipContent>Edit</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger render={<span />}>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setStudentToDelete(student)}
+                        aria-label={`Delete ${student.name}`}
+                        data-testid="delete-student"
+                      >
+                        <Trash2 className="h-4 w-4 text-zinc-400" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Delete</TooltipContent>
+                  </Tooltip>
                 </div>
               </CardContent>
             </Card>

--- a/plan/langteach-beta/task20.5b-desktop-design-polish.md
+++ b/plan/langteach-beta/task20.5b-desktop-design-polish.md
@@ -1,0 +1,172 @@
+# T20.5b: Desktop Design Polish
+
+## Context
+
+After a UI design review (with the frontend-design plugin), 13 issues were identified across the desktop experience. The app has a solid foundation (Geist Variable font, indigo brand, consistent Card components, bg-zinc-50 content area) but needs polish in interaction feedback, space utilization, visual hierarchy, and component consistency. This plan addresses all 13 issues grouped into logical tasks.
+
+## Plan Review
+
+```
+### Summary
+Plan proposes 8 sub-tasks covering layout, pagination, labels, hover states, typography, week strip, empty states, and CEFR badge colors across ~11 files.
+
+### Assumptions Verified
+- LessonEditor.tsx uses `max-w-3xl` on main container (line 343): YES
+- LessonEditor.tsx title has `truncate` class (line 358): YES
+- UnscheduledDrafts.tsx exists as separate component: YES (renders all items, no limit)
+- QuickActions.tsx exists as separate component: YES (stat boxes with `border-zinc-100`)
+- Lessons.tsx filter selects show `SelectValue placeholder=` but `value` is set to `language ?? 'all'`, so SelectValue renders the selected item text "all" not the placeholder: YES, this is the root cause
+- Students.tsx card has NO hover classes (line 134): YES, confirmed
+- Lessons.tsx card already HAS `hover:shadow-sm hover:border-zinc-300` (line 229): YES
+- AppShell.tsx sidebar inactive items already have `hover:bg-zinc-100 hover:text-foreground` (line 44): YES! Plan is wrong here
+- LessonEditor.tsx "Generate" button already has icon + text + hover styling (line 596): YES, it's a ghost Button with Sparkles icon, not plain text
+- tooltip.tsx does not exist: YES, needs to be added via shadcn
+- components.json exists with shadcn config: YES
+
+### Critical (plan will fail without fixing)
+None
+
+### Important (likely to cause rework)
+- [x] **Task 4 (sidebar hover)**: AppShell.tsx line 44 already has `hover:bg-zinc-100 hover:text-foreground` on inactive nav items. The plan incorrectly states this is missing. Remove this item from Task 4.
+- [x] **Task 4 (Generate button)**: LessonEditor.tsx line 589-601 already uses a `<Button variant="ghost">` with `<Sparkles>` icon and hover styling (`hover:text-indigo-700 hover:bg-indigo-50`). It is NOT plain text. The plan says "Style Generate text as a small outlined button" but it already is one. The disabled "Generate" span on line 603-604 (when no sectionId) is the only plain-text instance. Revise Task 4.
+- [x] **Task 3 (filter labels)**: The issue is that when `value="all"` is set on the Select, it renders the SelectItem text "All languages" not the placeholder. So the fix is to change the SelectItem text from "All languages" to "Language: All", not to change the placeholder. Plan should be more precise.
+- [x] **Task 2 (UnscheduledDrafts)**: The component already has an expand/collapse toggle. The plan says "show first 5 items with Show all button" but the existing pattern collapses the entire card. The implementation should add a `showAll` state within the expanded view: show first 5 rows, then a "Show all N" button.
+
+### Minor (suggestions)
+- [x] **Task 1**: `max-w-5xl` is 1024px in Tailwind v3 but might differ in the project's config. Verify the actual computed value matches intent.
+- [x] **Task 5 (shadow-sm on cards)**: Adding shadow to Card component globally would affect all cards including metadata cards in LessonEditor. Better to add shadow at page level (Students.tsx, Lessons.tsx) rather than modifying card.tsx.
+- [x] **Task 8**: The CEFR badge in WeekStrip (line 80) uses a generic `variant="outline"` with no color classes. Plan should explicitly list this as a location to update.
+
+### Missing from plan
+- [x] Lessons.tsx already has `title` attributes on icon buttons (lines 257, 265, 276: "Clone", "Edit", "Delete"). Plan says to add Tooltip component wrapping these, but `title` already provides basic browser tooltips. If upgrading to shadcn Tooltip, should remove the `title` attributes to avoid double-tooltip.
+- [x] UnscheduledDrafts "Open" text (line 56) is inside a Link component that wraps the entire row. The row itself is already clickable. The "Open" label is redundant visual noise, not a separate action. Plan should consider removing it rather than styling it as a ghost button.
+- [x] No unit test updates mentioned for modified components (required by project feedback_frontend_unit_tests.md).
+
+### Verdict
+NEEDS REVISION -- several assumptions are incorrect (sidebar hover already exists, Generate is already styled, filter fix needs different approach). Core plan is sound but needs corrections before implementation.
+```
+
+## Revised Plan
+
+### Task 1: Lesson Editor Layout & Title Fix (Issues #1, #2)
+
+**Files:** `frontend/src/pages/LessonEditor.tsx`
+
+**Changes:**
+- Increase main container from `max-w-3xl` to `max-w-4xl` (896px, a safe middle ground)
+- Remove `truncate` from h1 title (line 358), allow it to wrap naturally
+- Header already uses `flex-wrap` (line 345), which handles overflow. Just removing truncate should suffice.
+- Update loading skeleton container to match new max-width (line 306)
+
+### Task 2: Dashboard Drafts Collapse & Quick Actions Polish (Issues #3, #12)
+
+**Files:** `frontend/src/components/dashboard/UnscheduledDrafts.tsx`, `frontend/src/components/dashboard/QuickActions.tsx`
+
+**UnscheduledDrafts changes:**
+- Add `showAll` state (default false)
+- When expanded but not showAll: render first 5 items, then a "Show all (N)" button
+- When showAll: render all items
+- Remove the standalone "Open" text span (line 56), the entire row is already a Link
+
+**QuickActions changes:**
+- Add subtle background tints to stat boxes: `bg-indigo-50/50` or a left border accent `border-l-2 border-l-indigo-400`
+- Change icon colors from `text-zinc-400` to `text-indigo-500` to match brand
+
+### Task 3: Lessons Filter Labels (Issue #4)
+
+**File:** `frontend/src/pages/Lessons.tsx`
+
+**Changes:**
+- Change SelectItem text for "all" options:
+  - Line 180: `"All languages"` to `"Language: All"`
+  - Line 189: `"All levels"` to `"Level: All"`
+  - Line 198: `"All statuses"` to `"Status: All"`
+- This works because when value="all" is selected, SelectValue renders the SelectItem's display text
+
+### Task 4: Hover & Interaction Feedback (Issues #5, #6, #7)
+
+**Files:** `frontend/src/pages/Students.tsx`, `frontend/src/pages/Lessons.tsx`
+
+**Students.tsx changes:**
+- Add `transition-all hover:shadow-sm hover:border-zinc-300` to student Card (line 134), matching the Lessons pattern
+
+**Tooltip setup:**
+- Install shadcn Tooltip: `cd frontend && npx shadcn@latest add tooltip`
+- Wrap icon-only buttons in Lessons.tsx (Copy, Edit link, Delete) with `<Tooltip>` and remove existing `title` attributes
+- Wrap icon-only buttons in Students.tsx (Edit link, Delete) similarly
+- Wrap icon-only buttons in LessonEditor.tsx toolbar (Copy, Delete, ExportButton)
+
+**NOT changing (already correct):**
+- Sidebar hover states (already have `hover:bg-zinc-100`)
+- Generate button styling (already a ghost Button with icon + hover)
+
+### Task 5: Typography & Visual Depth (Issues #8, #9)
+
+**Files:** `frontend/src/pages/Dashboard.tsx`, `frontend/src/pages/Students.tsx`, `frontend/src/pages/Lessons.tsx`, `frontend/src/pages/LessonEditor.tsx`, `frontend/src/pages/LessonNew.tsx`, `frontend/src/pages/StudentForm.tsx`
+
+**Changes:**
+- Upgrade h1 headings from `font-semibold` to `font-bold` on all pages for stronger hierarchy
+- Add `shadow-sm` to list Cards on Students.tsx (line 134) and Lessons.tsx (line 229) for depth
+- Do NOT modify card.tsx globally
+
+### Task 6: Week Strip Polish (Issue #10)
+
+**File:** `frontend/src/components/dashboard/WeekStrip.tsx`
+
+**Changes:**
+- Enhance "today" column: add `border-t-2 border-t-indigo-500` for a stronger accent
+- The SchedulePopover trigger is the "+" button (in SchedulePopover.tsx). Increase its size slightly or add visible text on desktop. Need to check SchedulePopover for the trigger button styling.
+
+### Task 7: Empty States for Lesson Editor Sections (Issue #11)
+
+**File:** `frontend/src/pages/LessonEditor.tsx`
+
+**Changes:**
+- Below each section textarea, when `sectionNotes[type]` is empty AND `blocks.length === 0`, show a subtle hint:
+  `<p className="text-xs text-zinc-400 italic">Use Generate to create content, or type your notes above.</p>`
+
+### Task 8: CEFR Badge Color System (Issue #13)
+
+**New file:** `frontend/src/lib/cefr-colors.ts`
+
+**Changes:**
+- Create helper `getCefrBadgeClasses(level: string): string` returning Tailwind classes:
+  - A1/A2: `text-emerald-700 border-emerald-200 bg-emerald-50`
+  - B1/B2: `text-indigo-700 border-indigo-200 bg-indigo-50` (current default)
+  - C1/C2: `text-purple-700 border-purple-200 bg-purple-50`
+- Update all CEFR badge locations:
+  - `Students.tsx` line 144
+  - `Lessons.tsx` line 239
+  - `LessonEditor.tsx` line 447
+  - `WeekStrip.tsx` line 80
+  - `UnscheduledDrafts.tsx` line 52
+
+## Files to Modify
+
+| File | Tasks |
+|------|-------|
+| `frontend/src/pages/LessonEditor.tsx` | 1, 5, 7, 8 |
+| `frontend/src/pages/Dashboard.tsx` | 5 |
+| `frontend/src/pages/Students.tsx` | 4, 5, 8 |
+| `frontend/src/pages/Lessons.tsx` | 3, 4, 5, 8 |
+| `frontend/src/pages/LessonNew.tsx` | 5 |
+| `frontend/src/pages/StudentForm.tsx` | 5 |
+| `frontend/src/components/dashboard/UnscheduledDrafts.tsx` | 2, 8 |
+| `frontend/src/components/dashboard/QuickActions.tsx` | 2 |
+| `frontend/src/components/dashboard/WeekStrip.tsx` | 6, 8 |
+| `frontend/src/components/ui/tooltip.tsx` | 4 (new, from shadcn) |
+| `frontend/src/lib/cefr-colors.ts` | 8 (new helper) |
+
+## Verification
+
+1. `cd frontend && npm run build` passes with zero errors
+2. `cd frontend && npm test` passes all unit tests (update/add tests for modified components)
+3. Visual review with `/review-ui` at desktop (1920x1080) confirming:
+   - Lesson editor title no longer truncates
+   - Dashboard shows max 5 drafts with "Show all" button
+   - Filter dropdowns show "Language: All", "Level: All", "Status: All"
+   - Student cards show hover feedback
+   - CEFR badges show different colors per level group
+   - Icon buttons have shadcn tooltips on hover
+   - h1 headings are bolder
+4. Existing e2e tests still pass


### PR DESCRIPTION
## Summary
- Wider lesson editor layout (`max-w-4xl`), title wraps instead of truncating
- CEFR badge color system: A1/A2 emerald, B1/B2 indigo, C1/C2 purple (5 locations)
- Shadcn tooltips on all icon-only buttons (Lessons, Students, LessonEditor)
- Upgraded h1 headings to `font-bold` across all 6 pages
- Card `shadow-sm` + hover depth on Students and Lessons list cards
- Filter labels clarified: "Language: All", "Level: All", "Status: All"
- UnscheduledDrafts: shows first 5 items with "Show all (N)" button, removed redundant "Open" text
- QuickActions stat boxes: indigo brand accents (border, background tint, icon color)
- Week strip "today" column: added `border-t-2 border-t-indigo-500` accent
- Empty state hint in lesson editor sections when no notes and no content blocks
- 3 new test files (cefr-colors, UnscheduledDrafts, QuickActions) adding 18 unit tests

## Test plan
- [x] `npm run build` passes with zero errors
- [x] `npm test` passes (165 tests, 24 files)
- [x] `dotnet build` passes (0 warnings)
- [x] `dotnet test` passes (103 passed, 5 skipped integration)
- [x] `az bicep build` passes
- [ ] Visual review at desktop (1920x1080) confirming all 13 UI issues addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips throughout the app for improved action guidance
  * Introduced collapsible unscheduled drafts list with "Show all" button
  * Added helper text in lesson editor for better guidance

* **Visual Enhancements**
  * Enhanced dashboard tiles with indigo accent borders and backgrounds
  * Color-coded CEFR level badges (emerald: A1-A2, indigo: B1-B2, purple: C1-C2)
  * Improved card styling with better shadows and hover effects
  * Updated typography for clearer visual hierarchy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->