### PR TITLE
fix(#254): remove Instituto Cervantes misattribution from curriculum template label

### DIFF
--- a/e2e/tests/courses.spec.ts
+++ b/e2e/tests/courses.spec.ts
@@ -271,7 +271,7 @@ test('generate lesson from curriculum entry', async ({ browser }) => {
   await context.close()
 })
 
-test('create course from Instituto Cervantes template', async ({ browser }) => {
+test('create course from structured curriculum template', async ({ browser }) => {
   const context = await createMockAuthContext(browser)
   const page = await context.newPage()
 

--- a/frontend/src/pages/CourseNew.test.tsx
+++ b/frontend/src/pages/CourseNew.test.tsx
@@ -154,4 +154,20 @@ describe('CourseNew wizard', () => {
       expect(screen.queryByRole('button', { name: /dismiss/i })).not.toBeInTheDocument()
     })
   })
+
+  it('template checkbox label does not reference Instituto Cervantes', async () => {
+    const user = userEvent.setup()
+    wrapper(<CourseNew />)
+
+    fireEvent.change(screen.getByTestId('course-name'), { target: { value: 'My Course' } })
+    await user.click(screen.getByTestId('language-select'))
+    await user.click(await screen.findByRole('option', { name: 'Spanish' }))
+    await user.click(screen.getByTestId('cefr-select'))
+    await user.click(await screen.findByRole('option', { name: 'B1' }))
+
+    const checkbox = await screen.findByTestId('use-template-checkbox')
+    const label = checkbox.closest('label')
+    expect(label?.textContent).not.toMatch(/Instituto Cervantes/i)
+    expect(label?.textContent).toMatch(/structured curriculum template/i)
+  })
 })

--- a/frontend/src/pages/CourseNew.tsx
+++ b/frontend/src/pages/CourseNew.tsx
@@ -202,7 +202,7 @@ export default function CourseNew() {
                       className="h-4 w-4 rounded border-zinc-300 text-blue-600 focus:ring-blue-500"
                     />
                     <span className="text-sm font-normal text-zinc-700">
-                      Use Instituto Cervantes curriculum template
+                      Use structured curriculum template
                     </span>
                   </label>
 

--- a/plan/langteach-beta/task254-fix-attribution.md
+++ b/plan/langteach-beta/task254-fix-attribution.md
@@ -1,0 +1,24 @@
+# Task #254 — Fix curriculum template attribution: not Instituto Cervantes
+
+## Problem
+The UI checkbox says "Use Instituto Cervantes curriculum template" but the data is NOT from Instituto Cervantes. It's from Jordi's academy and an internet source (clarified 2026-03-21 email). Displaying "Instituto Cervantes" is a misattribution that undermines credibility.
+
+## Scope of changes
+
+**User-visible (must fix):**
+1. `frontend/src/pages/CourseNew.tsx:205` — rename checkbox label to "Use structured curriculum template"
+2. `e2e/tests/courses.spec.ts:274` — rename test to match new label
+
+**Not user-visible (no action):**
+- `.claude/memory/` — historical references, fine to leave
+- `plan/` — design docs, no impact on users
+- No JSON data files or C# files reference "Instituto Cervantes"
+
+## Implementation
+
+Simple text replacement in 2 files. No logic changes.
+
+## Acceptance Criteria (from issue)
+- [x] UI checkbox no longer says "Instituto Cervantes"
+- [x] No user-visible references to "Instituto Cervantes" remain in the app
+- [x] Data file metadata updated if it references Instituto Cervantes (N/A - no data files affected)


### PR DESCRIPTION
## Summary

- Renames "Use Instituto Cervantes curriculum template" label to "Use structured curriculum template" in `CourseNew.tsx`
- Updates the matching e2e test name
- Adds a unit test asserting the label no longer references Instituto Cervantes

**Why:** Jordi clarified on 2026-03-21 that the curriculum data is not from Instituto Cervantes — it's from his academy and an internet source. Displaying "Instituto Cervantes" undermines credibility.

Closes #254

## Test plan

- [x] Unit test: `template checkbox label does not reference Instituto Cervantes` (412 passing)
- [x] E2e test renamed to `create course from structured curriculum template`
- [x] Frontend build: zero errors
- [x] Backend build + tests: 180 passing
- [x] UI review: POLISHED (label reads naturally, no visual regressions)

## Config & Infrastructure

- [ ] No new secrets, env vars, or infrastructure changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test cases and course creation UI labels related to curriculum template selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->