### PR TITLE
feat(#324): add PedagogyConfigService for pedagogy JSON composition

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs
@@ -1,0 +1,261 @@
+using FluentAssertions;
+using LangTeach.Api.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace LangTeach.Api.Tests.Services;
+
+public class PedagogyConfigServiceTests
+{
+    private readonly SectionProfileService _sps = new(NullLogger<SectionProfileService>.Instance);
+    private readonly PedagogyConfigService _sut;
+
+    public PedagogyConfigServiceTests()
+    {
+        _sut = new PedagogyConfigService(NullLogger<PedagogyConfigService>.Instance, _sps);
+    }
+
+    // --- Smoke ---
+
+    [Fact]
+    public void ServiceLoads_WithoutThrowing()
+    {
+        // Constructor must complete without throwing; catalog, CEFR rules, L1, templates, etc. loaded
+        _sut.Should().NotBeNull();
+    }
+
+    // --- Cross-layer validation ---
+
+    [Fact]
+    public void StartupValidation_ServiceConstructsWithoutThrowing_AllCrossLayerRefsValid()
+    {
+        // If the constructor completes (verified by ServiceLoads_WithoutThrowing),
+        // ValidateCrossLayerRefs() passed — all exercise type IDs referenced across
+        // CEFR rules, L1 adjustments, template overrides, and style substitutions
+        // exist in the exercise type catalog.
+        _sut.Should().NotBeNull();
+        // Spot-check: expanded forbidden IDs are non-empty strings (confirms pattern expansion ran)
+        var forbiddenCheck = _sut.GetForbiddenExerciseTypeIds("warmup", "A1");
+        forbiddenCheck.Should().OnlyContain(id => id.Length > 0, "all expanded IDs should be non-empty strings");
+    }
+
+    // --- GetValidExerciseTypes ---
+
+    [Fact]
+    public void GetValidExerciseTypes_WarmUp_A1_ReturnsSectionValidTypes_SubsetOfCefrAppropriate()
+    {
+        var result = _sut.GetValidExerciseTypes("warmup", "A1");
+
+        // Must only contain types from A1 appropriateExerciseTypes AND warmup A1 validExerciseTypes
+        result.Should().NotBeEmpty();
+        // WarmUp A1 validExerciseTypes are EO-01, EO-03, PRAG-01, LUD-06, LUD-07
+        result.Should().Contain("EO-01");
+        result.Should().Contain("EO-03");
+    }
+
+    [Fact]
+    public void GetValidExerciseTypes_WarmUp_A1_ContainsNoGrammarTypes()
+    {
+        // WarmUp forbids GR-* for all levels
+        var result = _sut.GetValidExerciseTypes("warmup", "A1");
+
+        result.Should().NotContain(id => id.StartsWith("GR-", StringComparison.OrdinalIgnoreCase),
+            because: "WarmUp forbids all GR-* exercise types");
+    }
+
+    [Fact]
+    public void GetValidExerciseTypes_L1Mandarin_WarmUp_A1_CO06IsBlocked()
+    {
+        // Mandarin (sinitic-japonic family) has CO-06 in additionalExerciseTypes.
+        // WarmUp forbids CO-* pattern. CO-06 must be blocked even after L1 addition (re-filter step).
+        var result = _sut.GetValidExerciseTypes("warmup", "A1", nativeLang: "mandarin");
+
+        result.Should().NotContain("CO-06",
+            because: "WarmUp forbids all CO-* types; CO-06 added by Mandarin L1 must be re-filtered out");
+    }
+
+    [Fact]
+    public void GetValidExerciseTypes_GrammarFocusTemplate_Practice_A1_GR01IsFirst()
+    {
+        // Grammar Focus template has GR-01 as first priorityExerciseType for practice.
+        // It must appear before non-priority types in the result.
+        var result = _sut.GetValidExerciseTypes("practice", "A1", templateId: "grammar-focus");
+
+        result.Should().Contain("GR-01");
+        result[0].Should().Be("GR-01", because: "GR-01 is the first priority type for Grammar Focus practice and must appear first");
+    }
+
+    // --- GetForbiddenExerciseTypeIds ---
+
+    [Fact]
+    public void GetForbiddenExerciseTypeIds_WarmUp_A1_ExpandsAllGRPattern()
+    {
+        // WarmUp forbids GR-* pattern. Should expand to all GR-xx IDs in the catalog (10 types: GR-01 to GR-10).
+        var result = _sut.GetForbiddenExerciseTypeIds("warmup", "A1");
+
+        for (var i = 1; i <= 10; i++)
+        {
+            var id = $"GR-{i:D2}";
+            result.Should().Contain(id, because: $"GR-* pattern should expand to include {id}");
+        }
+    }
+
+    [Fact]
+    public void GetForbiddenExerciseTypeIds_WarmUp_A1_AlsoExpandsEEAndCOPatterns()
+    {
+        var result = _sut.GetForbiddenExerciseTypeIds("warmup", "A1");
+
+        // EE-* and CO-* are also forbidden for WarmUp
+        result.Should().Contain(id => id.StartsWith("EE-", StringComparison.OrdinalIgnoreCase),
+            because: "WarmUp forbids EE-* pattern");
+        result.Should().Contain(id => id.StartsWith("CO-", StringComparison.OrdinalIgnoreCase),
+            because: "WarmUp forbids CO-* pattern");
+    }
+
+    // --- GetGrammarScope ---
+
+    [Theory]
+    [InlineData("A1")]
+    [InlineData("A2")]
+    [InlineData("B1")]
+    [InlineData("B2")]
+    public void GetGrammarScope_LowerLevels_ReturnsBothInScopeAndOutOfScope(string level)
+    {
+        var result = _sut.GetGrammarScope(level);
+
+        result.InScope.Should().NotBeEmpty(because: $"CEFR {level} should have grammar in-scope");
+        result.OutOfScope.Should().NotBeEmpty(because: $"CEFR {level} should have grammar out-of-scope");
+    }
+
+    [Fact]
+    public void GetGrammarScope_C1_OutOfScopeIsEmpty()
+    {
+        // C1 has no grammar out-of-scope (student has command of full system)
+        var result = _sut.GetGrammarScope("C1");
+
+        result.InScope.Should().NotBeEmpty();
+        result.OutOfScope.Should().BeEmpty(because: "C1 grammarOutOfScope is an empty array");
+    }
+
+    // --- GetVocabularyGuidance ---
+
+    [Theory]
+    [InlineData("A1")]
+    [InlineData("A2")]
+    [InlineData("B1")]
+    [InlineData("B2")]
+    public void GetVocabularyGuidance_LowerLevels_ReturnsNumericFields(string level)
+    {
+        var result = _sut.GetVocabularyGuidance(level);
+
+        result.ProductiveMin.Should().NotBeNull(because: $"CEFR {level} uses numeric vocabulary targets");
+        result.ProductiveMax.Should().NotBeNull();
+        result.Approach.Should().BeNull(because: $"CEFR {level} does not use a string approach description");
+    }
+
+    [Theory]
+    [InlineData("C1")]
+    [InlineData("C2")]
+    public void GetVocabularyGuidance_UpperLevels_ReturnsApproachString(string level)
+    {
+        var result = _sut.GetVocabularyGuidance(level);
+
+        result.Approach.Should().NotBeNullOrEmpty(because: $"CEFR {level} uses a vocabulary approach description, not numeric targets");
+        result.ProductiveMin.Should().BeNull(because: $"CEFR {level} does not have numeric vocabulary counts");
+    }
+
+    // --- GetL1Adjustments ---
+
+    [Fact]
+    public void GetL1Adjustments_Mandarin_ReturnsCO06InAdditionalTypes()
+    {
+        var result = _sut.GetL1Adjustments("mandarin");
+
+        result.Should().NotBeNull();
+        result!.AdditionalExerciseTypes.Should().Contain("CO-06",
+            because: "Mandarin (sinitic-japonic) has CO-06 as an additional exercise type");
+    }
+
+    [Fact]
+    public void GetL1Adjustments_English_ReturnsGermanicFamilyAdjustments()
+    {
+        // "english" is in germanic family's languages list but not in specificLanguages
+        var result = _sut.GetL1Adjustments("english");
+
+        result.Should().NotBeNull(because: "English is listed in the germanic language family");
+        result!.IncreaseEmphasis.Should().Contain("GR-08",
+            because: "Germanic family increases emphasis on GR-08 (inductive discovery)");
+    }
+
+    [Fact]
+    public void GetL1Adjustments_UnknownLanguage_ReturnsNull()
+    {
+        var result = _sut.GetL1Adjustments("klingon");
+
+        result.Should().BeNull(because: "Unknown languages should return null");
+    }
+
+    // --- GetTemplateOverride ---
+
+    [Fact]
+    public void GetTemplateOverride_GrammarFocus_PracticeHasMinVarietyOf3()
+    {
+        var result = _sut.GetTemplateOverride("grammar-focus");
+
+        result.Should().NotBeNull();
+        result!.Sections.Should().ContainKey("practice");
+        result.Sections["practice"].MinExerciseVarietyOverride.Should().Be(3,
+            because: "Grammar Focus practice requires at least 3 different exercise formats");
+    }
+
+    [Fact]
+    public void GetTemplateOverride_Conversation_PresentationIsOptional()
+    {
+        var result = _sut.GetTemplateOverride("conversation");
+
+        result.Should().NotBeNull();
+        result!.Sections.Should().ContainKey("presentation");
+        result.Sections["presentation"].Required.Should().BeFalse(
+            because: "Conversation template has optional presentation section");
+    }
+
+    [Fact]
+    public void GetTemplateOverride_UnknownTemplate_ReturnsNull()
+    {
+        _sut.GetTemplateOverride("nonexistent-template").Should().BeNull();
+    }
+
+    // --- GetStyleSubstitutions ---
+
+    [Fact]
+    public void GetStyleSubstitutions_RolePlay_ReturnsEntryWithEO04AndEO08()
+    {
+        // EO-01 is in the role-play rejects list
+        var result = _sut.GetStyleSubstitutions(["EO-01"]);
+
+        result.Should().HaveCount(1);
+        result[0].Label.Should().Be("role-play");
+        result[0].SubstituteWith.Should().Contain("EO-04");
+        result[0].SubstituteWith.Should().Contain("EO-08");
+    }
+
+    [Fact]
+    public void GetStyleSubstitutions_NoMatch_ReturnsEmpty()
+    {
+        var result = _sut.GetStyleSubstitutions(["NONEXISTENT-99"]);
+
+        result.Should().BeEmpty();
+    }
+
+    // --- GetCourseRules ---
+
+    [Fact]
+    public void GetCourseRules_ReturnsNonNull_WithVarietyRules()
+    {
+        var result = _sut.GetCourseRules();
+
+        result.Should().NotBeNull();
+        result.VarietyRules.Should().NotBeNull();
+        result.VarietyRules.PracticeTypeCombination.NoRepeatWithinSessions.Should().Be(3);
+        result.VarietyRules.WarmUpFormat.MaxConsecutiveRepeats.Should().Be(2);
+    }
+}

--- a/backend/LangTeach.Api/AI/PedagogyConfig.cs
+++ b/backend/LangTeach.Api/AI/PedagogyConfig.cs
@@ -1,0 +1,111 @@
+namespace LangTeach.Api.AI;
+
+// Exercise catalog (exercise-types.json)
+public record ExerciseCatalog(ExerciseTypeEntry[] ExerciseTypes);
+
+public record ExerciseTypeEntry(string Id, string Category);
+
+// CEFR level rules (cefr-levels/*.json)
+// A1-B2 use vocabularyPerLesson (numeric); C1-C2 use vocabularyApproach (string).
+// Both fields are nullable — deserialization picks up whichever is present.
+public record CefrLevelRules(
+    string Level,
+    string[] GrammarInScope,
+    string[] GrammarOutOfScope,
+    string[] AppropriateExerciseTypes,
+    InappropriateExerciseEntry[] InappropriateExerciseTypes,
+    VocabularyPerLesson? VocabularyPerLesson,
+    string? VocabularyApproach,
+    string InstructionLanguage,
+    string MetalanguageLevel,
+    string ErrorCorrection,
+    string ScaffoldingDefault
+);
+
+public record InappropriateExerciseEntry(string Id, string Reason);
+
+public record VocabularyPerLesson(VocabularyRange Productive, VocabularyRange Receptive);
+
+public record VocabularyRange(int Min, int Max);
+
+// L1 influence (l1-influence.json)
+public record L1InfluenceFile(
+    Dictionary<string, LanguageFamily> LanguageFamilies,
+    Dictionary<string, SpecificLanguage> SpecificLanguages
+);
+
+public record LanguageFamily(
+    string[] Languages,
+    string[] Strengths,
+    string[] Weaknesses,
+    LanguageFamilyAdjustments Adjustments
+);
+
+public record LanguageFamilyAdjustments(
+    string[] IncreaseEmphasis,
+    string[] DecreaseEmphasis,
+    string[] AdditionalExerciseTypes,
+    string[] TemplatePreference,
+    string Notes
+);
+
+public record SpecificLanguage(
+    string? Family,
+    string[] FalseFriends,
+    string[] PositiveTransfer,
+    string AdditionalNotes
+);
+
+// Template overrides (template-overrides.json)
+public record TemplateOverridesFile(List<TemplateOverrideEntry> Templates);
+
+public record TemplateOverrideEntry(
+    string Id,
+    string Name,
+    Dictionary<string, SectionOverride> Sections,
+    Dictionary<string, string> LevelVariations,
+    TemplateRestriction[] Restrictions
+);
+
+public record TemplateRestriction(string Type, string Value, string Reason);
+
+public record SectionOverride(
+    bool Required,
+    string? OverrideGuidance,
+    string[] PriorityExerciseTypes,
+    int? MinExerciseVarietyOverride,
+    string? Notes
+);
+
+// Course rules (course-rules.json)
+public record CourseRulesFile(
+    CourseVarietyRules VarietyRules,
+    Dictionary<string, Dictionary<string, SkillRange>> SkillDistribution,
+    GrammarProgression GrammarProgression
+);
+
+public record CourseVarietyRules(
+    PracticeTypeCombinationRule PracticeTypeCombination,
+    ProductionTypeAlternationRule ProductionTypeAlternation,
+    WarmUpFormatRule WarmUpFormat,
+    CompetencyCoverageRule CompetencyCoverage
+);
+
+public record PracticeTypeCombinationRule(int NoRepeatWithinSessions, string Description);
+public record ProductionTypeAlternationRule(bool AlternateWrittenOral, string Description);
+public record WarmUpFormatRule(int MaxConsecutiveRepeats, string Description);
+public record CompetencyCoverageRule(int WindowSize, string[] RequiredCompetencies, string Description);
+public record SkillRange(double Min, double Max);
+public record GrammarProgression(string Model, RecyclingRule[] RecyclingRules);
+public record RecyclingRule(string Trigger, string Action);
+
+// Style substitutions (style-substitutions.json)
+public record StyleSubstitutionsFile(StyleSubstitution[] Substitutions);
+
+public record StyleSubstitution(
+    string[] Rejects,
+    string Label,
+    string[] SubstituteWith,
+    string[] NeverSubstituteWith,
+    string Rule
+);

--- a/backend/LangTeach.Api/AI/PedagogyConfigDtos.cs
+++ b/backend/LangTeach.Api/AI/PedagogyConfigDtos.cs
@@ -1,0 +1,31 @@
+namespace LangTeach.Api.AI;
+
+/// <summary>
+/// Output DTO for GetGrammarScope — contains in-scope and out-of-scope grammar lists for a CEFR level.
+/// Not a JSON deserialization model; constructed by PedagogyConfigService from CefrLevelRules data.
+/// </summary>
+public record GrammarScope(string[] InScope, string[] OutOfScope);
+
+/// <summary>
+/// Output DTO for GetVocabularyGuidance.
+/// A1-B2: ProductiveMin/Max and ReceptiveMin/Max are set (numeric vocabulary targets).
+/// C1-C2: Approach is set (qualitative description); numeric fields are null.
+/// </summary>
+public record VocabularyGuidance(
+    int? ProductiveMin,
+    int? ProductiveMax,
+    int? ReceptiveMin,
+    int? ReceptiveMax,
+    string? Approach
+);
+
+/// <summary>
+/// Output DTO for GetL1Adjustments — combines family-level adjustments and language-specific notes.
+/// Not a JSON deserialization model; composed from L1InfluenceFile data.
+/// </summary>
+public record L1Adjustments(
+    string[] AdditionalExerciseTypes,
+    string[] IncreaseEmphasis,
+    string[] DecreaseEmphasis,
+    string Notes
+);

--- a/backend/LangTeach.Api/LangTeach.Api.csproj
+++ b/backend/LangTeach.Api/LangTeach.Api.csproj
@@ -18,6 +18,16 @@
                       Link="SectionProfiles\%(Filename)%(Extension)" />
     <EmbeddedResource Include="..\..\data\pedagogy\exercise-types.json"
                       Link="Pedagogy\exercise-types.json" />
+    <EmbeddedResource Include="..\..\data\pedagogy\cefr-levels\*.json"
+                      Link="Pedagogy\CefrLevels\%(Filename)%(Extension)" />
+    <EmbeddedResource Include="..\..\data\pedagogy\l1-influence.json"
+                      Link="Pedagogy\l1-influence.json" />
+    <EmbeddedResource Include="..\..\data\pedagogy\template-overrides.json"
+                      Link="Pedagogy\template-overrides.json" />
+    <EmbeddedResource Include="..\..\data\pedagogy\course-rules.json"
+                      Link="Pedagogy\course-rules.json" />
+    <EmbeddedResource Include="..\..\data\pedagogy\style-substitutions.json"
+                      Link="Pedagogy\style-substitutions.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/LangTeach.Api/Program.cs
+++ b/backend/LangTeach.Api/Program.cs
@@ -121,6 +121,7 @@ builder.Services.AddHttpClient("Claude", (sp, client) =>
 });
 builder.Services.AddScoped<IClaudeClient, ClaudeApiClient>();
 builder.Services.AddSingleton<ISectionProfileService, SectionProfileService>();
