### PR TITLE
Fix WarmUp generation: icebreaker, not vocabulary drill

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -394,6 +394,32 @@ public class PromptServiceTests
         req.SystemPrompt.Should().NotContain("Target grammar structures");
     }
 
+    // --- WarmUp icebreaker constraint ---
+
+    [Fact]
+    public void LessonPlanPrompt_UserPrompt_ContainsWarmUpIcebreakerGuidance()
+    {
+        var req = _sut.BuildLessonPlanPrompt(BaseCtx());
+
+        req.UserPrompt.Should().Contain("conversational icebreaker");
+    }
+
+    [Fact]
+    public void LessonPlanPrompt_UserPrompt_ProhibitsVocabularyListInWarmUp()
+    {
+        var req = _sut.BuildLessonPlanPrompt(BaseCtx());
+
+        req.UserPrompt.Should().Contain("NEVER generate a vocabulary list");
+    }
+
+    [Fact]
+    public void LessonPlanPrompt_UserPrompt_ProhibitsGrammarDrillInWarmUp()
+    {
+        var req = _sut.BuildLessonPlanPrompt(BaseCtx());
+
+        req.UserPrompt.Should().Contain("grammar drill");
+    }
+
     // --- No phantom materials constraint ---
 
     [Fact]

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -213,7 +213,18 @@ public class PromptService : IPromptService
     {
         var topic = Sanitize(ctx.Topic);
         const string schema = """{"title":"","objectives":[""],"sections":{"warmUp":"","presentation":"","practice":"","production":"","wrapUp":""}}""";
-        return $"Generate a complete lesson plan for the lesson on \"{topic}\". Return JSON:\n{schema}\nEach section should be detailed enough for the teacher to follow without additional preparation. Focus on activities suitable for one-on-one online tutoring. Do not reference physical classroom resources like whiteboards, projectors, or video players.";
+        return $"""
+        Generate a complete lesson plan for the lesson on "{topic}". Return JSON:
+        {schema}
+        Each section should be detailed enough for the teacher to follow without additional preparation. Focus on activities suitable for one-on-one online tutoring. Do not reference physical classroom resources like whiteboards, projectors, or video players.
+
+        Section guidelines:
+        - warmUp (2-5 min): A conversational icebreaker. Use a discussion question, opinion prompt, or anecdote starter that the student can answer freely. There is no right or wrong answer. NEVER generate a vocabulary list, grammar drill, translation exercise, or fill-in-blank activity for warmUp. The sole purpose is to get the student talking and relaxed before the lesson begins.
+        - presentation: Introduce the new language (vocabulary, grammar, or structure) with examples in context. Explain meanings and usage.
+        - practice: Controlled activities where the student practises the new language (fill-in-blank, matching, short answers). Correction is expected.
+        - production: A free or communicative activity where the student uses the new language independently with minimal guidance.
+        - wrapUp (2-3 min): Brief review of what was covered and preview of homework or next session.
+        """;
     }
 
     private static string CurriculumSystemPrompt(CurriculumContext ctx)

--- a/plan/langteach-beta/task226-fix-warmup-generation.md
+++ b/plan/langteach-beta/task226-fix-warmup-generation.md
@@ -1,0 +1,38 @@
+# Task #226: Fix WarmUp Generation — Icebreaker, Not Vocabulary Drill
+
+## Problem
+
+`LessonPlanUserPrompt` in `PromptService.cs` (line 212-217) gives Claude no per-section guidance.
+Claude defaults to vocabulary drills for warmUp because that's a safe, generic activity.
+Teacher QA confirmed 5/5 personas generated vocabulary drills instead of icebreakers.
+
+## Root Cause
+
+```csharp
+"Each section should be detailed enough for the teacher to follow..."
+```
+
+No description of what each section type is or what it must/must not contain.
+
+## Fix
+
+Add per-section description to `LessonPlanUserPrompt`:
+
+- **warmUp**: Conversational icebreaker (discussion question, opinion prompt, anecdote starter). 2-5 min. No right/wrong answers. NEVER a vocabulary list, grammar drill, or fill-in-blank exercise.
+- **presentation**: Introduce new language (vocabulary, grammar, structure). Examples in context.
+- **practice**: Controlled exercises targeting the new language. Can include fill-in-blank, matching, etc.
+- **production**: Free/communicative activity where student uses new language independently.
+- **wrapUp**: Brief review and homework preview.
+
+## Files to Change
+
+- `backend/LangTeach.Api/AI/PromptService.cs` — update `LessonPlanUserPrompt`
+- `backend/LangTeach.Api.Tests/AI/PromptServiceIntegrationTests.cs` — add/update test for warmUp constraint
+
+## Acceptance Criteria
+
+1. WarmUp prompt explicitly specifies conversational/icebreaker format
+2. WarmUp prompt explicitly prohibits vocabulary lists, grammar drills, and fill-in-blank
+3. Teacher QA re-run confirms WarmUp is no longer a vocabulary drill for at least 3 personas
+
+## No frontend/backend API changes required (prompt engineering only)


### PR DESCRIPTION
## Summary

- Updated `LessonPlanUserPrompt` in `PromptService.cs` to add per-section guidance for the lesson plan generator
- WarmUp is now explicitly defined as a conversational icebreaker (discussion question, opinion prompt, anecdote starter, 2-5 min, no right/wrong answers)
- Vocabulary lists, grammar drills, translation exercises, and fill-in-blank activities are explicitly prohibited in WarmUp
- Added section guidelines for all 5 sections (warmUp, presentation, practice, production, wrapUp) for consistency

## Test plan

- [ ] 3 new unit tests in `PromptServiceTests.cs` verify the prompt contains icebreaker guidance and prohibits vocabulary/grammar drills
- [ ] All 166 backend tests pass
- [ ] All 370 frontend tests pass
- [ ] Teacher QA re-run should confirm WarmUp is no longer a vocabulary drill (acceptance criterion #3 from the issue)

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for warm-up section constraints in lesson plan generation to ensure proper guideline enforcement.

* **Improvements**
  * Enhanced lesson plan generation with more detailed, structured guidelines for each section (warm-up, presentation, practice, production, wrap-up), including specific time ranges and phase-specific constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->