### PR TITLE
test: verify A1 GR-02 levelSpecificNotes injection in exercises prompt (#316)

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -1331,6 +1331,26 @@ public class PromptServiceTests
         req.UserPrompt.Should().Contain("2 sentences", because: "the level-specific note should constrain GR-04 explanation length at B2");
     }
 
+    [Fact]
+    public void ExercisesPrompt_A1_InjectsGR02MaxOptionsConstraint()
+    {
+        var ctx = BaseCtx() with { CefrLevel = "A1" };
+
+        var req = _sut.BuildExercisesPrompt(ctx);
+
+        req.UserPrompt.Should().Contain("Maximum 3 options",
+            because: "the A1 GR-02 levelSpecificNotes entry must be injected into the exercises prompt");
+    }
+
+    [Fact]
+    public void ExercisesPrompt_B1_DoesNotInjectGR02MaxOptionsConstraint()
+    {
+        var req = _sut.BuildExercisesPrompt(BaseCtx()); // B1
+
+        req.UserPrompt.Should().NotContain("Maximum 3 options",
+            because: "B1 has no GR-02 options constraint; only A1 is restricted to 3 MC options");
+    }
+
     // --- Snapshot: key blocks present for representative combinations ---
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/Services/SectionProfileServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/SectionProfileServiceTests.cs
@@ -497,6 +497,15 @@ public class SectionProfileServiceTests
     }
 
     [Fact]
+    public void GetLevelSpecificNotes_Practice_A1_ReturnsGR02MaxOptionsNote()
+    {
+        var notes = _sut.GetLevelSpecificNotes("practice", "A1");
+        var gr02 = notes.FirstOrDefault(n => n.ExerciseTypeId == "GR-02");
+        gr02.Should().NotBeNull(because: "practice A1 should have a GR-02 note constraining MC option count");
+        gr02!.Note.Should().Contain("3 options", because: "the note should enforce a maximum of 3 MC options at A1");
+    }
+
+    [Fact]
     public void GetLevelSpecificNotes_UnknownSection_ReturnsEmpty()
     {
         _sut.GetLevelSpecificNotes("nosuchsection", "B2").Should().BeEmpty();

--- a/plan/langteach-beta/task316-a1-mc-level-notes.md
+++ b/plan/langteach-beta/task316-a1-mc-level-notes.md
@@ -1,0 +1,46 @@
+# Task 316 - Enforce A1 MC option count constraint from section profile
+
+## Issue
+#316 - Enforce A1 MC option count constraint from section profile (max 3 options)
+
+## Status: Implementation already complete — tests missing
+
+The implementation described in the issue was delivered as part of prior sprint tasks.
+`PromptService.BuildExerciseGuidanceBlock` already:
+1. Calls `_profiles.GetLevelSpecificNotes(section, level)`
+2. Filters notes by valid exercise types
+3. Appends them to the exercise prompt as "Exercise type notes:"
+
+The A1 `practice.json` entry already has:
+```json
+{"exerciseTypeId": "GR-02", "note": "Maximum 3 options per item at A1"}
+```
+
+GR-02 is in A1's `validExerciseTypes`, so it passes the filter and is injected.
+
+## What remains: tests to verify A1/GR-02 injection
+
+### SectionProfileServiceTests.cs (1 new test)
+```
+GetLevelSpecificNotes_Practice_A1_ReturnsGR02MaxOptionsNote
+  - _sut.GetLevelSpecificNotes("practice", "A1") returns note with ExerciseTypeId=="GR-02"
+  - note.Note.Should().Contain("3 options")
+```
+
+### PromptServiceTests.cs (2 new tests)
+```
+ExercisesPrompt_A1_InjectsGR02MaxOptionsConstraint
+  - ctx = BaseCtx() with { CefrLevel = "A1" }
+  - req.UserPrompt.Should().Contain("Maximum 3 options")
+  - because: "A1 GR-02 levelSpecificNotes note must reach the exercises prompt"
+
+ExercisesPrompt_B1_DoesNotInjectGR02MaxOptionsConstraint
+  - ctx = BaseCtx() (B1)
+  - req.UserPrompt.Should().NotContain("Maximum 3 options")
+  - because: "B1 has no GR-02 options constraint — only A1 is restricted to 3"
+```
+
+## No code changes to PromptService or SectionProfileService needed
+
+The implementation is correct and generic (no level conditionals).
+All criteria are met by existing code; these tests close the verification gap.


### PR DESCRIPTION
## Summary

- Closes #316
- The implementation (injecting `levelSpecificNotes` into the exercise prompt via `BuildExerciseGuidanceBlock`) was already delivered in a prior sprint task. This PR adds the missing test coverage verifying the A1/GR-02 case specifically.
- Three unit tests added:
  - `GetLevelSpecificNotes_Practice_A1_ReturnsGR02MaxOptionsNote` in `SectionProfileServiceTests`
  - `ExercisesPrompt_A1_InjectsGR02MaxOptionsConstraint` in `PromptServiceTests`
  - `ExercisesPrompt_B1_DoesNotInjectGR02MaxOptionsConstraint` in `PromptServiceTests`

## Test plan

- [x] `dotnet test` - 590 passed, 0 failed
- [x] All 3 new tests pass, confirming "Maximum 3 options" note is injected for A1 and absent for B1
- [x] QA verify: PASS
- [x] Code review: PASS
- [x] Sophy (config-vs-code boundary): PASS
- [x] Architecture review: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for CEFR level-specific exercise constraints, ensuring A1 level exercises enforce a maximum of 3 multiple-choice options while higher levels do not apply this restriction.
  * Added test coverage for level-specific notes retrieval to validate correct constraint messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->