### PR TITLE
fix: prevent AI from referencing phantom materials (#184)

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -358,4 +358,35 @@ public class PromptServiceTests
 
         req.SystemPrompt.Should().NotContain("reference materials");
     }
+
+    // --- No phantom materials constraint ---
+
+    [Fact]
+    public void SystemPrompt_IncludesSelfContainedConstraint_WhenNoMaterials()
+    {
+        var req = _sut.BuildExercisesPrompt(BaseCtx());
+
+        req.SystemPrompt.Should().Contain("self-contained and work with text alone");
+        req.SystemPrompt.Should().Contain("Do not reference images, audio clips, videos, physical objects");
+    }
+
+    [Fact]
+    public void SystemPrompt_IncludesSelfContainedConstraint_WhenMaterialsEmpty()
+    {
+        var ctx = BaseCtx() with { MaterialFileNames = [] };
+
+        var req = _sut.BuildExercisesPrompt(ctx);
+
+        req.SystemPrompt.Should().Contain("self-contained and work with text alone");
+    }
+
+    [Fact]
+    public void SystemPrompt_OmitsSelfContainedConstraint_WhenMaterialsProvided()
+    {
+        var ctx = BaseCtx() with { MaterialFileNames = ["worksheet.pdf"] };
+
+        var req = _sut.BuildExercisesPrompt(ctx);
+
+        req.SystemPrompt.Should().NotContain("self-contained and work with text alone");
+    }
 }

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -116,6 +116,11 @@ public class PromptService : IPromptService
                 sb.AppendLine($"- {Sanitize(name)}");
             sb.AppendLine("Use these materials as source/inspiration for the generated content. Adapt, reference, or build upon them as appropriate for the student's level.");
         }
+        else
+        {
+            sb.AppendLine();
+            sb.AppendLine("IMPORTANT: All content must be self-contained and work with text alone. Do not reference images, audio clips, videos, physical objects, or any external materials. Every exercise, example, and activity must be completable using only the text provided.");
+        }
 
         sb.AppendLine();
         sb.AppendLine("Respond ONLY with valid JSON matching the schema below. No markdown, no prose, no code fences. Start your response with { and end with }.");

--- a/plan/langteach-beta/task184-no-phantom-materials.md
+++ b/plan/langteach-beta/task184-no-phantom-materials.md
@@ -1,0 +1,31 @@
+# Task 184: Fix AI generates exercises referencing materials that don't exist
+
+## Problem
+The AI generates exercises referencing images, audio, video, or physical objects that don't exist in the lesson. Example: "describe this picture" when there is no picture.
+
+## Root Cause
+`BuildSystemPrompt` in `PromptService.cs` never tells the AI what it can't reference. When materials are uploaded, it says "use these materials," but when no materials exist, there's no constraint preventing the AI from assuming resources are available.
+
+## Solution
+Add a self-contained content constraint to `BuildSystemPrompt` that:
+- When NO materials are uploaded: instructs the AI to create only self-contained, text-based content. Never reference images, audio, video, or physical objects.
+- When materials ARE uploaded: the existing block already handles this (lines 111-118). No change needed.
+
+This applies globally to all content types since it's in the shared system prompt.
+
+## Changes
+
+### 1. `backend/LangTeach.Api/AI/PromptService.cs`
+- After the materials block (line 118) / before the JSON instruction (line 120), add a conditional constraint:
+  - If `MaterialFileNames` is null or empty: append "All content must be self-contained and work with text alone. Never reference images, audio clips, videos, physical objects, or any external materials that are not part of this lesson."
+  - If materials exist: no additional constraint (existing block suffices)
+
+### 2. `backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs`
+- Test: system prompt includes self-contained constraint when no materials
+- Test: system prompt does NOT include self-contained constraint when materials are provided (the materials block takes precedence)
+
+## Out of Scope
+- No changes to user prompts per content type
+- No changes to `LessonPlanUserPrompt` (it already has "Do not reference physical classroom resources")
+- No frontend changes
+- No database changes


### PR DESCRIPTION
## Summary
- Added a "no phantom materials" constraint to `BuildSystemPrompt` in `PromptService.cs`
- When no materials are uploaded, the AI is instructed to create only self-contained, text-only content (no references to images, audio, video, or physical objects)
- When materials ARE uploaded, the existing behavior is preserved (AI can reference them)
- Added 3 unit tests covering the constraint presence/absence logic

## Test plan
- [x] All 45 PromptServiceTests pass (including 3 new ones)
- [x] Full backend test suite passes (138 passed, 5 skipped)
- [x] Frontend build and 334 unit tests pass
- [x] Bicep build passes

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved AI exercise generation: When no materials are provided, generated exercises are now strictly constrained to be self-contained and text-only, eliminating potential references to non-existent external media.

* **Tests**
  * Added comprehensive test cases for exercise prompt generation across different material configurations and availability states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->