### PR TITLE
fix(#352): increase MaxTokens for content blocks prone to truncation

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/ClaudeApiClientUnitTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/ClaudeApiClientUnitTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using FluentAssertions;
 using LangTeach.Api.AI;
 using LangTeach.Api.Tests.Helpers;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace LangTeach.Api.Tests.AI;
@@ -115,9 +116,76 @@ public class ClaudeApiClientUnitTests
         chunks.Should().Equal("Hello", " world");
     }
 
+    [Fact]
+    public async Task StreamAsync_MessageDeltaWithMaxTokensStopReason_LogsWarning()
+    {
+        var sseBody = string.Join("\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-haiku-4-5-20251001\",\"usage\":{\"input_tokens\":50}}}",
+            "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"partial\"}}",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"max_tokens\"},\"usage\":{\"output_tokens\":100}}",
+            "data: {\"type\":\"message_stop\"}",
+            "");
+
+        var capturingLogger = new CapturingLogger<ClaudeApiClient>();
+        var handler    = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(sseBody, Encoding.UTF8, "text/event-stream"),
+        });
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.anthropic.com") };
+        var factory    = new FakeHttpClientFactory(httpClient);
+        var client     = new ClaudeApiClient(factory, capturingLogger);
+
+        var chunks = new List<string>();
+        await foreach (var chunk in client.StreamAsync(new ClaudeRequest("sys", "hi", ClaudeModel.Haiku, MaxTokens: 100)))
+            chunks.Add(chunk);
+
+        chunks.Should().Equal("partial");
+        capturingLogger.Entries.Should().ContainSingle(e =>
+            e.Level == LogLevel.Warning && e.Message.Contains("max_tokens"));
+    }
+
+    [Fact]
+    public async Task StreamAsync_MessageDeltaWithEndTurnStopReason_DoesNotLogWarning()
+    {
+        var sseBody = string.Join("\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-haiku-4-5-20251001\",\"usage\":{\"input_tokens\":50}}}",
+            "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"complete\"}}",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":10}}",
+            "data: {\"type\":\"message_stop\"}",
+            "");
+
+        var capturingLogger = new CapturingLogger<ClaudeApiClient>();
+        var handler    = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(sseBody, Encoding.UTF8, "text/event-stream"),
+        });
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://api.anthropic.com") };
+        var factory    = new FakeHttpClientFactory(httpClient);
+        var client     = new ClaudeApiClient(factory, capturingLogger);
+
+        var chunks = new List<string>();
+        await foreach (var chunk in client.StreamAsync(new ClaudeRequest("sys", "hi", ClaudeModel.Haiku)))
+            chunks.Add(chunk);
+
+        chunks.Should().Equal("complete");
+        capturingLogger.Entries.Should().NotContain(e => e.Level == LogLevel.Warning);
+    }
+
     // Minimal IHttpClientFactory implementation that returns a pre-built client.
     private sealed class FakeHttpClientFactory(HttpClient client) : IHttpClientFactory
     {
         public HttpClient CreateClient(string name) => client;
+    }
+
+    // Simple logger that captures log entries for assertion.
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception)));
     }
 }

--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -217,20 +217,20 @@ public class PromptServiceTests
         => _sut.BuildVocabularyPrompt(BaseCtx()).MaxTokens.Should().Be(2048);
 
     [Fact]
-    public void GrammarPrompt_HasMaxTokens1500()
-        => _sut.BuildGrammarPrompt(BaseCtx()).MaxTokens.Should().Be(1500);
+    public void GrammarPrompt_HasMaxTokens3000()
+        => _sut.BuildGrammarPrompt(BaseCtx()).MaxTokens.Should().Be(3000);
 
     [Fact]
-    public void ExercisesPrompt_HasMaxTokens2048()
-        => _sut.BuildExercisesPrompt(BaseCtx()).MaxTokens.Should().Be(2048);
+    public void ExercisesPrompt_HasMaxTokens4096()
+        => _sut.BuildExercisesPrompt(BaseCtx()).MaxTokens.Should().Be(4096);
 
     [Fact]
-    public void ConversationPrompt_HasMaxTokens1500()
-        => _sut.BuildConversationPrompt(BaseCtx()).MaxTokens.Should().Be(1500);
+    public void ConversationPrompt_HasMaxTokens3000()
+        => _sut.BuildConversationPrompt(BaseCtx()).MaxTokens.Should().Be(3000);
 
     [Fact]
-    public void ReadingPrompt_HasMaxTokens2048()
-        => _sut.BuildReadingPrompt(BaseCtx()).MaxTokens.Should().Be(2048);
+    public void ReadingPrompt_HasMaxTokens4096()
+        => _sut.BuildReadingPrompt(BaseCtx()).MaxTokens.Should().Be(4096);
 
     [Fact]
     public void HomeworkPrompt_HasMaxTokens1024()

