### PR TITLE
Move WrapUp closing constraint from code to section profile JSON

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/SectionProfileServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/SectionProfileServiceTests.cs
@@ -577,4 +577,34 @@ public class SectionProfileServiceTests
         note!.Note.Should().Contain("1 sentence",
             because: "the note must explicitly cap written output at one sentence");
     }
+
+    // --- GetClosingConstraint ---
+
+    [Theory]
+    [InlineData("A1")]
+    [InlineData("A2")]
+    [InlineData("B1")]
+    [InlineData("B2")]
+    [InlineData("C1")]
+    [InlineData("C2")]
+    public void GetClosingConstraint_Wrapup_AllLevels_ReturnsNoNewMaterialConstraint(string level)
+    {
+        var constraint = _sut.GetClosingConstraint("wrapup", level);
+        constraint.Should().NotBeNullOrEmpty(because: $"wrapup {level} must have a closing constraint");
+        constraint.Should().Contain("Do not introduce new vocabulary",
+            because: "the constraint must prohibit introducing new material");
+    }
+
+    [Fact]
+    public void GetClosingConstraint_Warmup_ReturnsNull()
+    {
+        _sut.GetClosingConstraint("warmup", "B1").Should().BeNull(
+            because: "only wrapup has a closing constraint; other sections return null");
+    }
+
+    [Fact]
+    public void GetClosingConstraint_UnknownSection_ReturnsNull()
+    {
+        _sut.GetClosingConstraint("unknown", "B1").Should().BeNull();
+    }
 }

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -586,7 +586,7 @@ public class PromptService : IPromptService
                 topic:           topic,
                 templateName:    ctx.TemplateName,
                 mainInstruction: $"Generate a wrap-up reflection conversation for a {level} level lesson on \"{topic}\".",
