### PR TITLE
feat: allow CE-01/CE-02 for A2 practice and CE-01 for A1 practice (#364)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs
@@ -318,6 +318,30 @@ public class PedagogyConfigServiceTests
         result.Should().NotContain("PRAG-02", because: "PRAG-02 was merged into EE-09 and no longer exists in the catalog");
     }
 
+    // --- CE-* practice relaxation (#364) ---
+
+    [Fact]
+    public void GetValidExerciseTypes_Practice_A2_ContainsCE01AndCE02()
+    {
+        // CE-01 and CE-02 are in A2 validExerciseTypes and in A2 CEFR appropriate types.
+        // This test documents the pre-existing behavior and guards against regression.
+        var result = _sut.GetValidExerciseTypes("practice", "A2");
+
+        result.Should().Contain("CE-01", because: "CE-01 (global comprehension) is valid for A2 practice");
+        result.Should().Contain("CE-02", because: "CE-02 (detailed comprehension) is valid for A2 practice");
+    }
+
+    [Fact]
+    public void GetValidExerciseTypes_Practice_A1_ContainsCE01()
+    {
+        // CE-01 was added to A1 practice validExerciseTypes in task #364.
+        // CE-01 is in A1 CEFR appropriate types, so it passes the intersection.
+        var result = _sut.GetValidExerciseTypes("practice", "A1");
+
+        result.Should().Contain("CE-01", because: "CE-01 (gist reading) supports read-and-match vocabulary consolidation at A1");
+        result.Should().NotContain("CE-02", because: "CE-02 (detailed comprehension) is not in A1 practice validExerciseTypes");
+    }
+
     // --- GetResolvedScope ---
 
     [Theory]

--- a/data/section-profiles/practice.json
+++ b/data/section-profiles/practice.json
@@ -25,11 +25,16 @@
         "GR-07",
         "GR-09",
         "VOC-05",
+        "CE-01",
         "EO-01",
         "LUD-06",
         "LUD-07"
       ],
       "levelSpecificNotes": [
+        {
+          "exerciseTypeId": "CE-01",
+          "note": "At A1, use only very short texts (2-3 sentences). Tasks should be picture-supported matching or simple True/False (does the sentence match the picture/title?). No inferential or detail questions."
+        },
         {
           "exerciseTypeId": "GR-01",
           "note": "Always provide a word bank listing all answer options in the hint field"

--- a/plan/langteach-beta/task364-relax-a2-practice-ce.md
+++ b/plan/langteach-beta/task364-relax-a2-practice-ce.md
@@ -1,0 +1,24 @@
+# Task 364: Relax A2 Practice CE-* Blanket Ban
+
+## Problem
+A1-A2 practice profiles had a blanket CE-* forbidden pattern at A1. At A2, CE-01 and CE-02 were already allowed in `validExerciseTypes` but the issue needed verification.
+
+## Findings
+- **A2**: CE-01, CE-02 already in `validExerciseTypes` in practice.json (pre-existing, before #363). A2 CEFR level file includes CE-01, CE-02, CE-03, CE-06. The intersection passes CE-01/CE-02 through correctly. AC1 is already met.
+- **A1**: CE-01 is in A1's CEFR appropriate types (`a1.json`) but NOT in A1 practice `validExerciseTypes`. The old CE-* blanket ban (in `forbiddenExerciseTypes`) was removed by task #363, but CE-01 was never added to A1's section valid list.
+- **A1 decision**: Add CE-01 to A1 practice `validExerciseTypes`. Rationale: CE-01 (global comprehension/gist reading) starts at A1 in the catalog. At A1, read-and-match exercises using very short texts (picture-word matching, simple True/False) are pedagogically valid. Constrain via `levelSpecificNotes` to max 2-3 sentences, picture-supported where possible.
+
+## Changes
+
+### data/section-profiles/practice.json
+- Add CE-01 to A1 `validExerciseTypes`
+- Add levelSpecificNote for CE-01 at A1: constrain to very short texts (2-3 sentences), picture-supported match or True/False
+
+### backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs
+- Add test: `GetValidExerciseTypes_Practice_A2_ContainsCE01AndCE02`
+- Add test: `GetValidExerciseTypes_Practice_A1_ContainsCE01`
+
+## Acceptance Criteria
+- [ ] A2 practice surfaces CE-01 and CE-02 via GetValidExerciseTypes (already true, test confirms it)
+- [ ] A1 decision documented (add CE-01 with levelSpecificNote)
+- [ ] All backend tests pass


### PR DESCRIPTION
## Summary

- **A2 practice** (pre-existing, now guarded by tests): CE-01 (global comprehension) and CE-02 (vocabulary in context) were already present in `practice.json` A2 `validExerciseTypes`. `GetValidExerciseTypes()` correctly surfaces them via the CEFR intersection. Two regression tests confirm this behavior.

- **A1 practice** (new): Adds CE-01 to A1 `validExerciseTypes`. The old blanket `CE-*` ban was in `forbiddenExerciseTypes` (removed by #363); this PR completes the relaxation by explicitly allowing CE-01 for A1. A `levelSpecificNote` constrains usage to very short texts (2-3 sentences), picture-supported matching or True/False format only - no inferential or detail questions.

**A1 decision rationale:** CE-01 `cefrRange` starts at A1 in the exercise catalog. Simple read-and-match activities using short illustrated texts are standard at A1 in Aula Internacional 1. CE-02 (detailed comprehension) is intentionally excluded from A1 as it demands tracking multiple specific facts, which exceeds typical A1 processing capacity.

## Files changed

- `data/section-profiles/practice.json`: CE-01 added to A1 `validExerciseTypes` + `levelSpecificNote`
- `backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs`: 2 new tests

## Test plan

- [x] `GetValidExerciseTypes_Practice_A2_ContainsCE01AndCE02` - regression guard for A2
- [x] `GetValidExerciseTypes_Practice_A1_ContainsCE01` - verifies new A1 allowance
- [x] All backend tests pass (dotnet test: PASS via build-verify)
- [x] No frontend changes needed (pure config + test)

## Config & Infrastructure

- No secrets or env vars changed
- No new infra required

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CE-01 exercise type support for A1 level learners with tailored constraints
  * A1 exercises now limited to 2-3 sentence texts with picture-supported matching or simple True/False tasks
* **Tests**
  * Added test coverage for exercise type validation across proficiency levels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->