### PR TITLE
fix: activate MockAuth0Provider and skip incompatible CI tests

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -70,6 +70,7 @@ jobs:
             "VITE_AUTH0_CLIENT_ID=${{ secrets.VITE_AUTH0_CLIENT_ID }}" \
             "VITE_AUTH0_AUDIENCE=${{ secrets.VITE_AUTH0_AUDIENCE }}" \
             "VITE_API_URL=http://localhost:5000" \
+            "VITE_E2E_TEST_MODE=true" \
             > frontend/.env.local
 
       - name: Start services

--- a/e2e/tests/auth-diagnostic.spec.ts
+++ b/e2e/tests/auth-diagnostic.spec.ts
@@ -6,11 +6,13 @@ test('GET /api/health returns 200 without token', async ({ request }) => {
 })
 
 test('GET /api/auth/me returns 401 without token', async ({ request }) => {
+  test.skip(!!process.env.CI, 'Backend runs in E2ETesting mode in CI — all requests are authenticated')
   const response = await request.get('http://localhost:5000/api/auth/me')
   expect(response.status()).toBe(401)
 })
 
 test('frontend redirects unauthenticated user to Auth0 login page', async ({ page }) => {
+  test.skip(!!process.env.CI, 'Frontend runs with MockAuth0Provider in CI — no Auth0 redirect occurs')
   await page.context().clearCookies()
   await page.evaluate(() => { localStorage.clear(); sessionStorage.clear() }).catch(() => {})
 
@@ -22,6 +24,7 @@ test('frontend redirects unauthenticated user to Auth0 login page', async ({ pag
 })
 
 test('Auth0 login page shows email/password and Google options', async ({ page }) => {
+  test.skip(!!process.env.CI, 'Frontend runs with MockAuth0Provider in CI — no Auth0 redirect occurs')
   await page.context().clearCookies()
   await page.goto('/', { waitUntil: 'domcontentloaded' })
   await page.waitForURL(/auth0\.com/, { timeout: 10000 })


### PR DESCRIPTION
## Root cause (follow-up to #87)

After #87 merged, the mock-auth tests still failed. Investigation showed:

1. **`VITE_E2E_TEST_MODE` was never set** — `main.tsx` only activates `MockAuth0Provider` when `VITE_E2E_TEST_MODE=true`. Without it the frontend used real Auth0 and every mock-auth test redirected to the Auth0 login page (`h1 = "Welcome"`).

2. **Three auth-diagnostic tests are incompatible with E2ETesting mode** — In CI the backend runs as `E2ETesting` (accepts all tokens unconditionally) and the frontend runs with `MockAuth0Provider` (no Auth0 redirect). Tests asserting a 401 or an Auth0 redirect are therefore always wrong in CI.

## Changes
- Add `VITE_E2E_TEST_MODE=true` to the frontend `.env.local` created in the nightly workflow
- Add `test.skip(!!process.env.CI)` to the three auth-diagnostic tests that require real Auth0 mode

## Test plan
- [ ] Trigger nightly E2E workflow manually and confirm only `GET /api/health` runs from auth-diagnostic (the rest are skipped), mock-auth tests all pass, auth-me is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced E2E test workflow configuration to improve frontend testing
  * Updated authentication tests to conditionally skip in CI environments for better test reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->