### PR TITLE
feat: add PR template with config and infrastructure checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+-
+
+## Test Plan
+
+- [ ]
+
+## Config & Infrastructure
+
+Check any that apply to this PR:
+
+- [ ] This PR adds NO new environment variables, secrets, or config keys
+- [ ] New secrets have been added to Key Vault (or `docker-compose*.yml` / `.env.e2e` for local/e2e)
+- [ ] New container app environment variables have been added to `infra/main.bicep`
+- [ ] New infrastructure resources have been added to Bicep templates
+- [ ] No new infrastructure resources added
+
+---
+
+Closes #

--- a/plan/langteach-beta/task221-pr-template.md
+++ b/plan/langteach-beta/task221-pr-template.md
@@ -1,0 +1,28 @@
+# Task 221: Add PR Template Checklist for New Secrets and Environment Variables
+
+## Goal
+Create `.github/PULL_REQUEST_TEMPLATE.md` with a checklist that surfaces config and infrastructure dependencies at PR review time.
+
+## Acceptance Criteria
+- [ ] PR template exists at `.github/PULL_REQUEST_TEMPLATE.md`
+- [ ] Template includes a "Config & Infrastructure" checklist section
+- [ ] Template pre-populates on every new PR in the repo
+- [ ] Existing PR description fields (summary, test plan) are preserved
+
+## Implementation Plan
+
+### 1. Create `.github/PULL_REQUEST_TEMPLATE.md`
+
+Sections:
+- **Summary**: bullet points of what changed and why
+- **Test Plan**: markdown checklist of how to verify
+- **Config & Infrastructure** (new): checklist for new secrets/env vars, Bicep changes, API route changes
+- **Closes**: issue reference
+
+### 2. No other files to change
+
+PR template is picked up automatically by GitHub for all new PRs.
+
+## Out of Scope
+- CI secret validation (tracked in #222/#223)
+- Azure Container App rollback/alerting (tracked in #224)


### PR DESCRIPTION
## Summary

- Adds `.github/PULL_REQUEST_TEMPLATE.md` so every new PR pre-populates with a Config & Infrastructure checklist
- Checklist asks authors to confirm new secrets are in Key Vault, new env vars are in Bicep, and new infra resources are templated
- Preserves existing Summary and Test Plan sections

## Test Plan

- [ ] Open a new draft PR in this repo and verify the template text pre-populates automatically
- [ ] Confirm all four sections are present: Summary, Test Plan, Config & Infrastructure, Closes

## Config & Infrastructure

- [ ] This PR adds NO new environment variables, secrets, or config keys

---

Closes #221