+builder.Services.AddSingleton<IPedagogyConfigService, PedagogyConfigService>();
 builder.Services.AddScoped<IPromptService, PromptService>();
 
 builder.Services.AddOptions<GenerationLimitsOptions>()
@@ -159,6 +160,7 @@ var app = builder.Build();
 
 // Eagerly resolve singletons that load embedded resources so malformed JSON fails at startup.
 _ = app.Services.GetRequiredService<ISectionProfileService>();
+_ = app.Services.GetRequiredService<IPedagogyConfigService>();
 
 // Apply pending migrations and seed reference data on startup
 using (var scope = app.Services.CreateScope())

--- a/backend/LangTeach.Api/Services/CefrLevelNormalizer.cs
+++ b/backend/LangTeach.Api/Services/CefrLevelNormalizer.cs
@@ -1,0 +1,23 @@
+namespace LangTeach.Api.Services;
+
+/// <summary>
+/// Shared CEFR level normalization logic used by both SectionProfileService and PedagogyConfigService.
+/// Accepts "A1", "A1.1", "B2.2" etc. and returns the canonical major band (e.g. "A1", "B2").
+/// </summary>
+internal static class CefrLevelNormalizer
+{
+    private static readonly string[] KnownLevels = ["A1", "A2", "B1", "B2", "C1", "C2"];
+
+    public static string Normalize(string cefrLevel)
+    {
+        if (string.IsNullOrWhiteSpace(cefrLevel)) return string.Empty;
+        var upper = cefrLevel.Trim().ToUpperInvariant();
+        if (KnownLevels.Contains(upper, StringComparer.Ordinal)) return upper;
+        foreach (var known in KnownLevels)
+        {
+            if (upper.StartsWith(known, StringComparison.Ordinal))
+                return known;
+        }
+        return upper; // Return as-is; profile lookup will miss and return empty/default
+    }
+}

