### PR TITLE
fix: Spanish subjunctive temporal correlation in exercises prompt (#378)

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -258,6 +258,29 @@ public class PromptServiceTests
         req.UserPrompt.Should().Contain("\"explanation\":\"\"");
     }
 
+    [Fact]
+    public void ExercisesPrompt_Spanish_IncludesSubjunctiveTemporalCorrelationRule()
+    {
+        var ctx = BaseCtx() with { Language = "Spanish" };
+        var req = _sut.BuildExercisesPrompt(ctx);
+
+        req.UserPrompt.Should().Contain("SUBJUNCTIVE TEMPORAL CORRELATION");
+        req.UserPrompt.Should().Contain("present subjunctive");
+        req.UserPrompt.Should().Contain("imperfect subjunctive");
+    }
+
+    [Theory]
+    [InlineData("English")]
+    [InlineData("French")]
+    [InlineData("German")]
+    public void ExercisesPrompt_NonSpanish_DoesNotIncludeSubjunctiveTemporalCorrelationRule(string language)
+    {
+        var ctx = BaseCtx() with { Language = language };
+        var req = _sut.BuildExercisesPrompt(ctx);
+
+        req.UserPrompt.Should().NotContain("SUBJUNCTIVE TEMPORAL CORRELATION");
+    }
+
     // --- JSON schema injected ---
 
     [Theory]

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -380,6 +380,14 @@ public class PromptService : IPromptService
         if (!string.IsNullOrEmpty(scopeConstraint))
             prompt += "\n" + scopeConstraint;
 
+        if (string.Equals(ctx.Language, "Spanish", StringComparison.OrdinalIgnoreCase))
+            prompt += "\nGRAMMAR ACCURACY — SUBJUNCTIVE TEMPORAL CORRELATION (mandatory): " +
+                      "When generating exercises or answer choices that involve the subjunctive mood, " +
+                      "apply the correct temporal correlation rule: " +
+                      "present or future tense in the main clause → present subjunctive (e.g. 'pueda', 'haga'); " +
+                      "past or conditional tense in the main clause → imperfect subjunctive (e.g. 'pudiera', 'hiciera'). " +
+                      "Never mark an answer correct if it violates this rule.";
+
         return prompt;
     }
 

--- a/plan/langteach-beta/task378-exam-prep-subjunctive-fix.md
+++ b/plan/langteach-beta/task378-exam-prep-subjunctive-fix.md
@@ -1,0 +1,47 @@
+# Task #378: Exam Prep — Fix Wrong Subjunctive Temporal Correlation
+
+## Problem
+
+`ExercisesUserPrompt()` in `PromptService.cs` lacks any constraint about grammar accuracy in generated MC answers.
+The AI (generating Spanish content) produced: "No creo que el gobierno _____ tomar esa decisión" → `pudiera` (wrong) instead of `pueda` (correct). The explanation even reinforced the wrong rule.
+
+## Root Cause
+
+`ExercisesUserPrompt` builds a prompt that asks for exercises but gives no instruction about temporal correlation for the subjunctive. The AI defaults to a common learner error.
+
+## Fix
+
+**File:** `backend/LangTeach.Api/AI/PromptService.cs`
+**Method:** `ExercisesUserPrompt()`
+
+Add a language-gated block after `levelGuidance` that, when `ctx.Language` is `"Spanish"` (case-insensitive), appends an explicit temporal correlation rule:
+
+```csharp
+if (string.Equals(ctx.Language, "Spanish", StringComparison.OrdinalIgnoreCase))
+{
+    prompt += "\nGRAMMAR ACCURACY — SUBJUNCTIVE TEMPORAL CORRELATION (mandatory): " +
+              "When generating exercises or answer choices that involve the subjunctive mood, " +
+              "apply the correct temporal correlation rule: " +
+              "present or future tense in the main clause → present subjunctive (e.g. 'pueda', 'haga'); " +
+              "past or conditional tense in the main clause → imperfect subjunctive (e.g. 'pudiera', 'hiciera'). " +
+              "Never mark an answer correct if it violates this rule.";
+}
+```
+
+## Tests
+
+Add 2 unit tests in `PromptServiceTests.cs`:
+1. `ExercisesPrompt_Spanish_IncludesSubjunctiveTemporalCorrelationRule` — verifies the constraint appears in the prompt when language is Spanish
+2. `ExercisesPrompt_NonSpanish_DoesNotIncludeSubjunctiveTemporalCorrelationRule` — verifies French/German do not include it
+
+## Acceptance Criteria Check
+
+- [x] Constraint added to exercises generation prompt
+- [ ] Teacher QA Ana Exam B2 persona confirms fix (post-merge criterion per issue)
+- [x] All backend tests pass
+- [ ] prior-findings.md updated (post-merge per issue)
+
+## Files Changed
+
+- `backend/LangTeach.Api/AI/PromptService.cs` — add constraint block in `ExercisesUserPrompt`
+- `backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs` — 2 new unit tests


### PR DESCRIPTION
## Summary

- Adds an explicit Spanish-gated SUBJUNCTIVE TEMPORAL CORRELATION constraint to `ExercisesUserPrompt()` in `PromptService.cs`
- When `ctx.Language` is `"Spanish"` (case-insensitive), appends a mandatory rule: present main clause → present subjunctive (`pueda`, `haga`); past/conditional main clause → imperfect subjunctive (`pudiera`, `hiciera`)
- Prevents the AI from teaching wrong grammar in MC exercises (e.g. `pudiera` instead of `pueda` after `No creo que`)

## Test plan

- [ ] 2 new unit tests: `ExercisesPrompt_Spanish_IncludesSubjunctiveTemporalCorrelationRule` and `ExercisesPrompt_NonSpanish_DoesNotIncludeSubjunctiveTemporalCorrelationRule`
- [ ] All 475 backend tests pass, all 561 frontend tests pass
- [ ] Post-merge: run Teacher QA `ana-exam` persona to confirm no incorrect subjunctive temporal correlation in Practice MC exercises
- [ ] Post-merge: update `prior-findings.md` traceability row for #378

## Config & Infrastructure Checklist

- [x] No new secrets, env vars, or infra changes

Fixes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spanish language exercises now enforce correct subjunctive temporal correlation rules, ensuring proper tense mapping between main and dependent clauses.

* **Tests**
  * Added comprehensive test coverage verifying Spanish subjunctive rules are properly applied in exercises while not affecting other supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->