--- a/backend/LangTeach.Api/AI/ClaudeApiClient.cs
+++ b/backend/LangTeach.Api/AI/ClaudeApiClient.cs
@@ -73,12 +73,18 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
         var content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
 
         using var httpRequest = new HttpRequestMessage(HttpMethod.Post, "/v1/messages") { Content = content };
+
+        var sw = Stopwatch.StartNew();
         using var response    = await client.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, ct);
 
         await EnsureSuccessAsync(response, ct);
 
         using var stream = await response.Content.ReadAsStreamAsync(ct);
         using var reader = new StreamReader(stream);
+
+        var usedModel    = modelId;
+        var inputTokens  = 0;
+        var outputTokens = 0;
 
         while (!reader.EndOfStream && !ct.IsCancellationRequested)
         {
@@ -98,11 +104,47 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
                 if (!eventRoot.TryGetProperty("type", out var typeProp)) continue;
                 var type = typeProp.GetString();
 
+                if (type == "message_start")
+                {
+                    if (eventRoot.TryGetProperty("message", out var msg))
+                    {
+                        if (msg.TryGetProperty("model", out var m))
+                            usedModel = m.GetString() ?? modelId;
+                        if (msg.TryGetProperty("usage", out var startUsage) &&
+                            startUsage.TryGetProperty("input_tokens", out var it))
+                            inputTokens = it.GetInt32();
+                    }
+                    continue;
+                }
+
+                if (type == "message_delta")
+                {
+                    if (eventRoot.TryGetProperty("usage", out var deltaUsage) &&
+                        deltaUsage.TryGetProperty("output_tokens", out var ot))
+                        outputTokens = ot.GetInt32();
+
+                    var stopReason = string.Empty;
+                    if (eventRoot.TryGetProperty("delta", out var deltaObj) &&
+                        deltaObj.TryGetProperty("stop_reason", out var sr))
+                        stopReason = sr.GetString() ?? string.Empty;
+
+                    if (stopReason == "max_tokens")
+                        logger.LogWarning(
+                            "Claude stream truncated: max_tokens ({MaxTokens}) reached. model={Model} input={Input} output={Output}",
+                            request.MaxTokens, usedModel, inputTokens, outputTokens);
+
+                    sw.Stop();
+                    logger.LogInformation(
+                        "Claude stream: model={Model} input={Input} output={Output} latency={Latency}ms stopReason={StopReason}",
+                        usedModel, inputTokens, outputTokens, sw.ElapsedMilliseconds, stopReason);
+                    continue;
+                }
+
                 if (type == "message_stop") break;
                 if (type != "content_block_delta") continue;
 
-                if (eventRoot.TryGetProperty("delta", out var delta) &&
-                    delta.TryGetProperty("text", out var textProp))
+                if (eventRoot.TryGetProperty("delta", out var textDelta) &&
+                    textDelta.TryGetProperty("text", out var textProp))
                 {
                     chunk = textProp.GetString();
                 }
@@ -114,6 +156,7 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
 
             if (chunk is not null) yield return chunk;
         }
+
     }
 
     private static object BuildRequestBody(ClaudeRequest request, string modelId, bool stream)

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -22,16 +22,16 @@ public class PromptService : IPromptService
         new(BuildSystemPrompt(ctx), VocabularyUserPrompt(ctx), ClaudeModel.Haiku, MaxTokens: 2048);
 
     public ClaudeRequest BuildGrammarPrompt(GenerationContext ctx) =>
-        new(BuildSystemPrompt(ctx), GrammarUserPrompt(ctx), ClaudeModel.Sonnet, MaxTokens: 1500);
+        new(BuildSystemPrompt(ctx), GrammarUserPrompt(ctx), ClaudeModel.Sonnet, MaxTokens: 3000);
 
     public ClaudeRequest BuildExercisesPrompt(GenerationContext ctx) =>
-        new(BuildSystemPrompt(ctx), ExercisesUserPrompt(ctx), ClaudeModel.Haiku, MaxTokens: 2048);
+        new(BuildSystemPrompt(ctx), ExercisesUserPrompt(ctx), ClaudeModel.Haiku, MaxTokens: 4096);
 
     public ClaudeRequest BuildConversationPrompt(GenerationContext ctx) =>
-        new(BuildSystemPrompt(ctx), ConversationUserPrompt(ctx), ClaudeModel.Haiku, MaxTokens: 1500);
+        new(BuildSystemPrompt(ctx), ConversationUserPrompt(ctx), ClaudeModel.Haiku, MaxTokens: 3000);
 
     public ClaudeRequest BuildReadingPrompt(GenerationContext ctx) =>
-        new(BuildSystemPrompt(ctx), ReadingUserPrompt(ctx), ClaudeModel.Sonnet, MaxTokens: 2048);
+        new(BuildSystemPrompt(ctx), ReadingUserPrompt(ctx), ClaudeModel.Sonnet, MaxTokens: 4096);
 
     public ClaudeRequest BuildHomeworkPrompt(GenerationContext ctx) =>
         new(BuildSystemPrompt(ctx), HomeworkUserPrompt(ctx), ClaudeModel.Sonnet, MaxTokens: 1024);

