### PR TITLE
feat: strengthen WarmUp/WrapUp conversation prompts with full section profile data (#371)

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -1429,6 +1429,131 @@ public class PromptServiceTests
             because: "practice section has full scope; no scope constraint should be emitted");
     }
 
+    // --- Full section profile data in conversation prompts (task #371) ---
+
+    [Fact]
+    public void ConversationUserPrompt_WarmUp_B1_ScopeConstraintAppearsBeforeJsonSchema()
+    {
+        var ctx = BaseCtx() with { SectionType = "WarmUp" };
+
+        var req = _sut.BuildConversationPrompt(ctx);
+
+        var constraintIdx = req.UserPrompt.IndexOf("exactly 1 scenario", StringComparison.Ordinal);
+        var schemaIdx     = req.UserPrompt.IndexOf("{\"scenarios\"", StringComparison.Ordinal);
+        constraintIdx.Should().BeGreaterThan(-1, because: "scope constraint must be present");
+        schemaIdx.Should().BeGreaterThan(-1, because: "JSON schema must be present");
+        constraintIdx.Should().BeLessThan(schemaIdx,
+            because: "scope constraint must appear before the JSON schema to act as a strong signal");
+    }
+
+    [Fact]
+    public void ConversationUserPrompt_WarmUp_B1_ContainsDuration()
+    {
+        var ctx = BaseCtx() with { SectionType = "WarmUp" };
+
+        var req = _sut.BuildConversationPrompt(ctx);
+
+        req.UserPrompt.Should().Contain("3-5 minutes",
+            because: "WarmUp B1 duration is 3-5 minutes per warmup.json");
+    }
+
+    [Fact]
+    public void ConversationUserPrompt_WarmUp_B1_ContainsInteractionPattern()
+    {
+        var ctx = BaseCtx() with { SectionType = "WarmUp" };
+
+        var req = _sut.BuildConversationPrompt(ctx);
+
+        req.UserPrompt.Should().Contain("student-led",
+            because: "WarmUp B1 interaction pattern is student-led per warmup.json");
+    }
+
+    [Fact]
+    public void ConversationUserPrompt_WarmUp_B1_ContainsForbiddenReasons()
+    {
+        var ctx = BaseCtx() with { SectionType = "WarmUp" };
+
+        var req = _sut.BuildConversationPrompt(ctx);
+
+        req.UserPrompt.Should().Contain("Grammar drills",
+            because: "WarmUp B1 has forbidden GR-* types; reason must appear as constraint");
+        req.UserPrompt.Should().Contain("Written production",
+            because: "WarmUp B1 has forbidden EE-* types; reason must appear as constraint");
+    }
+
+    [Fact]
+    public void ConversationUserPrompt_WrapUp_B1_ScopeConstraintAppearsBeforeJsonSchema()
+    {
+        var ctx = BaseCtx() with { SectionType = "WrapUp" };
+
+        var req = _sut.BuildConversationPrompt(ctx);
+
+        var constraintIdx = req.UserPrompt.IndexOf("exactly 1 scenario", StringComparison.Ordinal);
+        var schemaIdx     = req.UserPrompt.IndexOf("{\"scenarios\"", StringComparison.Ordinal);
+        constraintIdx.Should().BeGreaterThan(-1, because: "scope constraint must be present");
+        schemaIdx.Should().BeGreaterThan(-1, because: "JSON schema must be present");
+        constraintIdx.Should().BeLessThan(schemaIdx,
+            because: "scope constraint must appear before the JSON schema");
+    }
+
+    [Fact]
+    public void ConversationUserPrompt_WrapUp_B1_ContainsNoNewMaterialConstraint()
+    {
+        var ctx = BaseCtx() with { SectionType = "WrapUp" };
+
+        var req = _sut.BuildConversationPrompt(ctx);
+
+        req.UserPrompt.Should().Contain("Do not introduce new vocabulary",
+            because: "WrapUp must explicitly forbid introducing new material");
+    }
+
+    [Fact]
+    public void ConversationUserPrompt_WrapUp_B1_ContainsDuration()
+    {
+        var ctx = BaseCtx() with { SectionType = "WrapUp" };
+
+        var req = _sut.BuildConversationPrompt(ctx);
+
+        req.UserPrompt.Should().Contain("2-4 minutes",
+            because: "WrapUp B1 duration is 2-4 minutes per wrapup.json");
+    }
+
+    [Fact]
+    public void ConversationUserPrompt_WrapUp_B1_ContainsInteractionPattern()
+    {
+        var ctx = BaseCtx() with { SectionType = "WrapUp" };
+
+        var req = _sut.BuildConversationPrompt(ctx);
+
+        req.UserPrompt.Should().Contain("student-led",
+            because: "WrapUp B1 interaction pattern is student-led per wrapup.json");
+    }
+
+    [Fact]
+    public void ConversationUserPrompt_WrapUp_B1_ContainsForbiddenReasons()
+    {
+        var ctx = BaseCtx() with { SectionType = "WrapUp" };
+
+        var req = _sut.BuildConversationPrompt(ctx);
+
+        req.UserPrompt.Should().Contain("Games introduce new activity type",
+            because: "WrapUp B1 has forbidden LUD-* types; reason must appear as constraint");
+    }
+
+    [Fact]
+    public void ConversationUserPrompt_GenericPath_UnchangedByRefactor()
+    {
+        // Verify the generic (non-WarmUp, non-WrapUp) path is not affected
+        var ctx = BaseCtx() with { SectionType = null };
+
+        var req = _sut.BuildConversationPrompt(ctx);
+
+        req.UserPrompt.Should().Contain("2-3 scenarios",
+            because: "generic conversation path must still request 2-3 scenarios");
+        req.UserPrompt.Should().NotContain("Duration:",
+            because: "generic path does not inject section profile data");
+    }
+
     [Fact]
     public void LessonPlanUserPrompt_WarmUp_HasScopeLabelInSectionHeader()
     {

--- a/backend/LangTeach.Api.Tests/Services/SectionProfileServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/SectionProfileServiceTests.cs
@@ -459,4 +459,28 @@ public class SectionProfileServiceTests
     {
         _sut.GetScope("warmup", "Z9").Should().BeNull();
     }
+
+    // --- GetInteractionPattern ---
+
+    [Theory]
+    [InlineData("warmup",  "A1", "teacher-led")]
+    [InlineData("warmup",  "B1", "student-led")]
+    [InlineData("wrapup",  "A1", "teacher-led")]
+    [InlineData("wrapup",  "B1", "student-led")]
+    public void GetInteractionPattern_KnownSectionAndLevel_ReturnsExpectedPattern(string section, string level, string expected)
+    {
+        _sut.GetInteractionPattern(section, level).Should().Be(expected);
+    }
+
+    [Fact]
+    public void GetInteractionPattern_UnknownSection_ReturnsEmptyString()
+    {
+        _sut.GetInteractionPattern("nosuchsection", "B1").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetInteractionPattern_UnknownLevel_ReturnsEmptyString()
+    {
+        _sut.GetInteractionPattern("warmup", "Z9").Should().BeEmpty();
+    }
 }

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -385,43 +385,73 @@ public class PromptService : IPromptService
 
     private string ConversationUserPrompt(GenerationContext ctx)
     {
-        var topic = Sanitize(ctx.Topic);
-        var level = Sanitize(ctx.CefrLevel);
+        var topic   = Sanitize(ctx.Topic);
+        var level   = Sanitize(ctx.CefrLevel);
         var section = ctx.SectionType;
 
         if (string.Equals(section, "WarmUp", StringComparison.OrdinalIgnoreCase))
-        {
-            var guidance = _profiles.GetGuidance("warmup", level);
-            var constraint = _pedagogy.GetScopeConstraint("warmup", level, ctx.TemplateName, "conversation");
-            var prompt = $$"""
-            Generate a warm-up icebreaker conversation activity for a {{level}} level lesson on "{{topic}}". Return JSON:
-            {"scenarios":[{"setup":"","roleA":"Teacher","roleB":"Student","roleAPhrases":[""],"roleBPhrases":[""]}]}
-            {{guidance}}
-            """;
-            if (!string.IsNullOrEmpty(constraint))
-                prompt += "\n" + constraint;
-            return prompt;
-        }
+            return BuildSectionConversationPrompt(
+                sectionKey:      "warmup",
+                level:           level,
+                topic:           topic,
+                templateName:    ctx.TemplateName,
+                mainInstruction: $"Generate a warm-up icebreaker conversation activity for a {level} level lesson on \"{topic}\".",
+                extraConstraint: null);
 
         if (string.Equals(section, "WrapUp", StringComparison.OrdinalIgnoreCase))
-        {
-            var guidance = _profiles.GetGuidance("wrapup", level);
-            var constraint = _pedagogy.GetScopeConstraint("wrapup", level, ctx.TemplateName, "conversation");
-            var prompt = $$"""
-            Generate a wrap-up reflection conversation for a {{level}} level lesson on "{{topic}}". Return JSON:
-            {"scenarios":[{"setup":"","roleA":"Teacher","roleB":"Student","roleAPhrases":[""],"roleBPhrases":[""]}]}
-            {{guidance}}
-            """;
-            if (!string.IsNullOrEmpty(constraint))
-                prompt += "\n" + constraint;
-            return prompt;
-        }
+            return BuildSectionConversationPrompt(
+                sectionKey:      "wrapup",
+                level:           level,
+                topic:           topic,
+                templateName:    ctx.TemplateName,
+                mainInstruction: $"Generate a wrap-up reflection conversation for a {level} level lesson on \"{topic}\".",
+                extraConstraint: "IMPORTANT: Review only content from this lesson. Do not introduce new vocabulary, grammar structures, or situations.");
 
         return $$"""
         Generate conversation scenarios for the lesson on "{{topic}}". Return JSON:
         {"scenarios":[{"setup":"","roleA":"","roleB":"","roleAPhrases":[""],"roleBPhrases":[""]}]}
         Include 2-3 scenarios using {{level}}-appropriate language.
         """;
+    }
+
+    private string BuildSectionConversationPrompt(
+        string sectionKey, string level, string topic, string? templateName,
+        string mainInstruction, string? extraConstraint)
+    {
+        var constraint       = _pedagogy.GetScopeConstraint(sectionKey, level, templateName, "conversation");
+        var duration         = _profiles.GetDuration(sectionKey, level);
+        var interactionPattern = _profiles.GetInteractionPattern(sectionKey, level);
+        var forbiddenReasons = _profiles.GetRawForbiddenExerciseTypes(sectionKey, level)
+            .Select(f => f.Reason)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(5)
+            .ToArray();
+        var guidance = _profiles.GetGuidance(sectionKey, level);
+
+        var sb = new StringBuilder();
+
+        if (!string.IsNullOrEmpty(constraint))
+            sb.AppendLine(constraint);
+        if (!string.IsNullOrEmpty(extraConstraint))
+            sb.AppendLine(extraConstraint);
+        if (duration is not null)
+            sb.AppendLine($"Duration: {duration.Min}-{duration.Max} minutes.");
+        if (!string.IsNullOrEmpty(interactionPattern))
+            sb.AppendLine($"Interaction pattern: {interactionPattern}.");
+        if (forbiddenReasons.Length > 0)
+        {
+            sb.AppendLine("Do not generate activities that:");
+            foreach (var reason in forbiddenReasons)
+                sb.AppendLine($"- {reason}");
+        }
+
+        sb.AppendLine($"{mainInstruction} Return JSON:");
+        sb.AppendLine("{\"scenarios\":[{\"setup\":\"\",\"roleA\":\"Teacher\",\"roleB\":\"Student\",\"roleAPhrases\":[\"\"],\"roleBPhrases\":[\"\"]}]}");
+
+        if (!string.IsNullOrEmpty(guidance))
+            sb.Append(guidance);
+
+        return sb.ToString().TrimEnd();
     }
 
     private string ReadingUserPrompt(GenerationContext ctx)

--- a/backend/LangTeach.Api/Services/ISectionProfileService.cs
+++ b/backend/LangTeach.Api/Services/ISectionProfileService.cs
@@ -50,6 +50,12 @@ public interface ISectionProfileService
     string? GetScope(string sectionType, string cefrLevel);
 
     /// <summary>
+    /// Returns the interaction pattern for a section at the given CEFR level (e.g. "teacher-led", "student-led").
+    /// Returns an empty string if the section or level is not found.
+    /// </summary>
+    string GetInteractionPattern(string sectionType, string cefrLevel);
+
+    /// <summary>
     /// Returns all distinct non-null scope values found across all section profile levels.
     /// Used by PedagogyConfigService to validate scope values against scope-constraints.json.
     /// </summary>

--- a/backend/LangTeach.Api/Services/SectionProfileService.cs
+++ b/backend/LangTeach.Api/Services/SectionProfileService.cs
@@ -140,6 +140,16 @@ public class SectionProfileService : ISectionProfileService
         return null;
     }
 
