### PR TITLE
feat(#152): grammar-constrained content generation

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -425,6 +425,39 @@ public class PromptServiceTests
         req.SystemPrompt.Should().NotContain("Target grammar structures");
     }
 
+    // --- Teacher grammar instructions ---
+
+    [Fact]
+    public void SystemPrompt_IncludesTeacherGrammarConstraints_WhenProvided()
+    {
+        var ctx = BaseCtx() with { TeacherGrammarConstraints = "include subjunctive, only regular verbs" };
+
+        var req = _sut.BuildLessonPlanPrompt(ctx);
+
+        req.SystemPrompt.Should().Contain("Additional grammar instructions from the teacher:");
+        req.SystemPrompt.Should().Contain("include subjunctive, only regular verbs");
+    }
+
+    [Fact]
+    public void SystemPrompt_OmitsTeacherGrammarConstraints_WhenNull()
+    {
+        var ctx = BaseCtx();
+
+        var req = _sut.BuildLessonPlanPrompt(ctx);
+
+        req.SystemPrompt.Should().NotContain("Additional grammar instructions from the teacher:");
+    }
+
+    [Fact]
+    public void SystemPrompt_OmitsTeacherGrammarConstraints_WhenWhitespace()
+    {
+        var ctx = BaseCtx() with { TeacherGrammarConstraints = "   " };
+
+        var req = _sut.BuildLessonPlanPrompt(ctx);
+
+        req.SystemPrompt.Should().NotContain("Additional grammar instructions from the teacher:");
+    }
+
     // --- WarmUp icebreaker constraint ---
 
     [Fact]

--- a/backend/LangTeach.Api/AI/IPromptService.cs
+++ b/backend/LangTeach.Api/AI/IPromptService.cs
@@ -61,5 +61,6 @@ public record GenerationContext(
     DifficultyDto[]? StudentDifficulties = null,
     IReadOnlyList<string>? GrammarConstraints = null,
     string? TemplateName = null,
-    string? CurriculumObjectives = null
+    string? CurriculumObjectives = null,
+    string? TeacherGrammarConstraints = null
 );

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -59,6 +59,13 @@ public class PromptService : IPromptService
                 sb.AppendLine($"- {Sanitize(g)}");
         }
 
+        if (!string.IsNullOrWhiteSpace(ctx.TeacherGrammarConstraints))
+        {
+            sb.AppendLine();
+            sb.AppendLine("Additional grammar instructions from the teacher:");
+            sb.AppendLine(Sanitize(ctx.TeacherGrammarConstraints));
+        }
+
         if (ctx.StudentName is not null)
         {
             var interests  = ctx.StudentInterests?.Select(Sanitize).Where(s => s.Length > 0).ToArray() ?? [];

--- a/backend/LangTeach.Api/Controllers/GenerateController.cs
+++ b/backend/LangTeach.Api/Controllers/GenerateController.cs
@@ -164,7 +164,8 @@ public class GenerateController : ControllerBase
             StudentDifficulties: TopDifficulties(student),
             GrammarConstraints: SpanishGrammarConstraints(language, cefrLevel),
             TemplateName: templateName,
-            CurriculumObjectives: lesson.Objectives
+            CurriculumObjectives: lesson.Objectives,
+            TeacherGrammarConstraints: request.GrammarConstraints
         );
 
         var claudeRequest = buildPrompt(_promptService, ctx);
@@ -311,7 +312,8 @@ public class GenerateController : ControllerBase
             StudentDifficulties: TopDifficulties(student),
             GrammarConstraints: SpanishGrammarConstraints(language, cefrLevel),
             TemplateName: templateName,
-            CurriculumObjectives: lesson.Objectives
+            CurriculumObjectives: lesson.Objectives,
+            TeacherGrammarConstraints: request.GrammarConstraints
         );
 
         var claudeRequest = buildPrompt(ctx);
@@ -377,6 +379,7 @@ public class GenerateController : ControllerBase
                 request.StudentId,
                 request.ExistingNotes,
                 request.Direction,
+                request.GrammarConstraints,
                 targetedDifficulties = ctx.StudentDifficulties
             }),
             CreatedAt = DateTime.UtcNow,

--- a/backend/LangTeach.Api/DTOs/GenerateRequest.cs
+++ b/backend/LangTeach.Api/DTOs/GenerateRequest.cs
@@ -24,4 +24,7 @@ public class GenerateRequest
 
     [MaxLength(200)]
     public string? Direction { get; set; }
+
+    [MaxLength(500)]
+    public string? GrammarConstraints { get; set; }
 }

--- a/frontend/src/api/generate.ts
+++ b/frontend/src/api/generate.ts
@@ -12,6 +12,7 @@ export interface GenerateRequest {
   style?: string
   existingNotes?: string
   direction?: string
+  grammarConstraints?: string
 }
 
 export interface TargetedDifficulty {

--- a/frontend/src/components/lesson/GeneratePanel.test.tsx
+++ b/frontend/src/components/lesson/GeneratePanel.test.tsx
@@ -465,6 +465,70 @@ describe('GeneratePanel - quota exhausted', () => {
   })
 })
 
