### PR TITLE
fix: skip registration test in CI

### DIFF
--- a/e2e/tests/registration.spec.ts
+++ b/e2e/tests/registration.spec.ts
@@ -11,6 +11,7 @@ import { deleteTeacherByEmail } from '../helpers/db-helper'
  * is in the same state as a genuine first-time login.
  */
 test('first login creates teacher record with email', async ({ browser }) => {
+  test.skip(!!process.env.CI, 'Requires real Auth0 browser login — not runnable in CI')
   const apiBase = process.env.VITE_API_BASE_URL ?? 'http://localhost:5000'
 
   // ── Step 1: log in and capture Auth0 sub + bearer token ──────────────────


### PR DESCRIPTION
## Summary
- `registration.spec.ts` uses `createAuthenticatedContext` (real Auth0 browser login), which is incompatible with `VITE_E2E_TEST_MODE=true` — the frontend never redirects to Auth0 so the username field never appears and the test times out.
- Added `test.skip(!!process.env.CI)`, consistent with the same fix applied to `auth-me`, `provider-switch`, and the auth-diagnostic tests.

This is the last remaining failure after #87, #90, and the `provider-switch` fix. Expected result: 21 passed, 6 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test execution configuration for CI environment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->