--- a/plan/langteach-beta/task352-fix-content-truncation.md
+++ b/plan/langteach-beta/task352-fix-content-truncation.md
@@ -1,0 +1,52 @@
+# Task 352: Fix Content Truncation in AI-Generated Exercises
+
+## Root Cause (Confirmed by Teacher QA Data)
+
+Spanish JSON tokenizes at ~3 chars/token (denser than English prose). After the pedagogy
+config refactor (#319-#327), prompts now produce longer, more detailed responses that exceed
+the existing MaxTokens limits.
+
+Evidence from lesson-content.json files:
+- `exercises` block: ~7500 chars ≈ 2500 tokens → MaxTokens 2048 → TRUNCATED
+- `grammar` block: ~5300 chars ≈ 1770 tokens → MaxTokens 1500 → TRUNCATED (Carmen B2.1)
+- `conversation` block: ~5500 chars ≈ 1833 tokens → MaxTokens 1500 → TRUNCATED (Carmen WrapUp)
+
+Secondary issue: `StreamAsync` does not detect `stop_reason: "max_tokens"` from Claude's
+`message_delta` SSE event, so truncation is silent in production logs.
+
+## Changes
+
+### 1. PromptService.cs — increase MaxTokens
+
+| Prompt | Before | After | Reason |
+|--------|--------|-------|--------|
+| Grammar | 1500 | 3000 | B2 grammar with detailed common mistakes exceeds 1500 |
+| Exercises | 2048 | 4096 | 6 MC + fill-in-blank + matching with explanations can exceed 2048 |
+| Conversation | 1500 | 3000 | Multi-scenario conversations at B2 exceed 1500 |
+| Reading | 2048 | 4096 | 300-500 word passage + questions + vocab highlights at B2+ |
+| LessonPlan | 8192 | 8192 | No evidence of truncation; keep unchanged |
+| Vocabulary | 2048 | 2048 | Short format; no truncation observed |
+| Homework | 1024 | 1024 | Short format; no truncation observed |
+| FreeText | 1024 | 1024 | Short prose; no truncation observed |
+
+### 2. ClaudeApiClient.cs — streaming truncation detection
+
+Add `message_start` and `message_delta` parsing to `StreamAsync`:
+- `message_start`: capture input token count (stored in local var)
+- `message_delta`: capture output token count + stop_reason
+  - If `stop_reason == "max_tokens"`: log `LogWarning` with MaxTokens value
+  - At stream completion: log `LogInformation` with model, input, output, latency (mirrors CompleteAsync)
+
+### 3. PromptServiceTests.cs — update assertions
+
+Update 4 MaxTokens tests to match new values:
+- `GrammarPrompt_HasMaxTokens1500` → assert 3000
+- `ExercisesPrompt_HasMaxTokens2048` → assert 4096
+- `ConversationPrompt_HasMaxTokens1500` → assert 3000
+- `ReadingPrompt_HasMaxTokens2048` → assert 4096
+
+## Out of Scope
+
+- WarmUp/WrapUp overgeneration (BUG 4, BUG 5 from sprint-reviewer report) — separate issue
+- L1 field mismatch (BUG 3) — separate issue
+- Teacher QA re-run — triggered by user after merge


### PR DESCRIPTION
## Summary

- Increases MaxTokens for 4 content types that were being truncated mid-response after the pedagogy config refactor (#319-#327)
- Adds streaming truncation detection in `ClaudeApiClient.StreamAsync` so `stop_reason: "max_tokens"` is visible in production logs
- 4 MaxTokens test assertions updated + 2 new unit tests for truncation detection

## Root Cause

Spanish JSON tokenises at ~3 chars/token. After the pedagogy config refactor added per-section exercise guidance and level rules to prompts, generated content grew beyond existing limits:

| Content type | Old limit | Observed output | New limit |
|---|---|---|---|
| Exercises | 2048 | ~2500 tokens (7500 chars) | 4096 |
| Grammar | 1500 | ~1770 tokens (5300 chars) | 3000 |
| Conversation | 1500 | ~1833 tokens (5500 chars) | 3000 |
| Reading | 2048 | (pre-emptive increase) | 4096 |

Evidence from `lesson-content.json` in Teacher QA runs: exercises block ends mid-sentence (`"Permanent` cut off), Q6 MC question starts but has no options or answer.

## Test Plan

- [x] All 6 pre-push checks pass (401 backend + 560 frontend tests)
- [x] Architecture review: PASS
- [x] Code review: PASS WITH NOTES (addressed: moved telemetry log to `message_delta` handler to fire even on client disconnect)
- [x] QA verify: PASS WITH GAPS (AC4 = Teacher QA re-run deferred to post-merge)
- [ ] Teacher QA re-run with at least 2 personas to confirm no truncation (user action post-merge)

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Increased maximum response lengths for Grammar, Exercises, Conversation, and Reading modules—enabling more comprehensive and detailed content
  * Enhanced API monitoring with improved latency tracking and usage metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->