### PR TITLE
fix: empty curriculum template dropdown for A1 level

### DIFF
--- a/e2e/tests/courses.spec.ts
+++ b/e2e/tests/courses.spec.ts
@@ -352,3 +352,42 @@ test('create course from Instituto Cervantes template', async ({ browser }) => {
 
   await context.close()
 })
+
+test('A1 templates appear in dropdown when A1 is selected', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  const A1_MOCK_TEMPLATES = [
+    { level: 'A1.1', cefrLevel: 'A1', unitCount: 6, sampleGrammar: ['Verbo llamarse', 'Artículos definidos'] },
+    { level: 'A1.2', cefrLevel: 'A1', unitCount: 5, sampleGrammar: ['Presente indicativo'] },
+    { level: 'A1.3', cefrLevel: 'A1', unitCount: 4, sampleGrammar: ['Números y fechas'] },
+  ]
+
+  await page.route('**/api/curriculum-templates', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(A1_MOCK_TEMPLATES) })
+  })
+
+  await page.goto('/courses/new')
+  await expect(page.locator('h1')).toHaveText('New Course', { timeout: NAV_TIMEOUT })
+
+  await page.getByTestId('language-select').click()
+  await page.getByRole('option', { name: 'Spanish' }).click()
+  await expect(page.getByTestId('language-select')).toContainText('Spanish', { timeout: UI_TIMEOUT })
+
+  await page.getByTestId('cefr-select').click()
+  await page.getByRole('option', { name: 'A1' }).click()
+  await expect(page.getByTestId('cefr-select')).toContainText('A1', { timeout: UI_TIMEOUT })
+
+  await expect(page.getByTestId('use-template-checkbox')).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.getByTestId('use-template-checkbox').check()
+
+  await expect(page.getByTestId('template-select')).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.getByTestId('template-select').click()
+
+  await expect(page.getByRole('option', { name: /A1\.1/ })).toBeVisible({ timeout: UI_TIMEOUT })
+  await expect(page.getByRole('option', { name: /A1\.2/ })).toBeVisible({ timeout: UI_TIMEOUT })
+  await expect(page.getByRole('option', { name: /A1\.3/ })).toBeVisible({ timeout: UI_TIMEOUT })
+  await expect(page.getByRole('option', { name: /B1/ })).not.toBeVisible()
+
+  await context.close()
+})

