### PR TITLE
fix: use Serilog namespace for prompt debug logging env var (#370)

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -49,7 +49,7 @@ services:
       dockerfile: backend/LangTeach.Api/Dockerfile
     environment:
       ASPNETCORE_ENVIRONMENT: E2ETesting
-      Logging__LogLevel__LangTeach.Api.AI: Debug
+      Serilog__MinimumLevel__Override__LangTeach.Api.AI: Debug
       ConnectionStrings__Default: "Server=sqlserver,1433;Database=LangTeach;User Id=sa;Password=${SA_PASSWORD};TrustServerCertificate=true"
       Auth0__Domain: "${AUTH0_DOMAIN}"
       Auth0__Audience: "${AUTH0_AUDIENCE}"

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -47,7 +47,7 @@ services:
     environment:
       # Development environment uses real Auth0 JWT validation (not E2ETesting bypass)
       ASPNETCORE_ENVIRONMENT: Development
-      Logging__LogLevel__LangTeach.Api.AI: Debug
+      Serilog__MinimumLevel__Override__LangTeach.Api.AI: Debug
       ConnectionStrings__Default: "Server=sqlserver,1433;Database=LangTeachQA;User Id=sa;Password=${SA_PASSWORD};TrustServerCertificate=true"
       Auth0__Domain: "${AUTH0_DOMAIN}"
       Auth0__Audience: "${AUTH0_AUDIENCE}"

--- a/plan/langteach-beta/task370-serilog-prompt-logging.md
+++ b/plan/langteach-beta/task370-serilog-prompt-logging.md
@@ -1,0 +1,26 @@
+# Task 370: Fix Serilog prompt logging env var namespace
+
+## Problem
+
+`docker-compose.qa.yml` and `docker-compose.e2e.yml` set:
+```
+Logging__LogLevel__LangTeach.Api.AI: Debug
+```
+
+This targets the Microsoft logging provider. The app uses Serilog (`Program.cs:32-33`), which reads from the `Serilog` config section and silently ignores `Logging__*` overrides.
+
+## Fix
+
+Replace in both compose files:
+```
+Serilog__MinimumLevel__Override__LangTeach.Api.AI: Debug
+```
+
+## Files changed
+
+- `docker-compose.qa.yml` line 50
+- `docker-compose.e2e.yml` line 52
+
+## Verification
+
+Run QA stack, generate one content block, confirm `PromptSystem` and `PromptUser` log lines appear in `docker compose logs api`.


### PR DESCRIPTION
## Summary

- Replaces `Logging__LogLevel__LangTeach.Api.AI: Debug` with `Serilog__MinimumLevel__Override__LangTeach.Api.AI: Debug` in both `docker-compose.qa.yml` and `docker-compose.e2e.yml`
- The old env var targeted the Microsoft logging provider; the app uses Serilog which reads from `Serilog__*` config keys and silently ignored the old override
- This unblocks `PromptSystem`/`PromptUser` Debug log lines in QA container logs, enabling root-cause diagnosis of CQ-1, CQ-2, CQ-3

## Test plan

- [ ] Run QA stack: `docker compose -f docker-compose.qa.yml up`
- [ ] Generate one content block via Teacher QA
- [ ] Confirm `PromptSystem` and `PromptUser` lines appear in `docker compose logs api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated logging configuration for test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->