### PR TITLE
fix(#346): widen Docker build context to repo root for data/ embedded resources

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Used when building the API image with context = repo root.
+# Excludes directories not needed by the backend build.
+.git
+**/bin
+**/obj
+**/node_modules
+frontend/
+e2e/
+.claude/
+plan/
+docs/
+feedback/
+template-specific/

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -3,9 +3,9 @@ name: Backend CI/CD
 on:
   push:
     branches: [main, 'sprint/*']
-    paths: ['backend/**', '.github/workflows/backend.yml']
+    paths: ['backend/**', 'data/**', '.github/workflows/backend.yml']
   pull_request:
-    paths: ['backend/**', '.github/workflows/backend.yml']
+    paths: ['backend/**', 'data/**', '.github/workflows/backend.yml']
 
 permissions:
   contents: read
@@ -133,7 +133,7 @@ jobs:
             --image ${{ env.IMAGE_NAME }}:${{ github.sha }} \
             --image ${{ env.IMAGE_NAME }}:latest \
             -f backend/LangTeach.Api/Dockerfile \
-            backend
+            .
 
       - name: Configure ACR registry on Container App
         run: |

--- a/backend/LangTeach.Api/Dockerfile
+++ b/backend/LangTeach.Api/Dockerfile
@@ -1,9 +1,10 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
-COPY LangTeach.Api/*.csproj LangTeach.Api/
-RUN dotnet restore LangTeach.Api/LangTeach.Api.csproj
-COPY LangTeach.Api/ LangTeach.Api/
-RUN dotnet publish LangTeach.Api/LangTeach.Api.csproj -c Release -o /app
+COPY backend/LangTeach.Api/*.csproj backend/LangTeach.Api/
+RUN dotnet restore backend/LangTeach.Api/LangTeach.Api.csproj
+COPY backend/LangTeach.Api/ backend/LangTeach.Api/
+COPY data/ data/
+RUN dotnet publish backend/LangTeach.Api/LangTeach.Api.csproj -c Release -o /app
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0
 RUN apt-get update && apt-get install -y --no-install-recommends curl libfontconfig1 libfreetype6 && rm -rf /var/lib/apt/lists/*

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -45,8 +45,8 @@ services:
 
   api:
     build:
-      context: ./backend
-      dockerfile: LangTeach.Api/Dockerfile
+      context: .
+      dockerfile: backend/LangTeach.Api/Dockerfile
     environment:
       ASPNETCORE_ENVIRONMENT: E2ETesting
       ConnectionStrings__Default: "Server=sqlserver,1433;Database=LangTeach;User Id=sa;Password=${SA_PASSWORD};TrustServerCertificate=true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,8 @@ services:
 
   api:
     build:
-      context: ./backend
-      dockerfile: LangTeach.Api/Dockerfile
+      context: .
+      dockerfile: backend/LangTeach.Api/Dockerfile
     container_name: langteach-api
     ports:
       - "5000:5000"

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -6,6 +6,12 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 
 *Cleared 2026-03-27 during Student-Aware Curriculum sprint close. 14 entries deleted, 9 batched into issues #301, #302, #304.*
 
+## PR #346 (2026-03-28) — #346 fix Docker e2e build context
+
+| Severity | File | Note |
+|---|---|---|
+| Minor | `.dockerignore` | `scripts/` and `.github/` dirs not excluded — tiny size (~8KB), no functional impact. Could be added for completeness. |
+
 ## PR #334 (2026-03-28) — #326 frontend section content types
 
 | Severity | File | Note |

--- a/plan/langteach-beta/task346-fix-docker-e2e-build-context.md
+++ b/plan/langteach-beta/task346-fix-docker-e2e-build-context.md
@@ -1,0 +1,119 @@
+# Task 346: Fix Docker e2e Build Context to Include data/ Directory
+
+**Issue:** #346
+**Branch:** worktree-task-t346-fix-docker-e2e-build-context
+**Sprint:** sprint/student-aware-curriculum
+
+## Problem
+
+The pedagogy config sprint embedded JSON files from `data/` as EmbeddedResources in
+`backend/LangTeach.Api/LangTeach.Api.csproj` using relative paths `..\..\data\...`. When
+`dotnet build` runs locally, the working directory is `backend/LangTeach.Api/`, so the path
+resolves correctly. But both `docker-compose.e2e.yml` and `docker-compose.yml` set the API
+build context to `./backend`, meaning `data/` (at repo root) is invisible to the Docker build.
+Result: `dotnet publish` cannot find the embedded resource files and the API image fails to build.
+
+Volume mounts won't fix this because embedded resources are compiled into the DLL at build time
+(not loaded from disk at runtime). The only correct fix is to widen the build context.
+
+## Approach: Widen API Build Context to Repo Root
+
+Change the API service `context:` from `./backend` to `.` in both compose files. Update the
+Dockerfile COPY paths to be relative to the new repo-root context. Create a root `.dockerignore`
+to avoid sending large irrelevant directories (frontend, e2e, node_modules) to the Docker daemon.
+
+The EmbeddedResource paths in the csproj (`..\..\data\...`) resolve correctly with the new
+context: the project file is at `/src/backend/LangTeach.Api/`, so `../../data/` = `/src/data/`,
+which is exactly where we COPY `data/` to.
+
+## Files to Change
+
+### 1. `backend/LangTeach.Api/Dockerfile`
+
+Current (context = `./backend`):
+```dockerfile
+WORKDIR /src
+COPY LangTeach.Api/*.csproj LangTeach.Api/
+RUN dotnet restore LangTeach.Api/LangTeach.Api.csproj
+COPY LangTeach.Api/ LangTeach.Api/
+RUN dotnet publish LangTeach.Api/LangTeach.Api.csproj -c Release -o /app
+```
+
+New (context = `.` repo root):
+```dockerfile
+WORKDIR /src
+COPY backend/LangTeach.Api/*.csproj backend/LangTeach.Api/
+RUN dotnet restore backend/LangTeach.Api/LangTeach.Api.csproj
+COPY backend/LangTeach.Api/ backend/LangTeach.Api/
+COPY data/ data/
+RUN dotnet publish backend/LangTeach.Api/LangTeach.Api.csproj -c Release -o /app
+```
+
+### 2. `docker-compose.e2e.yml`
+
+Change API service build:
+```yaml
+    build:
+      context: .
+      dockerfile: backend/LangTeach.Api/Dockerfile
+```
+
+### 3. `docker-compose.yml`
+
+Change API service build:
+```yaml
+    build:
+      context: .
+      dockerfile: backend/LangTeach.Api/Dockerfile
+```
+
+### 4. `.dockerignore` (new file at repo root)
+
+Docker uses the `.dockerignore` from the build context root. Currently `backend/.dockerignore`
+covers `./backend` context builds; it won't be used once context is `.`. Create a root
+`.dockerignore` that excludes large irrelevant directories:
+
+```
+.git
+**/bin
+**/obj
+**/node_modules
+frontend/
+e2e/
+.claude/
+plan/
+docs/
+data/curricula/
+```
+
+Note: `data/curricula/` is excluded (not needed by the API build; curricula are loaded via
+separate EmbeddedResource entries already in the .csproj). Wait - actually the csproj DOES
+include `data/curricula/instituto_educativo/*.json` as EmbeddedResources, so we must NOT
+exclude `data/curricula/`. Remove that entry.
+
+Corrected `.dockerignore`:
+```
+.git
+**/bin
+**/obj
+**/node_modules
+frontend/
+e2e/
+.claude/
+plan/
+docs/
+```
+
+## Acceptance Criteria Check
+
+- `docker compose -f docker-compose.e2e.yml --env-file .env.e2e up --build` succeeds (build
+  can reach `data/` for embedded resources)
+- Backend container loads all pedagogy JSON files (they're embedded in the DLL, so this is
+  implicit in a successful build)
+- Dev stack (`docker-compose.yml`) also builds successfully with the same context change
+- Pre-push checks pass (dotnet build, dotnet test run natively and are not affected)
+
+## No Test Changes Needed
+
+This is a pure infrastructure change. All backend tests run natively (not in Docker) so
+pre-push checks pass already. The acceptance criteria are verified by a successful Docker build.


### PR DESCRIPTION
## Summary

- The API Dockerfile used `context: ./backend`, making `data/` invisible to Docker builds
- JSON files in `data/` are `EmbeddedResource` entries compiled into the DLL at build time — volume mounts cannot fix this
- Widens build context to `.` (repo root) across both compose files, the Dockerfile, and `az acr build` in CI

## Changes

- `backend/LangTeach.Api/Dockerfile`: COPY paths updated to `backend/LangTeach.Api/` and `data/` from repo root
- `docker-compose.e2e.yml` + `docker-compose.yml`: `context: .` + `dockerfile: backend/LangTeach.Api/Dockerfile`
- `.dockerignore` (new): excludes `frontend/`, `e2e/`, `.claude/`, `plan/`, `docs/`, `feedback/` to keep build context lean
- `.github/workflows/backend.yml`: `az acr build` context changed to `.`; `data/**` added to path triggers so data-only changes rebuild and redeploy the image

## Test plan

- [ ] `docker compose -f docker-compose.e2e.yml --env-file .env.e2e up --build` succeeds (blocked previously)
- [ ] Backend container loads all pedagogy JSON files (embedded in DLL during build)
- [ ] Teacher QA runs successfully against sprint branch (unblocked by this fix)
- [ ] Dev stack (`docker-compose.yml`) builds successfully
- [ ] All 399 backend unit tests pass (pre-push verified)
- [ ] All 560 frontend unit tests pass (pre-push verified)

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized Docker build configuration across development and production environments by adjusting build contexts and paths
  * Added `.dockerignore` file to reduce Docker image build artifacts
  * Updated CI/CD pipeline to monitor data directory changes alongside backend code
  * Modified Dockerfile to include data directory in build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->