### PR TITLE
fix: make QA stack independent of dev stack

### DIFF
--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -3,6 +3,8 @@
 # Data persists across runs via named volumes — do NOT use 'down -v' unless resetting.
 # Playwright runs from the HOST against http://localhost:5175.
 #
+# Ports (host): frontend 5175, API 5176 (independent of dev stack on 5000/5173).
+#
 # Prerequisites:
 #   cp .env.qa.example .env.qa  # fill in secrets once
 #   # Create the Auth0 QA user first (see .claude/skills/teacher-qa/SKILL.md)
@@ -52,6 +54,8 @@ services:
       # Host-side Playwright connects through localhost:5175
       AllowedOrigins__E2e: "http://localhost:5175"
       AzureBlobStorage__ConnectionString: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
+    ports:
+      - "5176:5000"
     healthcheck:
       test: curl -sf http://localhost:5000/health || exit 1
       interval: 10s
@@ -71,7 +75,7 @@ services:
     environment:
       # Real Auth0 mode — frontend uses Auth0Provider, not MockAuth0Provider
       VITE_E2E_TEST_MODE: "false"
-      VITE_API_URL: "http://api:5000"
+      VITE_API_URL: "http://localhost:5176"
       VITE_API_PROXY_TARGET: "http://api:5000"
       VITE_AUTH0_DOMAIN: "${AUTH0_DOMAIN}"
       VITE_AUTH0_CLIENT_ID: "${VITE_AUTH0_CLIENT_ID}"


### PR DESCRIPTION
## Summary\n\n- Map QA API to host port 5176 so the browser can reach it (previously only accessible via Docker-internal DNS `api:5000`)\n- Update `VITE_API_URL` to `http://localhost:5176` for host browser access\n- Document port layout: dev 5000/5173, QA 5176/5175, e2e internal-only\n\n**Root cause:** The QA stack was copied from the e2e stack, but QA runs Playwright on the host (not inside Docker). The browser could not resolve Docker DNS `http://api:5000`, causing CORS errors and Teacher QA test failures.\n\n## Test plan\n\n- [x] `curl http://localhost:5176/health` returns 200 from host\n- [x] QA frontend at `http://localhost:5175` can reach the API without CORS errors\n- [x] Port 5176 does not conflict with dev (5000) or e2e stacks\n- [ ] Teacher QA sprint reviewer runs successfully (pending QA user re-onboarding)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated QA environment configuration to enhance API accessibility for local testing and development. Backend services are now directly accessible through improved port routing, enabling easier debugging and comprehensive testing of API functionality. This configuration change streamlines the development and QA testing workflow while preserving essential service health monitoring capabilities and service isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->