### PR TITLE
fix(#346): apply build context fix to docker-compose.qa.yml

### DIFF
--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -42,8 +42,8 @@ services:
 
   api:
     build:
-      context: ./backend
-      dockerfile: LangTeach.Api/Dockerfile
+      context: .
+      dockerfile: backend/LangTeach.Api/Dockerfile
     environment:
       # Development environment uses real Auth0 JWT validation (not E2ETesting bypass)
       ASPNETCORE_ENVIRONMENT: Development


### PR DESCRIPTION
## Summary

- `docker-compose.qa.yml` had the same broken build context (`./backend`) that #346 fixed for the e2e and dev compose files
- Changes `context: ./backend` to `context: .` and `dockerfile` path accordingly
- Without this fix, the QA stack cannot build because the Dockerfile now expects `data/` at the repo root

This was discovered when running Teacher QA for sprint close: the QA stack returned 400 on lesson creation because it was running stale containers from before the Dockerfile change.

Closes #346 (follow-up)

## Test plan

- [x] QA stack rebuilt and all 5 Teacher QA personas ran successfully with this fix applied locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to adjust the build context path structure for QA environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->