### PR TITLE
fix: sentence ordering prompt must produce grammatically correct Spanish (#430)

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -2047,6 +2047,28 @@ public class PromptServiceTests
             because: "A2 also uses sentence ordering for controlled practice");
     }
 
+    [Fact]
+    public void ExercisesPrompt_SentenceOrdering_ContainsGrammaticalCorrectnessConstraint()
+    {
+        var ctx = BaseCtx() with { CefrLevel = "A1" };
+
+        var req = _sut.BuildExercisesPrompt(ctx);
+
+        req.UserPrompt.Should().Contain("grammatically correct",
+            because: "the prompt must explicitly require that assembled fragments form a grammatically correct sentence");
+    }
+
+    [Fact]
+    public void ExercisesPrompt_IncludesGrammarScopeForCefrLevelOverreachPrevention()
+    {
+        var ctx = BaseCtx() with { CefrLevel = "B1" };
+
+        var req = _sut.BuildExercisesPrompt(ctx);
+
+        req.UserPrompt.Should().Contain("GRAMMAR SCOPE",
+            because: "exercises must include the CEFR grammar scope block to prevent level overreach (e.g. imperfect subjunctive at B1.1)");
+    }
+
     // --- Sentence transformation format ---
 
     [Fact]

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -525,7 +525,7 @@ public class PromptService : IPromptService
         var prompt = $$"""
         Generate practice exercises for the lesson on "{{topic}}". Return JSON using one or more of these formats:
         {"fillInBlank":[{"sentence":"","answer":"","hint":"","explanation":"","stage":""}],"multipleChoice":[{"question":"","options":[""],"answer":"","explanation":"","stage":""}],"matching":[{"left":"","right":"","explanation":"","stage":""}],"trueFalse":[{"statement":"","isTrue":true,"justification":"","sourcePassage":"","stage":""}],"sentenceOrdering":[{"fragments":[""],"correctOrder":[0],"hint":"","explanation":"","stage":""}],"sentenceTransformation":[{"prompt":"","original":"","expected":"","alternatives":[""],"explanation":"","stage":""}]}
-        sentenceOrdering: fragments is an array of words or phrases; correctOrder is the array of fragment indices that form the correct sentence (e.g. fragments=["en","vivo","Barcelona","yo"], correctOrder=[3,1,0,2] gives "yo vivo en Barcelona"). Use sentenceOrdering for A1/A2/B1 levels where testing syntax awareness without requiring production is appropriate.
+        sentenceOrdering: fragments is an array of words or phrases; correctOrder is the array of fragment indices that form the correct sentence (e.g. fragments=["en","vivo","Barcelona","yo"], correctOrder=[3,1,0,2] gives "yo vivo en Barcelona"). CRITICAL: joining the fragments in correctOrder MUST produce a grammatically correct, natural Spanish sentence — verify this before outputting each item. Use sentenceOrdering for A1/A2/B1 levels where testing syntax awareness without requiring production is appropriate.
         sentenceTransformation: prompt is the transformation instruction; original is the source sentence; expected is the primary correct answer; alternatives lists other acceptable answers. Use for B1+ levels for tense changes, voice transformations, reported speech, and register shifts. Maps to DELE "transformaciones gramaticales".
         {{levelGuidance}}
         Include at least 3 items for each format you use. For each exercise, include a concise explanation (2-3 sentences) of why the correct answer is correct, considering the student's level and common L1 interference patterns.
@@ -542,6 +542,10 @@ public class PromptService : IPromptService
         var scopeConstraint = _pedagogy.GetScopeConstraint(ctx.SectionType ?? "", level, ctx.TemplateName, "exercises");
         if (!string.IsNullOrEmpty(scopeConstraint))
             prompt += "\n" + scopeConstraint;
+
+        var grammarScope = BuildGrammarScopeBlock(level);
+        if (!string.IsNullOrEmpty(grammarScope))
+            prompt += "\n\n" + grammarScope;
 
         var templateGuidance = BuildTemplateGuidanceBlock(ctx.TemplateName, ctx.SectionType, level);
         if (!string.IsNullOrEmpty(templateGuidance))

--- a/plan/langteach-beta/task430-sentence-ordering-fix.md
+++ b/plan/langteach-beta/task430-sentence-ordering-fix.md
@@ -1,0 +1,61 @@
+# Task 430 — Fix: Sentence Ordering Exercises Generate Grammatically Incorrect Assembled Sentences
+
+## Problem
+
+The `sentenceOrdering` prompt in `ExercisesUserPrompt` has two gaps:
+
+1. **No grammatical correctness constraint**: The prompt describes the mechanics (fragments + correctOrder indices) but never tells Claude that the assembled sentence MUST be grammatically correct. Claude can generate fragments that, when joined in correctOrder, produce a malformed sentence.
+2. **No CEFR grammar scope in exercises**: `ExercisesUserPrompt` includes `GetGrammarConstraints` (language-level rules) but NOT `BuildGrammarScopeBlock` (CEFR in-scope / out-of-scope grammar). This allows level overreach: B1.1 exercises can contain imperfect subjunctive, a B1.2+ structure.
+
+## Root Cause
+
+`ExercisesUserPrompt` (PromptService.cs ~line 517) omits:
+- An explicit "assembled result must be grammatically correct" instruction for `sentenceOrdering`
+- `BuildGrammarScopeBlock(level)` — used in grammar prompts but not exercises
+
+## Changeset
+
+### 1. `backend/LangTeach.Api/AI/PromptService.cs` — `ExercisesUserPrompt`
+
+**a) Strengthen the sentenceOrdering description** (in the multi-line prompt string, line ~528):
+
+Replace current:
+> sentenceOrdering: fragments is an array of words or phrases; correctOrder is the array of fragment indices that form the correct sentence (e.g. fragments=["en","vivo","Barcelona","yo"], correctOrder=[3,1,0,2] gives "yo vivo en Barcelona"). Use sentenceOrdering for A1/A2/B1 levels where testing syntax awareness without requiring production is appropriate.
+
+With:
+> sentenceOrdering: fragments is an array of words or phrases; correctOrder is the array of fragment indices that form the correct sentence (e.g. fragments=["en","vivo","Barcelona","yo"], correctOrder=[3,1,0,2] gives "yo vivo en Barcelona"). CRITICAL: joining the fragments in correctOrder MUST produce a grammatically correct, natural Spanish sentence — verify this before outputting each item. Use sentenceOrdering for A1/A2/B1 levels where testing syntax awareness without requiring production is appropriate.
+
+**b) Add `BuildGrammarScopeBlock` to the exercises prompt** — insert after the existing `scopeConstraint` block (after line ~544):
+
+```csharp
+var grammarScope = BuildGrammarScopeBlock(level);
+if (!string.IsNullOrEmpty(grammarScope))
+    prompt += "\n\n" + grammarScope;
+```
+
+### 2. `backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs`
+
+Add 2 tests in the "Sentence ordering format" section (after the two existing tests ~line 2038):
+
+**Test 1**: `ExercisesPrompt_SentenceOrdering_ContainsGrammaticalCorrectnessConstraint`
+- Build A1 exercises prompt
+- Assert UserPrompt contains "grammatically correct" (or similar unique phrase from the new instruction)
+
+**Test 2**: `ExercisesPrompt_B1_IncludesGrammarScopeForExercises`
+- Build B1.1 exercises prompt
+- Assert UserPrompt contains "GRAMMAR SCOPE" (the header from `BuildGrammarScopeBlock`)
+- This ensures CEFR level grammar scope gates exercises content, preventing overreach
+
+## Test Coverage Mapping
+
+| Acceptance criterion | Test |
+|---|---|
+| Prompt explicitly instructs grammatically correct assembly | Test 1 |
+| CEFR level overreach prevented for exercises | Test 2 |
+| Hans A1 / Isabel B1.1 Teacher QA (post-deploy) | manual / teacher-qa skill |
+
+## Out of Scope
+
+- Frontend changes (no rendering issue; problem is at prompt level)
+- New e2e test (the existing `sentence-ordering-type.spec.ts` covers the happy path)
+- Grammar validation service check on the assembled sentence (would require AI call; the prompt fix is sufficient and proportionate for MVP)


### PR DESCRIPTION
## Summary

- Add explicit grammatical correctness constraint to `sentenceOrdering` prompt: assembled fragments MUST form a correct Spanish sentence
- Add `BuildGrammarScopeBlock` to `ExercisesUserPrompt` to prevent CEFR level overreach (was present in grammar/reading/lesson-plan prompts but missing from exercises)
- 2 new backend unit tests

## Root Cause

`ExercisesUserPrompt` described the `sentenceOrdering` mechanics but never told Claude to verify the assembled result is grammatical. The exercises prompt also lacked the CEFR grammar scope block, allowing level overreach (e.g. imperfect subjunctive at B1.1).

## Test plan

- [x] `ExercisesPrompt_SentenceOrdering_ContainsGrammaticalCorrectnessConstraint` passes
- [x] `ExercisesPrompt_IncludesGrammarScopeForCefrLevelOverreachPrevention` passes
- [x] All existing tests pass (57 frontend, all backend)
- [ ] Hans A1 Teacher QA: sentence ordering exercises assemble to grammatically correct sentences (manual post-deploy)
- [ ] Isabel B1.1 Teacher QA: same, no imperfect subjunctive (manual post-deploy)

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sentence-ordering exercises to ensure assembled fragments are grammatically correct.
  * Enhanced grammar-scope targeting in exercises to prevent including grammar beyond the intended proficiency level.

* **Tests**
  * Added test coverage for sentence-ordering prompt validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->