### PR TITLE
fix: section profile pedagogy accuracy (Isaac P1 findings #367)

### DIFF
--- a/data/section-profiles/practice.json
+++ b/data/section-profiles/practice.json
@@ -8,14 +8,13 @@
       "competencies": ["reading", "writing"],
       "scaffolding": "high",
       "interactionPattern": "teacher-led",
-      "validExerciseTypes": ["GR-01", "GR-02", "GR-06", "GR-07", "GR-09", "VOC-05", "EO-01"],
+      "validExerciseTypes": ["GR-01", "GR-02", "GR-06", "GR-07", "GR-09", "VOC-05", "EO-01", "LUD-06", "LUD-07"],
       "forbiddenExerciseTypes": [
         {"id": "GR-03", "pattern": null, "reason": "Sentence transformation requires prior command of the target form; inappropriate at A1"},
         {"id": "GR-04", "pattern": null, "reason": "Error correction requires meta-awareness of the rule; too demanding at A1"},
         {"id": "GR-08", "pattern": null, "reason": "Inductive discovery is a presentation task, not a practice drill"},
-        {"id": null, "pattern": "CE-*", "reason": "Reading comprehension tasks are not practice exercises for grammar/vocabulary"},
-        {"id": null, "pattern": "EE-*", "reason": "Extended writing is production, not controlled practice"},
-        {"id": null, "pattern": "LUD-*", "reason": "Ludic activities belong to warm-up or optional extension, not structured practice"}
+        {"id": null, "pattern": "CE-*", "reason": "Reading comprehension tasks are not practice exercises for grammar/vocabulary at A1"},
+        {"id": null, "pattern": "EE-*", "reason": "Extended writing is production, not controlled practice"}
       ],
       "levelSpecificNotes": [
         {"exerciseTypeId": "GR-01", "note": "Always provide a word bank listing all answer options in the hint field"},
@@ -31,14 +30,12 @@
       "competencies": ["reading", "writing"],
       "scaffolding": "medium",
       "interactionPattern": "teacher-guided",
-      "validExerciseTypes": ["GR-01", "GR-02", "GR-06", "GR-07", "GR-09", "VOC-05", "VOC-06", "EO-01"],
+      "validExerciseTypes": ["GR-01", "GR-02", "GR-06", "GR-07", "GR-09", "VOC-05", "VOC-06", "EO-01", "CE-01", "CE-02", "LUD-05", "LUD-06", "LUD-07"],
       "forbiddenExerciseTypes": [
         {"id": "GR-03", "pattern": null, "reason": "Sentence transformation requires prior command of the target form; not yet appropriate at A2"},
         {"id": "GR-04", "pattern": null, "reason": "Error correction requires meta-awareness of the rule; too demanding at A2"},
         {"id": "GR-08", "pattern": null, "reason": "Inductive discovery is a presentation task, not a practice drill"},
-        {"id": null, "pattern": "CE-*", "reason": "Reading comprehension tasks are not practice exercises for grammar/vocabulary"},
-        {"id": null, "pattern": "EE-*", "reason": "Extended writing is production, not controlled practice"},
-        {"id": null, "pattern": "LUD-*", "reason": "Ludic activities belong to warm-up or optional extension, not structured practice"}
+        {"id": null, "pattern": "EE-*", "reason": "Extended writing is production, not controlled practice"}
       ],
       "levelSpecificNotes": [
         {"exerciseTypeId": "GR-02", "note": "Maximum 4 options per item at A2"},
@@ -53,11 +50,10 @@
       "competencies": ["reading", "writing", "speaking"],
       "scaffolding": "low",
       "interactionPattern": "student-led",
-      "validExerciseTypes": ["GR-01", "GR-02", "GR-03", "GR-04", "GR-09", "GR-10", "VOC-04", "VOC-05", "VOC-07", "CE-01", "CE-03", "CE-06", "EO-01"],
+      "validExerciseTypes": ["GR-01", "GR-02", "GR-03", "GR-04", "GR-09", "GR-10", "VOC-04", "VOC-05", "VOC-07", "CE-01", "CE-03", "CE-06", "EO-01", "LUD-05", "LUD-06", "LUD-07"],
       "forbiddenExerciseTypes": [
         {"id": "GR-08", "pattern": null, "reason": "Inductive discovery is a presentation task, not a practice drill"},
-        {"id": null, "pattern": "EE-*", "reason": "Extended writing is production, not controlled practice"},
-        {"id": null, "pattern": "LUD-*", "reason": "Ludic activities belong to warm-up or optional extension, not structured practice"}
+        {"id": null, "pattern": "EE-*", "reason": "Extended writing is production, not controlled practice"}
       ],
       "levelSpecificNotes": [
         {"exerciseTypeId": "GR-04", "note": "Sentence-level corrections only at B1; discourse-level error correction is B2+"},
@@ -72,11 +68,10 @@
       "competencies": ["reading", "writing", "speaking"],
       "scaffolding": "low",
       "interactionPattern": "student-led",
-      "validExerciseTypes": ["GR-01", "GR-02", "GR-03", "GR-04", "GR-09", "GR-10", "VOC-04", "VOC-07", "VOC-10", "CE-01", "CE-02", "CE-03", "CE-04", "CE-06", "CE-07"],
+      "validExerciseTypes": ["GR-01", "GR-02", "GR-03", "GR-04", "GR-09", "GR-10", "VOC-04", "VOC-07", "VOC-10", "CE-01", "CE-02", "CE-03", "CE-04", "CE-06", "CE-07", "LUD-05"],
       "forbiddenExerciseTypes": [
         {"id": "GR-08", "pattern": null, "reason": "Inductive discovery is a presentation task, not a practice drill"},
-        {"id": null, "pattern": "EE-*", "reason": "Extended writing is production, not controlled practice"},
-        {"id": null, "pattern": "LUD-*", "reason": "Ludic activities belong to warm-up or optional extension, not structured practice"}
+        {"id": null, "pattern": "EE-*", "reason": "Extended writing is production, not controlled practice"}
       ],
       "levelSpecificNotes": [
         {"exerciseTypeId": "GR-04", "note": "Discourse-level error correction is appropriate at B2; include cohesion and register errors, not only morphosyntax"}

--- a/data/section-profiles/production.json
+++ b/data/section-profiles/production.json
@@ -3,7 +3,7 @@
   "levels": {
     "A1": {
       "contentTypes": ["conversation"],
-      "guidance": "Production MUST be a guided writing task with sentence frames provided. Ask the student to write 3-5 sentences using new vocabulary or structures from this lesson. Guided writing is appropriate and achievable even at A1.",
+      "guidance": "Production MUST be a guided writing task with sentence frames provided. Ask the student to write 3-5 sentences using new vocabulary or structures from this lesson. Guided writing is appropriate and achievable even at A1. Alternatively, a guided dialogue (EO-01) with fully scripted turns and 2 pre-given response options per turn is appropriate when the session focus is oral production.",
       "duration": { "min": 5, "max": 8 },
       "competencies": ["writing", "speaking"],
       "scaffolding": "high",
@@ -32,7 +32,7 @@
     },
     "A2": {
       "contentTypes": ["conversation"],
-      "guidance": "Guided writing with a model paragraph provided. Student writes 4-6 sentences using the target grammar and vocabulary. A short opinion sentence or simple description. Scaffolding phrase starters optional.",
+      "guidance": "Guided writing with a model paragraph provided. Student writes 4-6 sentences using the target grammar and vocabulary. A short opinion sentence or simple description. Scaffolding phrase starters optional. A short guided dialogue (EO-01 or EO-08, 2-3 turns) is a valid alternative when the session focus is oral production.",
       "duration": { "min": 5, "max": 8 },
       "competencies": ["writing", "speaking"],
       "scaffolding": "medium",

--- a/data/section-profiles/warmup.json
+++ b/data/section-profiles/warmup.json
@@ -23,7 +23,7 @@
     },
     "A2": {
       "contentTypes": ["conversation"],
-      "guidance": "Open personal questions using preterite/present tense. Expect a 2-3 sentence response. Example: Que hiciste el fin de semana? Include 2-3 suggested follow-up questions. Note: preterite only after introduction in A2.1+.",
+      "guidance": "Open personal questions using present tense. Expect a 2-3 sentence response. Example: Que haces los fines de semana? Include 2-3 suggested follow-up questions. Note: Use preterite only if the student has already learned it.",
       "duration": { "min": 2, "max": 4 },
       "scope": "brief",
       "competencies": ["interaction"],

--- a/plan/langteach-beta/task367-section-profile-pedagogy-fixes.md
+++ b/plan/langteach-beta/task367-section-profile-pedagogy-fixes.md
@@ -1,0 +1,62 @@
+# Task 367: Fix section profile pedagogical accuracy (Isaac review P1 findings)
+
+## Source
+Isaac (pedagogy reviewer) P1 findings on 5 section profiles during sprint close.
+
+## What was already done (task362)
+- production.json A1/A2: "speaking" added to competencies
+- warmup.json A2: note "preterite only after introduction in A2.1+" appended
+- warmup.json B1 scaffolding: "low" -> "medium"
+
+## Remaining changes
+
+### 1. practice.json: LUD-* ban at A1-B2 (Finding 1)
+
+Remove the `{"id": null, "pattern": "LUD-*", ...}` entry from forbiddenExerciseTypes at A1, A2, B1, B2.
+Add ludic types to validExerciseTypes, respecting catalog cefrRange:
+- A1: add LUD-06 (A1-B1), LUD-07 (A1-B1). Skip LUD-05 (starts at A2).
+- A2: add LUD-05 (A2-C2), LUD-06, LUD-07
+- B1: add LUD-05, LUD-06, LUD-07 (LUD-06/07 max B1 — this is their last valid level)
+- B2: add LUD-05 only (LUD-06/07 cap at B1)
+Keep LUD-* ban at C1 and C2 — mechanical games don't match discourse-level practice.
+
+All three have available: false, uiRenderer: null (no renderer built yet). Adding to JSON is correct
+pedagogical intent; runtime filtering by `available` field handles exclusion until renderer ships.
+
+### 2. practice.json: CE-* ban at A2 (Finding 2)
+
+Remove `{"id": null, "pattern": "CE-*", ...}` from A2 forbiddenExerciseTypes.
+Add CE-01 and CE-02 to A2 validExerciseTypes.
+Keep CE-* ban at A1 (reading practice extremely limited at A1 per Isaac).
+
+### 3. production.json: guidance text A1/A2 (Finding 3)
+
+Competencies already fixed in task362 ("speaking" present). Only guidance text needs update.
+
+A1 current: "Production MUST be a guided writing task with sentence frames provided.
+Ask the student to write 3-5 sentences using new vocabulary or structures from this lesson.
+Guided writing is appropriate and achievable even at A1."
+
+A1 fix: append "Alternatively, a guided dialogue (EO-01) with fully scripted turns and 2 pre-given
+options per turn is appropriate when the session focus is oral production."
+
+A2 current: "Guided writing with a model paragraph provided. Student writes 4-6 sentences using the
+target grammar and vocabulary. A short opinion sentence or simple description.
+Scaffolding phrase starters optional."
+
+A2 fix: append "A short guided dialogue (EO-01 or EO-08, 2-3 turns) is a valid alternative
+when the session focus is oral production."
+
+### 4. warmup.json: A2 example (Finding 4)
+
+Current: "Open personal questions using preterite/present tense. ... Example: Que hiciste el fin de
+semana? ... Note: preterite only after introduction in A2.1+."
+
+Fix: change opening to "present/familiar tense", change example to "Que haces los fines de semana?",
+update note to "Use preterite only if the student has already learned it."
+
+## Tests expected to pass
+- SectionProfileServiceTests: cross-layer validation (IDs exist, no valid/forbidden overlap)
+- PedagogyConfigServiceTests: GetValidExerciseTypes still filters by available:false, so LUD types
+  won't appear in effective runtime lists (consistent with existing warmup behavior)
+- No schema changes; no C# code changes


### PR DESCRIPTION
## Summary

- **practice.json**: Remove blanket `LUD-*` ban from A1-B2; add LUD-05/06/07 to `validExerciseTypes` respecting cefrRange (LUD-06/07 cap B1, LUD-05 starts A2). Keep ban at C1-C2.
- **practice.json**: Remove `CE-*` ban from A2; add CE-01/CE-02 to A2 `validExerciseTypes`. Keep ban at A1.
- **production.json**: Update A1/A2 guidance to mention oral production (EO-01) as a valid alternative alongside guided writing.
- **warmup.json**: Change A2 example from preterite to present tense ("Que haces los fines de semana?"); clarify preterite note.

JSON-only changes. No C# or TypeScript code modified.

## Test plan

- [x] 455 backend tests pass (includes SectionProfileService cross-layer validation: no valid/forbidden overlap, all IDs exist in catalog)
- [x] 560 frontend tests pass
- [x] QA verify: all 6 acceptance criteria met
- [x] Code review: PASS (cefrRange constraints verified, no overlaps)
- [x] No conflicts with sprint branch

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated exercise eligibility rules and constraints across proficiency levels.
  * Extended production section guidance to include oral alternatives alongside written tasks.
  * Refined warmup section grammar instruction to emphasize present tense usage with updated examples and conditions for preterite application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->