--- a/frontend/src/pages/CourseNew.test.tsx
+++ b/frontend/src/pages/CourseNew.test.tsx
@@ -31,6 +31,8 @@ function wrapper(ui: React.ReactElement) {
 
 describe('CourseNew wizard', () => {
   const MOCK_TEMPLATES = [
+    { level: 'A1.1', cefrLevel: 'A1', unitCount: 6, sampleGrammar: ['Verbo llamarse', 'Artículos'] },
+    { level: 'A1.2', cefrLevel: 'A1', unitCount: 5, sampleGrammar: ['Presente indicativo'] },
     { level: 'B1.1', cefrLevel: 'B1', unitCount: 7, sampleGrammar: ['Present subjunctive', 'Past tenses'] },
     { level: 'B1.2', cefrLevel: 'B1', unitCount: 5, sampleGrammar: ['Conditional sentences'] },
   ]
@@ -105,6 +107,39 @@ describe('CourseNew wizard', () => {
     // language and level selects are harder to trigger in unit tests — tested in e2e
     // just verify the button exists
     expect(screen.getByTestId('generate-curriculum-btn')).toBeInTheDocument()
+  })
+
+  describe('template filtering by CEFR level', () => {
+    it('shows only A1 templates when A1 is selected', async () => {
+      const user = userEvent.setup()
+      wrapper(<CourseNew />)
+
+      await user.click(screen.getByTestId('cefr-select'))
+      await user.click(await screen.findByRole('option', { name: 'A1' }))
+
+      await user.click(screen.getByTestId('use-template-checkbox'))
+
+      await user.click(screen.getByTestId('template-select'))
+
+      expect(await screen.findByRole('option', { name: /A1\.1/ })).toBeInTheDocument()
+      expect(await screen.findByRole('option', { name: /A1\.2/ })).toBeInTheDocument()
+      expect(screen.queryByRole('option', { name: /B1\.1/ })).not.toBeInTheDocument()
+    })
+
+    it('shows only B1 templates when B1 is selected', async () => {
+      const user = userEvent.setup()
+      wrapper(<CourseNew />)
+
+      await user.click(screen.getByTestId('cefr-select'))
+      await user.click(await screen.findByRole('option', { name: 'B1' }))
+
+      await user.click(screen.getByTestId('use-template-checkbox'))
+
+      await user.click(screen.getByTestId('template-select'))
+
+      expect(await screen.findByRole('option', { name: /B1\.1/ })).toBeInTheDocument()
+      expect(screen.queryByRole('option', { name: /A1\.1/ })).not.toBeInTheDocument()
+    })
   })
 
   describe('CEFR mismatch warning', () => {

--- a/frontend/src/pages/CourseNew.tsx
+++ b/frontend/src/pages/CourseNew.tsx
@@ -39,10 +39,10 @@ export default function CourseNew() {
     queryFn: () => getStudents(),
   })
 
-  const { data: allTemplates } = useQuery({
+  const { data: allTemplates, isLoading: templatesLoading } = useQuery({
     queryKey: ['curriculum-templates'],
     queryFn: getCurriculumTemplates,
-    enabled: useTemplate && !!targetCefrLevel && mode === 'general',
+    enabled: !!targetCefrLevel && mode === 'general',
   })
 
   const templates = allTemplates?.filter(t => t.cefrLevel === targetCefrLevel) ?? []
@@ -212,9 +212,10 @@ export default function CourseNew() {
                         <Select
                           value={selectedTemplate}
                           onValueChange={v => setSelectedTemplate(v ?? '')}
+                          disabled={templatesLoading}
                         >
                           <SelectTrigger data-testid="template-select">
-                            <SelectValue placeholder="Select a template" />
+                            <SelectValue placeholder={templatesLoading ? 'Loading templates...' : 'Select a template'} />
                           </SelectTrigger>
                           <SelectContent>
                             {templates.map(t => (

--- a/plan/langteach-beta/task253-fix-a1-curriculum-dropdown.md
+++ b/plan/langteach-beta/task253-fix-a1-curriculum-dropdown.md
@@ -1,0 +1,77 @@
+# Task #253 - Fix Empty Curriculum Template Dropdown for A1
+
+## Problem Analysis
+
+**Root cause:** Race condition in `CourseNew.tsx`. The template query has:
+```javascript
+enabled: useTemplate && !!targetCefrLevel && mode === 'general'
+```
+
+This means templates are only fetched **after** the user checks "Use curriculum template". When the user checks the box and immediately opens the dropdown, `allTemplates` is `undefined` (query still loading) and `templates = []` - resulting in an empty dropdown.
+
+This affects ALL levels the first time, but A1 is the most basic level teachers try first, so they discover it there.
+
+**Backend confirmed working:** All 10 `CurriculumTemplateServiceTests` pass. A1 templates (A1.1, A1.2, A1.3) are correctly embedded and returned by the API with `cefrLevel: "A1"`.
+
+**Frontend filter confirmed correct:** `allTemplates.filter(t => t.cefrLevel === targetCefrLevel)` is logically sound once data is available.
+
+**Missing coverage:** No unit test or e2e test exercises the A1 template path. Existing tests only use B1 mock data.
+
+## Fix Plan
+
+### 1. Prefetch templates when CEFR level is selected (`CourseNew.tsx`)
+
+Change:
+```javascript
+enabled: useTemplate && !!targetCefrLevel && mode === 'general',
+```
+To:
+```javascript
+enabled: !!targetCefrLevel && mode === 'general',
+```
+
+This starts fetching templates as soon as the user selects a CEFR level, so data is ready (or close to ready) when they check the checkbox. No wasted fetches - templates are only a few KB and cached by React Query.
+
+### 2. Add loading state to template dropdown
+
+While templates are loading, show a disabled select with "Loading templates..." text, not a silently empty dropdown.
+
+Extract the `isPending` state from the query:
+```javascript
+const { data: allTemplates, isPending: templatesLoading } = useQuery({...})
+```
+
+In the template Select:
+```jsx
+<Select disabled={templatesLoading} ...>
+  <SelectTrigger>
+    <SelectValue placeholder={templatesLoading ? 'Loading templates...' : 'Select a template'} />
+  </SelectTrigger>
+  ...
+</Select>
+```
+
+### 3. Add unit test for A1 template filtering (`CourseNew.test.tsx`)
+
+Add a test that:
+1. Mocks A1 templates (level: 'A1.1', cefrLevel: 'A1')
+2. Selects A1 as CEFR level
+3. Checks "Use template"
+4. Opens the template select
+5. Expects A1.1 to appear as an option
+
+### 4. Extend e2e test for A1 (`courses.spec.ts`)
+
+Add an A1 template creation test alongside the existing B1 test to prevent regression.
+
+## Files to Change
+
+- `frontend/src/pages/CourseNew.tsx` - fix enabled condition + loading state
+- `frontend/src/pages/CourseNew.test.tsx` - add A1 template test
+- `e2e/tests/courses.spec.ts` - add A1 e2e test
+
+## Acceptance Criteria Mapping
+
+- [x] A1 templates appear in dropdown (fix: prefetch + loading state ensures data is ready)
+- [x] All other CEFR levels also populate (fix applies to all levels)
+- [x] Unit test covering template filtering logic (new A1 unit test)


### PR DESCRIPTION
## Summary

- Root cause: template query had `enabled: useTemplate && !!targetCefrLevel` — it only fired after the teacher checked the "Use template" checkbox. On first interaction `allTemplates` was `undefined` (still loading), so the dropdown silently showed no options. A1 was the first level affected because it's the most basic level teachers try first.
- Fix: removed `useTemplate &&` from the `enabled` condition so templates prefetch as soon as a CEFR level is selected. Added `isLoading` guard to disable the Select and show "Loading templates..." placeholder while the query resolves.
- Extended mock data and tests to cover A1 templates explicitly.

## Test plan

- [ ] Verify `CourseNew.tsx` `enabled` condition is now `!!targetCefrLevel && mode === 'general'`
- [ ] Select A1 level, check "Use template" — dropdown should show A1.1, A1.2, A1.3 immediately (no empty flash)
- [ ] Select B1 level, check "Use template" — only B1 sub-levels appear, no A1 options
- [ ] All 413 frontend unit tests pass
- [ ] All 180 backend tests pass

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Templates are now filtered to display only those matching the selected CEFR level in the course creation flow.
  * Added loading state feedback when fetching templates.

* **Tests**
  * Added comprehensive test coverage for template filtering by CEFR level across unit and end-to-end tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->