--- a/backend/LangTeach.Api/Services/IPedagogyConfigService.cs
+++ b/backend/LangTeach.Api/Services/IPedagogyConfigService.cs
@@ -1,0 +1,54 @@
+using LangTeach.Api.AI;
+
+namespace LangTeach.Api.Services;
+
+public interface IPedagogyConfigService
+{
+    /// <summary>
+    /// Returns valid exercise type IDs for the given section, level, optional template, and optional native language.
+    /// Composition: CEFR appropriate ∩ section valid, minus forbidden (with pattern expansion),
+    /// re-ordered by template priorities, plus L1 additional types, re-filtered for forbidden.
+    /// When sectionValid is null (no filter defined), cefrTypes are used as the base.
+    /// </summary>
+    string[] GetValidExerciseTypes(string section, string level, string? templateId = null, string? nativeLang = null);
+
+    /// <summary>
+    /// Returns the expanded forbidden exercise type IDs for a section+level.
+    /// Patterns (e.g. "GR-*") are expanded against the exercise type catalog.
+    /// </summary>
+    string[] GetForbiddenExerciseTypeIds(string section, string level);
+
+    /// <summary>
+    /// Returns in-scope and out-of-scope grammar lists for the CEFR level.
+    /// Returns empty arrays if the level is not found.
+    /// </summary>
+    GrammarScope GetGrammarScope(string level);
+
+    /// <summary>
+    /// Returns vocabulary guidance for the level.
+    /// Numeric (ProductiveMin/Max, ReceptiveMin/Max) for A1-B2.
+    /// String approach (Approach) for C1-C2.
+    /// </summary>
+    VocabularyGuidance GetVocabularyGuidance(string level);
+
+    /// <summary>
+    /// Returns L1 adjustments for the native language, combining family adjustments with
+    /// language-specific notes. Returns null if the language is not found.
+    /// </summary>
+    L1Adjustments? GetL1Adjustments(string nativeLang);
+
+    /// <summary>
+    /// Returns the template override entry for the given template ID. Returns null if not found.
+    /// </summary>
+    TemplateOverrideEntry? GetTemplateOverride(string templateId);
+
+    /// <summary>
+    /// Returns the full course rules configuration (variety rules, skill distribution, grammar progression).
+    /// </summary>
+    CourseRulesFile GetCourseRules();
+
+    /// <summary>
+    /// Returns substitution entries whose Rejects list contains any of the given type IDs.
+    /// </summary>
+    StyleSubstitution[] GetStyleSubstitutions(string[] rejectedTypes);
+}

--- a/backend/LangTeach.Api/Services/ISectionProfileService.cs
+++ b/backend/LangTeach.Api/Services/ISectionProfileService.cs
@@ -1,3 +1,5 @@
+using LangTeach.Api.AI;
+
 namespace LangTeach.Api.Services;
 
 public interface ISectionProfileService
