### PR TITLE
fix: nightly e2e API health check uses real endpoint

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Wait for API
         run: |
           timeout 120 bash -c '
-            until curl -s -o /dev/null -w "%{http_code}" http://localhost:5000/health 2>/dev/null | grep -qE "^2[0-9]{2}$"; do
+            until curl -s -o /dev/null http://localhost:5000/api/auth/me 2>/dev/null; do
               echo "Waiting for API..."
               sleep 2
             done


### PR DESCRIPTION
## Summary
- The API has no `/health` endpoint, causing the nightly e2e wait loop to timeout on 404
- Changed to `/api/auth/me` which returns 401 unauthenticated (proving server is up)

## Test plan
- [ ] Trigger nightly e2e manually after merge, verify API wait step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved API readiness check in end-to-end testing pipeline for more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->