### PR TITLE
test: pedagogy JSON data consistency edge-case tests (#347)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs
@@ -246,6 +246,51 @@ public class PedagogyConfigServiceTests
         result.Should().BeEmpty();
     }
 
+    // --- Data consistency edge cases ---
+
+    [Fact]
+    public void GetL1Adjustments_Persian_DoesNotThrowAndReturnsSpecificNotes()
+    {
+        // Persian has family: null in l1-influence.json.
+        // ResolveLang must not throw on null family; it should return only specific language data.
+        var result = _sut.GetL1Adjustments("persian");
+
+        result.Should().NotBeNull(because: "Persian has additionalNotes even though family is null");
+        result!.Notes.Should().NotBeNullOrEmpty(because: "Persian has additionalNotes in specificLanguages");
+        result.AdditionalExerciseTypes.Should().BeEmpty(
+            because: "Persian has no family, so no family-level additional exercise types apply");
+    }
+
+    [Fact]
+    public void GetValidExerciseTypes_WarmUp_B1_ConversationTemplate_LowercaseKeyFindsWarmUpSection()
+    {
+        // template-overrides.json uses "warmUp" (camelCase) as the section key.
+        // Callers pass "warmup" (lowercase, the SectionProfileService convention).
+        // The case-insensitive Sections dictionary must find the section and apply priority re-ordering.
+        var result = _sut.GetValidExerciseTypes("warmup", "B1", templateId: "conversation");
+
+        result.Should().Contain("EO-08",
+            because: "Conversation template warmUp section lists EO-08 as a priority type");
+        result[0].Should().Be("EO-08",
+            because: "EO-08 is the only priority type for warmUp in the Conversation template and must appear first");
+    }
+
+    [Fact]
+    public void GetAllStyleSubstitutions_RolePlay_NeverSubstituteWithPreservesGlobPattern()
+    {
+        // style-substitutions.json uses ["EE-*"] in neverSubstituteWith.
+        // The raw glob pattern must be preserved so consumers (e.g. PromptService) can pass it
+        // to the AI and future services can implement proper pattern matching.
+        var subs = _sut.GetAllStyleSubstitutions();
+
+        var rolePlay = subs.FirstOrDefault(s => s.Label == "role-play");
+        rolePlay.Should().NotBeNull(because: "style-substitutions.json must have a role-play entry");
+        rolePlay!.NeverSubstituteWith.Should().Contain("EE-*",
+            because: "role-play neverSubstituteWith uses a glob pattern that must be preserved verbatim");
+        rolePlay.NeverSubstituteWith.Should().NotContain("EE-01",
+            because: "the pattern must not be pre-expanded to concrete IDs; consumers handle matching");
+    }
+
     // --- GetCourseRules ---
 
     [Fact]

--- a/plan/langteach-beta/task347-pedagogy-json-consistency.md
+++ b/plan/langteach-beta/task347-pedagogy-json-consistency.md
@@ -1,0 +1,60 @@
+# Task 347: Fix pedagogy JSON data consistency issues
+
+## Status: PLAN
+
+## Summary
+
+All 4 data consistency issues are already handled in the existing C# code. The task
+is to add unit tests that lock in the correct behavior before Pedagogical Quality
+sprint consumers are built.
+
+## Issue Analysis
+
+### 1. Persian `family: null` (already null-guarded in code)
+- `SpecificLanguage.Family` is `string?` in PedagogyConfig.cs
+- `ResolveLang` line 326: `if (specific.Family is not null && ...)`
+- Persian returns `(null, specific)` -- no NullReferenceException
+- **Missing: no test for Persian specifically**
+
+### 2. vocabularyPerLesson vs vocabularyApproach (already handled)
+- Both fields are nullable in `CefrLevelRules`
+- `GetVocabularyGuidance` already handles both cases
+- Tests `GetVocabularyGuidance_UpperLevels_ReturnsApproachString` and `_LowerLevels_ReturnsNumericFields` already cover this
+- **No new test needed**
+
+### 3. warmUp vs warmup casing (already handled)
+- Template sections dict uses `StringComparer.OrdinalIgnoreCase`
+- `NormalizeSection` maps "warmup" -> "warmUp" for template lookups
+- **Missing: no test for cross-file key lookup with lowercase "warmup"**
+
+### 4. neverSubstituteWith glob patterns (already handled for current consumer)
+- PromptService uses `string.Join(", ", sub.NeverSubstituteWith)` - passes "EE-*" as text to AI
+- `ValidateCrossLayerRefs` skips wildcard entries (`Where(id => !id.Contains('*'))`)
+- **Missing: no test verifying glob pattern is preserved (not incorrectly expanded or stripped)**
+
+## Implementation
+
+### File to modify
+`backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs`
+
+### Tests to add (3 new tests)
+
+1. **Persian null family** - `GetL1Adjustments_Persian_DoesNotThrowAndReturnsSpecificNotes`
+   - Call `GetL1Adjustments("persian")`
+   - Assert: not null (Persian has additionalNotes)
+   - Assert: Notes contains Persian-specific content
+   - Assert: AdditionalExerciseTypes is empty (no family adjustments)
+
+2. **warmUp/warmup cross-file casing** - `GetValidExerciseTypes_WarmUp_ConversationTemplate_LowercaseKeyFindsWarmUpSection`
+   - Call `GetValidExerciseTypes("warmup", "B1", templateId: "conversation")`
+   - Assert: contains EO-08 (Conversation template's warmUp priorityExerciseTypes includes EO-08)
+   - Assert: EO-08 is first (priority re-ordering worked via case-insensitive lookup)
+
+3. **NeverSubstituteWith glob preserved** - `GetAllStyleSubstitutions_RolePlay_NeverSubstituteWithPreservesGlobPattern`
+   - Call `GetAllStyleSubstitutions()`
+   - Find "role-play" substitution
+   - Assert: NeverSubstituteWith contains "EE-*" (raw pattern preserved, not expanded)
+   - This also confirms ValidateCrossLayerRefs skipped the wildcard entry (service constructed without throwing)
+
+## No other file changes needed
+The C# code and JSON files are already correct. No data changes, no service changes.


### PR DESCRIPTION
## Summary

- All 4 pedagogy JSON data consistency issues from #347 are **already handled** in `PedagogyConfigService` (built in the Student-Aware Curriculum sprint)
- This PR adds 3 unit tests that lock in the correct behavior before Pedagogical Quality sprint consumers are built

## Changes

`PedagogyConfigServiceTests.cs` — 3 new tests in a "Data consistency edge cases" section:

| Test | Edge case |
|------|-----------|
| `GetL1Adjustments_Persian_DoesNotThrowAndReturnsSpecificNotes` | Persian `family: null` — `ResolveLang` null-guard prevents NullReferenceException; specific notes still returned |
| `GetValidExerciseTypes_WarmUp_B1_ConversationTemplate_LowercaseKeyFindsWarmUpSection` | `warmup` (lowercase) correctly finds `warmUp` (camelCase) section in template via `OrdinalIgnoreCase` dict + `NormalizeSection` |
| `GetAllStyleSubstitutions_RolePlay_NeverSubstituteWithPreservesGlobPattern` | `"EE-*"` glob preserved verbatim in `NeverSubstituteWith`; not pre-expanded (consumers handle matching) |

## Test plan

- [x] All 3 new tests pass
- [x] Full test suite passes: 474 backend + 561 frontend (0 failures)
- [x] No code or data changes — tests only

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases to verify data consistency handling for edge cases in pedagogy configuration, including null value handling, case-insensitive lookups, and glob pattern preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->