### PR TITLE
feat: remove dead forbiddenExerciseTypes from section profiles (#363)

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -1563,14 +1563,14 @@ public class PromptServiceTests
     [Fact]
     public void ConversationUserPrompt_WarmUp_B1_ContainsForbiddenReasons()
     {
+        // After cleanup: only CO-* is retained (guards against CO-06 via L1 AdditionalExerciseTypes).
+        // GR-* and EE-* were removed as fully redundant with the validExerciseTypes allowlist.
         var ctx = BaseCtx() with { SectionType = "WarmUp" };
 
         var req = _sut.BuildConversationPrompt(ctx);
 
-        req.UserPrompt.Should().Contain("Grammar drills",
-            because: "WarmUp B1 has forbidden GR-* types; reason must appear as constraint");
-        req.UserPrompt.Should().Contain("Written production",
-            because: "WarmUp B1 has forbidden EE-* types; reason must appear as constraint");
+        req.UserPrompt.Should().Contain("Listening comprehension tasks require audio resources",
+            because: "WarmUp B1 retains only CO-* forbidden; its reason must appear as constraint");
     }
 
     [Fact]
@@ -1624,12 +1624,14 @@ public class PromptServiceTests
     [Fact]
     public void ConversationUserPrompt_WrapUp_B1_ContainsForbiddenReasons()
     {
+        // After cleanup: only CO-* is retained (guards against CO-06 via L1 AdditionalExerciseTypes).
+        // LUD-*, GR-*, EE-*, VOC-* were removed as fully redundant with the validExerciseTypes allowlist.
         var ctx = BaseCtx() with { SectionType = "WrapUp" };
 
         var req = _sut.BuildConversationPrompt(ctx);
 
-        req.UserPrompt.Should().Contain("Games introduce new activity type",
-            because: "WrapUp B1 has forbidden LUD-* types; reason must appear as constraint");
+        req.UserPrompt.Should().Contain("Listening tasks introduce new content",
+            because: "WrapUp B1 retains only CO-* forbidden; its reason must appear as constraint");
     }
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs
@@ -87,28 +87,18 @@ public class PedagogyConfigServiceTests
     // --- GetForbiddenExerciseTypeIds ---
 
     [Fact]
-    public void GetForbiddenExerciseTypeIds_WarmUp_A1_ExpandsAllGRPattern()
+    public void GetForbiddenExerciseTypeIds_WarmUp_A1_ExpandsCOPattern()
     {
-        // WarmUp forbids GR-* pattern. Should expand to all GR-xx IDs in the catalog (10 types: GR-01 to GR-10).
+        // WarmUp retains only CO-* forbidden (guards against CO-06 via L1 AdditionalExerciseTypes).
+        // GR-* and EE-* were removed as fully redundant (not injectable via L1 additions).
         var result = _sut.GetForbiddenExerciseTypeIds("warmup", "A1");
 
-        for (var i = 1; i <= 10; i++)
-        {
-            var id = $"GR-{i:D2}";
-            result.Should().Contain(id, because: $"GR-* pattern should expand to include {id}");
-        }
-    }
-
-    [Fact]
-    public void GetForbiddenExerciseTypeIds_WarmUp_A1_AlsoExpandsEEAndCOPatterns()
-    {
-        var result = _sut.GetForbiddenExerciseTypeIds("warmup", "A1");
-
-        // EE-* and CO-* are also forbidden for WarmUp
-        result.Should().Contain(id => id.StartsWith("EE-", StringComparison.OrdinalIgnoreCase),
-            because: "WarmUp forbids EE-* pattern");
         result.Should().Contain(id => id.StartsWith("CO-", StringComparison.OrdinalIgnoreCase),
-            because: "WarmUp forbids CO-* pattern");
+            because: "WarmUp forbids CO-* pattern to guard against L1 injection of CO-06");
+        result.Should().NotContain(id => id.StartsWith("GR-", StringComparison.OrdinalIgnoreCase),
+            because: "GR-* was removed from warmup forbidden as fully redundant with the validExerciseTypes allowlist");
+        result.Should().NotContain(id => id.StartsWith("EE-", StringComparison.OrdinalIgnoreCase),
+            because: "EE-* was removed from warmup forbidden as fully redundant with the validExerciseTypes allowlist");
     }
 
     // --- GetGrammarScope ---

