### PR TITLE
feat(qa): add QA reviewer skill and agent

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# LangTeach SaaS — Project Rules
+# LangTeach SaaS -- Project Rules
 
 ## Worktree-First Workflow
 
@@ -71,11 +71,11 @@ When a task is marked complete:
 7. Stop -- do NOT merge. The user reviews the PR and merges manually.
 
 **Pre-push checks (must all pass before pushing):**
-- `az bicep build --file infra/main.bicep` — zero warnings, zero errors
-- `cd backend && dotnet build` — zero warnings, zero errors
-- `cd backend && dotnet test` — all tests pass
-- `cd frontend && npm run build` — zero errors
-- `cd frontend && npm test` — all unit tests pass
+- `az bicep build --file infra/main.bicep` -- zero warnings, zero errors
+- `cd backend && dotnet build` -- zero warnings, zero errors
+- `cd backend && dotnet test` -- all tests pass
+- `cd frontend && npm run build` -- zero errors
+- `cd frontend && npm test` -- all unit tests pass
 - If any check fails, fix it before pushing. Never push with known failures or warnings.
 
 **Branch protection rules:**
@@ -85,4 +85,4 @@ When a task is marked complete:
 
 ## Memory
 
-Claude's persistent memory for this project lives in `.claude/memory/`. These are not source files — do not read, modify, or include them in code searches or codebase exploration. Memory is managed separately via the auto-memory system.
+Claude's persistent memory for this project lives in `.claude/memory/`. These are not source files -- do not read, modify, or include them in code searches or codebase exploration. Memory is managed separately via the auto-memory system.

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -14,7 +14,7 @@ You are a QA verification agent. Your job is to check whether the code changes o
 
 Try these sources in order:
 1. The caller's prompt (if they passed an issue number)
-2. Branch name: extract `<N>` from `task/t<N>-*` or `worktree-task-t<N>-*` pattern
+2. Branch name: extract `<N>` from `task-t<N>-*`, `task/t<N>-*`, or `worktree-task-t<N>-*` pattern
 3. Recent commit messages: look for `Closes #N`, `Fixes #N`, or `#N` references in `git log main..HEAD --oneline`
 
 If no issue number is found, report an error and stop.

--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -20,7 +20,7 @@ Review GitHub issues for completeness and quality before implementation. This sk
 Based on the argument:
 
 - **Specific issue**: `gh issue view <N> --json number,title,body,labels,milestone`
-- **All in milestone (no args)**: first determine current milestone from `gh milestone list`, then `gh issue list --milestone "<name>" --state open --json number,title,body,labels,milestone --limit 100`, filter out those already labeled `qa:ready`
+- **All in milestone (no args)**: run `gh milestone list --state open --json title,dueOn` and pick the milestone with the earliest due date (or the only open one). Then `gh issue list --milestone "<name>" --state open --json number,title,body,labels,milestone --limit 100`, filter out those already labeled `qa:ready`
 - **Named milestone**: `gh issue list --milestone "<name>" --state open --json number,title,body,labels,milestone --limit 100`, filter out those already labeled `qa:ready`
 
 ### Step 2: Evaluate Each Issue
@@ -54,7 +54,7 @@ Apply the quality rubric to each issue.
 3. Done
 
 **If must-have findings exist:**
-1. Invoke the PM agent with the following prompt:
+1. Use the Agent tool with `subagent_type: "pm"` to invoke the PM agent with the following prompt:
 
 ```
 QA has reviewed issue #<N> (<title>) and found these gaps:
@@ -73,7 +73,7 @@ For accepted findings, provide the exact text to add to the issue body. For stru
 
 2. Apply PM's accepted changes:
    - For label/milestone fixes: `gh issue edit <N> --add-label "<label>"` or `gh issue edit <N> --milestone "<name>"`
-   - For body content: `gh issue edit <N> --body "<updated body>"` (preserve existing content, append new sections)
+   - For body content: write the updated body to a temp file and use `gh issue edit <N> --body-file /tmp/issue-body.md` (preserve existing content, append new sections). This avoids shell escaping issues with markdown.
 3. For refuted content findings: note as "PM declined, flagged for user review" in the comment. Do NOT block `qa:ready` for PM-refuted content findings.
 4. For refuted structural findings (labels, milestone): these are non-negotiable. Keep as a gap.
 


### PR DESCRIPTION
## Summary
- Added `/qa` skill: issue quality gate that validates GitHub issues against a rubric (problem statement, acceptance criteria, labels, milestone, scope), coordinates with PM agent for content decisions, and manages `qa:ready` labels
- Added `qa` agent: pre-PR verification that checks implementation coverage against all acceptance criteria from the linked GitHub issue
- Updated Task Completion Protocol in CLAUDE.md to include QA verification step (step 3) between pre-push checks and code review

Closes #106

## Test plan
- [ ] Run `/qa 101` on a poorly-defined issue and verify it produces findings and coordinates with PM
- [ ] Run `/qa 95` on a well-defined issue and verify it passes quickly with `qa:ready`
- [ ] On a task branch, invoke the `qa` agent and verify criteria table with coverage assessment
- [ ] Verify CLAUDE.md protocol flows: pre-push checks -> QA -> review

🤖 Generated with [Claude Code](https://claude.com/claude-code)