+    public string GetInteractionPattern(string sectionType, string cefrLevel)
+    {
+        var profile = GetProfile(sectionType);
+        if (profile is null) return string.Empty;
+        var level = NormalizeLevel(cefrLevel);
+        if (profile.Levels.TryGetValue(level, out var lp))
+            return lp.InteractionPattern ?? string.Empty;
+        return string.Empty;
+    }
+
     public string[] GetAllScopeValues() =>
         _profiles.Values
             .SelectMany(p => p.Levels.Values)

--- a/plan/langteach-beta/task371-conversation-prompt-section-profile.md
+++ b/plan/langteach-beta/task371-conversation-prompt-section-profile.md
@@ -1,0 +1,68 @@
+# Task 371 - Strengthen WarmUp/WrapUp Conversation Prompts
+
+## Problem
+
+`ConversationUserPrompt` uses only `GetGuidance()` and `GetScopeConstraint()` from section profiles.
+Five fields are ignored: Duration, InteractionPattern, Scaffolding, ForbiddenExerciseTypes, LevelSpecificNotes.
+The scope constraint is also appended AFTER the JSON schema, making it a weak signal.
+
+Root violations (Teacher QA 2026-03-29):
+- WarmUp (CQ-2): generates multi-scenario full conversations instead of a 3-5 min icebreaker
+- WrapUp (CQ-3): introduces new vocabulary/situations instead of reviewing lesson content
+
+## Fix
+
+### 1. Add `GetInteractionPattern` to `ISectionProfileService`
+
+New method: `string GetInteractionPattern(string sectionType, string cefrLevel)`
+
+### 2. Implement in `SectionProfileService`
+
+Read from `SectionLevelProfile.InteractionPattern`.
+
+### 3. Update `ConversationUserPrompt` in `PromptService`
+
+New prompt structure for WarmUp and WrapUp:
+
+```
+[SCOPE CONSTRAINT] ← moved before JSON schema
+[no new material constraint - WrapUp only]
+Duration: X-Y minutes.
+Interaction pattern: Z.
+Do not generate activities that:
+- [forbidden reason 1]
+- [forbidden reason 2]
+- ...
+Generate [description] for a {level} level lesson on "{topic}". Return JSON:
+{...JSON schema...}
+[GUIDANCE]
+```
+
+Changes per section:
+- **WarmUp**: scope constraint first, then duration + interaction pattern + forbidden reasons (up to 5 deduplicated), then main instruction + JSON + guidance
+- **WrapUp**: same, plus explicit "IMPORTANT: Review only content from this lesson. Do not introduce new vocabulary, grammar structures, or situations."
+
+### 4. Unit tests
+
+Add to `PromptServiceTests.cs`:
+- `ConversationUserPrompt_WarmUp_B1_ScopeConstraintAppearsBeforeJsonSchema`
+- `ConversationUserPrompt_WarmUp_B1_ContainsDuration` (3-5 minutes from warmup.json B1)
+- `ConversationUserPrompt_WarmUp_B1_ContainsInteractionPattern` ("student-led")
+- `ConversationUserPrompt_WarmUp_B1_ContainsForbiddenReasons` (e.g., "Grammar drills")
+- `ConversationUserPrompt_WrapUp_B1_ScopeConstraintAppearsBeforeJsonSchema`
+- `ConversationUserPrompt_WrapUp_B1_ContainsNoNewMaterialConstraint`
+- `ConversationUserPrompt_WrapUp_B1_ContainsDuration` (2-4 minutes from wrapup.json B1)
+- `ConversationUserPrompt_WrapUp_B1_ContainsInteractionPattern` ("student-led")
+
+## Files to change
+
+- `backend/LangTeach.Api/Services/ISectionProfileService.cs` - add `GetInteractionPattern`
+- `backend/LangTeach.Api/Services/SectionProfileService.cs` - implement it
+- `backend/LangTeach.Api/AI/PromptService.cs` - update `ConversationUserPrompt`
+- `backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs` - add 8 new tests
+
+## Out of scope
+
+- Other content type prompts (exercises, grammar, etc.)
+- Schema changes
+- New WrapUp content types


### PR DESCRIPTION
## Summary
- Moves scope constraint before the JSON schema in WarmUp/WrapUp conversation prompts (stronger AI signal)
- Front-loads duration, interaction pattern, and forbidden exercise reasons from section profile data
- Adds explicit "no new material" constraint for WrapUp sections
- Exposes `GetInteractionPattern` via `ISectionProfileService`
- Extracts shared `BuildSectionConversationPrompt` helper to eliminate WarmUp/WrapUp duplication

## Test plan
- [ ] 9 new unit tests for WarmUp B1 and WrapUp B1 prompt content (scope ordering, duration, interaction pattern, forbidden reasons, no-new-material)
- [ ] 3 new `GetInteractionPattern` tests in SectionProfileServiceTests
- [ ] All 471 backend unit tests pass
- [ ] All 560 frontend unit tests pass

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced warm-up and wrap-up section prompts with duration guidance, interaction patterns, and activity constraints.

* **Tests**
  * Added comprehensive test coverage for conversation prompt generation with section-specific configurations.
  * Extended test coverage for interaction pattern retrieval across different lesson sections and proficiency levels.

* **Refactor**
  * Optimized prompt construction logic for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->