--- a/data/section-profiles/practice.json
+++ b/data/section-profiles/practice.json
@@ -3,128 +3,302 @@
   "weaknessTargetingGuidance": "include at least 1 exercise targeting: {weaknesses}. If no weakness data is available for this student, omit this instruction entirely.",
   "levels": {
     "A1": {
-      "contentTypes": ["exercises", "conversation"],
+      "contentTypes": [
+        "exercises",
+        "conversation"
+      ],
       "guidance": "Prefer matching and categorization tasks. For fill-in-blank items, always provide a word bank — list the answer options in the hint field. Max 3 options for multiple-choice. Do not include sentence transformation or error correction tasks.",
-      "duration": { "min": 8, "max": 12 },
-      "competencies": ["reading", "writing"],
+      "duration": {
+        "min": 8,
+        "max": 12
+      },
+      "competencies": [
+        "reading",
+        "writing"
+      ],
       "scaffolding": "high",
       "interactionPattern": "teacher-led",
-      "validExerciseTypes": ["GR-01", "GR-02", "GR-06", "GR-07", "GR-09", "VOC-05", "EO-01", "LUD-06", "LUD-07"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation requires prior command of the target form; inappropriate at A1"},
-        {"id": "GR-04", "pattern": null, "reason": "Error correction requires meta-awareness of the rule; too demanding at A1"},
-        {"id": "GR-08", "pattern": null, "reason": "Inductive discovery is a presentation task, not a practice drill"},
-        {"id": null, "pattern": "CE-*", "reason": "Reading comprehension tasks are not practice exercises for grammar/vocabulary at A1"},
-        {"id": null, "pattern": "EE-*", "reason": "Extended writing is production, not controlled practice"}
+      "validExerciseTypes": [
+        "GR-01",
+        "GR-02",
+        "GR-06",
+        "GR-07",
+        "GR-09",
+        "VOC-05",
+        "EO-01",
+        "LUD-06",
+        "LUD-07"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "GR-01", "note": "Always provide a word bank listing all answer options in the hint field"},
-        {"exerciseTypeId": "GR-02", "note": "Maximum 3 options per item at A1"},
-        {"exerciseTypeId": "GR-07", "note": "Use only 3-4 words per sentence to order; longer sequences are confusing at A1"}
+        {
+          "exerciseTypeId": "GR-01",
+          "note": "Always provide a word bank listing all answer options in the hint field"
+        },
+        {
+          "exerciseTypeId": "GR-02",
+          "note": "Maximum 3 options per item at A1"
+        },
+        {
+          "exerciseTypeId": "GR-07",
+          "note": "Use only 3-4 words per sentence to order; longer sequences are confusing at A1"
+        }
       ],
       "minExerciseVariety": 1
     },
     "A2": {
-      "contentTypes": ["exercises", "conversation", "error-correction"],
+      "contentTypes": [
+        "exercises",
+        "conversation",
+        "error-correction"
+      ],
       "guidance": "Fill-in-blank with optional word bank, multiple-choice with 4 options, true/false with justification required. Use simple contextual items rather than isolated drills.",
-      "duration": { "min": 8, "max": 12 },
-      "competencies": ["reading", "writing"],
+      "duration": {
+        "min": 8,
+        "max": 12
+      },
+      "competencies": [
+        "reading",
+        "writing"
+      ],
       "scaffolding": "medium",
       "interactionPattern": "teacher-guided",
-      "validExerciseTypes": ["GR-01", "GR-02", "GR-04", "GR-06", "GR-07", "GR-09", "VOC-05", "VOC-06", "EO-01", "CE-01", "CE-02", "CE-10", "LUD-05", "LUD-06", "LUD-07"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation requires prior command of the target form; not yet appropriate at A2"},
-        {"id": "GR-08", "pattern": null, "reason": "Inductive discovery is a presentation task, not a practice drill"},
-        {"id": null, "pattern": "EE-*", "reason": "Extended writing is production, not controlled practice"}
+      "validExerciseTypes": [
+        "GR-01",
+        "GR-02",
+        "GR-04",
+        "GR-06",
+        "GR-07",
+        "GR-09",
+        "VOC-05",
+        "VOC-06",
+        "EO-01",
+        "CE-01",
+        "CE-02",
+        "CE-10",
+        "LUD-05",
+        "LUD-06",
+        "LUD-07"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "GR-02", "note": "Maximum 4 options per item at A2"},
-        {"exerciseTypeId": "GR-01", "note": "Word bank is optional at A2 but recommended for new structures"},
-        {"exerciseTypeId": "GR-04", "note": "Simple agreement/gender errors only. Single-clause sentences."},
-        {"exerciseTypeId": "GR-07", "note": "Use 5-6 word single-clause sentences at A2; one step up from A1 (3-4 words) but still single-clause"}
+        {
+          "exerciseTypeId": "GR-02",
+          "note": "Maximum 4 options per item at A2"
+        },
+        {
+          "exerciseTypeId": "GR-01",
+          "note": "Word bank is optional at A2 but recommended for new structures"
+        },
+        {
+          "exerciseTypeId": "GR-04",
+          "note": "Simple agreement/gender errors only. Single-clause sentences."
+        },
+        {
+          "exerciseTypeId": "GR-07",
+          "note": "Use 5-6 word single-clause sentences at A2; one step up from A1 (3-4 words) but still single-clause"
+        }
       ],
       "minExerciseVariety": 1
     },
     "B1": {
-      "contentTypes": ["exercises", "conversation", "guided-writing", "error-correction"],
+      "contentTypes": [
+        "exercises",
+        "conversation",
+        "guided-writing",
+        "error-correction"
+      ],
       "guidance": "Use at least 2 different exercise formats (e.g. fill-in-blank AND multiple-choice — do not rely on just one type). Include transformation and error correction items.",
-      "duration": { "min": 10, "max": 15 },
-      "competencies": ["reading", "writing", "speaking"],
+      "duration": {
+        "min": 10,
+        "max": 15
+      },
+      "competencies": [
+        "reading",
+        "writing",
+        "speaking"
+      ],
       "scaffolding": "low",
       "interactionPattern": "student-led",
-      "validExerciseTypes": ["GR-01", "GR-02", "GR-03", "GR-04", "GR-07", "GR-09", "GR-10", "VOC-04", "VOC-05", "VOC-07", "CE-01", "CE-03", "CE-10", "CE-06", "EO-01", "LUD-05", "LUD-06", "LUD-07"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-08", "pattern": null, "reason": "Inductive discovery is a presentation task, not a practice drill"},
-        {"id": null, "pattern": "EE-*", "reason": "Extended writing is production, not controlled practice"}
+      "validExerciseTypes": [
+        "GR-01",
+        "GR-02",
+        "GR-03",
+        "GR-04",
+        "GR-07",
+        "GR-09",
+        "GR-10",
+        "VOC-04",
+        "VOC-05",
+        "VOC-07",
+        "CE-01",
+        "CE-03",
+        "CE-10",
+        "CE-06",
+        "EO-01",
+        "LUD-05",
+        "LUD-06",
+        "LUD-07"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "GR-04", "note": "Sentence-level corrections only at B1; discourse-level error correction is B2+"},
-        {"exerciseTypeId": "GR-07", "note": "Use phrase-level ordering at B1: reorder clauses or multi-word chunks rather than individual words"},
-        {"exerciseTypeId": "GR-10", "note": "Use a short (80-120 word) authentic-style source text from which student extracts and organises the target forms"}
+        {
+          "exerciseTypeId": "GR-04",
+          "note": "Sentence-level corrections only at B1; discourse-level error correction is B2+"
+        },
+        {
+          "exerciseTypeId": "GR-07",
+          "note": "Use phrase-level ordering at B1: reorder clauses or multi-word chunks rather than individual words"
+        },
+        {
+          "exerciseTypeId": "GR-10",
+          "note": "Use a short (80-120 word) authentic-style source text from which student extracts and organises the target forms"
+        }
       ],
       "minExerciseVariety": 2
     },
     "B2": {
-      "contentTypes": ["exercises", "conversation", "guided-writing", "error-correction"],
+      "contentTypes": [
+        "exercises",
+        "conversation",
+        "guided-writing",
+        "error-correction"
+      ],
       "guidance": "Pragmatic appropriateness, register selection, discourse completion tasks. Multi-step activities with nuanced distractors. Error correction at discourse level.",
-      "duration": { "min": 10, "max": 15 },
-      "competencies": ["reading", "writing", "speaking"],
+      "duration": {
+        "min": 10,
+        "max": 15
+      },
+      "competencies": [
+        "reading",
+        "writing",
+        "speaking"
+      ],
       "scaffolding": "low",
       "interactionPattern": "student-led",
-      "validExerciseTypes": ["GR-01", "GR-02", "GR-03", "GR-04", "GR-09", "GR-10", "VOC-04", "VOC-07", "VOC-10", "CE-01", "CE-02", "CE-03", "CE-10", "CE-04", "CE-06", "CE-07", "LUD-05"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-08", "pattern": null, "reason": "Inductive discovery is a presentation task, not a practice drill"},
-        {"id": null, "pattern": "EE-*", "reason": "Extended writing is production, not controlled practice"}
+      "validExerciseTypes": [
+        "GR-01",
+        "GR-02",
+        "GR-03",
+        "GR-04",
+        "GR-09",
+        "GR-10",
+        "VOC-04",
+        "VOC-07",
+        "VOC-10",
+        "CE-01",
+        "CE-02",
+        "CE-03",
+        "CE-10",
+        "CE-04",
+        "CE-06",
+        "CE-07",
+        "LUD-05"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "GR-04", "note": "Register errors, subjunctive/indicative confusion, false cognates. Discourse-level corrections permitted. Include cohesion and register errors, not only morphosyntax. Keep each explanation to a maximum of 2 sentences: one identifying the error type, one stating the rule."}
+        {
+          "exerciseTypeId": "GR-04",
+          "note": "Register errors, subjunctive/indicative confusion, false cognates. Discourse-level corrections permitted. Include cohesion and register errors, not only morphosyntax. Keep each explanation to a maximum of 2 sentences: one identifying the error type, one stating the rule."
+        }
       ],
       "minExerciseVariety": 2
     },
     "C1": {
-      "contentTypes": ["exercises", "conversation", "guided-writing", "error-correction"],
+      "contentTypes": [
+        "exercises",
+        "conversation",
+        "guided-writing",
+        "error-correction"
+      ],
       "guidance": "Minimize purely mechanical items (basic fill-in-blank, simple matching) in favor of reformulation, paraphrase, register transfer, and pragmatic inference tasks.",
-      "duration": { "min": 10, "max": 15 },
-      "competencies": ["reading", "writing", "speaking"],
+      "duration": {
+        "min": 10,
+        "max": 15
+      },
+      "competencies": [
+        "reading",
+        "writing",
+        "speaking"
+      ],
       "scaffolding": "none",
       "interactionPattern": "student-led",
-      "validExerciseTypes": ["GR-04", "GR-10", "VOC-04", "VOC-07", "VOC-10", "VOC-11", "CE-01", "CE-02", "CE-03", "CE-10", "CE-04", "CE-05", "CE-07", "CE-08", "CE-09", "EE-09"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-01", "pattern": null, "reason": "Basic fill-in-blank is too mechanical for C1; use reformulation or transformation tasks instead"},
-        {"id": "GR-02", "pattern": null, "reason": "Simple multiple choice is too mechanical for C1"},
-        {"id": "GR-05", "pattern": null, "reason": "Paradigm drilling is beneath C1 level"},
-        {"id": "GR-06", "pattern": null, "reason": "Simple matching is too mechanical for C1"},
-        {"id": "GR-07", "pattern": null, "reason": "Word ordering is too mechanical for C1"},
-        {"id": "GR-08", "pattern": null, "reason": "Inductive discovery is a presentation task, not a practice drill"},
-        {"id": null, "pattern": "LUD-*", "reason": "Ludic activities belong to warm-up or optional extension, not structured practice"}
+      "validExerciseTypes": [
+        "GR-04",
+        "GR-10",
+        "VOC-04",
+        "VOC-07",
+        "VOC-10",
+        "VOC-11",
+        "CE-01",
+        "CE-02",
+        "CE-03",
+        "CE-10",
+        "CE-04",
+        "CE-05",
+        "CE-07",
+        "CE-08",
+        "CE-09",
+        "EE-09"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "GR-04", "note": "Error correction at C1 focuses on pragmatic and register violations. Keep each explanation to a maximum of 2 sentences: one identifying the error category, one explaining the pragmatic or register constraint."},
-        {"exerciseTypeId": "EE-09", "note": "Register transformation at C1 should require precise control of register markers, not just lexical swaps"},
-        {"exerciseTypeId": "CE-09", "note": "Critical reading in practice: student argues against the text's position to demonstrate analytical distance"}
+        {
+          "exerciseTypeId": "GR-04",
+          "note": "Error correction at C1 focuses on pragmatic and register violations. Keep each explanation to a maximum of 2 sentences: one identifying the error category, one explaining the pragmatic or register constraint."
+        },
+        {
+          "exerciseTypeId": "EE-09",
+          "note": "Register transformation at C1 should require precise control of register markers, not just lexical swaps"
+        },
+        {
+          "exerciseTypeId": "CE-09",
+          "note": "Critical reading in practice: student argues against the text's position to demonstrate analytical distance"
+        }
       ],
       "minExerciseVariety": 2
     },
     "C2": {
-      "contentTypes": ["exercises", "conversation", "guided-writing", "error-correction"],
+      "contentTypes": [
+        "exercises",
+        "conversation",
+        "guided-writing",
+        "error-correction"
+      ],
       "guidance": "Reformulation, paraphrase, register transfer, pragmatic inference. No mechanical drills. Tasks require nuance and register awareness. Student evaluates alternative formulations.",
-      "duration": { "min": 10, "max": 15 },
-      "competencies": ["reading", "writing", "speaking"],
+      "duration": {
+        "min": 10,
+        "max": 15
+      },
+      "competencies": [
+        "reading",
+        "writing",
+        "speaking"
+      ],
       "scaffolding": "none",
       "interactionPattern": "student-led",
-      "validExerciseTypes": ["GR-04", "GR-10", "VOC-07", "VOC-10", "VOC-11", "CE-01", "CE-02", "CE-03", "CE-10", "CE-04", "CE-05", "CE-07", "CE-08", "CE-09", "EE-09", "EE-11"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-01", "pattern": null, "reason": "Basic fill-in-blank is too mechanical for C2; use reformulation or transformation tasks instead"},
-        {"id": "GR-02", "pattern": null, "reason": "Simple multiple choice is too mechanical for C2"},
-        {"id": "GR-05", "pattern": null, "reason": "Paradigm drilling is beneath C2 level"},
-        {"id": "GR-06", "pattern": null, "reason": "Simple matching is too mechanical for C2"},
-        {"id": "GR-07", "pattern": null, "reason": "Word ordering is too mechanical for C2"},
-        {"id": "GR-08", "pattern": null, "reason": "Inductive discovery is a presentation task, not a practice drill"},
-        {"id": null, "pattern": "LUD-*", "reason": "Ludic activities belong to warm-up or optional extension, not structured practice"}
+      "validExerciseTypes": [
+        "GR-04",
+        "GR-10",
+        "VOC-07",
+        "VOC-10",
+        "VOC-11",
+        "CE-01",
+        "CE-02",
+        "CE-03",
+        "CE-10",
+        "CE-04",
+        "CE-05",
+        "CE-07",
+        "CE-08",
+        "CE-09",
+        "EE-09",
+        "EE-11"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "EE-11", "note": "Written mediation at C2: student rewrites a specialized text for a non-specialist audience, maintaining accuracy and adjusting register"},
-        {"exerciseTypeId": "GR-04", "note": "Error correction at C2 includes pragmatic inappropriateness and register violations, not only grammatical errors. Keep each explanation to a maximum of 2 sentences."}
+        {
+          "exerciseTypeId": "EE-11",
+          "note": "Written mediation at C2: student rewrites a specialized text for a non-specialist audience, maintaining accuracy and adjusting register"
+        },
+        {
+          "exerciseTypeId": "GR-04",
+          "note": "Error correction at C2 includes pragmatic inappropriateness and register violations, not only grammatical errors. Keep each explanation to a maximum of 2 sentences."
+        }
       ],
       "minExerciseVariety": 2
     }

--- a/data/section-profiles/presentation.json
+++ b/data/section-profiles/presentation.json
@@ -2,188 +2,265 @@
   "sectionType": "presentation",
   "levels": {
     "A1": {
-      "contentTypes": ["grammar", "vocabulary", "reading", "conversation", "noticing-task"],
+      "contentTypes": [
+        "grammar",
+        "vocabulary",
+        "reading",
+        "conversation",
+        "noticing-task"
+      ],
       "guidance": "Isolated vocabulary with L1 translations. Clear grammar paradigms with minimal metalanguage. Max 8-10 new items. L1 support appropriate. Use simple, concrete examples the student can relate to.",
-      "duration": { "min": 8, "max": 12 },
-      "competencies": ["reading", "listening"],
+      "duration": {
+        "min": 8,
+        "max": 12
+      },
+      "competencies": [
+        "reading",
+        "listening"
+      ],
       "scaffolding": "high",
       "interactionPattern": "teacher-led",
-      "validExerciseTypes": ["VOC-01", "VOC-02", "GR-08", "GR-09", "CE-01", "CE-02"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-01", "pattern": null, "reason": "Fill-in-blank is a practice drill, not an input/discovery task"},
-        {"id": "GR-02", "pattern": null, "reason": "Multiple choice tests knowledge, not suitable for first exposure"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation requires prior command of the form"},
-        {"id": "EO-02", "pattern": null, "reason": "Open role-play is a production task; presentation is input stage"},
-        {"id": "EO-05", "pattern": null, "reason": "Sustained monologue is a production task"},
-        {"id": "EO-06", "pattern": null, "reason": "Debate is a production task"},
-        {"id": "EE-04", "pattern": null, "reason": "Extended description is a production task"},
-        {"id": "EE-05", "pattern": null, "reason": "Narration is a production task"},
-        {"id": "EE-06", "pattern": null, "reason": "Letter/email writing is a production task"},
-        {"id": "EE-07", "pattern": null, "reason": "Opinion essay is a production task"},
-        {"id": "EE-08", "pattern": null, "reason": "Summary requires prior reading comprehension, not for input stage"},
-        {"id": "EE-09", "pattern": null, "reason": "Register transformation requires command of both registers"},
-        {"id": "EE-10", "pattern": null, "reason": "Creative writing is a production task"},
-        {"id": "EE-11", "pattern": null, "reason": "Written mediation is a production task"},
-        {"id": null, "pattern": "LUD-*", "reason": "Games are for practice consolidation, not language input/discovery"}
+      "validExerciseTypes": [
+        "VOC-01",
+        "VOC-02",
+        "GR-08",
+        "GR-09",
+        "CE-01",
+        "CE-02"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "GR-08", "note": "Minimal metalanguage; elicit the rule with yes/no questions and pointing at the example. Noticing tasks only at A1.2; not appropriate at A1.1 where the grammar system is not yet sufficiently populated for inductive discovery"},
-        {"exerciseTypeId": "VOC-01", "note": "Include L1 translations for all items; maximum 8-10 new words per lesson"}
+        {
+          "exerciseTypeId": "GR-08",
+          "note": "Minimal metalanguage; elicit the rule with yes/no questions and pointing at the example. Noticing tasks only at A1.2; not appropriate at A1.1 where the grammar system is not yet sufficiently populated for inductive discovery"
+        },
+        {
+          "exerciseTypeId": "VOC-01",
+          "note": "Include L1 translations for all items; maximum 8-10 new words per lesson"
+        }
       ],
       "minExerciseVariety": 1
     },
     "A2": {
-      "contentTypes": ["grammar", "vocabulary", "reading", "conversation", "noticing-task"],
+      "contentTypes": [
+        "grammar",
+        "vocabulary",
+        "reading",
+        "conversation",
+        "noticing-task"
+      ],
       "guidance": "Vocabulary in short contextual sentences. Grammar through noticing tasks: present examples, elicit the rule. Short authentic-style texts (50-80 words) as input.",
-      "duration": { "min": 8, "max": 12 },
-      "competencies": ["reading", "listening"],
+      "duration": {
+        "min": 8,
+        "max": 12
+      },
+      "competencies": [
+        "reading",
+        "listening"
+      ],
       "scaffolding": "medium",
       "interactionPattern": "teacher-led",
-      "validExerciseTypes": ["VOC-01", "VOC-02", "VOC-04", "GR-08", "GR-09", "CE-01", "CE-02", "CE-06"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-01", "pattern": null, "reason": "Fill-in-blank is a practice drill, not an input/discovery task"},
-        {"id": "GR-02", "pattern": null, "reason": "Multiple choice tests knowledge, not suitable for first exposure"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation requires prior command of the form"},
-        {"id": "EO-02", "pattern": null, "reason": "Open role-play is a production task; presentation is input stage"},
-        {"id": "EO-05", "pattern": null, "reason": "Sustained monologue is a production task"},
-        {"id": "EO-06", "pattern": null, "reason": "Debate is a production task"},
-        {"id": "EE-04", "pattern": null, "reason": "Extended description is a production task"},
-        {"id": "EE-05", "pattern": null, "reason": "Narration is a production task"},
-        {"id": "EE-06", "pattern": null, "reason": "Letter/email writing is a production task"},
-        {"id": "EE-07", "pattern": null, "reason": "Opinion essay is a production task"},
-        {"id": "EE-08", "pattern": null, "reason": "Summary requires prior reading comprehension, not for input stage"},
-        {"id": "EE-09", "pattern": null, "reason": "Register transformation requires command of both registers"},
-        {"id": "EE-10", "pattern": null, "reason": "Creative writing is a production task"},
-        {"id": "EE-11", "pattern": null, "reason": "Written mediation is a production task"},
-        {"id": null, "pattern": "LUD-*", "reason": "Games are for practice consolidation, not language input/discovery"}
+      "validExerciseTypes": [
+        "VOC-01",
+        "VOC-02",
+        "VOC-04",
+        "GR-08",
+        "GR-09",
+        "CE-01",
+        "CE-02",
+        "CE-06"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "GR-08", "note": "Present 2-3 clear examples; ask 'Que notas?' before explaining the rule"},
-        {"exerciseTypeId": "CE-06", "note": "Use gap-fill cloze only with a word bank at A2; gapless cloze is B1+"}
+        {
+          "exerciseTypeId": "GR-08",
+          "note": "Present 2-3 clear examples; ask 'Que notas?' before explaining the rule"
+        },
+        {
+          "exerciseTypeId": "CE-06",
+          "note": "Use gap-fill cloze only with a word bank at A2; gapless cloze is B1+"
+        }
       ],
       "minExerciseVariety": 1
     },
     "B1": {
-      "contentTypes": ["grammar", "vocabulary", "reading", "conversation", "noticing-task"],
+      "contentTypes": [
+        "grammar",
+        "vocabulary",
+        "reading",
+        "conversation",
+        "noticing-task"
+      ],
       "guidance": "Introduce new language through authentic-style excerpts (100-150 words). When the lesson includes a grammar point, use guided discovery: present data, ask the student to formulate the rule. Include typical L1 interference notes. When no grammar point is targeted, let the text or content carry the input.",
-      "duration": { "min": 10, "max": 15 },
-      "competencies": ["reading", "listening"],
+      "duration": {
+        "min": 10,
+        "max": 15
+      },
+      "competencies": [
+        "reading",
+        "listening"
+      ],
       "scaffolding": "medium",
       "interactionPattern": "teacher-guided",
-      "validExerciseTypes": ["VOC-04", "VOC-07", "GR-08", "GR-09", "GR-10", "CE-01", "CE-02", "CE-03", "CE-04", "CE-06"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-01", "pattern": null, "reason": "Fill-in-blank is a practice drill, not an input/discovery task"},
-        {"id": "GR-02", "pattern": null, "reason": "Multiple choice tests knowledge, not suitable for first exposure"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation requires prior command of the form"},
-        {"id": "EO-02", "pattern": null, "reason": "Open role-play is a production task; presentation is input stage"},
-        {"id": "EO-05", "pattern": null, "reason": "Sustained monologue is a production task"},
-        {"id": "EO-06", "pattern": null, "reason": "Debate is a production task"},
-        {"id": "EE-04", "pattern": null, "reason": "Extended description is a production task"},
-        {"id": "EE-05", "pattern": null, "reason": "Narration is a production task"},
-        {"id": "EE-06", "pattern": null, "reason": "Letter/email writing is a production task"},
-        {"id": "EE-07", "pattern": null, "reason": "Opinion essay is a production task"},
-        {"id": "EE-08", "pattern": null, "reason": "Summary requires prior reading comprehension, not for input stage"},
-        {"id": "EE-09", "pattern": null, "reason": "Register transformation requires command of both registers"},
-        {"id": "EE-10", "pattern": null, "reason": "Creative writing is a production task"},
-        {"id": "EE-11", "pattern": null, "reason": "Written mediation is a production task"},
-        {"id": null, "pattern": "LUD-*", "reason": "Games are for practice consolidation, not language input/discovery"}
+      "validExerciseTypes": [
+        "VOC-04",
+        "VOC-07",
+        "GR-08",
+        "GR-09",
+        "GR-10",
+        "CE-01",
+        "CE-02",
+        "CE-03",
+        "CE-04",
+        "CE-06"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "GR-10", "note": "Highlight or underline the target forms in the source text before asking student to extract and organise them"},
-        {"exerciseTypeId": "GR-08", "note": "Ask student to formulate the rule in their own words before confirming; include L1 interference notes"}
+        {
+          "exerciseTypeId": "GR-10",
+          "note": "Highlight or underline the target forms in the source text before asking student to extract and organise them"
+        },
+        {
+          "exerciseTypeId": "GR-08",
+          "note": "Ask student to formulate the rule in their own words before confirming; include L1 interference notes"
+        }
       ],
       "minExerciseVariety": 1
     },
     "B2": {
-      "contentTypes": ["grammar", "vocabulary", "reading", "conversation", "noticing-task"],
+      "contentTypes": [
+        "grammar",
+        "vocabulary",
+        "reading",
+        "conversation",
+        "noticing-task"
+      ],
       "guidance": "Register-appropriate authentic texts as the primary input vehicle. When the lesson targets grammar, focus on nuance: indicative vs subjunctive, aspect, discourse markers. Student formulates rules from data. When grammar is not the focus, the text serves vocabulary expansion and comprehension.",
-      "duration": { "min": 10, "max": 15 },
-      "competencies": ["reading", "listening"],
+      "duration": {
+        "min": 10,
+        "max": 15
+      },
+      "competencies": [
+        "reading",
+        "listening"
+      ],
       "scaffolding": "low",
       "interactionPattern": "student-led",
-      "validExerciseTypes": ["VOC-04", "VOC-07", "VOC-10", "GR-08", "GR-10", "CE-01", "CE-02", "CE-03", "CE-04", "CE-05", "CE-06", "CE-07", "CE-08"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-01", "pattern": null, "reason": "Fill-in-blank is a practice drill, not an input/discovery task"},
-        {"id": "GR-02", "pattern": null, "reason": "Multiple choice tests knowledge, not suitable for first exposure"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation requires prior command of the form"},
-        {"id": "EO-02", "pattern": null, "reason": "Open role-play is a production task; presentation is input stage"},
-        {"id": "EO-05", "pattern": null, "reason": "Sustained monologue is a production task"},
-        {"id": "EO-06", "pattern": null, "reason": "Debate is a production task"},
-        {"id": "EE-04", "pattern": null, "reason": "Extended description is a production task"},
-        {"id": "EE-05", "pattern": null, "reason": "Narration is a production task"},
-        {"id": "EE-06", "pattern": null, "reason": "Letter/email writing is a production task"},
-        {"id": "EE-07", "pattern": null, "reason": "Opinion essay is a production task"},
-        {"id": "EE-08", "pattern": null, "reason": "Summary requires prior reading comprehension, not for input stage"},
-        {"id": "EE-09", "pattern": null, "reason": "Register transformation requires command of both registers"},
-        {"id": "EE-10", "pattern": null, "reason": "Creative writing is a production task"},
-        {"id": "EE-11", "pattern": null, "reason": "Written mediation is a production task"},
-        {"id": null, "pattern": "LUD-*", "reason": "Games are for practice consolidation, not language input/discovery"}
+      "validExerciseTypes": [
+        "VOC-04",
+        "VOC-07",
+        "VOC-10",
+        "GR-08",
+        "GR-10",
+        "CE-01",
+        "CE-02",
+        "CE-03",
+        "CE-04",
+        "CE-05",
+        "CE-06",
+        "CE-07",
+        "CE-08"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "CE-08", "note": "Use register/intent identification to feed discussion of pragmatic nuance; connect to grammar point"},
-        {"exerciseTypeId": "VOC-10", "note": "Present idioms in authentic context only; explain cultural connotation, not just meaning"}
+        {
+          "exerciseTypeId": "CE-08",
+          "note": "Use register/intent identification to feed discussion of pragmatic nuance; connect to grammar point"
+        },
+        {
+          "exerciseTypeId": "VOC-10",
+          "note": "Present idioms in authentic context only; explain cultural connotation, not just meaning"
+        }
       ],
       "minExerciseVariety": 1
     },
     "C1": {
-      "contentTypes": ["grammar", "vocabulary", "reading", "conversation", "noticing-task"],
+      "contentTypes": [
+        "grammar",
+        "vocabulary",
+        "reading",
+        "conversation",
+        "noticing-task"
+      ],
       "guidance": "Collocations, idioms, pragmatic functions, register shifts. Ungraded authentic texts. Grammar: pragmatic and sociolinguistic nuance. Student analyses and categorises independently.",
-      "duration": { "min": 10, "max": 15 },
-      "competencies": ["reading", "listening"],
+      "duration": {
+        "min": 10,
+        "max": 15
+      },
+      "competencies": [
+        "reading",
+        "listening"
+      ],
       "scaffolding": "none",
       "interactionPattern": "student-led",
-      "validExerciseTypes": ["VOC-07", "VOC-10", "VOC-11", "GR-08", "GR-10", "CE-01", "CE-02", "CE-03", "CE-04", "CE-05", "CE-06", "CE-07", "CE-08", "CE-09"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-01", "pattern": null, "reason": "Fill-in-blank is a practice drill, not an input/discovery task"},
-        {"id": "GR-02", "pattern": null, "reason": "Multiple choice tests knowledge, not suitable for first exposure"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation requires prior command of the form"},
-        {"id": "EO-02", "pattern": null, "reason": "Open role-play is a production task; presentation is input stage"},
-        {"id": "EO-05", "pattern": null, "reason": "Sustained monologue is a production task"},
-        {"id": "EO-06", "pattern": null, "reason": "Debate is a production task"},
-        {"id": "EE-04", "pattern": null, "reason": "Extended description is a production task"},
-        {"id": "EE-05", "pattern": null, "reason": "Narration is a production task"},
-        {"id": "EE-06", "pattern": null, "reason": "Letter/email writing is a production task"},
-        {"id": "EE-07", "pattern": null, "reason": "Opinion essay is a production task"},
-        {"id": "EE-08", "pattern": null, "reason": "Summary requires prior reading comprehension, not for input stage"},
-        {"id": "EE-09", "pattern": null, "reason": "Register transformation requires command of both registers"},
-        {"id": "EE-10", "pattern": null, "reason": "Creative writing is a production task"},
-        {"id": "EE-11", "pattern": null, "reason": "Written mediation is a production task"},
-        {"id": null, "pattern": "LUD-*", "reason": "Games are for practice consolidation, not language input/discovery"}
+      "validExerciseTypes": [
+        "VOC-07",
+        "VOC-10",
+        "VOC-11",
+        "GR-08",
+        "GR-10",
+        "CE-01",
+        "CE-02",
+        "CE-03",
+        "CE-04",
+        "CE-05",
+        "CE-06",
+        "CE-07",
+        "CE-08",
+        "CE-09"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "CE-09", "note": "Critical reading feeds metalinguistic analysis; ask student to evaluate the author's argumentation strategy"},
-        {"exerciseTypeId": "VOC-11", "note": "Word formation at C1 includes derivation chains and productivity rules, not just memorised pairs"}
+        {
+          "exerciseTypeId": "CE-09",
+          "note": "Critical reading feeds metalinguistic analysis; ask student to evaluate the author's argumentation strategy"
+        },
+        {
+          "exerciseTypeId": "VOC-11",
+          "note": "Word formation at C1 includes derivation chains and productivity rules, not just memorised pairs"
+        }
       ],
       "minExerciseVariety": 1
     },
     "C2": {
-      "contentTypes": ["grammar", "vocabulary", "reading", "conversation", "noticing-task"],
+      "contentTypes": [
+        "grammar",
+        "vocabulary",
+        "reading",
+        "conversation",
+        "noticing-task"
+      ],
       "guidance": "Collocations, idioms, pragmatic functions at near-native level. Authentic texts without grading. Mediation, paraphrase, register transfer as input tasks. Student leads analysis.",
-      "duration": { "min": 10, "max": 15 },
-      "competencies": ["reading", "listening"],
+      "duration": {
+        "min": 10,
+        "max": 15
+      },
+      "competencies": [
+        "reading",
+        "listening"
+      ],
       "scaffolding": "none",
       "interactionPattern": "student-led",
-      "validExerciseTypes": ["VOC-07", "VOC-10", "VOC-11", "GR-08", "GR-10", "CE-01", "CE-02", "CE-03", "CE-04", "CE-05", "CE-06", "CE-07", "CE-08", "CE-09"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-01", "pattern": null, "reason": "Fill-in-blank is a practice drill, not an input/discovery task"},
-        {"id": "GR-02", "pattern": null, "reason": "Multiple choice tests knowledge, not suitable for first exposure"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation requires prior command of the form"},
-        {"id": "EO-02", "pattern": null, "reason": "Open role-play is a production task; presentation is input stage"},
-        {"id": "EO-05", "pattern": null, "reason": "Sustained monologue is a production task"},
-        {"id": "EO-06", "pattern": null, "reason": "Debate is a production task"},
-        {"id": "EE-04", "pattern": null, "reason": "Extended description is a production task"},
-        {"id": "EE-05", "pattern": null, "reason": "Narration is a production task"},
-        {"id": "EE-06", "pattern": null, "reason": "Letter/email writing is a production task"},
-        {"id": "EE-07", "pattern": null, "reason": "Opinion essay is a production task"},
-        {"id": "EE-08", "pattern": null, "reason": "Summary requires prior reading comprehension, not for input stage"},
-        {"id": "EE-09", "pattern": null, "reason": "Register transformation requires command of both registers"},
-        {"id": "EE-10", "pattern": null, "reason": "Creative writing is a production task"},
-        {"id": "EE-11", "pattern": null, "reason": "Written mediation is a production task"},
-        {"id": null, "pattern": "LUD-*", "reason": "Games are for practice consolidation, not language input/discovery"}
+      "validExerciseTypes": [
+        "VOC-07",
+        "VOC-10",
+        "VOC-11",
+        "GR-08",
+        "GR-10",
+        "CE-01",
+        "CE-02",
+        "CE-03",
+        "CE-04",
+        "CE-05",
+        "CE-06",
+        "CE-07",
+        "CE-08",
+        "CE-09"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "CE-05", "note": "Ordering paragraphs at C2 should use ungraded authentic fragments; student justifies coherence decisions"},
-        {"exerciseTypeId": "GR-08", "note": "At C2, noticing tasks focus on pragmatic and sociolinguistic nuance (register shifts, implicature); not morphosyntax"}
+        {
+          "exerciseTypeId": "CE-05",
+          "note": "Ordering paragraphs at C2 should use ungraded authentic fragments; student justifies coherence decisions"
+        },
+        {
+          "exerciseTypeId": "GR-08",
+          "note": "At C2, noticing tasks focus on pragmatic and sociolinguistic nuance (register shifts, implicature); not morphosyntax"
+        }
       ],
       "minExerciseVariety": 1
     }

--- a/data/section-profiles/production.json
+++ b/data/section-profiles/production.json
@@ -3,171 +3,245 @@
   "weaknessTargetingGuidance": "create a context where these areas arise naturally — only if the weakness area is compatible with this lesson's linguistic content; do not import unrelated structures.",
   "levels": {
     "A1": {
-      "contentTypes": ["conversation", "guided-writing"],
+      "contentTypes": [
+        "conversation",
+        "guided-writing"
+      ],
       "guidance": "Production MUST be a guided writing task with sentence frames provided. Ask the student to write 3-5 sentences using new vocabulary or structures from this lesson. Guided writing is appropriate and achievable even at A1. Alternatively, a guided dialogue (EO-01) with fully scripted turns and 2 pre-given response options per turn is appropriate when the session focus is oral production.",
-      "duration": { "min": 5, "max": 8 },
-      "competencies": ["writing", "speaking"],
+      "duration": {
+        "min": 5,
+        "max": 8
+      },
+      "competencies": [
+        "writing",
+        "speaking"
+      ],
       "scaffolding": "high",
       "interactionPattern": "independent",
-      "validExerciseTypes": ["EE-01", "EE-02", "EE-03", "EO-01"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-01", "pattern": null, "reason": "Fill-in-blank is controlled practice, not free production"},
-        {"id": "GR-02", "pattern": null, "reason": "Multiple choice is controlled practice, not free production"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation is controlled practice, not free production"},
-        {"id": "GR-04", "pattern": null, "reason": "Error correction is metalinguistic analysis, not production"},
-        {"id": "GR-05", "pattern": null, "reason": "Conjugation paradigms are drills, not production"},
-        {"id": "GR-06", "pattern": null, "reason": "Matching is controlled practice, not production"},
-        {"id": "GR-07", "pattern": null, "reason": "Word ordering is controlled practice, not production"},
-        {"id": "VOC-01", "pattern": null, "reason": "Vocabulary lists with translations are presentation, not production"},
-        {"id": "VOC-02", "pattern": null, "reason": "Vocabulary matching is presentation/practice, not production"},
-        {"id": "VOC-03", "pattern": null, "reason": "Semantic categorisation is presentation/practice, not production"},
-        {"id": null, "pattern": "CE-*", "reason": "Reading comprehension is reception, not production"},
-        {"id": null, "pattern": "LUD-*", "reason": "Ludic activities are not production tasks"}
+      "validExerciseTypes": [
+        "EE-01",
+        "EE-02",
+        "EE-03",
+        "EO-01"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "EE-01", "note": "Provide a full model sentence for each frame; student fills in only the target vocabulary or structure"},
-        {"exerciseTypeId": "EE-02", "note": "Sentence frames must supply the subject and verb; student completes the complement only"},
-        {"exerciseTypeId": "EO-01", "note": "Guided dialogue must be fully scripted at A1; student chooses from 2 pre-given responses per turn"}
+        {
+          "exerciseTypeId": "EE-01",
+          "note": "Provide a full model sentence for each frame; student fills in only the target vocabulary or structure"
+        },
+        {
+          "exerciseTypeId": "EE-02",
+          "note": "Sentence frames must supply the subject and verb; student completes the complement only"
+        },
+        {
+          "exerciseTypeId": "EO-01",
+          "note": "Guided dialogue must be fully scripted at A1; student chooses from 2 pre-given responses per turn"
+        }
       ],
       "minExerciseVariety": 1
     },
     "A2": {
-      "contentTypes": ["conversation", "guided-writing"],
+      "contentTypes": [
+        "conversation",
+        "guided-writing"
+      ],
       "guidance": "Guided writing with a model paragraph provided. Student writes 4-6 sentences using the target grammar and vocabulary. A short opinion sentence or simple description. Scaffolding phrase starters optional. A short guided dialogue (EO-01 or EO-08, 2-3 turns) is a valid alternative when the session focus is oral production.",
-      "duration": { "min": 5, "max": 8 },
-      "competencies": ["writing", "speaking"],
+      "duration": {
+        "min": 5,
+        "max": 8
+      },
+      "competencies": [
+        "writing",
+        "speaking"
+      ],
       "scaffolding": "medium",
       "interactionPattern": "independent",
-      "validExerciseTypes": ["EE-01", "EE-02", "EE-03", "EE-04", "EO-01", "EO-08"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-01", "pattern": null, "reason": "Fill-in-blank is controlled practice, not free production"},
-        {"id": "GR-02", "pattern": null, "reason": "Multiple choice is controlled practice, not free production"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation is controlled practice, not free production"},
-        {"id": "GR-04", "pattern": null, "reason": "Error correction is metalinguistic analysis, not production"},
-        {"id": "GR-05", "pattern": null, "reason": "Conjugation paradigms are drills, not production"},
-        {"id": "GR-06", "pattern": null, "reason": "Matching is controlled practice, not production"},
-        {"id": "GR-07", "pattern": null, "reason": "Word ordering is controlled practice, not production"},
-        {"id": "VOC-01", "pattern": null, "reason": "Vocabulary lists with translations are presentation, not production"},
-        {"id": "VOC-02", "pattern": null, "reason": "Vocabulary matching is presentation/practice, not production"},
-        {"id": "VOC-03", "pattern": null, "reason": "Semantic categorisation is presentation/practice, not production"},
-        {"id": null, "pattern": "CE-*", "reason": "Reading comprehension is reception, not production"},
-        {"id": null, "pattern": "LUD-*", "reason": "Ludic activities are not production tasks"}
+      "validExerciseTypes": [
+        "EE-01",
+        "EE-02",
+        "EE-03",
+        "EE-04",
+        "EO-01",
+        "EO-08"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "EE-04", "note": "Description tasks at A2 must provide an image or explicit topic prompt; 3-5 sentences maximum"},
-        {"exerciseTypeId": "EO-08", "note": "Free conversation at A2 is a short exchange on a familiar topic; 2-3 turns only"}
+        {
+          "exerciseTypeId": "EE-04",
+          "note": "Description tasks at A2 must provide an image or explicit topic prompt; 3-5 sentences maximum"
+        },
+        {
+          "exerciseTypeId": "EO-08",
+          "note": "Free conversation at A2 is a short exchange on a familiar topic; 2-3 turns only"
+        }
       ],
       "minExerciseVariety": 1
     },
     "B1": {
-      "contentTypes": ["conversation", "exercises", "guided-writing"],
+      "contentTypes": [
+        "conversation",
+        "exercises",
+        "guided-writing"
+      ],
       "guidance": "Production must be a communicative task: an opinion paragraph, a short role-play scenario description, or a problem-solving task where the student uses new language in a meaningful context. 80-120 words.",
-      "duration": { "min": 8, "max": 12 },
-      "competencies": ["writing", "speaking"],
+      "duration": {
+        "min": 8,
+        "max": 12
+      },
+      "competencies": [
+        "writing",
+        "speaking"
+      ],
       "scaffolding": "low",
       "interactionPattern": "independent",
-      "validExerciseTypes": ["EE-05", "EE-06", "EE-07", "EO-02", "EO-05", "EO-06", "EO-07", "PRAG-01", "PRAG-05"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-01", "pattern": null, "reason": "Fill-in-blank is controlled practice, not free production"},
-        {"id": "GR-02", "pattern": null, "reason": "Multiple choice is controlled practice, not free production"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation is controlled practice, not free production"},
-        {"id": "GR-04", "pattern": null, "reason": "Error correction is metalinguistic analysis, not production"},
-        {"id": "GR-05", "pattern": null, "reason": "Conjugation paradigms are drills, not production"},
-        {"id": "GR-06", "pattern": null, "reason": "Matching is controlled practice, not production"},
-        {"id": "GR-07", "pattern": null, "reason": "Word ordering is controlled practice, not production"},
-        {"id": "VOC-01", "pattern": null, "reason": "Vocabulary lists with translations are presentation, not production"},
-        {"id": "VOC-02", "pattern": null, "reason": "Vocabulary matching is presentation/practice, not production"},
-        {"id": "VOC-03", "pattern": null, "reason": "Semantic categorisation is presentation/practice, not production"},
-        {"id": null, "pattern": "CE-*", "reason": "Reading comprehension is reception, not production"},
-        {"id": null, "pattern": "LUD-*", "reason": "Ludic activities are not production tasks"}
+      "validExerciseTypes": [
+        "EE-05",
+        "EE-06",
+        "EE-07",
+        "EO-02",
+        "EO-05",
+        "EO-06",
+        "EO-07",
+        "PRAG-01",
+        "PRAG-05"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "EE-07", "note": "Opinion paragraph at B1: 80-120 words; student states a position and gives 2 reasons; no formal essay structure required"},
-        {"exerciseTypeId": "EO-02", "note": "Open role-play at B1 must have a clear communicative goal (buy a ticket, make a complaint) and a 3-4 turn minimum expectation"}
+        {
+          "exerciseTypeId": "EE-07",
+          "note": "Opinion paragraph at B1: 80-120 words; student states a position and gives 2 reasons; no formal essay structure required"
+        },
+        {
+          "exerciseTypeId": "EO-02",
+          "note": "Open role-play at B1 must have a clear communicative goal (buy a ticket, make a complaint) and a 3-4 turn minimum expectation"
+        }
       ],
       "minExerciseVariety": 1
     },
     "B2": {
-      "contentTypes": ["conversation", "reading", "exercises", "guided-writing"],
+      "contentTypes": [
+        "conversation",
+        "reading",
+        "exercises",
+        "guided-writing"
+      ],
       "guidance": "Structured argument, formal email, or extended communicative task using the target register. 150-200 words. Authentic stimulus (text or question) may be used as springboard.",
-      "duration": { "min": 10, "max": 15 },
-      "competencies": ["writing", "speaking"],
+      "duration": {
+        "min": 10,
+        "max": 15
+      },
+      "competencies": [
+        "writing",
+        "speaking"
+      ],
       "scaffolding": "low",
       "interactionPattern": "independent",
-      "validExerciseTypes": ["EE-06", "EE-07", "EE-08", "EE-09", "EO-02", "EO-05", "EO-06", "EO-07", "EO-09", "PRAG-01", "PRAG-05"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-01", "pattern": null, "reason": "Fill-in-blank is controlled practice, not free production"},
-        {"id": "GR-02", "pattern": null, "reason": "Multiple choice is controlled practice, not free production"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation is controlled practice, not free production"},
-        {"id": "GR-04", "pattern": null, "reason": "Error correction is metalinguistic analysis, not production"},
-        {"id": "GR-05", "pattern": null, "reason": "Conjugation paradigms are drills, not production"},
-        {"id": "GR-06", "pattern": null, "reason": "Matching is controlled practice, not production"},
-        {"id": "GR-07", "pattern": null, "reason": "Word ordering is controlled practice, not production"},
-        {"id": "VOC-01", "pattern": null, "reason": "Vocabulary lists with translations are presentation, not production"},
-        {"id": "VOC-02", "pattern": null, "reason": "Vocabulary matching is presentation/practice, not production"},
-        {"id": "VOC-03", "pattern": null, "reason": "Semantic categorisation is presentation/practice, not production"},
-        {"id": null, "pattern": "CE-*", "reason": "Reading comprehension is reception, not production"},
-        {"id": null, "pattern": "LUD-*", "reason": "Ludic activities are not production tasks"}
+      "validExerciseTypes": [
+        "EE-06",
+        "EE-07",
+        "EE-08",
+        "EE-09",
+        "EO-02",
+        "EO-05",
+        "EO-06",
+        "EO-07",
+        "EO-09",
+        "PRAG-01",
+        "PRAG-05"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "EE-06", "note": "Formal email at B2 must specify register constraints (formal vs semi-formal) and functional goal (complaint, request, enquiry)"},
-        {"exerciseTypeId": "EO-09", "note": "Oral mediation at B2: student summarises a 100-150 word text for a non-specialist; 3-4 minutes speaking time"}
+        {
+          "exerciseTypeId": "EE-06",
+          "note": "Formal email at B2 must specify register constraints (formal vs semi-formal) and functional goal (complaint, request, enquiry)"
+        },
+        {
+          "exerciseTypeId": "EO-09",
+          "note": "Oral mediation at B2: student summarises a 100-150 word text for a non-specialist; 3-4 minutes speaking time"
+        }
       ],
       "minExerciseVariety": 1
     },
     "C1": {
-      "contentTypes": ["conversation", "reading", "exercises", "guided-writing"],
+      "contentTypes": [
+        "conversation",
+        "reading",
+        "exercises",
+        "guided-writing"
+      ],
       "guidance": "open-ended task requiring autonomous extended language use: a structured argument, a creative writing piece, or a task requiring register and pragmatic awareness. 200+ words.",
-      "duration": { "min": 10, "max": 15 },
-      "competencies": ["writing", "speaking"],
+      "duration": {
+        "min": 10,
+        "max": 15
+      },
+      "competencies": [
+        "writing",
+        "speaking"
+      ],
       "scaffolding": "none",
       "interactionPattern": "independent",
-      "validExerciseTypes": ["EE-07", "EE-08", "EE-09", "EE-10", "EE-11", "EO-05", "EO-06", "EO-07", "EO-09", "PRAG-01", "PRAG-05"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-01", "pattern": null, "reason": "Fill-in-blank is controlled practice, not free production"},
-        {"id": "GR-02", "pattern": null, "reason": "Multiple choice is controlled practice, not free production"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation is controlled practice, not free production"},
-        {"id": "GR-04", "pattern": null, "reason": "Error correction is metalinguistic analysis, not production"},
-        {"id": "GR-05", "pattern": null, "reason": "Conjugation paradigms are drills, not production"},
-        {"id": "GR-06", "pattern": null, "reason": "Matching is controlled practice, not production"},
-        {"id": "GR-07", "pattern": null, "reason": "Word ordering is controlled practice, not production"},
-        {"id": "VOC-01", "pattern": null, "reason": "Vocabulary lists with translations are presentation, not production"},
-        {"id": "VOC-02", "pattern": null, "reason": "Vocabulary matching is presentation/practice, not production"},
-        {"id": "VOC-03", "pattern": null, "reason": "Semantic categorisation is presentation/practice, not production"},
-        {"id": null, "pattern": "CE-*", "reason": "Reading comprehension is reception, not production"},
-        {"id": null, "pattern": "LUD-*", "reason": "Ludic activities are not production tasks"}
+      "validExerciseTypes": [
+        "EE-07",
+        "EE-08",
+        "EE-09",
+        "EE-10",
+        "EE-11",
+        "EO-05",
+        "EO-06",
+        "EO-07",
+        "EO-09",
+        "PRAG-01",
+        "PRAG-05"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "EE-09", "note": "Register transformation at C1: student rewrites a formal text as informal and vice versa, maintaining full propositional content"},
-        {"exerciseTypeId": "EO-07", "note": "Negotiation at C1: open-ended scenario with conflicting interests; student must reach a compromise using pragmatic strategies"}
+        {
+          "exerciseTypeId": "EE-09",
+          "note": "Register transformation at C1: student rewrites a formal text as informal and vice versa, maintaining full propositional content"
+        },
+        {
+          "exerciseTypeId": "EO-07",
+          "note": "Negotiation at C1: open-ended scenario with conflicting interests; student must reach a compromise using pragmatic strategies"
+        }
       ],
       "minExerciseVariety": 1
     },
     "C2": {
-      "contentTypes": ["conversation", "reading", "exercises", "guided-writing"],
+      "contentTypes": [
+        "conversation",
+        "reading",
+        "exercises",
+        "guided-writing"
+      ],
       "guidance": "Essay, debate position, mediation task, or creative writing requiring near-native register control. 200+ words. Student selects appropriate register and genre without prompting.",
-      "duration": { "min": 10, "max": 15 },
-      "competencies": ["writing", "speaking"],
+      "duration": {
+        "min": 10,
+        "max": 15
+      },
+      "competencies": [
+        "writing",
+        "speaking"
+      ],
       "scaffolding": "none",
       "interactionPattern": "independent",
-      "validExerciseTypes": ["EE-07", "EE-08", "EE-09", "EE-10", "EE-11", "EO-05", "EO-06", "EO-07", "EO-09", "PRAG-01", "PRAG-05"],
-      "forbiddenExerciseTypes": [
-        {"id": "GR-01", "pattern": null, "reason": "Fill-in-blank is controlled practice, not free production"},
-        {"id": "GR-02", "pattern": null, "reason": "Multiple choice is controlled practice, not free production"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation is controlled practice, not free production"},
-        {"id": "GR-04", "pattern": null, "reason": "Error correction is metalinguistic analysis, not production"},
-        {"id": "GR-05", "pattern": null, "reason": "Conjugation paradigms are drills, not production"},
-        {"id": "GR-06", "pattern": null, "reason": "Matching is controlled practice, not production"},
-        {"id": "GR-07", "pattern": null, "reason": "Word ordering is controlled practice, not production"},
-        {"id": "VOC-01", "pattern": null, "reason": "Vocabulary lists with translations are presentation, not production"},
-        {"id": "VOC-02", "pattern": null, "reason": "Vocabulary matching is presentation/practice, not production"},
-        {"id": "VOC-03", "pattern": null, "reason": "Semantic categorisation is presentation/practice, not production"},
-        {"id": null, "pattern": "CE-*", "reason": "Reading comprehension is reception, not production"},
-        {"id": null, "pattern": "LUD-*", "reason": "Ludic activities are not production tasks"}
+      "validExerciseTypes": [
+        "EE-07",
+        "EE-08",
+        "EE-09",
+        "EE-10",
+        "EE-11",
+        "EO-05",
+        "EO-06",
+        "EO-07",
+        "EO-09",
+        "PRAG-01",
+        "PRAG-05"
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "EE-11", "note": "Written mediation at C2: student adapts a specialised or literary text for a lay audience, selecting register and managing information density independently"},
-        {"exerciseTypeId": "EE-10", "note": "Creative writing at C2 may be unstructured; student chooses genre, register, and narrative voice autonomously"}
+        {
+          "exerciseTypeId": "EE-11",
+          "note": "Written mediation at C2: student adapts a specialised or literary text for a lay audience, selecting register and managing information density independently"
+        },
+        {
+          "exerciseTypeId": "EE-10",
+          "note": "Creative writing at C2 may be unstructured; student chooses genre, register, and narrative voice autonomously"
+        }
       ],
       "minExerciseVariety": 1
     }

--- a/data/section-profiles/warmup.json
+++ b/data/section-profiles/warmup.json
@@ -11,8 +11,6 @@
       "interactionPattern": "teacher-led",
       "validExerciseTypes": ["EO-01", "EO-03", "PRAG-01", "LUD-06", "LUD-07"],
       "forbiddenExerciseTypes": [
-        {"id": null, "pattern": "GR-*", "reason": "Grammar drills contradict the anxiety-reduction and conversational purpose of WarmUp"},
-        {"id": null, "pattern": "EE-*", "reason": "Written production is inappropriate for an oral warm-up stage"},
         {"id": null, "pattern": "CO-*", "reason": "Listening comprehension tasks require audio resources not suited to WarmUp"}
       ],
       "levelSpecificNotes": [
@@ -31,8 +29,6 @@
       "interactionPattern": "teacher-led",
       "validExerciseTypes": ["EO-01", "EO-03", "EO-08", "PRAG-01", "PRAG-03", "LUD-05", "LUD-07"],
       "forbiddenExerciseTypes": [
-        {"id": null, "pattern": "GR-*", "reason": "Grammar drills contradict the anxiety-reduction and conversational purpose of WarmUp"},
-        {"id": null, "pattern": "EE-*", "reason": "Written production is inappropriate for an oral warm-up stage"},
         {"id": null, "pattern": "CO-*", "reason": "Listening comprehension tasks require audio resources not suited to WarmUp"}
       ],
       "levelSpecificNotes": [
@@ -51,8 +47,6 @@
       "interactionPattern": "student-led",
       "validExerciseTypes": ["EO-08", "PRAG-01", "PRAG-03", "PRAG-04", "PRAG-05"],
       "forbiddenExerciseTypes": [
-        {"id": null, "pattern": "GR-*", "reason": "Grammar drills contradict the anxiety-reduction and conversational purpose of WarmUp"},
-        {"id": null, "pattern": "EE-*", "reason": "Written production is inappropriate for an oral warm-up stage"},
         {"id": null, "pattern": "CO-*", "reason": "Listening comprehension tasks require audio resources not suited to WarmUp"}
       ],
       "levelSpecificNotes": [
@@ -70,8 +64,6 @@
       "interactionPattern": "student-led",
       "validExerciseTypes": ["EO-08", "PRAG-01", "PRAG-03", "PRAG-04", "PRAG-05"],
       "forbiddenExerciseTypes": [
-        {"id": null, "pattern": "GR-*", "reason": "Grammar drills contradict the anxiety-reduction and conversational purpose of WarmUp"},
-        {"id": null, "pattern": "EE-*", "reason": "Written production is inappropriate for an oral warm-up stage"},
         {"id": null, "pattern": "CO-*", "reason": "Listening comprehension tasks require audio resources not suited to WarmUp"}
       ],
       "levelSpecificNotes": [
@@ -89,8 +81,6 @@
       "interactionPattern": "student-led",
       "validExerciseTypes": ["EO-07", "EO-08", "PRAG-01", "PRAG-04", "PRAG-05"],
       "forbiddenExerciseTypes": [
-        {"id": null, "pattern": "GR-*", "reason": "Grammar drills contradict the anxiety-reduction and conversational purpose of WarmUp"},
-        {"id": null, "pattern": "EE-*", "reason": "Written production is inappropriate for an oral warm-up stage"},
         {"id": null, "pattern": "CO-*", "reason": "Listening comprehension tasks require audio resources not suited to WarmUp"}
       ],
       "levelSpecificNotes": [
@@ -108,8 +98,6 @@
       "interactionPattern": "student-led",
       "validExerciseTypes": ["EO-08", "EO-09", "PRAG-01", "PRAG-04", "PRAG-05"],
       "forbiddenExerciseTypes": [
-        {"id": null, "pattern": "GR-*", "reason": "Grammar drills contradict the anxiety-reduction and conversational purpose of WarmUp"},
-        {"id": null, "pattern": "EE-*", "reason": "Written production is inappropriate for an oral warm-up stage"},
         {"id": null, "pattern": "CO-*", "reason": "Listening comprehension tasks require audio resources not suited to WarmUp"}
       ],
       "levelSpecificNotes": [

--- a/data/section-profiles/wrapup.json
+++ b/data/section-profiles/wrapup.json
@@ -3,261 +3,219 @@
   "weaknessTargetingGuidance": "ask the student to rate their confidence with each area (1-3 scale) and identify one specific difficulty that remains.",
   "levels": {
     "A1": {
-      "contentTypes": ["conversation"],
+      "contentTypes": [
+        "conversation"
+      ],
       "guidance": "Teacher-led recap: ask the student to repeat 2-3 key words or phrases from the lesson. Ask: What did we learn today? Use yes/no or either/or questions. Preview homework with one simple sentence.",
-      "duration": { "min": 2, "max": 3 },
+      "duration": {
+        "min": 2,
+        "max": 3
+      },
       "scope": "brief",
-      "competencies": ["interaction"],
+      "competencies": [
+        "interaction"
+      ],
       "scaffolding": "high",
       "interactionPattern": "teacher-led",
-      "validExerciseTypes": ["EO-08", "PRAG-01"],
+      "validExerciseTypes": [
+        "EO-08",
+        "PRAG-01"
+      ],
       "forbiddenExerciseTypes": [
-        {"id": null, "pattern": "LUD-*", "reason": "Games introduce new activity type at the close of the lesson; wrap-up should consolidate, not stimulate"},
-        {"id": null, "pattern": "CO-*", "reason": "Listening tasks introduce new content; wrap-up should not introduce new material"},
-        {"id": null, "pattern": "CE-*", "reason": "Reading comprehension introduces new text content; inappropriate for consolidation close"},
-        {"id": "GR-01", "pattern": null, "reason": "Mechanical drills are practice tasks; wrap-up is reflection, not drilling"},
-        {"id": "GR-02", "pattern": null, "reason": "Mechanical drills are practice tasks; wrap-up is reflection, not drilling"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation is a practice task, not appropriate for lesson close"},
-        {"id": "GR-04", "pattern": null, "reason": "Error correction is a practice task, not appropriate for lesson close"},
-        {"id": "GR-05", "pattern": null, "reason": "Conjugation paradigms are drills, not appropriate for lesson close"},
-        {"id": "GR-06", "pattern": null, "reason": "Matching exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "GR-07", "pattern": null, "reason": "Word ordering is a practice task, not appropriate for lesson close"},
-        {"id": "GR-08", "pattern": null, "reason": "Inductive discovery is a presentation task; no new grammar at close"},
-        {"id": "GR-09", "pattern": null, "reason": "Classification exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "EE-04", "pattern": null, "reason": "Extended description requires significant writing time; not appropriate for a short close"},
-        {"id": "EE-05", "pattern": null, "reason": "Narration is a production task requiring extended time; not appropriate for wrap-up"},
-        {"id": "EE-06", "pattern": null, "reason": "Letter/email writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-07", "pattern": null, "reason": "Opinion essay requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-08", "pattern": null, "reason": "Summary writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-09", "pattern": null, "reason": "Register transformation requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-10", "pattern": null, "reason": "Creative writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-11", "pattern": null, "reason": "Written mediation requires extended time; not appropriate for wrap-up"},
-        {"id": "VOC-01", "pattern": null, "reason": "Vocabulary lists are presentation tasks; no new vocabulary at close"},
-        {"id": "VOC-02", "pattern": null, "reason": "Vocabulary matching is a practice task, not appropriate for lesson close"},
-        {"id": "VOC-03", "pattern": null, "reason": "Semantic categorisation is a practice task, not appropriate for lesson close"},
-        {"id": "VOC-04", "pattern": null, "reason": "Vocabulary in context tasks involve new texts; not appropriate for wrap-up"},
-        {"id": "VOC-05", "pattern": null, "reason": "Completing sentences with vocabulary is a practice drill, not a reflection task"},
-        {"id": "VOC-06", "pattern": null, "reason": "Synonyms/antonyms exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "VOC-07", "pattern": null, "reason": "Collocations practice is not appropriate for lesson close"}
+        {
+          "id": null,
+          "pattern": "CO-*",
+          "reason": "Listening tasks introduce new content; wrap-up should not introduce new material"
+        }
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "EO-08", "note": "At A1, constrain free conversation to 2-3 yes/no or either/or questions about lesson content; do not allow open-ended production"}
+        {
+          "exerciseTypeId": "EO-08",
+          "note": "At A1, constrain free conversation to 2-3 yes/no or either/or questions about lesson content; do not allow open-ended production"
+        }
       ],
       "minExerciseVariety": 1
     },
     "A2": {
-      "contentTypes": ["conversation"],
+      "contentTypes": [
+        "conversation"
+      ],
       "guidance": "Student names 3-4 things they learned or practiced. Teacher prompts if needed: Que aprendiste hoy? Brief homework preview. Keep to 2-3 teacher turns.",
-      "duration": { "min": 2, "max": 4 },
+      "duration": {
+        "min": 2,
+        "max": 4
+      },
       "scope": "brief",
-      "competencies": ["interaction"],
+      "competencies": [
+        "interaction"
+      ],
       "scaffolding": "medium",
       "interactionPattern": "teacher-guided",
-      "validExerciseTypes": ["EO-08", "PRAG-01", "PRAG-03"],
+      "validExerciseTypes": [
+        "EO-08",
+        "PRAG-01",
+        "PRAG-03"
+      ],
       "forbiddenExerciseTypes": [
-        {"id": null, "pattern": "LUD-*", "reason": "Games introduce new activity type at the close of the lesson; wrap-up should consolidate, not stimulate"},
-        {"id": null, "pattern": "CO-*", "reason": "Listening tasks introduce new content; wrap-up should not introduce new material"},
-        {"id": null, "pattern": "CE-*", "reason": "Reading comprehension introduces new text content; inappropriate for consolidation close"},
-        {"id": "GR-01", "pattern": null, "reason": "Mechanical drills are practice tasks; wrap-up is reflection, not drilling"},
-        {"id": "GR-02", "pattern": null, "reason": "Mechanical drills are practice tasks; wrap-up is reflection, not drilling"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation is a practice task, not appropriate for lesson close"},
-        {"id": "GR-04", "pattern": null, "reason": "Error correction is a practice task, not appropriate for lesson close"},
-        {"id": "GR-05", "pattern": null, "reason": "Conjugation paradigms are drills, not appropriate for lesson close"},
-        {"id": "GR-06", "pattern": null, "reason": "Matching exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "GR-07", "pattern": null, "reason": "Word ordering is a practice task, not appropriate for lesson close"},
-        {"id": "GR-08", "pattern": null, "reason": "Inductive discovery is a presentation task; no new grammar at close"},
-        {"id": "GR-09", "pattern": null, "reason": "Classification exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "EE-04", "pattern": null, "reason": "Extended description requires significant writing time; not appropriate for a short close"},
-        {"id": "EE-05", "pattern": null, "reason": "Narration is a production task requiring extended time; not appropriate for wrap-up"},
-        {"id": "EE-06", "pattern": null, "reason": "Letter/email writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-07", "pattern": null, "reason": "Opinion essay requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-08", "pattern": null, "reason": "Summary writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-09", "pattern": null, "reason": "Register transformation requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-10", "pattern": null, "reason": "Creative writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-11", "pattern": null, "reason": "Written mediation requires extended time; not appropriate for wrap-up"},
-        {"id": "VOC-01", "pattern": null, "reason": "Vocabulary lists are presentation tasks; no new vocabulary at close"},
-        {"id": "VOC-02", "pattern": null, "reason": "Vocabulary matching is a practice task, not appropriate for lesson close"},
-        {"id": "VOC-03", "pattern": null, "reason": "Semantic categorisation is a practice task, not appropriate for lesson close"},
-        {"id": "VOC-04", "pattern": null, "reason": "Vocabulary in context tasks involve new texts; not appropriate for wrap-up"},
-        {"id": "VOC-05", "pattern": null, "reason": "Completing sentences with vocabulary is a practice drill, not a reflection task"},
-        {"id": "VOC-06", "pattern": null, "reason": "Synonyms/antonyms exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "VOC-07", "pattern": null, "reason": "Collocations practice is not appropriate for lesson close"}
+        {
+          "id": null,
+          "pattern": "CO-*",
+          "reason": "Listening tasks introduce new content; wrap-up should not introduce new material"
+        }
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "PRAG-03", "note": "Cultural content at A2 wrap-up should be a very brief (1-2 sentence) connection to the lesson topic, not a new extended cultural discussion"}
+        {
+          "exerciseTypeId": "PRAG-03",
+          "note": "Cultural content at A2 wrap-up should be a very brief (1-2 sentence) connection to the lesson topic, not a new extended cultural discussion"
+        }
       ],
       "minExerciseVariety": 1
     },
     "B1": {
-      "contentTypes": ["conversation"],
+      "contentTypes": [
+        "conversation"
+      ],
       "guidance": "Student summarises the lesson in 3-4 sentences. Teacher corrects and adds. Ask: What felt easy? What do you want to practise more? Brief homework or next session preview.",
-      "duration": { "min": 2, "max": 4 },
+      "duration": {
+        "min": 2,
+        "max": 4
+      },
       "scope": "brief",
-      "competencies": ["interaction"],
+      "competencies": [
+        "interaction"
+      ],
       "scaffolding": "low",
       "interactionPattern": "student-led",
-      "validExerciseTypes": ["EO-08", "PRAG-01", "PRAG-03", "PRAG-04"],
+      "validExerciseTypes": [
+        "EO-08",
+        "PRAG-01",
+        "PRAG-03",
+        "PRAG-04"
+      ],
       "forbiddenExerciseTypes": [
-        {"id": null, "pattern": "LUD-*", "reason": "Games introduce new activity type at the close of the lesson; wrap-up should consolidate, not stimulate"},
-        {"id": null, "pattern": "CO-*", "reason": "Listening tasks introduce new content; wrap-up should not introduce new material"},
-        {"id": null, "pattern": "CE-*", "reason": "Reading comprehension introduces new text content; inappropriate for consolidation close"},
-        {"id": "GR-01", "pattern": null, "reason": "Mechanical drills are practice tasks; wrap-up is reflection, not drilling"},
-        {"id": "GR-02", "pattern": null, "reason": "Mechanical drills are practice tasks; wrap-up is reflection, not drilling"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation is a practice task, not appropriate for lesson close"},
-        {"id": "GR-04", "pattern": null, "reason": "Error correction is a practice task, not appropriate for lesson close"},
-        {"id": "GR-05", "pattern": null, "reason": "Conjugation paradigms are drills, not appropriate for lesson close"},
-        {"id": "GR-06", "pattern": null, "reason": "Matching exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "GR-07", "pattern": null, "reason": "Word ordering is a practice task, not appropriate for lesson close"},
-        {"id": "GR-08", "pattern": null, "reason": "Inductive discovery is a presentation task; no new grammar at close"},
-        {"id": "GR-09", "pattern": null, "reason": "Classification exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "EE-04", "pattern": null, "reason": "Extended description requires significant writing time; not appropriate for a short close"},
-        {"id": "EE-05", "pattern": null, "reason": "Narration is a production task requiring extended time; not appropriate for wrap-up"},
-        {"id": "EE-06", "pattern": null, "reason": "Letter/email writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-07", "pattern": null, "reason": "Opinion essay requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-08", "pattern": null, "reason": "Summary writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-09", "pattern": null, "reason": "Register transformation requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-10", "pattern": null, "reason": "Creative writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-11", "pattern": null, "reason": "Written mediation requires extended time; not appropriate for wrap-up"},
-        {"id": "VOC-01", "pattern": null, "reason": "Vocabulary lists are presentation tasks; no new vocabulary at close"},
-        {"id": "VOC-02", "pattern": null, "reason": "Vocabulary matching is a practice task, not appropriate for lesson close"},
-        {"id": "VOC-03", "pattern": null, "reason": "Semantic categorisation is a practice task, not appropriate for lesson close"},
-        {"id": "VOC-04", "pattern": null, "reason": "Vocabulary in context tasks involve new texts; not appropriate for wrap-up"},
-        {"id": "VOC-05", "pattern": null, "reason": "Completing sentences with vocabulary is a practice drill, not a reflection task"},
-        {"id": "VOC-06", "pattern": null, "reason": "Synonyms/antonyms exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "VOC-07", "pattern": null, "reason": "Collocations practice is not appropriate for lesson close"}
+        {
+          "id": null,
+          "pattern": "CO-*",
+          "reason": "Listening tasks introduce new content; wrap-up should not introduce new material"
+        }
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "PRAG-04", "note": "Intercultural comparison at B1 wrap-up: one brief observation connecting lesson content to student's own culture; not an extended discussion"}
+        {
+          "exerciseTypeId": "PRAG-04",
+          "note": "Intercultural comparison at B1 wrap-up: one brief observation connecting lesson content to student's own culture; not an extended discussion"
+        }
       ],
       "minExerciseVariety": 1
     },
     "B2": {
-      "contentTypes": ["conversation"],
+      "contentTypes": [
+        "conversation"
+      ],
       "guidance": "Student summarises and evaluates: what was new, what was confirmed, what needs more practice. Teacher adds nuance. Optional: identify one item to research independently before next session.",
-      "duration": { "min": 2, "max": 5 },
+      "duration": {
+        "min": 2,
+        "max": 5
+      },
       "scope": "brief",
-      "competencies": ["interaction"],
+      "competencies": [
+        "interaction"
+      ],
       "scaffolding": "low",
       "interactionPattern": "student-led",
-      "validExerciseTypes": ["EO-08", "PRAG-01", "PRAG-03", "PRAG-04"],
+      "validExerciseTypes": [
+        "EO-08",
+        "PRAG-01",
+        "PRAG-03",
+        "PRAG-04"
+      ],
       "forbiddenExerciseTypes": [
-        {"id": null, "pattern": "LUD-*", "reason": "Games introduce new activity type at the close of the lesson; wrap-up should consolidate, not stimulate"},
-        {"id": null, "pattern": "CO-*", "reason": "Listening tasks introduce new content; wrap-up should not introduce new material"},
-        {"id": null, "pattern": "CE-*", "reason": "Reading comprehension introduces new text content; inappropriate for consolidation close"},
-        {"id": "GR-01", "pattern": null, "reason": "Mechanical drills are practice tasks; wrap-up is reflection, not drilling"},
-        {"id": "GR-02", "pattern": null, "reason": "Mechanical drills are practice tasks; wrap-up is reflection, not drilling"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation is a practice task, not appropriate for lesson close"},
-        {"id": "GR-04", "pattern": null, "reason": "Error correction is a practice task, not appropriate for lesson close"},
-        {"id": "GR-05", "pattern": null, "reason": "Conjugation paradigms are drills, not appropriate for lesson close"},
-        {"id": "GR-06", "pattern": null, "reason": "Matching exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "GR-07", "pattern": null, "reason": "Word ordering is a practice task, not appropriate for lesson close"},
-        {"id": "GR-08", "pattern": null, "reason": "Inductive discovery is a presentation task; no new grammar at close"},
-        {"id": "GR-09", "pattern": null, "reason": "Classification exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "EE-04", "pattern": null, "reason": "Extended description requires significant writing time; not appropriate for a short close"},
-        {"id": "EE-05", "pattern": null, "reason": "Narration is a production task requiring extended time; not appropriate for wrap-up"},
-        {"id": "EE-06", "pattern": null, "reason": "Letter/email writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-07", "pattern": null, "reason": "Opinion essay requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-08", "pattern": null, "reason": "Summary writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-09", "pattern": null, "reason": "Register transformation requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-10", "pattern": null, "reason": "Creative writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-11", "pattern": null, "reason": "Written mediation requires extended time; not appropriate for wrap-up"},
-        {"id": "VOC-01", "pattern": null, "reason": "Vocabulary lists are presentation tasks; no new vocabulary at close"},
-        {"id": "VOC-02", "pattern": null, "reason": "Vocabulary matching is a practice task, not appropriate for lesson close"},
-        {"id": "VOC-03", "pattern": null, "reason": "Semantic categorisation is a practice task, not appropriate for lesson close"},
-        {"id": "VOC-04", "pattern": null, "reason": "Vocabulary in context tasks involve new texts; not appropriate for wrap-up"},
-        {"id": "VOC-05", "pattern": null, "reason": "Completing sentences with vocabulary is a practice drill, not a reflection task"},
-        {"id": "VOC-06", "pattern": null, "reason": "Synonyms/antonyms exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "VOC-07", "pattern": null, "reason": "Collocations practice is not appropriate for lesson close"}
+        {
+          "id": null,
+          "pattern": "CO-*",
+          "reason": "Listening tasks introduce new content; wrap-up should not introduce new material"
+        }
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "EO-08", "note": "At B2, prompt student to articulate what was confirmed vs what was new; this metacognitive distinction aids long-term retention"}
+        {
+          "exerciseTypeId": "EO-08",
+          "note": "At B2, prompt student to articulate what was confirmed vs what was new; this metacognitive distinction aids long-term retention"
+        }
       ],
       "minExerciseVariety": 1
     },
     "C1": {
-      "contentTypes": ["conversation"],
+      "contentTypes": [
+        "conversation"
+      ],
       "guidance": "Student reflects on difficulty and explains why: what was cognitively demanding, what register choices were made, what gaps remain. Teacher listens, adds metalinguistic comment if relevant.",
-      "duration": { "min": 3, "max": 5 },
+      "duration": {
+        "min": 3,
+        "max": 5
+      },
       "scope": "brief",
-      "competencies": ["interaction"],
+      "competencies": [
+        "interaction"
+      ],
       "scaffolding": "none",
       "interactionPattern": "student-led",
-      "validExerciseTypes": ["EO-08", "EO-09", "PRAG-01", "PRAG-04"],
+      "validExerciseTypes": [
+        "EO-08",
+        "EO-09",
+        "PRAG-01",
+        "PRAG-04"
+      ],
       "forbiddenExerciseTypes": [
-        {"id": null, "pattern": "LUD-*", "reason": "Games introduce new activity type at the close of the lesson; wrap-up should consolidate, not stimulate"},
-        {"id": null, "pattern": "CO-*", "reason": "Listening tasks introduce new content; wrap-up should not introduce new material"},
-        {"id": null, "pattern": "CE-*", "reason": "Reading comprehension introduces new text content; inappropriate for consolidation close"},
-        {"id": "GR-01", "pattern": null, "reason": "Mechanical drills are practice tasks; wrap-up is reflection, not drilling"},
-        {"id": "GR-02", "pattern": null, "reason": "Mechanical drills are practice tasks; wrap-up is reflection, not drilling"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation is a practice task, not appropriate for lesson close"},
-        {"id": "GR-04", "pattern": null, "reason": "Error correction is a practice task, not appropriate for lesson close"},
-        {"id": "GR-05", "pattern": null, "reason": "Conjugation paradigms are drills, not appropriate for lesson close"},
-        {"id": "GR-06", "pattern": null, "reason": "Matching exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "GR-07", "pattern": null, "reason": "Word ordering is a practice task, not appropriate for lesson close"},
-        {"id": "GR-08", "pattern": null, "reason": "Inductive discovery is a presentation task; no new grammar at close"},
-        {"id": "GR-09", "pattern": null, "reason": "Classification exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "EE-04", "pattern": null, "reason": "Extended description requires significant writing time; not appropriate for a short close"},
-        {"id": "EE-05", "pattern": null, "reason": "Narration is a production task requiring extended time; not appropriate for wrap-up"},
-        {"id": "EE-06", "pattern": null, "reason": "Letter/email writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-07", "pattern": null, "reason": "Opinion essay requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-08", "pattern": null, "reason": "Summary writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-09", "pattern": null, "reason": "Register transformation requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-10", "pattern": null, "reason": "Creative writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-11", "pattern": null, "reason": "Written mediation requires extended time; not appropriate for wrap-up"},
-        {"id": "VOC-01", "pattern": null, "reason": "Vocabulary lists are presentation tasks; no new vocabulary at close"},
-        {"id": "VOC-02", "pattern": null, "reason": "Vocabulary matching is a practice task, not appropriate for lesson close"},
-        {"id": "VOC-03", "pattern": null, "reason": "Semantic categorisation is a practice task, not appropriate for lesson close"},
-        {"id": "VOC-04", "pattern": null, "reason": "Vocabulary in context tasks involve new texts; not appropriate for wrap-up"},
-        {"id": "VOC-05", "pattern": null, "reason": "Completing sentences with vocabulary is a practice drill, not a reflection task"},
-        {"id": "VOC-06", "pattern": null, "reason": "Synonyms/antonyms exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "VOC-07", "pattern": null, "reason": "Collocations practice is not appropriate for lesson close"}
+        {
+          "id": null,
+          "pattern": "CO-*",
+          "reason": "Listening tasks introduce new content; wrap-up should not introduce new material"
+        }
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "EO-09", "note": "At C1, oral mediation as reflection: ask student to explain the lesson's key grammar or lexical concept to an imaginary non-native speaker; this reveals metalinguistic understanding"}
+        {
+          "exerciseTypeId": "EO-09",
+          "note": "At C1, oral mediation as reflection: ask student to explain the lesson's key grammar or lexical concept to an imaginary non-native speaker; this reveals metalinguistic understanding"
+        }
       ],
       "minExerciseVariety": 1
     },
     "C2": {
-      "contentTypes": ["conversation"],
+      "contentTypes": [
+        "conversation"
+      ],
       "guidance": "Student reflects on difficulty, metalinguistic awareness, and register decisions. Identifies one self-directed learning goal for the week. Teacher confirms or refines.",
-      "duration": { "min": 3, "max": 5 },
+      "duration": {
+        "min": 3,
+        "max": 5
+      },
       "scope": "brief",
-      "competencies": ["interaction"],
+      "competencies": [
+        "interaction"
+      ],
       "scaffolding": "none",
       "interactionPattern": "student-led",
-      "validExerciseTypes": ["EO-08", "EO-09", "PRAG-01", "PRAG-04"],
+      "validExerciseTypes": [
+        "EO-08",
+        "EO-09",
+        "PRAG-01",
+        "PRAG-04"
+      ],
       "forbiddenExerciseTypes": [
-        {"id": null, "pattern": "LUD-*", "reason": "Games introduce new activity type at the close of the lesson; wrap-up should consolidate, not stimulate"},
-        {"id": null, "pattern": "CO-*", "reason": "Listening tasks introduce new content; wrap-up should not introduce new material"},
-        {"id": null, "pattern": "CE-*", "reason": "Reading comprehension introduces new text content; inappropriate for consolidation close"},
-        {"id": "GR-01", "pattern": null, "reason": "Mechanical drills are practice tasks; wrap-up is reflection, not drilling"},
-        {"id": "GR-02", "pattern": null, "reason": "Mechanical drills are practice tasks; wrap-up is reflection, not drilling"},
-        {"id": "GR-03", "pattern": null, "reason": "Sentence transformation is a practice task, not appropriate for lesson close"},
-        {"id": "GR-04", "pattern": null, "reason": "Error correction is a practice task, not appropriate for lesson close"},
-        {"id": "GR-05", "pattern": null, "reason": "Conjugation paradigms are drills, not appropriate for lesson close"},
-        {"id": "GR-06", "pattern": null, "reason": "Matching exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "GR-07", "pattern": null, "reason": "Word ordering is a practice task, not appropriate for lesson close"},
-        {"id": "GR-08", "pattern": null, "reason": "Inductive discovery is a presentation task; no new grammar at close"},
-        {"id": "GR-09", "pattern": null, "reason": "Classification exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "EE-04", "pattern": null, "reason": "Extended description requires significant writing time; not appropriate for a short close"},
-        {"id": "EE-05", "pattern": null, "reason": "Narration is a production task requiring extended time; not appropriate for wrap-up"},
-        {"id": "EE-06", "pattern": null, "reason": "Letter/email writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-07", "pattern": null, "reason": "Opinion essay requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-08", "pattern": null, "reason": "Summary writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-09", "pattern": null, "reason": "Register transformation requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-10", "pattern": null, "reason": "Creative writing requires extended time; not appropriate for wrap-up"},
-        {"id": "EE-11", "pattern": null, "reason": "Written mediation requires extended time; not appropriate for wrap-up"},
-        {"id": "VOC-01", "pattern": null, "reason": "Vocabulary lists are presentation tasks; no new vocabulary at close"},
-        {"id": "VOC-02", "pattern": null, "reason": "Vocabulary matching is a practice task, not appropriate for lesson close"},
-        {"id": "VOC-03", "pattern": null, "reason": "Semantic categorisation is a practice task, not appropriate for lesson close"},
-        {"id": "VOC-04", "pattern": null, "reason": "Vocabulary in context tasks involve new texts; not appropriate for wrap-up"},
-        {"id": "VOC-05", "pattern": null, "reason": "Completing sentences with vocabulary is a practice drill, not a reflection task"},
-        {"id": "VOC-06", "pattern": null, "reason": "Synonyms/antonyms exercises are practice tasks, not appropriate for lesson close"},
-        {"id": "VOC-07", "pattern": null, "reason": "Collocations practice is not appropriate for lesson close"}
+        {
+          "id": null,
+          "pattern": "CO-*",
+          "reason": "Listening tasks introduce new content; wrap-up should not introduce new material"
+        }
       ],
       "levelSpecificNotes": [
-        {"exerciseTypeId": "EO-09", "note": "At C2, oral mediation as reflection may be extended: student selects a concept from the lesson and explains its usage constraints to an imaginary learner at a lower level"},
-        {"exerciseTypeId": "EO-08", "note": "Free reflection at C2: student identifies one register decision or pragmatic choice made during production and evaluates whether it was optimal"}
+        {
+          "exerciseTypeId": "EO-09",
+          "note": "At C2, oral mediation as reflection may be extended: student selects a concept from the lesson and explains its usage constraints to an imaginary learner at a lower level"
+        },
+        {
+          "exerciseTypeId": "EO-08",
+          "note": "Free reflection at C2: student identifies one register decision or pragmatic choice made during production and evaluates whether it was optimal"
+        }
       ],
       "minExerciseVariety": 1
     }

--- a/plan/langteach-beta/task363-remove-forbidden-exercise-types.md
+++ b/plan/langteach-beta/task363-remove-forbidden-exercise-types.md
@@ -1,0 +1,59 @@
+# Task 363: Remove dead forbiddenExerciseTypes from section profiles
+
+## Problem
+~600 lines of `forbiddenExerciseTypes` JSON across 5 section profiles are redundant.
+`GetValidExerciseTypes()` in `PedagogyConfigService` already enforces the `validExerciseTypes`
+allowlist via intersection (steps 3-5). The forbidden filter is only meaningful at step 8
+(re-filter after L1 `AdditionalExerciseTypes` injection in step 7).
+
+The only L1 additional type across all `l1-influence.json` entries is `CO-06`
+(Phonetic discrimination). So the only forbidden entries worth keeping are those that
+block `CO-*` in sections where phonetic drills are inappropriate.
+
+## Analysis by section
+
+### warmup.json
+Each of 6 levels has: `GR-*` (remove), `EE-*` (remove), `CO-*` (KEEP - guards against CO-06 via L1).
+
+### presentation.json
+Each of 6 levels has specific IDs (GR-01..03, EO-02, EO-05/06, EE-04..11) and `LUD-*`.
+None match CO-06. **Remove all forbiddenExerciseTypes arrays.**
+
+### practice.json
+A1/A2/B1/B2 have GR and EE patterns. C1/C2 have GR and LUD patterns.
+None match CO-06. **Remove all forbiddenExerciseTypes arrays.**
+
+### production.json
+Each level has GR-01..07, VOC-01..03, CE-*, LUD-*. None match CO-06.
+**Remove all forbiddenExerciseTypes arrays.**
+
+### wrapup.json
+Each of 6 levels has many entries including `CO-*`. Keep only `CO-*` (guards against CO-06).
+Remove all other entries.
+
+## C# model
+`ForbiddenExerciseTypes` stays in `SectionLevelProfile` because warmup and wrapup still use it.
+No model changes.
+
+## Steps
+
+1. Edit `data/section-profiles/warmup.json`: strip `GR-*` and `EE-*` entries from all 6 levels,
+   leave only `CO-*` entry per level.
+2. Edit `data/section-profiles/presentation.json`: remove `forbiddenExerciseTypes` property from
+   all 6 level objects.
+3. Edit `data/section-profiles/practice.json`: remove `forbiddenExerciseTypes` property from
+   all 6 level objects.
+4. Edit `data/section-profiles/production.json`: remove `forbiddenExerciseTypes` property from
+   all 6 level objects.
+5. Edit `data/section-profiles/wrapup.json`: strip all entries except `CO-*` from all 6 levels.
+6. Update `PedagogyConfigServiceTests.cs`:
+   - `GetForbiddenExerciseTypeIds_WarmUp_A1_ExpandsAllGRPattern`: GR-* no longer in warmup, remove
+     or rename to test that GR-01..10 are NOT in the warmup forbidden list.
+   - `GetForbiddenExerciseTypeIds_WarmUp_A1_AlsoExpandsEEAndCOPatterns`: remove the EE-* assertion;
+     keep (and rename to `_OnlyCOPattern`) asserting only CO-* remains.
+7. Run `dotnet test` in `backend/` to verify all tests pass.
+
+## No e2e test needed
+This is a JSON data-only change. `GetValidExerciseTypes()` behavior is unchanged (CO-* entries
+preserved where needed). Existing `PedagogyConfigServiceTests` cover the intersection + forbidden
+logic. No new test cases required.


### PR DESCRIPTION
## Summary

- `forbiddenExerciseTypes` arrays fully removed from `presentation`, `practice`, and `production` section profiles (all entries were redundant with the `validExerciseTypes` allowlist)
- `warmup` and `wrapup` retain only the `CO-*` entry per level - the only meaningful guard, since `CO-06` is the sole `AdditionalExerciseType` injectable via L1 influence and must be blocked from these reflection/conversation-only sections
- `ForbiddenExerciseTypes` property kept in the C# model (entries remain in warmup/wrapup)
- 4 tests updated in `PromptServiceTests` and `PedagogyConfigServiceTests` to reflect the reduced forbidden lists

Closes #363

## Test plan

- [x] All 651 backend tests pass
- [x] `GetForbiddenExerciseTypeIds_WarmUp_A1_ExpandsCOPattern` verifies CO-* retained and GR-*/EE-* removed
- [x] `ConversationUserPrompt_WarmUp_B1_ContainsForbiddenReasons` checks CO-* reason appears in prompt
- [x] `ConversationUserPrompt_WrapUp_B1_ContainsForbiddenReasons` checks CO-* reason appears in prompt
- [x] QA verify: PASS
- [x] Code review: PASS
- [x] Architecture review: PASS
- [x] Isaac pedagogy review: SOUND

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test cases to verify exercise-type constraints for learning sections.

* **Chores**
  * Simplified exercise-type restriction configuration across section profiles.
  * Removed redundant constraint lists; restrictions now expressed through allowed exercise types only.
  * Reformatted configuration files for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->