### PR TITLE
fix: remove stale prompt instructions and replace negative restriction framing (#365)

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -562,7 +562,6 @@ public class PromptServiceTests
         req.UserPrompt.Should().Contain("practice");
         req.UserPrompt.Should().Contain("production");
         req.UserPrompt.Should().Contain("wrapUp");
-        req.UserPrompt.Should().Contain("All five sections");
     }
 
     [Fact]
@@ -644,7 +643,7 @@ public class PromptServiceTests
 
         var req = _sut.BuildLessonPlanPrompt(ctx);
 
-        req.UserPrompt.Should().Contain("Do not use [LUD] exercises in this lesson.");
+        req.UserPrompt.Should().Contain("Ludic activities are inappropriate in reading comprehension lessons");
     }
 
     [Fact]
@@ -798,12 +797,15 @@ public class PromptServiceTests
     }
 
     [Fact]
-    public void LessonPlanPrompt_UserPrompt_AllFiveSectionsRequired()
+    public void LessonPlanPrompt_UserPrompt_AllFiveSectionNamesPresent()
     {
         var req = _sut.BuildLessonPlanPrompt(BaseCtx());
 
-        req.UserPrompt.Should().Contain("All five sections");
-        req.UserPrompt.Should().Contain("required in every lesson plan");
+        req.UserPrompt.Should().Contain("warmUp");
+        req.UserPrompt.Should().Contain("presentation");
+        req.UserPrompt.Should().Contain("practice");
+        req.UserPrompt.Should().Contain("production");
+        req.UserPrompt.Should().Contain("wrapUp");
     }
 
     [Fact]

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -916,8 +916,6 @@ public class PromptService : IPromptService
 
         Section guidelines:
         {sbSections.ToString().TrimEnd()}
-
-        All five sections (warmUp, presentation, practice, production, wrapUp) are required in every lesson plan.
         """;
 
         // Level variation from template (if present)
@@ -925,10 +923,10 @@ public class PromptService : IPromptService
             && templateEntry.LevelVariations.TryGetValue(cefrLevel, out var levelVariation))
             baseInstruction += $"\n\n{templateEntry.Name.ToUpperInvariant()} level note for {cefrLevel}: {levelVariation}";
 
-        // Restrictions from template (enforced as explicit constraints)
+        // Restrictions from template (contextual rationale for exercise type filtering)
         if (templateEntry?.Restrictions is { Length: > 0 })
             baseInstruction += "\n\n" + string.Join("\n", templateEntry.Restrictions
-                .Select(r => $"Do not use [{r.Value}] exercises in this lesson."));
+                .Select(r => r.Reason));
 
         // Grammar scope from CEFR level rules
         var grammarScope = BuildGrammarScopeBlock(cefrLevel);

--- a/plan/langteach-beta/task365-clean-prompt-service.md
+++ b/plan/langteach-beta/task365-clean-prompt-service.md
@@ -1,0 +1,25 @@
+# Task 365: Clean PromptService.cs minor duplication
+
+## Problem
+
+Two prompt bloat issues in `PromptService.cs`:
+
+1. **Line 920**: "All five sections (warmUp, presentation, practice, production, wrapUp) are required in every lesson plan." -- structurally enforced by `SectionOrder` array iteration.
+
+2. **Lines 929-931**: Template restrictions emit `Do not use [X] exercises in this lesson.` (negative framing). `GetValidExerciseTypes()` handles structural enforcement via section profile forbidden types. The `TemplateRestriction` record already has a `Reason` field with a human-readable explanation that is positive/contextual and more useful to the model.
+
+## Changes
+
+### `backend/LangTeach.Api/AI/PromptService.cs`
+
+1. Remove the "All five sections" sentence from the lesson plan prompt (line 920).
+
+2. Replace negative restriction framing with the restriction's `Reason` field:
+   - Old: `$"Do not use [{r.Value}] exercises in this lesson."`
+   - New: `r.Reason`
+
+## Test plan
+
+- All existing backend tests pass (`dotnet test`)
+- No new tests needed: this is pure prompt text change with no behavioral logic change
+- Teacher QA spot-check (via `/teacher-qa sprint`) confirms no regression in generated lesson quality


### PR DESCRIPTION
## Summary

- Removes redundant "All five sections required" sentence from lesson plan prompt (`SectionOrder` loop enforces this structurally)
- Replaces `Do not use [X] exercises` negative framing with `TemplateRestriction.Reason` (contextual rationale already authored in `template-overrides.json`)
- Updates 3 test assertions to match the new prompt text

Closes #365

## Test plan

- [x] `dotnet test` passes (3 updated tests, no new failures)
- [ ] Teacher QA spot-check at sprint review confirms no regression in generated lesson quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved lesson plan generation to present restrictions as contextual rationale rather than explicit constraints.
  * Refined validation logic for lesson structure section requirements.

* **Tests**
  * Updated test assertions to verify explicit section naming in lesson plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->