@@ -20,4 +22,18 @@ public interface ISectionProfileService
     /// Returns an empty array if the section or level is not found.
     /// </summary>
     string[] GetAllowedContentTypes(string sectionType, string cefrLevel);
+
+    /// <summary>
+    /// Returns the valid exercise type IDs for a section at the given CEFR level.
+    /// Returns null if the section or level is not found (no filter defined).
+    /// Used by PedagogyConfigService for composition.
+    /// </summary>
+    string[]? GetRawValidExerciseTypes(string sectionType, string cefrLevel);
+
+    /// <summary>
+    /// Returns the raw ForbiddenExerciseType entries for a section at the given CEFR level.
+    /// Patterns (e.g. "GR-*") are returned unexpanded. Returns empty if not found.
+    /// Used by PedagogyConfigService for pattern expansion and composition.
+    /// </summary>
+    ForbiddenExerciseType[] GetRawForbiddenExerciseTypes(string sectionType, string cefrLevel);
 }

--- a/backend/LangTeach.Api/Services/PedagogyConfigService.cs
+++ b/backend/LangTeach.Api/Services/PedagogyConfigService.cs
@@ -1,0 +1,341 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LangTeach.Api.AI;
+
+namespace LangTeach.Api.Services;
+
+public class PedagogyConfigService : IPedagogyConfigService
+{
+    private readonly ILogger<PedagogyConfigService> _log;
+    private readonly ISectionProfileService _sectionProfileService;
+
+    private readonly HashSet<string> _catalogIds;
+    private readonly Dictionary<string, CefrLevelRules> _cefrRules;
+    private readonly L1InfluenceFile _l1;
+    private readonly Dictionary<string, TemplateOverrideEntry> _templates;
+    private readonly CourseRulesFile _courseRules;
+    private readonly StyleSubstitution[] _substitutions;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        NumberHandling = JsonNumberHandling.AllowReadingFromString,
+    };
+
+    public PedagogyConfigService(
+        ILogger<PedagogyConfigService> logger,
+        ISectionProfileService sectionProfileService)
+    {
+        _log = logger;
+        _sectionProfileService = sectionProfileService;
+
+        var assembly = Assembly.GetExecutingAssembly();
+
+        // Load exercise type catalog (must be first — other validation depends on it)
+        var catalog = LoadJson<ExerciseCatalog>(assembly, "LangTeach.Api.Pedagogy.exercise-types.json");
+        _catalogIds = catalog.ExerciseTypes.Select(e => e.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        _log.LogInformation("PedagogyConfigService: loaded exercise catalog with {Count} types", _catalogIds.Count);
+
+        // Load CEFR level rules
+        _cefrRules = new Dictionary<string, CefrLevelRules>(StringComparer.OrdinalIgnoreCase);
+        const string cefrPrefix = "LangTeach.Api.Pedagogy.CefrLevels.";
+        foreach (var name in assembly.GetManifestResourceNames()
+            .Where(n => n.StartsWith(cefrPrefix, StringComparison.Ordinal) && n.EndsWith(".json", StringComparison.Ordinal)))
+        {
+            using var stream = assembly.GetManifestResourceStream(name)
+                ?? throw new InvalidOperationException($"PedagogyConfigService: could not open resource stream '{name}'");
+            var rule = JsonSerializer.Deserialize<CefrLevelRules>(stream, JsonOpts)
+                ?? throw new InvalidOperationException($"PedagogyConfigService: deserialized null for resource '{name}'");
+            _cefrRules[rule.Level] = rule;
+            _log.LogDebug("PedagogyConfigService: loaded CEFR rules for level '{Level}'", rule.Level);
+        }
+
+        // Load L1 influence
+        _l1 = LoadJson<L1InfluenceFile>(assembly, "LangTeach.Api.Pedagogy.l1-influence.json");
+
+        // Load template overrides — rebuild Sections dictionaries as case-insensitive so that
+        // callers using "warmup" (SectionProfileService convention) match JSON keys "warmUp"/"wrapUp"
+        var templatesFile = LoadJson<TemplateOverridesFile>(assembly, "LangTeach.Api.Pedagogy.template-overrides.json");
+        _templates = templatesFile.Templates.ToDictionary(
+            t => t.Id,
+            t => new TemplateOverrideEntry(
+                t.Id,
+                t.Name,
+                new Dictionary<string, SectionOverride>(t.Sections, StringComparer.OrdinalIgnoreCase),
+                t.LevelVariations,
+                t.Restrictions),
+            StringComparer.OrdinalIgnoreCase);
+
+        // Load course rules
+        _courseRules = LoadJson<CourseRulesFile>(assembly, "LangTeach.Api.Pedagogy.course-rules.json");
+
+        // Load style substitutions
+        var subsFile = LoadJson<StyleSubstitutionsFile>(assembly, "LangTeach.Api.Pedagogy.style-substitutions.json");
+        _substitutions = subsFile.Substitutions;
+
+        // Validate cross-layer references — fail fast on dangling IDs
+        ValidateCrossLayerRefs();
+
+        _log.LogInformation(
+            "PedagogyConfigService: ready. Levels={LevelCount}, Templates={TemplateCount}, CatalogTypes={CatalogCount}",
+            _cefrRules.Count, _templates.Count, _catalogIds.Count);
+    }
+
+    // --- Interface implementation ---
+
+    public string[] GetValidExerciseTypes(string section, string level, string? templateId = null, string? nativeLang = null)
+    {
+        var normalLevel = NormalizeLevel(level);
+
+        // Step 1: CEFR appropriate types for the level
+        string[] cefrTypes = _cefrRules.TryGetValue(normalLevel, out var cefrRule)
+            ? cefrRule.AppropriateExerciseTypes
+            : [];
+        _log.LogDebug("PedagogyConfigService: CEFR {Level} appropriateExerciseTypes={Count}", normalLevel, cefrTypes.Length);
+
+        // Step 2: Section valid types — null means no section filter, use cefrTypes directly
+        var sectionValid = _sectionProfileService.GetRawValidExerciseTypes(section, level);
+        string[] sectionTypes = sectionValid ?? cefrTypes;
+        _log.LogDebug("PedagogyConfigService: Section '{Section}' {Level} validExerciseTypes={Count} nullFilter={IsNull}",
+            section, level, sectionTypes.Length, sectionValid is null);
+
+        // Step 3: Intersect CEFR ∩ section
+        var cefrSet = cefrTypes.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var base_ = sectionTypes.Where(t => cefrSet.Contains(t)).ToList();
+        _log.LogDebug("PedagogyConfigService: After intersection={Count}", base_.Count);
+
+        // Steps 4-5: Expand forbidden patterns and subtract
+        var rawForbidden = _sectionProfileService.GetRawForbiddenExerciseTypes(section, level);
+        var forbidden = ExpandForbiddenTypes(rawForbidden);
+        base_ = base_.Where(t => !forbidden.Contains(t)).ToList();
+        _log.LogDebug("PedagogyConfigService: After forbidden filter={Count} (forbidden={ForbiddenCount})", base_.Count, forbidden.Count);
+
+        // Step 6: Template priority re-order (does NOT add new types, only re-orders)
+        if (templateId is not null && _templates.TryGetValue(templateId, out var tmpl))
+        {
+            var normalSection = NormalizeSection(section);
+            if (tmpl.Sections.TryGetValue(normalSection, out var secOverride))
+            {
+                var prioritySet = secOverride.PriorityExerciseTypes.ToHashSet(StringComparer.OrdinalIgnoreCase);
+                var priorityFirst = base_.Where(t => prioritySet.Contains(t)).ToList();
+                var rest = base_.Where(t => !prioritySet.Contains(t)).ToList();
+                base_ = [.. priorityFirst, .. rest];
+                _log.LogDebug("PedagogyConfigService: Template '{Template}' re-ordered with {PriorityCount} priority types first",
+                    templateId, priorityFirst.Count);
+            }
+        }
+
+        // Step 7: Add L1 additional types (order-stable dedup via seen-set)
+        if (nativeLang is not null)
+        {
+            var (familyAdj, _) = ResolveLang(NormalizeLang(nativeLang));
+            if (familyAdj is not null && familyAdj.AdditionalExerciseTypes.Length > 0)
+            {
+                var seen = base_.ToHashSet(StringComparer.OrdinalIgnoreCase);
+                foreach (var id in familyAdj.AdditionalExerciseTypes)
+                {
+                    if (seen.Add(id))
+                        base_.Add(id);
+                }
+                _log.LogDebug("PedagogyConfigService: L1 '{Lang}' added {Count} types", nativeLang, familyAdj.AdditionalExerciseTypes.Length);
+            }
+        }
+
+        // Step 8: RE-FILTER forbidden — critical: L1 additions must not bypass section forbidden rules
+        base_ = base_.Where(t => !forbidden.Contains(t)).ToList();
+        _log.LogDebug("PedagogyConfigService: Final after re-filter={Count}", base_.Count);
+
+        return base_.ToArray();
+    }
+
+    public string[] GetForbiddenExerciseTypeIds(string section, string level)
+    {
+        var raw = _sectionProfileService.GetRawForbiddenExerciseTypes(section, level);
+        return [.. ExpandForbiddenTypes(raw)];
+    }
+
+    public GrammarScope GetGrammarScope(string level)
+    {
+        var normalLevel = NormalizeLevel(level);
+        if (!_cefrRules.TryGetValue(normalLevel, out var rule))
+            return new GrammarScope([], []);
+        return new GrammarScope(rule.GrammarInScope, rule.GrammarOutOfScope);
+    }
+
+    public VocabularyGuidance GetVocabularyGuidance(string level)
+    {
+        var normalLevel = NormalizeLevel(level);
+        if (!_cefrRules.TryGetValue(normalLevel, out var rule))
+            return new VocabularyGuidance(null, null, null, null, null);
+
+        // C1-C2: vocabularyApproach is a string description
+        if (rule.VocabularyApproach is not null)
+            return new VocabularyGuidance(null, null, null, null, rule.VocabularyApproach);
+
+        // A1-B2: vocabularyPerLesson has numeric productive/receptive ranges
+        if (rule.VocabularyPerLesson is not null)
+            return new VocabularyGuidance(
+                rule.VocabularyPerLesson.Productive.Min,
+                rule.VocabularyPerLesson.Productive.Max,
+                rule.VocabularyPerLesson.Receptive.Min,
+                rule.VocabularyPerLesson.Receptive.Max,
+                null);
+
+        return new VocabularyGuidance(null, null, null, null, null);
+    }
+
+    public L1Adjustments? GetL1Adjustments(string nativeLang)
+    {
+        var (familyAdj, specific) = ResolveLang(NormalizeLang(nativeLang));
+        if (familyAdj is null && specific is null)
+            return null;
+
+        var notes = string.Join(" ", new[]
+        {
+            familyAdj?.Notes,
+            specific?.AdditionalNotes
+        }.Where(s => !string.IsNullOrWhiteSpace(s)));
+
+        return new L1Adjustments(
+            AdditionalExerciseTypes: familyAdj?.AdditionalExerciseTypes ?? [],
+            IncreaseEmphasis: familyAdj?.IncreaseEmphasis ?? [],
+            DecreaseEmphasis: familyAdj?.DecreaseEmphasis ?? [],
+            Notes: notes
+        );
+    }
+
+    public TemplateOverrideEntry? GetTemplateOverride(string templateId) =>
+        _templates.TryGetValue(templateId, out var t) ? t : null;
+
+    public CourseRulesFile GetCourseRules() => _courseRules;
+
+    public StyleSubstitution[] GetStyleSubstitutions(string[] rejectedTypes)
+    {
+        var rejectedSet = rejectedTypes.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return _substitutions
+            .Where(s => s.Rejects.Any(r => rejectedSet.Contains(r)))
+            .ToArray();
+    }
+
+    // --- Private helpers ---
+
+    private static T LoadJson<T>(Assembly assembly, string resourceName)
+    {
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"PedagogyConfigService: embedded resource '{resourceName}' not found.");
+        return JsonSerializer.Deserialize<T>(stream, JsonOpts)
+            ?? throw new InvalidOperationException($"PedagogyConfigService: failed to deserialize '{resourceName}'.");
+    }
+
+    private HashSet<string> ExpandForbiddenTypes(ForbiddenExerciseType[] raw)
+    {
+        var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in raw)
+        {
+            if (entry.Id is not null)
+            {
+                result.Add(entry.Id);
+            }
+            else if (entry.Pattern is not null)
+            {
+                // Trailing-wildcard glob: "GR-*" matches all catalog IDs starting with "GR-"
+                var prefix = entry.Pattern.TrimEnd('*');
+                foreach (var id in _catalogIds.Where(id => id.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
+                    result.Add(id);
+            }
+        }
+        return result;
+    }
+
+    private (LanguageFamilyAdjustments? FamilyAdj, SpecificLanguage? Specific) ResolveLang(string lang)
+    {
+        // Check specificLanguages first; if found and has a family, return family adjustments + specific data
+        if (_l1.SpecificLanguages.TryGetValue(lang, out var specific))
+        {
+            LanguageFamilyAdjustments? familyAdj = null;
+            if (specific.Family is not null && _l1.LanguageFamilies.TryGetValue(specific.Family, out var fam))
+                familyAdj = fam.Adjustments;
+            return (familyAdj, specific);
+        }
+
+        // Scan language families to find which family lists this language
+        foreach (var (_, family) in _l1.LanguageFamilies)
+        {
+            if (family.Languages.Contains(lang, StringComparer.OrdinalIgnoreCase))
+                return (family.Adjustments, null);
+        }
+
+        return (null, null);
+    }
+
+    private void ValidateCrossLayerRefs()
+    {
+        var errors = new List<string>();
+
+        foreach (var (lvl, rule) in _cefrRules)
+        {
+            foreach (var id in rule.AppropriateExerciseTypes)
+            {
+                if (!_catalogIds.Contains(id))
+                    errors.Add($"CEFR {lvl} appropriateExerciseTypes: unknown ID '{id}'");
+            }
+            foreach (var entry in rule.InappropriateExerciseTypes)
+            {
+                if (!_catalogIds.Contains(entry.Id))
+                    errors.Add($"CEFR {lvl} inappropriateExerciseTypes: unknown ID '{entry.Id}'");
+            }
+        }
+
+        foreach (var (family, fam) in _l1.LanguageFamilies)
+        {
+            foreach (var id in fam.Adjustments.AdditionalExerciseTypes
+                .Concat(fam.Adjustments.IncreaseEmphasis)
+                .Concat(fam.Adjustments.DecreaseEmphasis)
+                .Where(id => !string.IsNullOrEmpty(id)))
+            {
+                if (!_catalogIds.Contains(id))
+                    errors.Add($"L1 family '{family}' references unknown ID '{id}'");
+            }
+        }
+
+        foreach (var (tId, tmpl) in _templates)
+        {
+            foreach (var (secName, sec) in tmpl.Sections)
+            {
+                foreach (var id in sec.PriorityExerciseTypes)
+                {
+                    if (!_catalogIds.Contains(id))
+                        errors.Add($"Template '{tId}' section '{secName}' priorityExerciseTypes: unknown ID '{id}'");
+                }
+            }
+        }
+
+        // Validate style substitutions — skip entries containing wildcards (they are exclusion patterns)
+        foreach (var sub in _substitutions)
+        {
+            foreach (var id in sub.Rejects.Concat(sub.SubstituteWith).Where(id => !id.Contains('*')))
+            {
+                if (!_catalogIds.Contains(id))
+                    errors.Add($"StyleSubstitution '{sub.Label}': unknown ID '{id}'");
+            }
+        }
+
+        if (errors.Count > 0)
+            throw new InvalidOperationException(
+                $"PedagogyConfigService startup validation failed:{Environment.NewLine}{string.Join(Environment.NewLine, errors)}");
+    }
+
+    private static string NormalizeLevel(string cefrLevel) =>
+        CefrLevelNormalizer.Normalize(cefrLevel);
+
+    private static string NormalizeSection(string section) => section.ToLowerInvariant() switch
+    {
+        "warmup" => "warmUp",
+        "wrapup" => "wrapUp",
+        _ => section,
+    };
+
+    private static string NormalizeLang(string lang) => lang.Trim().ToLowerInvariant();
+}