+describe('GeneratePanel - grammar constraints', () => {
+  it('renders grammar constraints textarea', () => {
+    mockUseGenerate.mockReturnValue({
+      status: 'idle',
+      output: null,
+      error: null,
+      quotaExceeded: false,
+      generate: vi.fn(),
+      abort: vi.fn(),
+    })
+
+    renderWithQuery(<GeneratePanel {...defaultProps} />)
+
+    expect(screen.getByTestId('grammar-constraints-textarea')).toBeInTheDocument()
+  })
+
+  it('passes grammarConstraints to the generate call', async () => {
+    const generateFn = vi.fn()
+    mockUseGenerate.mockReturnValue({
+      status: 'idle',
+      output: null,
+      error: null,
+      quotaExceeded: false,
+      generate: generateFn,
+      abort: vi.fn(),
+    })
+
+    renderWithQuery(<GeneratePanel {...defaultProps} />)
+
+    const user = userEvent.setup()
+    const textarea = screen.getByTestId('grammar-constraints-textarea')
+    await user.type(textarea, 'only regular verbs')
+
+    await user.click(screen.getByTestId('generate-btn'))
+
+    expect(generateFn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ grammarConstraints: 'only regular verbs' })
+    )
+  })
+
+  it('does not include grammarConstraints in request when textarea is empty', async () => {
+    const generateFn = vi.fn()
+    mockUseGenerate.mockReturnValue({
+      status: 'idle',
+      output: null,
+      error: null,
+      quotaExceeded: false,
+      generate: generateFn,
+      abort: vi.fn(),
+    })
+
+    renderWithQuery(<GeneratePanel {...defaultProps} />)
+
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('generate-btn'))
+
+    expect(generateFn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.not.objectContaining({ grammarConstraints: expect.anything() })
+    )
+  })
+})
+
 describe('GeneratePanel - task type dropdown casing', () => {
   it('displays task type in Title Case in the trigger', () => {
     mockUseGenerate.mockReturnValue({

--- a/frontend/src/components/lesson/GeneratePanel.tsx
+++ b/frontend/src/components/lesson/GeneratePanel.tsx
@@ -101,6 +101,7 @@ export function GeneratePanel({
   )
   const [style, setStyle] = useState('Conversational')
   const [direction, setDirection] = useState<string | undefined>(undefined)
+  const [grammarConstraints, setGrammarConstraints] = useState<string | undefined>(undefined)
   const [inserting, setInserting] = useState(false)
   const [insertError, setInsertError] = useState<string | null>(null)
 
@@ -121,7 +122,8 @@ export function GeneratePanel({
     studentId: lessonContext.studentId ?? undefined,
     existingNotes: lessonContext.existingNotes ?? undefined,
     direction,
-  }), [lessonId, lessonContext, style, direction])
+    grammarConstraints,
+  }), [lessonId, lessonContext, style, direction, grammarConstraints])
 
   const handleGenerate = () => {
     generate(taskType, request)
@@ -219,6 +221,20 @@ export function GeneratePanel({
             placeholder="e.g. Conversational"
           />
         </div>
+      </div>
+
+      <div className="space-y-1">
+        <Label className="text-xs">Grammar constraints (optional)</Label>
+        <Textarea
+          value={grammarConstraints ?? ''}
+          onChange={(e) => setGrammarConstraints(e.target.value || undefined)}
+          disabled={isStreaming}
+          rows={2}
+          maxLength={500}
+          className="resize-none text-xs"
+          placeholder="e.g. include subjunctive, only regular verbs, avoid passive voice"
+          data-testid="grammar-constraints-textarea"
+        />
       </div>
 
       {existingBlocks.length > 0 && (

--- a/plan/langteach-beta/task152-grammar-constraints.md
+++ b/plan/langteach-beta/task152-grammar-constraints.md
@@ -1,0 +1,88 @@
+# Task 152: Grammar-Constrained Content Generation
+
+## Goal
+Allow teachers to specify grammar constraints (include/exclude structures) when generating AI content. These constraints feed into the prompt service as additional generation parameters.
+
+## Current State
+- `GenerationContext.GrammarConstraints` exists and is used in `BuildSystemPrompt` to inject CEFR-level grammar structures from the curriculum syllabus (Spanish-only, auto-populated)
+- `GenerateRequest` DTO has no teacher-facing grammar constraints field
+- `GeneratePanel.tsx` has no grammar constraints input
+
+## Approach
+Add a **free-text** "Grammar constraints" field that the teacher fills in. Teacher constraints are a **separate concern** from the auto-generated curriculum constraints:
+- Auto-generated: "Use ONLY these structures from the curriculum syllabus"
+- Teacher-specified: Additional instructions (include X, avoid Y, only regular verbs, etc.)
+
+They're rendered as two separate blocks in the system prompt so the model understands both types.
+
+## Changes
+
+### 1. Backend DTO - `GenerateRequest.cs`
+Add:
+```csharp
+[MaxLength(500)]
+public string? GrammarConstraints { get; set; }
+```
+
+### 2. Backend AI - `IPromptService.cs`
+Add field to `GenerationContext` record in the optional tail (after `ExistingNotes`), with default null so existing callers using named args or `with` expressions are unaffected:
+```csharp
+string? TeacherGrammarInstructions = null,
+```
+`BaseCtx()` in PromptServiceTests uses positional construction for the first 11 args then stops; the new field is optional so no test changes needed for existing tests.
+
+### 3. Backend AI - `PromptService.cs`
+After the existing GrammarConstraints block (line 60) and BEFORE the student-profile section (line 62), add:
+```csharp
+if (!string.IsNullOrWhiteSpace(ctx.TeacherGrammarInstructions))
+{
+    sb.AppendLine();
+    sb.AppendLine($"Additional grammar instructions from the teacher:");
+    sb.AppendLine(Sanitize(ctx.TeacherGrammarInstructions));
+}
+```
+Prompt order: CEFR constraints -> teacher constraints -> student profile -> notes -> direction.
+
+### 4. Backend Controller - `GenerateController.cs`
+In both `GenerationContext` construction sites:
+- Streaming path (lines 142-168): add `TeacherGrammarInstructions: request.GrammarConstraints,`
+- Non-streaming path (around line 312): add same
+
+Also add `GrammarConstraints` to the `GenerationParams` JSON object stored on the content block (for audit consistency with `Direction` which is already captured there).
+
+### 5. Frontend API - `api/generate.ts`
+Add to `GenerateRequest` interface:
+```typescript
+grammarConstraints?: string
+```
+
+### 6. Frontend Component - `GeneratePanel.tsx`
+- Add `const [grammarConstraints, setGrammarConstraints] = useState<string | undefined>(undefined)`
+- Add `grammarConstraints` to the `request` useMemo AND to its dependency array `[lessonId, lessonContext, style, direction, grammarConstraints]`
+- Add a textarea input below the style field (always visible, optional)
+  - Label: "Grammar constraints (optional)"
+  - Placeholder: "e.g. include subjunctive, only regular verbs, avoid passive voice"
+  - `maxLength={500}`, `rows={2}`, `resize-none`
+
+## Tests
+
+### Backend unit test - `PromptServiceTests.cs`
+- `SystemPrompt_IncludesTeacherGrammarInstructions_WhenProvided` - verify the section appears
+- `SystemPrompt_OmitsTeacherGrammarInstructions_WhenNull` - verify it's absent when null/empty
+
+### Frontend unit test - `GeneratePanel.test.tsx`
+- Render panel, verify grammar constraints textarea is present
+- Type in it, verify it's included in the generate call
+
+### E2E test (manual for demo per acceptance criteria - already stated in issue)
+No new e2e test required; AC says "verified manually for demo".
+
+## Files to modify
+- `backend/LangTeach.Api/DTOs/GenerateRequest.cs`
+- `backend/LangTeach.Api/AI/IPromptService.cs`
+- `backend/LangTeach.Api/AI/PromptService.cs`
+- `backend/LangTeach.Api/Controllers/GenerateController.cs`
+- `backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs`
+- `frontend/src/api/generate.ts`
+- `frontend/src/components/lesson/GeneratePanel.tsx`
+- `frontend/src/components/lesson/GeneratePanel.test.tsx` (new or update)


### PR DESCRIPTION
## Summary

- Adds an optional **Grammar constraints** free-text field (max 500 chars) to the AI generation panel
- Teachers can specify structures to include/exclude (e.g. "include subjunctive, only regular verbs, no passive voice")
- Constraints are injected into the system prompt as a separate section, distinct from the auto-generated curriculum syllabus constraints
- Works for all 7 content types via both streaming and non-streaming controller paths

## Changes

- `GenerateRequest.cs`: new `GrammarConstraints` field
- `IPromptService.cs` / `PromptService.cs`: new `TeacherGrammarConstraints` in `GenerationContext`, rendered after CEFR constraint block
- `GenerateController.cs`: wired in both streaming (line 168) and non-streaming (line 313) paths; included in `GenerationParams` audit record
- `api/generate.ts`: `grammarConstraints?: string` on `GenerateRequest`
- `GeneratePanel.tsx`: textarea with proper `useMemo` dependency, always visible, optional

## Test plan

- [x] 3 backend unit tests (present, absent, whitespace cases in `PromptServiceTests`)
- [x] 3 frontend unit tests (renders, passes value, omits when empty)
- [x] All 261 backend tests pass, all 490 frontend tests pass
- [ ] Manual demo verification of generated content respecting constraints (per AC)

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional grammar constraints input field to the lesson generation interface with a 500-character maximum limit.

* **Tests**
  * Added comprehensive test coverage for grammar constraints validation and processing in the generation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->