### PR TITLE
fix: use actual section count in Generate All dialog

### DIFF
--- a/frontend/src/components/lesson/FullLessonGenerateButton.test.tsx
+++ b/frontend/src/components/lesson/FullLessonGenerateButton.test.tsx
@@ -98,12 +98,29 @@ describe('FullLessonGenerateButton', () => {
     expect(screen.getByTestId('generate-full-lesson-btn')).not.toBeDisabled()
   })
 
-  it('clicking opens confirmation dialog', async () => {
+  it('clicking opens confirmation dialog with correct section count', async () => {
     const user = userEvent.setup()
     renderButton()
     await user.click(screen.getByTestId('generate-full-lesson-btn'))
     expect(screen.getByText('Generate Full Lesson?')).toBeInTheDocument()
-    expect(screen.getByText(/This will generate content/)).toBeInTheDocument()
+    expect(screen.getByText(/all 5 sections/)).toBeInTheDocument()
+  })
+
+  it('confirmation dialog shows correct count for fewer sections', async () => {
+    const user = userEvent.setup()
+    const THREE_SECTIONS: LessonSection[] = SECTIONS.filter(
+      s => ['WarmUp', 'Practice', 'WrapUp'].includes(s.sectionType)
+    )
+    render(
+      <FullLessonGenerateButton
+        lessonId="lesson-1"
+        sections={THREE_SECTIONS}
+        lessonContext={LESSON_CONTEXT}
+        onBlockSaved={vi.fn()}
+      />
+    )
+    await user.click(screen.getByTestId('generate-full-lesson-btn'))
+    expect(screen.getByText(/all 3 sections/)).toBeInTheDocument()
   })
 
   it('canceling dialog does not call onBlockSaved', async () => {

--- a/frontend/src/components/lesson/FullLessonGenerateButton.tsx
+++ b/frontend/src/components/lesson/FullLessonGenerateButton.tsx
@@ -67,9 +67,9 @@ export function FullLessonGenerateButton({
   }, [])
 
   const disabled = !lessonContext.topic.trim() || !lessonContext.language.trim()
+  const activeSections = SECTION_ORDER.filter(t => sections.some(s => s.sectionType === t))
 
   const handleConfirm = async () => {
-    const activeSections = SECTION_ORDER.filter(t => sections.some(s => s.sectionType === t))
 
     setPhase('generating')
     setSectionStatus(Object.fromEntries(activeSections.map(s => [s, 'active'])))
@@ -177,7 +177,7 @@ export function FullLessonGenerateButton({
             </AlertDialogTitle>
             <AlertDialogDescription>
               {phase === 'confirming' && (
-                'This will generate content for all 5 sections. Existing notes will be preserved as context.'
+                `This will generate content for all ${activeSections.length} sections. Existing notes will be preserved as context.`
               )}
               {phase === 'error' && (errorMessage ?? 'An error occurred.')}
             </AlertDialogDescription>

--- a/plan/langteach-beta/task162-generate-all-section-count.md
+++ b/plan/langteach-beta/task162-generate-all-section-count.md
@@ -1,0 +1,13 @@
+# Task 162: Generate All button hardcodes '5 sections'
+
+## Problem
+The "Generate All" confirmation dialog says "all 5 sections" regardless of actual section count.
+
+## Fix
+- Move `activeSections` computation out of `handleConfirm` to component body (already used in render)
+- Replace hardcoded `'5 sections'` with template literal using `activeSections.length`
+- Add unit test verifying dynamic count with 3 sections
+
+## Files changed
+- `frontend/src/components/lesson/FullLessonGenerateButton.tsx` (line 180)
+- `frontend/src/components/lesson/FullLessonGenerateButton.test.tsx` (new test case)


### PR DESCRIPTION
## Summary
- Fixed the "Generate All" confirmation dialog hardcoding "5 sections" regardless of actual lesson section count
- Moved `activeSections` computation to component body so both the confirmation message and progress indicator share the same dynamic count
- Added unit test verifying correct count display with 3 sections

Closes #162

## Test plan
- [x] Unit tests pass (296/296, including new dynamic count test)
- [x] Frontend build passes
- [x] Backend build and tests pass (127 passed, 5 skipped)
- [x] Bicep build passes
- [x] UI review: POLISHED (dialog renders correctly at all viewports with dynamic count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Confirmation dialog for lesson generation now accurately displays the actual number of sections that will be generated instead of showing a generic message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->