### PR TITLE
fix: pass sectionType in FullLessonGenerateButton bulk generation (#375)

### DIFF
--- a/frontend/src/components/lesson/FullLessonGenerateButton.test.tsx
+++ b/frontend/src/components/lesson/FullLessonGenerateButton.test.tsx
@@ -311,6 +311,31 @@ describe('FullLessonGenerateButton', () => {
     await waitFor(() => expect(vi.mocked(generateApi.saveContentBlock)).toHaveBeenCalledTimes(4), { timeout: 3000 })
   })
 
+  it('streamText receives correct sectionType for each section', async () => {
+    const user = userEvent.setup()
+    const streamMock = vi.mocked(streamText)
+
+    streamMock.mockResolvedValue('{}')
+    vi.mocked(generateApi.saveContentBlock).mockImplementation((_lessonId, req) =>
+      Promise.resolve(makeBlock(req.lessonSectionId!, req.blockType as string))
+    )
+
+    renderButton()
+    await user.click(screen.getByTestId('generate-full-lesson-btn'))
+    await user.click(screen.getByTestId('confirm-generate-full-lesson'))
+
+    await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(5), { timeout: 3000 })
+
+    const calledSectionTypes = streamMock.mock.calls.map(
+      (c) => (c[1] as { sectionType?: string }).sectionType
+    )
+    expect(calledSectionTypes).toContain('WarmUp')
+    expect(calledSectionTypes).toContain('Presentation')
+    expect(calledSectionTypes).toContain('Practice')
+    expect(calledSectionTypes).toContain('Production')
+    expect(calledSectionTypes).toContain('WrapUp')
+  })
+
   it('error in one section does not stop other sections from completing', async () => {
     const user = userEvent.setup()
     const streamMock = vi.mocked(streamText)

--- a/frontend/src/components/lesson/FullLessonGenerateButton.tsx
+++ b/frontend/src/components/lesson/FullLessonGenerateButton.tsx
@@ -110,6 +110,7 @@ export function FullLessonGenerateButton({
             cefrLevel: lessonContext.cefrLevel,
             topic: lessonContext.topic,
             studentId: lessonContext.studentId,
+            sectionType,
           },
           token,
           controller.signal,
@@ -126,6 +127,7 @@ export function FullLessonGenerateButton({
             cefrLevel: lessonContext.cefrLevel,
             topic: lessonContext.topic,
             studentId: lessonContext.studentId,
+            sectionType,
           }),
         })
         if (controller.signal.aborted) return

--- a/plan/langteach-beta/task375-fulllesson-section-type.md
+++ b/plan/langteach-beta/task375-fulllesson-section-type.md
@@ -1,0 +1,28 @@
+# Task 375: FullLessonGenerateButton missing sectionType
+
+## Problem
+`FullLessonGenerateButton.tsx` omits `sectionType` from the `streamText` call and `generationParams`, so all conversation blocks (WarmUp, Production, WrapUp) receive the generic conversation prompt instead of section-specific prompts.
+
+## Fix (2 lines + 1 test)
+
+### 1. `streamText` call (~line 107)
+Add `sectionType` to the request body object.
+- The loop variable is `sectionType` (values: 'WarmUp', 'Production', 'WrapUp')
+- Backend uses `OrdinalIgnoreCase` comparison, so PascalCase is fine
+
+### 2. `generationParams` (~line 123)
+Add `sectionType` to the JSON.stringify object so regeneration also has section identity.
+
+### 3. Unit test in `FullLessonGenerateButton.test.tsx`
+Add test: "streamText receives correct sectionType for each section"
+- Mock streamText, assert each call received the expected sectionType
+- WarmUp → 'WarmUp', Production → 'Production', WrapUp → 'WrapUp'
+- Presentation → sectionType not required (grammar, not conversation) but still passed
+- Verify via `streamText.mock.calls`
+
+## Files changed
+- `frontend/src/components/lesson/FullLessonGenerateButton.tsx` (2-line fix)
+- `frontend/src/components/lesson/FullLessonGenerateButton.test.tsx` (1 new test)
+
+## No backend changes needed
+Backend already reads `SectionType` from `GenerateRequest` and routes to section-specific prompts. The fix is purely on the frontend payload.


### PR DESCRIPTION
## Summary

- Add `sectionType` to the `streamText` request body in `FullLessonGenerateButton` so WarmUp/Production/WrapUp conversation blocks receive section-specific prompts instead of the generic fallback
- Add `sectionType` to `generationParams` so regeneration from saved params preserves section identity
- Add unit test verifying all 5 sections pass the correct `sectionType` to `streamText`

## Root cause

The `sectionType` loop variable was available (line 100) but never included in the payload. The single-block `GeneratePanel` path already passes `sectionType` correctly — this was a gap only in the bulk generation flow.

## Test plan

- [ ] All 561 frontend unit tests pass (including new sectionType assertion)
- [ ] All 471 backend tests pass
- [ ] Prompt logs show `section=warmup` / `section=wrapup` after full-lesson generation (requires Teacher QA re-run post-merge, AC2/AC5)

## Config & Infrastructure

- No new secrets, env vars, or infra changes
- No DB migration

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for lesson section generation with section type validation across all five lesson section types (WarmUp, Presentation, Practice, Production, WrapUp).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->