--- a/backend/LangTeach.Api/Services/SectionProfileService.cs
+++ b/backend/LangTeach.Api/Services/SectionProfileService.cs
@@ -18,8 +18,6 @@ public class SectionProfileService : ISectionProfileService
         NumberHandling = JsonNumberHandling.AllowReadingFromString,
     };
 
-    private static readonly string[] KnownLevels = ["A1", "A2", "B1", "B2", "C1", "C2"];
-
     public SectionProfileService(ILogger<SectionProfileService> logger)
     {
         _log = logger;
@@ -102,25 +100,32 @@ public class SectionProfileService : ISectionProfileService
         return [];
     }
 
+    public string[]? GetRawValidExerciseTypes(string sectionType, string cefrLevel)
+    {
+        var profile = GetProfile(sectionType);
+        if (profile is null) return null;
+        var level = NormalizeLevel(cefrLevel);
+        if (profile.Levels.TryGetValue(level, out var lp))
+            return lp.ValidExerciseTypes;
+        return null;
+    }
+
+    public ForbiddenExerciseType[] GetRawForbiddenExerciseTypes(string sectionType, string cefrLevel)
+    {
+        var profile = GetProfile(sectionType);
+        if (profile is null) return [];
+        var level = NormalizeLevel(cefrLevel);
+        if (profile.Levels.TryGetValue(level, out var lp))
+            return lp.ForbiddenExerciseTypes ?? [];
+        return [];
+    }
+
     private SectionProfile? GetProfile(string sectionType)
     {
         var key = sectionType.Replace(" ", "", StringComparison.Ordinal).ToLowerInvariant();
         return _profiles.TryGetValue(key, out var profile) ? profile : null;
     }
 
