### PR TITLE
feat(#306): two-pass prompt and pedagogy review gate for sprint close

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -89,7 +89,7 @@ Freeze = Robert does not trigger the merge action. The sprint branch keeps recei
 3. Robert periodically triggers merge action to sync sprint -> main (unless frozen)
 4. Sprint close (three stages):
    - **Stage 1 (PM, main conversation):** Read the three backlog files (`plan/code-review-backlog.md`, `plan/ui-review-backlog.md`, `plan/observed-issues.md`). Triage each entry as FIX NOW / NEXT SPRINT / DELETE. Present triage to user. If FIX NOW items exist, those get implemented via normal worktree flow before proceeding. Batch NEXT SPRINT items into themed GitHub issues. Clear triaged entries from backlog files.
-   - **Stage 2 (agent):** After user approves backlogs, run the `sprint-close` agent. It verifies board/issues, runs Teacher QA, runs pedagogy review on QA results, and returns a pre-merge summary with a READY/NOT READY verdict.
+   - **Stage 2 (agent):** After user approves backlogs, run the `sprint-close` agent. It verifies board/issues, then runs a three-phase quality gate in order: (1) Teacher QA against the sprint branch, (2) prompt health review of `PromptService.cs` and `data/section-profiles/*.json` for redundancy/contradictions/negative bloat, (3) pedagogy review of Teacher QA output AND section profile guidance strings. Returns a READY/NOT READY verdict. Blockers: pedagogy RETHINK on a systemic issue, or critical prompt health findings (contradictions that actively produce wrong output).
    - **Stage 3 (cleanup, after user triggers merge action):** Close the milestone, delete the sprint branch, update memory (task status, sprint overviews), clear remaining backlog entries.
 5. Next sprint: new `sprint/<slug>` from `main`, update milestone view filter
 
@@ -148,7 +148,7 @@ GitHub Issues is the single source of truth for task tracking. Plan files remain
 
 ## Review Tools: Always Use Agents
 
-All review steps (`review-plan`, `qa-verify`, `review`, `architecture-reviewer`, `review-ui`) must be invoked as **agents** (via the Agent tool with the appropriate `subagent_type`), never as skills or slash commands. This keeps the main context window clean and prevents review output from consuming token budget. The `/qa` skill is the only exception (it's for interactive issue review with the user, not part of the task completion pipeline).
+All review steps (`review-plan`, `qa-verify`, `review`, `architecture-reviewer`, `prompt-health-reviewer`, `review-ui`) must be invoked as **agents** (via the Agent tool with the appropriate `subagent_type`), never as skills or slash commands. This keeps the main context window clean and prevents review output from consuming token budget. The `/qa` skill is the only exception (it's for interactive issue review with the user, not part of the task completion pipeline).
 
 ## Task Completion Protocol
 

--- a/.claude/agents/prompt-health-reviewer.md
+++ b/.claude/agents/prompt-health-reviewer.md
@@ -14,12 +14,26 @@ You are a prompt engineer reviewing LLM instruction templates for a language tea
 
 Before reviewing, read these files:
 
-1. **Prompt templates**: `backend/LangTeach.Api/AI/PromptService.cs` (the file under review)
-2. **Content type definitions**: grep for `ContentBlockType` or content type enums in `backend/` to understand what the code enforces structurally
-3. **Generation controller**: `backend/LangTeach.Api/Controllers/GenerateController.cs` to see what validation happens before prompts are built
-4. **Previous review** (if exists): glob `plan/sprints/prompt-health-review-*.md` and read the most recent one for context on known issues and prior findings
+1. **Prompt templates**: `backend/LangTeach.Api/AI/PromptService.cs` (always review)
+2. **Section profiles**: glob `data/section-profiles/*.json` and read all files (review if called during sprint close, or if the caller asks)
+3. **Structural enforcement**: read `backend/LangTeach.Api/Services/SectionProfileService.cs` to understand which profile fields reach the AI. Key fact: `GetGuidance()` returns ONLY the `guidance` string per level -- `hardConstraints` and metadata fields are NOT sent to the AI. `GetAllowedContentTypes()` drives the frontend dropdown but does NOT appear in prompts.
+4. **Generation controller**: `backend/LangTeach.Api/Controllers/GenerateController.cs` to see what validation happens before prompts are built
+5. **Previous review** (if exists): glob `plan/sprints/prompt-health-review-*.md` and read the most recent one for context on known issues and prior findings
 
 ## What You Evaluate
+
+### Section profiles (`data/section-profiles/*.json`)
+
+Only evaluate if you have been asked to review them (sprint close) or the caller provides them. For each profile's `guidance` strings per CEFR level:
+
+1. **Negative bloat in guidance**: "do not / never / avoid / do NOT" instructions in guidance strings. These reach the AI via `GetGuidance()`. Replace with positive equivalents where possible.
+2. **Redundancy with structural enforcement**: if a `contentType` is already excluded from the level's `contentTypes` array, a prompt instruction prohibiting that content type is dead weight. Cross-reference `contentTypes` before flagging.
+3. **Contradictions between levels**: guidance for adjacent levels (e.g. A2 and B1) should progress smoothly, not contradict.
+4. **Hedging language**: "minimize", "try to", "if possible" weaken instructions. Use clear, direct guidance.
+5. **`contentTypes` correctness**: verify the content types listed per level are plausible for that section and CEFR band. For example, `exercises` should not appear in `warmup` or `wrapup`. This is structural enforcement -- wrong entries here allow incorrect content types through the allowlist check. Flag obvious mismatches.
+6. **`hardConstraints` array**: these are NOT sent to the AI (confirmed: not in any `GetGuidance()` path). Do NOT flag them as prompt health issues. Note their existence in the report but mark as "not in AI path."
+
+### PromptService.cs
 
 For each prompt method in `PromptService.cs`, check:
 
@@ -65,17 +79,20 @@ Duplication wastes tokens and can create subtle contradictions when one copy get
 
 ### Sprint: <sprint name>
 ### Date: <date>
-### File: backend/LangTeach.Api/AI/PromptService.cs
+### Files reviewed: PromptService.cs [+ N section profile JSONs if applicable]
 
 ### Findings
 
 | # | Location | Category | Severity | Description | Recommended fix |
 |---|----------|----------|----------|-------------|-----------------|
-| 1 | method:line | redundant/contradictory/negative-bloat/stale/duplication | critical/important/minor | What's wrong | Specific fix |
+| 1 | PromptService.cs:method:line | redundant/contradictory/negative-bloat/stale/duplication | critical/important/minor | What's wrong | Specific fix |
+| 2 | warmup.json:A1:guidance | negative-bloat | important | ... | ... |
 
 ### Summary
 - N critical, N important, N minor
-- Overall health: CLEAN / NEEDS CLEANUP / URGENT (has contradictions affecting output)
+- PromptService.cs health: CLEAN / NEEDS CLEANUP / URGENT
+- Section profiles health: CLEAN / NEEDS CLEANUP / URGENT (or "not reviewed")
+- Overall: CLEAN / NEEDS CLEANUP / URGENT
 
 ### Delta from last review
 <If a previous review exists: which findings are new, which were fixed, which persist>

--- a/.claude/agents/sprint-close.md
+++ b/.claude/agents/sprint-close.md
@@ -1,6 +1,6 @@
 ---
 name: sprint-close
-description: Sprint close process (mechanical phases). Run AFTER backlog triage is done and user has approved. Verifies board/issues, runs Teacher QA + pedagogy review, and prepares the sprint for final merge to main.
+description: Sprint close process (mechanical phases). Run AFTER backlog triage is done and user has approved. Verifies board/issues, then runs a three-phase quality gate: Teacher QA, prompt health review (PromptService.cs + section profiles), and pedagogy review. Returns a READY/NOT READY verdict.
 model: claude-opus-4-6
 ---
 
@@ -40,36 +40,41 @@ This runs all personas (Ana A1, Marco B1, Carmen B2, Ana Exam) against the live 
 
 **Save the full Teacher QA output.** You will pass it to the pedagogy reviewer in Phase 3.
 
-## Phase 3: Pedagogy Review
+## Phase 2b: Prompt Health Review
 
-After Teacher QA completes, invoke the `pedagogy-reviewer` agent (use the Agent tool with `subagent_type: "pedagogy-reviewer"`). Pass it:
-
-```
-Sprint close pedagogy review. The Teacher QA agent just ran all personas against the sprint branch. Here are the results:
-
-<paste full Teacher QA output>
-
-Evaluate the overall pedagogical quality of the AI-generated content across all personas and levels. Focus on:
-1. Are CEFR level boundaries respected across all personas?
-2. Is the curriculum progression sound (grammar sequencing, competency balance)?
-3. Are L1 interference patterns being addressed appropriately for each student's native language?
-4. Is the exercise variety and methodology appropriate per level?
-5. Any systemic issues that appear across multiple personas?
-
-This is a sprint-level review, not individual lesson review. We want to know: is the AI generation quality good enough to ship to a real teacher?
-```
-
-## Phase 3b: Prompt Health Review
-
-After the pedagogy review, invoke the `prompt-health-reviewer` agent (use the Agent tool with `subagent_type: "prompt-health-reviewer"`). Pass it:
+After Teacher QA completes (and before the pedagogy review), invoke the `prompt-health-reviewer` agent (use the Agent tool with `subagent_type: "prompt-health-reviewer"`). Pass it:
 
 ```
-Sprint close prompt health review for <sprint name>. Review backend/LangTeach.Api/AI/PromptService.cs for redundancy, contradictions, negative bloat, stale patches, and duplication. Cross-reference against structural enforcement in the codebase (content type allowlists, controller validation, schema constraints).
+Sprint close prompt health review for <sprint name>.
 
-<If relevant: note any recent structural changes that affect what prompts need to say, e.g. "Content type allowlists were added in #305, restricting which types each section can generate.">
+Review both:
+1. backend/LangTeach.Api/AI/PromptService.cs -- check for redundancy, contradictions, negative bloat, stale patches, and duplication. Cross-reference against structural enforcement (content type allowlists in SectionProfileService, controller validation, schema constraints).
+2. data/section-profiles/*.json -- check each file's `guidance` strings per CEFR level for: negative bloat ("do not / never / avoid"), redundancy with structural enforcement (the contentTypes array already restricts what the AI can generate), contradictions between levels, and unclear or hedging language. Note: hardConstraints are NOT sent to the AI; focus on guidance strings and contentTypes correctness.
+
+<If relevant: note any recent structural changes, e.g. "Section profiles replaced the static SectionContentTypeAllowlist in #309. Content types are now enforced structurally per section per level.">
 ```
 
 Log findings in `plan/sprints/prompt-health-review-<sprint-slug>.md`. If any findings are severity critical, include them in the pre-merge summary as blocking items.
+
+## Phase 3: Pedagogy Review
+
+After the prompt health review completes, invoke the `pedagogy-reviewer` agent (use the Agent tool with `subagent_type: "pedagogy-reviewer"`). Pass it both the Teacher QA output AND a request to evaluate the section profiles directly:
+
+```
+Sprint close pedagogy review. Two inputs for you:
+
+1. Teacher QA results (all personas against the sprint branch):
+<paste full Teacher QA output>
+
+2. Section profile guidance strings (from data/section-profiles/*.json -- these are injected into AI prompts per section and CEFR level):
+<paste the guidance strings from each profile's levels, formatted clearly>
+
+Evaluate:
+A. Teacher QA quality: Are CEFR level boundaries respected? Is curriculum progression sound? Are L1 interference patterns addressed? Is exercise variety appropriate per level? Any systemic issues across personas?
+B. Section profile pedagogy: Is the CEFR progression correct across levels (A1 through C2)? Are activity types appropriate per level? Are duration estimates realistic for one-on-one online tutoring? Is the scaffolding progression sound (high at A1, none at C1/C2)? Are competency assignments correct per section type? Are interaction patterns appropriate?
+
+This is a sprint-level review. We want to know: is the AI generation quality good enough to ship to a real teacher?
+```
 
 ## Phase 4: Pre-Merge Summary
 
@@ -87,14 +92,15 @@ Present the final summary:
 - Overall quality: [summary]
 - Key findings: [list]
 
-### Pedagogy Review
-- Verdict: SOUND / ADJUST / RETHINK
-- Key findings: [summary]
-
-### Prompt Health
+### Prompt Health (Phase 2b)
+- Files reviewed: PromptService.cs + N section profile JSONs
 - Findings: N redundant, N contradictory, N negative bloat, N stale, N duplication
 - Critical items: [list or "none"]
 - Report: plan/sprints/prompt-health-review-<sprint-slug>.md
+
+### Pedagogy Review
+- Verdict: SOUND / ADJUST / RETHINK
+- Key findings: [summary]
 
 ### Ready to merge?
 YES — user can trigger merge-sprint-to-main GitHub Action
@@ -110,5 +116,6 @@ Return this summary to the main conversation. The main agent will present it to 
 
 - Never merge to main yourself. The user triggers the GitHub Action.
 - Never delete issues. Report open issues with no PR; the user decides.
-- The pedagogy reviewer must see Teacher QA results. Never skip Phase 3.
+- Prompt health review (Phase 2b) must run BEFORE pedagogy review (Phase 3). Clean the noise first, then the pedagogy expert reviews clean templates.
+- The pedagogy reviewer must see BOTH Teacher QA results AND section profile guidance strings. Never skip Phase 3.
 - Keep your final response under 3000 characters. Summary, not process narration.

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -142,7 +142,12 @@ Any gate can send the task back to implementation. The loop repeats until all th
 
 1. **Backlog triage (PM, interactive):** The PM reads the three backlog files (`plan/code-review-backlog.md`, `plan/ui-review-backlog.md`, `plan/observed-issues.md`) and classifies each entry as FIX NOW (blocks sprint quality), NEXT SPRINT (batch into a themed issue), or DELETE (not worth tracking). The user reviews and approves the triage. FIX NOW items get implemented via normal worktree flow before proceeding. NEXT SPRINT items are grouped into `type:polish` or `type:tech-debt` issues that go through the standard `/qa` gate.
 
-2. **Verification and quality gate (sprint-close agent):** After backlogs are clean, the `sprint-close` agent runs. It verifies all milestone issues are closed and on the board, runs Teacher QA against the sprint branch (all personas), passes the results to the pedagogy reviewer for a sprint-level quality assessment, then runs a **prompt health review** where a dedicated prompt-health-reviewer agent audits `PromptService.cs` for redundant constraints, contradictory instructions, negative bloat, stale patches, and duplication. Findings are logged to `plan/sprints/prompt-health-review-<sprint-slug>.md`. The agent returns a READY/NOT READY verdict. Blockers: pedagogy RETHINK on any systemic issue, or critical prompt health findings (contradictions that actively produce wrong output).
+2. **Verification and quality gate (sprint-close agent):** After backlogs are clean, the `sprint-close` agent runs. It verifies all milestone issues are closed and on the board, then runs a three-phase quality gate in order:
+   - **Teacher QA (Phase 2):** All personas run against the live sprint branch.
+   - **Prompt health review (Phase 2b):** A `prompt-health-reviewer` agent audits both `PromptService.cs` and `data/section-profiles/*.json` for redundant constraints, contradictory instructions, negative bloat (in guidance strings), stale patches, and duplication. Findings are logged to `plan/sprints/prompt-health-review-<sprint-slug>.md`. Running this BEFORE the pedagogy review means the pedagogy expert reviews clean templates, not noise.
+   - **Pedagogy review (Phase 3):** A `pedagogy-reviewer` agent evaluates Teacher QA output for sprint-level quality AND reviews the section profile guidance strings directly (CEFR progression, activity type appropriateness, duration estimates, scaffolding progression).
+
+   The agent returns a READY/NOT READY verdict. Blockers: pedagogy RETHINK on any systemic issue, or critical prompt health findings (contradictions that actively produce wrong output).
 
 3. **Cleanup (after user triggers merge):** Close the GitHub milestone, delete the sprint branch, update memory (task status, sprint overviews), clear the backlog files.
 
@@ -185,7 +190,8 @@ The Bash tool runs in Git Bash on Windows. Git Bash automatically translates Uni
 | Acceptance criteria | `qa-verify` agent | PASS verdict |
 | Code review | `review` agent | PASS or PASS WITH NOTES |
 | Consistency review | `architecture-reviewer` agent | PASS or PASS WITH NOTES (run in parallel with `review`) |
-| Prompt health | `prompt-health-reviewer` agent | CLEAN or NEEDS CLEANUP (only if `PromptService.cs` changed, run in parallel with `review`) |
+| Prompt health (per-PR) | `prompt-health-reviewer` agent | CLEAN or NEEDS CLEANUP (only if `PromptService.cs` changed, run in parallel with `review`); URGENT blocks push |
+| Prompt health (sprint close) | `prompt-health-reviewer` agent | Reviews `PromptService.cs` + all `data/section-profiles/*.json`; runs before pedagogy review |
 | UI review | `review-ui` agent | GOOD or POLISHED (only if `area:frontend` or `area:design`) |
 | CI + CodeRabbit | `gh pr checks` + `gh api` | No failures, no unresolved comments |
 

--- a/plan/langteach-beta/task306-sprint-close-prompt-review.md
+++ b/plan/langteach-beta/task306-sprint-close-prompt-review.md
@@ -1,0 +1,61 @@
+# Task 306: Sprint Close -- Two-Pass Prompt and Pedagogy Review Gate
+
+**Issue:** #306
+**Branch:** worktree-task-t306-sprint-close-prompt-review
+**Sprint:** sprint/student-aware-curriculum
+
+## Context
+
+#309 merged (PR #310). Section profiles live at `data/section-profiles/*.json` (warmup, presentation, practice, production, wrapup). The `SectionProfileService.GetGuidance()` method injects ONLY the `guidance` string per level into prompts -- `hardConstraints` and metadata fields are NOT sent to the AI.
+
+An earlier prompt health baseline review exists at `plan/sprints/prompt-health-review-student-aware-curriculum.md` (status: pre-#305). Several findings from that baseline remain unresolved in the current codebase.
+
+## What needs to be done
+
+### Part A: Permanent process changes
+
+1. **Update `sprint-close.md`** -- reorder phases:
+   - Current: Teacher QA (2) -> Pedagogy (3) -> Prompt Health (3b)
+   - Target: Teacher QA (2) -> Prompt Health (2b) -> Pedagogy (3)
+   - Expand Phase 2b scope: prompt health reviews BOTH `PromptService.cs` AND `data/section-profiles/*.json`
+   - Expand Phase 3: pedagogy reviewer receives Teacher QA output AND is asked to review JSON profile guidance strings directly (CEFR progression, activity types, durations, scaffolding)
+
+2. **Update `prompt-health-reviewer.md`** -- expand Context Loading:
+   - Add `data/section-profiles/*.json` to files to review
+   - Add review criteria for JSON profiles: are `guidance` strings positive? Contradictory across levels? Escalation-appropriate per CEFR? Redundant with structural enforcement?
+   - Note: `hardConstraints` array is NOT sent to the AI (not in any GetGuidance path); focus review on `guidance` strings and `contentTypes`
+
+3. **Update `CLAUDE.md`** sprint close Stage 2 bullet -- change "runs Teacher QA, runs pedagogy review on QA results" to mention two-pass sequence: Teacher QA then prompt health then pedagogy.
+
+4. **Update `docs/dev-workflow.md`** line 145 -- update sprint close description to reflect reordered sequence.
+
+### Part B: Run the reviews on this sprint (deferred -- user will complete interactively via /pm)
+
+The actual review runs (prompt-health-reviewer, pedagogy-reviewer, Teacher QA re-run, and fixing findings in PromptService.cs and JSON profiles) are out of scope for this PR. The issue will remain open. Part B acceptance criteria will be completed in a follow-up /pm session.
+
+### Part C: No tests needed (process/config/data files only)
+
+All changes in Part A are to agent definitions, CLAUDE.md, and docs. No code changes. No new tests required.
+
+## Files to change
+
+### Part A (process):
+- `.claude/agents/sprint-close.md`
+- `.claude/agents/prompt-health-reviewer.md`
+- `.claude/CLAUDE.md`
+- `docs/dev-workflow.md`
+
+## Order of execution
+
+1. Make process changes (Part A) -- commit and push, open PR
+2. Part B deferred to follow-up /pm session
+
+## Pre-push checks
+
+All 6 standard checks (no code changes, but must verify clean build).
+
+## Scope limits
+
+- Template-specific overrides (R&C, Exam Prep) stay as inline code; only fix their negative/contradictory instructions
+- L1 adaptation hooks: not in scope
+- `hardConstraints` in JSON files: only fix if they create confusion (they're not sent to AI, so low priority; can be left as documentation)


### PR DESCRIPTION
## Summary

- Reorder `sprint-close` agent phases: prompt health (Phase 2b) now runs **before** pedagogy review (Phase 3), so the pedagogy expert reviews clean templates instead of noisy ones
- Expand `prompt-health-reviewer` scope to cover `data/section-profiles/*.json` guidance strings in addition to `PromptService.cs` (checks negative bloat, redundancy with structural enforcement, contradictions, hedging, and `contentTypes` correctness)
- Update `CLAUDE.md` Stage 2 sprint close description to document the three-phase quality gate sequence
- Update `docs/dev-workflow.md` to match, including the gate summary table

Closes #306 (partial -- Part A process changes only; Part B review runs and content fixes are deferred to a follow-up /pm session)

## Test plan

- [ ] No application code changed; all 6 pre-push checks pass (verified: 338 backend + 554 frontend tests green)
- [ ] Verify `.claude/agents/sprint-close.md` Phase 2b appears between Phase 2 and Phase 3
- [ ] Verify `.claude/agents/prompt-health-reviewer.md` section profile evaluation section is present
- [ ] Verify CLAUDE.md and dev-workflow.md descriptions match the new ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)