-                extraConstraint: "IMPORTANT: Review only content from this lesson. Do not introduce new vocabulary, grammar structures, or situations.");
+                extraConstraint: _profiles.GetClosingConstraint("wrapup", level));
 
         return $$"""
         Generate conversation scenarios for the lesson on "{{topic}}". Return JSON:

--- a/backend/LangTeach.Api/AI/SectionProfile.cs
+++ b/backend/LangTeach.Api/AI/SectionProfile.cs
@@ -17,7 +17,8 @@ public record SectionLevelProfile(
     ForbiddenExerciseType[]? ForbiddenExerciseTypes = null,
     LevelSpecificNote[]? LevelSpecificNotes = null,
     int? MinExerciseVariety = null,
-    string? Scope = null
+    string? Scope = null,
+    string? ClosingConstraint = null
 );
 
 public record DurationRange(int Min, int Max);

--- a/backend/LangTeach.Api/Services/ISectionProfileService.cs
+++ b/backend/LangTeach.Api/Services/ISectionProfileService.cs
@@ -74,4 +74,10 @@ public interface ISectionProfileService
     /// for the student weakness list.
     /// </summary>
     string? GetWeaknessTargetingGuidance(string sectionType);
+
+    /// <summary>
+    /// Returns the closing constraint for a section at the given CEFR level, or null if none is set.
+    /// Used to inject section-specific closing instructions into the conversation prompt (e.g. "no new material").
+    /// </summary>
+    string? GetClosingConstraint(string sectionType, string cefrLevel);
 }

--- a/backend/LangTeach.Api/Services/SectionProfileService.cs
+++ b/backend/LangTeach.Api/Services/SectionProfileService.cs
@@ -157,6 +157,16 @@ public class SectionProfileService : ISectionProfileService
     public string? GetWeaknessTargetingGuidance(string sectionType) =>
         GetProfile(sectionType)?.WeaknessTargetingGuidance;
 
+    public string? GetClosingConstraint(string sectionType, string cefrLevel)
+    {
+        var profile = GetProfile(sectionType);
+        if (profile is null) return null;
+        var level = NormalizeLevel(cefrLevel);
+        if (profile.Levels.TryGetValue(level, out var lp))
+            return lp.ClosingConstraint;
+        return null;
+    }
+
     public string[] GetAllScopeValues() =>
         _profiles.Values
             .SelectMany(p => p.Levels.Values)

--- a/data/pedagogy/AUTHORING.md
+++ b/data/pedagogy/AUTHORING.md
@@ -135,4 +135,5 @@ The rules exist to make the common case clean. They are not a cage.
 | Add a structural content requirement unique to a template | Template override `overrideGuidance` (with `notes` explaining why) |
 | Make a section optional for a template | Template override `required: false` |
 | Leave a section unchanged for a template | Template override `overrideGuidance: null` |
+| Prevent new content at section close | Section profile `closingConstraint` field |
 | Change section behaviour permanently across all templates | Section profile (discuss first) |

--- a/data/section-profiles/wrapup.json
+++ b/data/section-profiles/wrapup.json
@@ -39,7 +39,8 @@
           "note": "Use a single fill-in sentence (1 sentence max) as a minimal written reflection, e.g. \"Today I learned ___.\" No extended writing."
         }
       ],
-      "minExerciseVariety": 1
+      "minExerciseVariety": 1,
+      "closingConstraint": "Do not introduce new vocabulary, grammar structures, or situations. Review only content from this lesson."
     },
     "A2": {
       "contentTypes": [
@@ -79,7 +80,8 @@
           "note": "Limit to 1 sentence of written reflection, e.g. \"The most useful word today was ___.\" Do not extend to multi-sentence writing tasks."
         }
       ],
-      "minExerciseVariety": 1
+      "minExerciseVariety": 1,
+      "closingConstraint": "Do not introduce new vocabulary, grammar structures, or situations. Review only content from this lesson."
     },
     "B1": {
       "contentTypes": [
@@ -115,7 +117,8 @@
           "note": "Intercultural comparison at B1 wrap-up: one brief observation connecting lesson content to student's own culture; not an extended discussion"
         }
       ],
-      "minExerciseVariety": 1
+      "minExerciseVariety": 1,
+      "closingConstraint": "Do not introduce new vocabulary, grammar structures, or situations. Review only content from this lesson."
     },
     "B2": {
       "contentTypes": [
@@ -151,7 +154,8 @@
           "note": "At B2, prompt student to articulate what was confirmed vs what was new; this metacognitive distinction aids long-term retention"
         }
       ],
-      "minExerciseVariety": 1
+      "minExerciseVariety": 1,
+      "closingConstraint": "Do not introduce new vocabulary, grammar structures, or situations. Review only content from this lesson."
     },
     "C1": {
       "contentTypes": [
@@ -188,7 +192,8 @@
           "note": "At C1, oral mediation as reflection: ask student to explain the lesson's key grammar or lexical concept to an imaginary non-native speaker; this reveals metalinguistic understanding"
         }
       ],
-      "minExerciseVariety": 1
+      "minExerciseVariety": 1,
+      "closingConstraint": "Do not introduce new vocabulary, grammar structures, or situations. Review only content from this lesson."
     },
     "C2": {
       "contentTypes": [
@@ -229,7 +234,8 @@
           "note": "Free reflection at C2: student identifies one register decision or pragmatic choice made during production and evaluates whether it was optimal"
         }
       ],
-      "minExerciseVariety": 1
+      "minExerciseVariety": 1,
+      "closingConstraint": "Do not introduce new vocabulary, grammar structures, or situations. Review only content from this lesson."
     }
   }
 }

--- a/plan/langteach-beta/task374-wrapup-closing-constraint.md
+++ b/plan/langteach-beta/task374-wrapup-closing-constraint.md
@@ -1,0 +1,35 @@
+# Task 374: Move WrapUp "no new material" constraint to section profile JSON
+
+## Goal
+Move the hardcoded `extraConstraint` in `PromptService.ConversationUserPrompt` for WrapUp into `wrapup.json`, following the config-vs-code pattern used by all other constraints.
+
+## Changes
+
+### 1. `SectionProfile.cs` - Add `ClosingConstraint` to `SectionLevelProfile`
+Add optional `string? ClosingConstraint = null` field to the record.
+
+### 2. `wrapup.json` - Populate `closingConstraint` at all CEFR levels
+Add `"closingConstraint": "IMPORTANT: Review only content from this lesson. Do not introduce new vocabulary, grammar structures, or situations."` to every level (A1-C2). The constraint is uniform across levels.
+
+### 3. `ISectionProfileService.cs` - Add `GetClosingConstraint`
+```csharp
+string? GetClosingConstraint(string sectionType, string cefrLevel);
+```
+
+### 4. `SectionProfileService.cs` - Implement `GetClosingConstraint`
+Pattern identical to `GetScope`: return `lp.ClosingConstraint` if found, else null.
+
+### 5. `PromptService.cs` - Remove hardcoded string
+In `ConversationUserPrompt`, replace the hardcoded `extraConstraint:` string with:
+```csharp
+extraConstraint: _profiles.GetClosingConstraint("wrapup", level)
+```
+
+### 6. Tests
+- `SectionProfileServiceTests.cs`: add test verifying `GetClosingConstraint("wrapup", "A1")` returns the expected string, and returns null for "warmup".
+- `PromptServiceTests.cs`: existing WrapUp conversation tests should still pass. Optionally verify the closing constraint text appears in generated prompt.
+
+## Notes
+- `ClosingConstraint` is optional (null default) so no existing JSON files break.
+- No schema or API changes needed; this is purely an internal config field.
+- `BuildSectionConversationPrompt` already handles `extraConstraint == null` gracefully.


### PR DESCRIPTION
## Summary

- Add optional `ClosingConstraint` field to `SectionLevelProfile` record
- Populate `wrapup.json` at all 6 CEFR levels with the "no new material" constraint (second-person imperative, consistent with AUTHORING.md voice convention)
- Add `GetClosingConstraint` to `ISectionProfileService` / `SectionProfileService` following the same pattern as `GetScope`
- Remove the hardcoded `extraConstraint` string from `PromptService.ConversationUserPrompt` (WrapUp branch)
- Document `closingConstraint` in `data/pedagogy/AUTHORING.md` Quick Reference table

## Test Plan

- [x] `SectionProfileServiceTests`: all 6 CEFR levels return the constraint; warmup and unknown sections return null
- [x] `PromptServiceTests`: existing WrapUp conversation test verifies constraint text appears in generated prompt
- [x] Full backend test suite: 672 passed, 0 failed

## Config & Infrastructure

- [x] This PR adds NO new environment variables, secrets, or config keys
- [x] No new infrastructure resources added

---

Closes #374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests validating wrap-up section constraints across all proficiency levels.

* **Refactor**
  * Converted wrap-up constraints from hardcoded to externally configurable values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->