-    private static string NormalizeLevel(string cefrLevel)
-    {
-        // Accept "A1", "A1.1", "B2.2" etc — normalise to major band
-        if (string.IsNullOrWhiteSpace(cefrLevel)) return string.Empty;
-        var upper = cefrLevel.Trim().ToUpperInvariant();
-        // Exact match first
-        if (KnownLevels.Contains(upper, StringComparer.Ordinal)) return upper;
-        // Prefix match: "A1.1" -> "A1"
-        foreach (var known in KnownLevels)
-        {
-            if (upper.StartsWith(known, StringComparison.Ordinal))
-                return known;
-        }
-        return upper; // Return as-is; profile lookup will miss and return empty
-    }
+    private static string NormalizeLevel(string cefrLevel) =>
+        CefrLevelNormalizer.Normalize(cefrLevel);
 }

--- a/plan/langteach-beta/task324-pedagogy-config-service.md
+++ b/plan/langteach-beta/task324-pedagogy-config-service.md
@@ -1,0 +1,293 @@
+# Task 324: Build PedagogyConfigService
+
+## Issue
+#324 — Build IPedagogyConfigService / PedagogyConfigService (load, validate, compose pedagogy JSON layers)
+
+## Context
+
+SectionProfileService is the reference singleton pattern: loads section-profiles/*.json as embedded resources, validates on startup, exposed via ISectionProfileService.
+
+PedagogyConfigService follows the same pattern but loads pedagogy/* JSON files and composes them into exercise type lists for prompt generation.
+
+### Key observations from codebase exploration
+
+**Already embedded:** `data/pedagogy/exercise-types.json` (as `LangTeach.Api.Pedagogy.exercise-types.json`)
+
+**Not yet embedded:** cefr-levels/*.json, l1-influence.json, template-overrides.json, course-rules.json, style-substitutions.json
+
+**C1/C2 vocabulary:** Uses `vocabularyApproach: "string"` instead of `vocabularyPerLesson: { productive: {min,max}, receptive: {min,max} }` — the field NAME changes, not just the type. The deserialization model must handle both fields independently.
+
+**Pattern expansion:** WarmUp forbiddenExerciseTypes uses `GR-*`, `EE-*`, `CO-*` patterns (null id + pattern field). These must be expanded against the exercise catalog to get concrete IDs.
+
+**Composition algorithm (GetValidExerciseTypes):**
+1. `cefrTypes = cefr[level].appropriateExerciseTypes`
+2. `sectionTypes = section[section][level].validExerciseTypes` (may be null — fallback to cefrTypes)
+3. `base = intersect(cefrTypes, sectionTypes)`
+4. `forbidden = expand_patterns(section[section][level].forbiddenExerciseTypes)` → concrete ID list
+5. `base = base - forbidden`
+6. If templateId: re-order base putting `template[templateId][section].priorityExerciseTypes` first (don't add new types)
+7. If nativeLang: `l1Extra = resolve(nativeLang).additionalExerciseTypes`; `base = base + l1Extra`
+8. **RE-FILTER:** `base = base - forbidden` (L1 additions must not bypass section forbidden rules)
+9. Return base (deduplicated, order preserved)
+
+**L1 lookup strategy:**
+1. Try `specificLanguages[lang]` → get `family` (if non-null) → return family adjustments + language-specific notes
+2. If not in specificLanguages: scan `languageFamilies` to find which family has `lang` in its `languages[]` → return that family's adjustments
+3. Return null if not found anywhere
+
+**Critical test case from issue:** CO-06 added by Mandarin (sinitic-japonic family `additionalExerciseTypes: ["CO-06"]`) must be removed in re-filter step when section=WarmUp because WarmUp forbids `CO-*`.
+
+## Files to Create
+
+### 1. `backend/LangTeach.Api/AI/PedagogyConfig.cs`
+C# records for all pedagogy JSON data models.
+
+```csharp
+// Exercise catalog (exercise-types.json)
+record ExerciseCatalog(ExerciseTypeEntry[] ExerciseTypes);
+record ExerciseTypeEntry(string Id, string Name, string Category, ...);
+
+// CEFR level rules (cefr-levels/*.json)
+// NOTE: A1-B2 use vocabularyPerLesson (numeric), C1-C2 use vocabularyApproach (string)
+// Both fields declared nullable; deserialization picks up whichever is present
+record CefrLevelRules(
+    string Level,
+    string[] GrammarInScope,
+    string[] GrammarOutOfScope,
+    string[] AppropriateExerciseTypes,
+    InappropriateExerciseEntry[] InappropriateExerciseTypes,
+    VocabularyPerLesson? VocabularyPerLesson,    // A1-B2 only
+    string? VocabularyApproach,                  // C1-C2 only
+    string InstructionLanguage,
+    string MetalanguageLevel,
+    string ErrorCorrection,
+    string ScaffoldingDefault
+);
+record InappropriateExerciseEntry(string Id, string Reason);
+record VocabularyPerLesson(VocabularyRange Productive, VocabularyRange Receptive);
+record VocabularyRange(int Min, int Max);
+
+// Output DTOs (returned by service methods)
+record GrammarScope(string[] InScope, string[] OutOfScope);
+record VocabularyGuidance(
+    int? ProductiveMin, int? ProductiveMax,
+    int? ReceptiveMin, int? ReceptiveMax,
+    string? Approach  // set for C1/C2
+);
+record L1Adjustments(
+    string[] AdditionalExerciseTypes,
+    string[] IncreaseEmphasis,
+    string[] DecreaseEmphasis,
+    string Notes
+);
+
+// L1 influence (l1-influence.json)
+record L1InfluenceFile(
+    Dictionary<string, LanguageFamily> LanguageFamilies,
+    Dictionary<string, SpecificLanguage> SpecificLanguages
+);
+record LanguageFamily(string[] Languages, string[] Strengths, string[] Weaknesses, LanguageFamilyAdjustments Adjustments);
+record LanguageFamilyAdjustments(
+    string[] IncreaseEmphasis, string[] DecreaseEmphasis,
+    string[] AdditionalExerciseTypes, string[] TemplatePreference, string Notes
+);
+record SpecificLanguage(string? Family, string[] FalseFriends, string[] PositiveTransfer, string AdditionalNotes);
+
+// Template overrides (template-overrides.json)
+record TemplateOverridesFile(List<TemplateOverrideEntry> Templates);
+record TemplateOverrideEntry(string Id, string Name, Dictionary<string, SectionOverride> Sections, Dictionary<string, string> LevelVariations, string[] Restrictions);
+record SectionOverride(bool Required, string? OverrideGuidance, string[] PriorityExerciseTypes, int? MinExerciseVarietyOverride, string? Notes);
+
+// Course rules (course-rules.json) — keep as JsonDocument or simple record
+record CourseRulesFile(
+    VarietyRules VarietyRules,
+    Dictionary<string, Dictionary<string, SkillDistributionEntry>> SkillDistribution,
+    GrammarProgression GrammarProgression
+);
+// ... sub-records as needed for VarietyRules, SkillDistributionEntry, GrammarProgression
+
+// Style substitutions (style-substitutions.json)
+record StyleSubstitutionsFile(StyleSubstitution[] Substitutions);
+record StyleSubstitution(string[] Rejects, string Label, string[] SubstituteWith, string[] NeverSubstituteWith, string Rule);
+```
+
+### 2. `backend/LangTeach.Api/Services/IPedagogyConfigService.cs`
+
+```csharp
+public interface IPedagogyConfigService
+{
+    /// Full composition: CEFR ∩ section, minus forbidden, ordered by template priority, plus L1, re-filtered
+    string[] GetValidExerciseTypes(string section, string level, string? templateId = null, string? nativeLang = null);
+
+    /// Returns expanded forbidden exercise type IDs for a section+level (patterns expanded against catalog)
+    string[] GetForbiddenExerciseTypeIds(string section, string level);
+
+    /// Returns in-scope and out-of-scope grammar lists for the CEFR level
+    GrammarScope GetGrammarScope(string level);
+
+    /// Returns vocabulary guidance — numeric for A1-B2, approach string for C1-C2
+    VocabularyGuidance GetVocabularyGuidance(string level);
+
+    /// Returns L1 adjustments for the native language (null if language not found)
+    L1Adjustments? GetL1Adjustments(string nativeLang);
+
+    /// Returns template override entry (null if templateId not found)
+    TemplateOverrideEntry? GetTemplateOverride(string templateId);
+
+    /// Returns the full course rules configuration
+    CourseRulesFile GetCourseRules();
+
+    /// Returns substitution entries whose Rejects list contains any of the given type IDs
+    StyleSubstitution[] GetStyleSubstitutions(string[] rejectedTypes);
+}
+```
+
+### 3. `backend/LangTeach.Api/Services/PedagogyConfigService.cs`
+
+Singleton. Constructor injects `ILogger<PedagogyConfigService>` and `ISectionProfileService`.
+
+**Constructor loading order:**
+1. Load exercise-types.json → build `_catalogIds` HashSet<string>
+2. Load cefr-levels/*.json → `_cefrRules` Dictionary<string, CefrLevelRules> (key=uppercase level)
+3. Load l1-influence.json → `_l1`
+4. Load template-overrides.json → `_templates` Dictionary<string, TemplateOverrideEntry>
+5. Load course-rules.json → `_courseRules`
+6. Load style-substitutions.json → `_substitutions`
+7. **Validate cross-layer refs** — see below
+8. Log startup summary at Information level
+
+**Startup validation** (throws InvalidOperationException on failure):
+- All IDs in cefr[level].appropriateExerciseTypes exist in catalog
+- All IDs in l1.languageFamilies[*].adjustments.additionalExerciseTypes/increaseEmphasis/decreaseEmphasis exist in catalog
+- All IDs in templates[*].sections[*].priorityExerciseTypes exist in catalog
+- All non-wildcard IDs in style-substitutions rejects/substituteWith exist in catalog
+- Section profile validation: ISectionProfileService is not asked to validate (done by SectionProfileService itself)
+
+**Private helpers:**
+- `LoadJson<T>(string resourceName)` — open embedded stream, deserialize, throw on null
+- `ExpandForbiddenPattern(string pattern)` — e.g. "GR-*" → all catalog IDs starting with "GR-"
+- `ExpandForbiddenTypes(ForbiddenExerciseType[] raw)` → string[] of concrete IDs
+- `NormalizeLevel(string level)` — same logic as SectionProfileService (prefix match to A1-C2)
+- `NormalizeLang(string lang)` — lowercase, trim
+- `ResolveLang(string lang)` → (LanguageFamilyAdjustments? familyAdj, SpecificLanguage? specific)
+
+**Resource name constants:**
+- Catalog: `"LangTeach.Api.Pedagogy.exercise-types.json"`
+- CEFR prefix: `"LangTeach.Api.Pedagogy.CefrLevels."` (scan all matching)
+- L1: `"LangTeach.Api.Pedagogy.l1-influence.json"`
+- Templates: `"LangTeach.Api.Pedagogy.template-overrides.json"`
+- CourseRules: `"LangTeach.Api.Pedagogy.course-rules.json"`
+- Substitutions: `"LangTeach.Api.Pedagogy.style-substitutions.json"`
+
+### 4. `backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs`
+
+10+ tests using `NullLogger` and a real `SectionProfileService` (same as SectionProfileServiceTests pattern):
+
+```csharp
+private readonly SectionProfileService _sps = new(NullLogger<SectionProfileService>.Instance);
+private readonly PedagogyConfigService _sut;
+
+public PedagogyConfigServiceTests()
+{
+    _sut = new PedagogyConfigService(NullLogger<PedagogyConfigService>.Instance, _sps);
+}
+```
+
+**Tests:**
+1. `ServiceLoads_WithoutThrowing` — constructor completes (smoke test)
+2. `GetValidExerciseTypes_Baseline_WarmUp_A1_ReturnsSectionIntersection` — result is subset of A1 appropriateExerciseTypes AND warmup A1 validExerciseTypes
+3. `GetValidExerciseTypes_GrammarFocus_Practice_A1_DoesNotReturnForbiddenTypes` — no GR-* types that are in forbidden; wait warmup forbidden is GR-*, but for practice it's different. Actually for practice, warmup forbidden is irrelevant. Let me use: WarmUp A1 should not contain any GR-xx types (GR-* pattern forbidden)
+4. `GetValidExerciseTypes_L1Mandarin_WarmUp_CO06_IsBlocked` — Mandarin adds CO-06 via L1, but WarmUp forbids CO-*, so CO-06 must NOT be in result
+5. `GetValidExerciseTypes_GrammarFocusTemplate_Practice_HasPriorityFirst` — GR-01 (priority type) appears before non-priority types in result
+6. `GetForbiddenExerciseTypeIds_WarmUp_A1_ExpandsAllGRPattern` — result contains all GR-xx IDs (e.g. GR-01 through GR-10)
+7. `GetGrammarScope_A1_ReturnsInScopeAndOutOfScope` — InScope and OutOfScope both non-empty
+8. `GetVocabularyGuidance_A1_ReturnsNumericFields` — ProductiveMin/Max non-null, Approach null
+9. `GetVocabularyGuidance_C1_ReturnsApproachString` — Approach non-null, ProductiveMin null
+10. `GetL1Adjustments_Mandarin_ReturnsCO06InAdditionalTypes` — additionalExerciseTypes contains "CO-06"
+11. `GetL1Adjustments_UnknownLanguage_ReturnsNull` — returns null for unknown language
+12. `GetStyleSubstitutions_RolePlay_ReturnsSubstitutesForEO01` — Rejects contains EO-01, returns substitution with EO-04/EO-08
+13. `GetTemplateOverride_GrammarFocus_ReturnsPracticeMinVarietyOf3` — sections["practice"].MinExerciseVarietyOverride == 3
+14. `CrossLayerValidation_AllReferencedIdsExistInCatalog` — iterates all referenced IDs in cefr rules and verifies they're in catalog (documents the integrity check)
+
+## Files to Modify
+
+### `backend/LangTeach.Api/LangTeach.Api.csproj`
+
+Add EmbeddedResource entries after the existing pedagogy entry:
+
+```xml
+<EmbeddedResource Include="..\..\data\pedagogy\cefr-levels\*.json"
+                  Link="Pedagogy\CefrLevels\%(Filename)%(Extension)" />
+<EmbeddedResource Include="..\..\data\pedagogy\l1-influence.json"
+                  Link="Pedagogy\l1-influence.json" />
+<EmbeddedResource Include="..\..\data\pedagogy\template-overrides.json"
+                  Link="Pedagogy\template-overrides.json" />
+<EmbeddedResource Include="..\..\data\pedagogy\course-rules.json"
+                  Link="Pedagogy\course-rules.json" />
+<EmbeddedResource Include="..\..\data\pedagogy\style-substitutions.json"
+                  Link="Pedagogy\style-substitutions.json" />
+```
+
+### `backend/LangTeach.Api/Services/ISectionProfileService.cs`
+
+Add method to expose raw forbidden exercise types (needed by PedagogyConfigService for composition and pattern expansion):
+
+```csharp
+/// Returns the raw ForbiddenExerciseType entries for a section at the given CEFR level.
+/// Used by PedagogyConfigService to expand patterns and compute forbidden IDs.
+ForbiddenExerciseType[] GetRawForbiddenExerciseTypes(string sectionType, string cefrLevel);
+```
+
+### `backend/LangTeach.Api/Services/SectionProfileService.cs`
+
+Implement `GetRawForbiddenExerciseTypes`:
+
+```csharp
+public ForbiddenExerciseType[] GetRawForbiddenExerciseTypes(string sectionType, string cefrLevel)
+{
+    var profile = GetProfile(sectionType);
+    if (profile is null) return [];
+    var level = NormalizeLevel(cefrLevel);
+    if (profile.Levels.TryGetValue(level, out var lp))
+        return lp.ForbiddenExerciseTypes ?? [];
+    return [];
+}
+```
+
+### `backend/LangTeach.Api/Program.cs`
+
+After `ISectionProfileService` registration line 123:
+
+```csharp
+builder.Services.AddSingleton<IPedagogyConfigService, PedagogyConfigService>();
+```
+
+In eager-resolve section (after line 161):
+
+```csharp
+_ = app.Services.GetRequiredService<IPedagogyConfigService>();
+```
+
+## Implementation Notes
+
+- JSON deserialization options: same `JsonSerializerOptions` as SectionProfileService (camelCase, case-insensitive, AllowReadingFromString)
+- `GetValidExerciseTypes` deduplicated result: use `Distinct(StringComparer.OrdinalIgnoreCase)` before returning
+- Pattern expansion: GR-* means prefix="GR-"; scan catalogIds where `id.StartsWith("GR-", OrdinalIgnoreCase)`
+- NeverSubstituteWith in style-substitutions uses wildcard ("EE-*") — don't validate these against catalog (they're exclusion patterns, not references)
+- CourseRulesFile deserialization: the JSON has nested objects (varietyRules, skillDistribution, grammarProgression); use concrete records for the fields used in tests, skip or use JsonElement for the rest
+- `GetStyleSubstitutions(string[] rejectedTypes)`: filter substitutions where any element of `substitution.Rejects` is in `rejectedTypes` (case-insensitive)
+- Debug logging: log each composition step in GetValidExerciseTypes (cefrTypes count, sectionTypes count, after intersection, after forbidden filter, after L1 merge, final count)
+
+## Test Strategy
+
+Tests instantiate real services against real embedded JSON (same approach as SectionProfileServiceTests). No mocking needed — the service is deterministic, fast, and in-process. Integration with real data is the right level here.
+
+The "dangling reference fails startup" AC is satisfied by:
+1. The constructor throwing `InvalidOperationException` when a bad ID is detected (production behavior)
+2. Test 14 (`CrossLayerValidation_AllReferencedIdsExistInCatalog`) — asserts that the real data passes its own validation rules
+
+## Out of Scope
+
+- Wiring `IPedagogyConfigService` into `IPromptService` / `PromptService` — this is the next task after #324
+- e2e tests — no user-visible behavior changes in this task, backend service only
+- No new HTTP endpoints — pure service layer


### PR DESCRIPTION
## Summary

- Introduces `IPedagogyConfigService` / `PedagogyConfigService` singleton that loads all pedagogy JSON layers at startup and exposes typed composition methods for prompt generation
- Implements 8-step composition algorithm: CEFR ∩ section valid types, minus forbidden (with GR-*/EE-*/CO-* pattern expansion), re-ordered by template priority, plus L1 additional types, RE-FILTER forbidden (L1 additions cannot bypass section forbidden rules)
- Startup validation: all cross-layer exercise type ID references checked against catalog; fails fast with `InvalidOperationException` on dangling refs
- Extends `ISectionProfileService` with `GetRawValidExerciseTypes` and `GetRawForbiddenExerciseTypes` for use in composition
- Extracts `NormalizeLevel` to shared `CefrLevelNormalizer` (removes duplication between `SectionProfileService` and `PedagogyConfigService`)

## Test plan

- [ ] All 6 pre-push checks pass (bicep, dotnet build, dotnet test 372 passed, npm lint, npm build, npm test 554 passed)
- [ ] 21 unit tests covering all 5 required scenarios: CO-06 + Mandarin WarmUp blocked, Grammar Focus Practice variety=3, C1/C2 vocabulary approach string, GR-* expansion to 10 types, startup validation smoke test
- [ ] No e2e tests needed — pure service layer, no HTTP endpoints added

## Notes

- This service is not yet wired into `PromptService` — that is a follow-on task
- `PedagogyConfig.cs` holds JSON deserialization models; `PedagogyConfigDtos.cs` holds output DTOs (separate per project convention)

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)