### PR TITLE
fix: template type not propagating to block-level generation (#429)

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -2344,4 +2344,94 @@ public class PromptServiceTests
         req.UserPrompt.Should().NotContain("L1 CONTRASTIVE NOTE",
             because: "no contrastive pattern matches 'preterite vs imperfect' for Italian");
     }
+
+    // --- Template name propagation to debug logs ---
+
+    [Theory]
+    [InlineData("Reading & Comprehension")]
+    [InlineData("Writing Skills")]
+    [InlineData("Exam Prep")]
+    public void BuildVocabularyPrompt_LogsTemplateName(string templateName)
+    {
+        var log = new FakeLogger<PromptService>();
+        var sut = new PromptService(ProfileService, PedagogyService, log, NoOpSchemas);
+        var ctx = BaseCtx() with { TemplateName = templateName };
+
+        sut.BuildVocabularyPrompt(ctx);
+
+        log.Entries.Should().Contain(e =>
+            e.Message.Contains($"template={templateName}"),
+            because: "BuildVocabularyPrompt must log the template name");
+    }
+
+    [Theory]
+    [InlineData("Reading & Comprehension")]
+    [InlineData("Writing Skills")]
+    [InlineData("Exam Prep")]
+    public void BuildExercisesPrompt_LogsTemplateName(string templateName)
+    {
+        var log = new FakeLogger<PromptService>();
+        var sut = new PromptService(ProfileService, PedagogyService, log, NoOpSchemas);
+        var ctx = BaseCtx() with { TemplateName = templateName, SectionType = "practice" };
+
+        sut.BuildExercisesPrompt(ctx);
+
+        log.Entries.Should().Contain(e =>
+            e.Message.Contains($"template={templateName}"),
+            because: "BuildExercisesPrompt must log the template name");
+    }
+
+    [Theory]
+    [InlineData("Reading & Comprehension")]
+    public void BuildReadingPrompt_LogsTemplateName(string templateName)
+    {
+        var log = new FakeLogger<PromptService>();
+        var sut = new PromptService(ProfileService, PedagogyService, log, NoOpSchemas);
+        var ctx = BaseCtx() with { TemplateName = templateName, SectionType = "presentation" };
+
+        sut.BuildReadingPrompt(ctx);
+
+        log.Entries.Should().Contain(e =>
+            e.Message.Contains($"template={templateName}"),
+            because: "BuildReadingPrompt must log the template name");
+    }
+
+    // --- Writing Skills template: guided-writing prompt structure ---
+
+    [Fact]
+    public void BuildGuidedWritingPrompt_WritingSkillsTemplate_LogsTemplateName()
+    {
+        var log = new FakeLogger<PromptService>();
+        var sut = new PromptService(ProfileService, PedagogyService, log, NoOpSchemas);
+        var ctx = BaseCtx() with
+        {
+            TemplateName = "Writing Skills",
+            SectionType = "production",
+            CefrLevel = "B1"
+        };
+
+        sut.BuildGuidedWritingPrompt(ctx);
+
+        log.Entries.Should().Contain(e =>
+            e.Message.Contains("template=Writing Skills"),
+            because: "BuildGuidedWritingPrompt must log the active template name for debugging");
+    }
+
+    [Fact]
+    public void BuildGuidedWritingPrompt_WritingSkillsTemplate_ProducesWritingTaskStructure()
+    {
+        var ctx = BaseCtx() with
+        {
+            TemplateName = "Writing Skills",
+            SectionType = "production",
+            CefrLevel = "B1"
+        };
+
+        var req = _sut.BuildGuidedWritingPrompt(ctx);
+
+        req.UserPrompt.Should().Contain("WORD COUNT",
+            because: "Guided writing prompt must specify the expected word count range");
+        req.UserPrompt.Should().Contain("tips",
+            because: "Guided writing prompt must include practical hints to help the student start");
+    }
 }

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -32,21 +32,21 @@ public class PromptService : IPromptService
     {
         var system = BuildSystemPrompt(ctx);
         var user   = VocabularyUserPrompt(ctx);
-        return BuildRequest("vocabulary", "vocabulary", ctx.CefrLevel, null, system, user, ClaudeModel.Haiku, 2048);
+        return BuildRequest("vocabulary", "vocabulary", ctx.CefrLevel, ctx.TemplateName, system, user, ClaudeModel.Haiku, 2048);
     }
 
     public ClaudeRequest BuildGrammarPrompt(GenerationContext ctx)
     {
         var system = BuildSystemPrompt(ctx);
         var user   = GrammarUserPrompt(ctx);
-        return BuildRequest("grammar", "grammar", ctx.CefrLevel, null, system, user, ClaudeModel.Sonnet, 3000);
+        return BuildRequest("grammar", "grammar", ctx.CefrLevel, ctx.TemplateName, system, user, ClaudeModel.Sonnet, 3000);
     }
 
     public ClaudeRequest BuildExercisesPrompt(GenerationContext ctx)
     {
         var system = BuildSystemPrompt(ctx);
         var user   = ExercisesUserPrompt(ctx);
-        return BuildRequest("exercises", "practice", ctx.CefrLevel, null, system, user, ClaudeModel.Haiku, 4096);
+        return BuildRequest("exercises", "practice", ctx.CefrLevel, ctx.TemplateName, system, user, ClaudeModel.Haiku, 4096);
     }
 
     public ClaudeRequest BuildConversationPrompt(GenerationContext ctx)
@@ -54,21 +54,21 @@ public class PromptService : IPromptService
         var system  = BuildSystemPrompt(ctx);
         var user    = ConversationUserPrompt(ctx);
         var section = ctx.SectionType ?? "conversation";
-        return BuildRequest("conversation", section, ctx.CefrLevel, null, system, user, ClaudeModel.Haiku, 3000);
+        return BuildRequest("conversation", section, ctx.CefrLevel, ctx.TemplateName, system, user, ClaudeModel.Haiku, 3000);
     }
 
     public ClaudeRequest BuildReadingPrompt(GenerationContext ctx)
     {
         var system = BuildSystemPrompt(ctx);
         var user   = ReadingUserPrompt(ctx);
-        return BuildRequest("reading", "reading", ctx.CefrLevel, null, system, user, ClaudeModel.Sonnet, 4096);
+        return BuildRequest("reading", "reading", ctx.CefrLevel, ctx.TemplateName, system, user, ClaudeModel.Sonnet, 4096);
     }
 
     public ClaudeRequest BuildHomeworkPrompt(GenerationContext ctx)
     {
         var system = BuildSystemPrompt(ctx);
         var user   = HomeworkUserPrompt(ctx);
-        return BuildRequest("homework", "homework", ctx.CefrLevel, null, system, user, ClaudeModel.Sonnet, 1024);
+        return BuildRequest("homework", "homework", ctx.CefrLevel, ctx.TemplateName, system, user, ClaudeModel.Sonnet, 1024);
     }
 
     public ClaudeRequest BuildFreeTextPrompt(GenerationContext ctx)
@@ -76,7 +76,7 @@ public class PromptService : IPromptService
         var system  = BuildSystemPrompt(ctx);
         var user    = FreeTextUserPrompt(ctx);
         var section = ctx.SectionType ?? "free-text";
-        return BuildRequest("free-text", section, ctx.CefrLevel, null, system, user, ClaudeModel.Haiku, 1024);
+        return BuildRequest("free-text", section, ctx.CefrLevel, ctx.TemplateName, system, user, ClaudeModel.Haiku, 1024);
     }
 
     public ClaudeRequest BuildGuidedWritingPrompt(GenerationContext ctx)
@@ -91,7 +91,7 @@ public class PromptService : IPromptService
     {
         var system = BuildSystemPrompt(ctx);
         var user   = ErrorCorrectionUserPrompt(ctx);
-        return BuildRequest("error-correction", "practice", ctx.CefrLevel, null, system, user, ClaudeModel.Sonnet, 3000);
+        return BuildRequest("error-correction", "practice", ctx.CefrLevel, ctx.TemplateName, system, user, ClaudeModel.Sonnet, 3000);
     }
 
     public ClaudeRequest BuildNoticingTaskPrompt(GenerationContext ctx)

--- a/frontend/src/components/lesson/FullLessonGenerateButton.test.tsx
+++ b/frontend/src/components/lesson/FullLessonGenerateButton.test.tsx
@@ -195,7 +195,7 @@ describe('FullLessonGenerateButton', () => {
     expect(new Set(blockTypes)).toEqual(new Set(['conversation', 'grammar', 'exercises']))
   })
 
-  it('exam-prep template uses free-text for WarmUp, Production, WrapUp', async () => {
+  it('exam-prep template uses conversation for WarmUp/WrapUp and exercises for Production', async () => {
     const user = userEvent.setup()
     const onBlockSaved = vi.fn()
     const streamMock = vi.mocked(streamText)
@@ -225,11 +225,11 @@ describe('FullLessonGenerateButton', () => {
       return { section: block.lessonSectionId, type: block.blockType }
     })
     const bySection = Object.fromEntries(calls.map(c => [c.section, c.type]))
-    expect(bySection['s1']).toBe('free-text')   // WarmUp
+    expect(bySection['s1']).toBe('conversation') // WarmUp: briefing conversation
     expect(bySection['s2']).toBe('grammar')      // Presentation
     expect(bySection['s3']).toBe('exercises')    // Practice
-    expect(bySection['s4']).toBe('free-text')    // Production
-    expect(bySection['s5']).toBe('free-text')    // WrapUp
+    expect(bySection['s4']).toBe('exercises')    // Production: written exam task
+    expect(bySection['s5']).toBe('conversation') // WrapUp: self-assessment conversation
   })
 
   it('all sections show active status simultaneously during generation', async () => {
@@ -371,6 +371,94 @@ describe('FullLessonGenerateButton', () => {
     expect(calledSectionTypes).toContain('Practice')
     expect(calledSectionTypes).toContain('Production')
     expect(calledSectionTypes).toContain('WrapUp')
+  })
+
+  it('Reading & Comprehension template: Presentation uses reading, Practice uses exercises', async () => {
+    const user = userEvent.setup()
+    const streamMock = vi.mocked(streamText)
+    streamMock.mockResolvedValue('{}')
+    vi.mocked(generateApi.saveContentBlock).mockImplementation((_lessonId, req) =>
+      Promise.resolve(makeBlock(req.lessonSectionId!, req.blockType as string))
+    )
+
+    renderWithQuery(
+      <FullLessonGenerateButton
+        lessonId="lesson-1"
+        sections={SECTIONS}
+        lessonContext={{ ...LESSON_CONTEXT, templateName: 'Reading & Comprehension' }}
+        onBlockSaved={vi.fn()}
+      />
+    )
+    await user.click(screen.getByTestId('generate-full-lesson-btn'))
+    await user.click(screen.getByTestId('confirm-generate-full-lesson'))
+    await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(5), { timeout: 3000 })
+
+    const callMap = Object.fromEntries(
+      streamMock.mock.calls.map((c) => [(c[1] as { sectionType?: string }).sectionType, c[0]])
+    )
+    expect(callMap['Presentation']).toBe('reading')
+    expect(callMap['Practice']).toBe('exercises')
+    expect(callMap['WarmUp']).toBe('conversation')
+    expect(callMap['Production']).toBe('conversation')
+    expect(callMap['WrapUp']).toBe('conversation')
+  })
+
+  it('Writing Skills template: Production uses guided-writing', async () => {
+    const user = userEvent.setup()
+    const streamMock = vi.mocked(streamText)
+    streamMock.mockResolvedValue('{}')
+    vi.mocked(generateApi.saveContentBlock).mockImplementation((_lessonId, req) =>
+      Promise.resolve(makeBlock(req.lessonSectionId!, req.blockType as string))
+    )
+
+    renderWithQuery(
+      <FullLessonGenerateButton
+        lessonId="lesson-1"
+        sections={SECTIONS}
+        lessonContext={{ ...LESSON_CONTEXT, templateName: 'Writing Skills' }}
+        onBlockSaved={vi.fn()}
+      />
+    )
+    await user.click(screen.getByTestId('generate-full-lesson-btn'))
+    await user.click(screen.getByTestId('confirm-generate-full-lesson'))
+    await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(5), { timeout: 3000 })
+
+    const callMap = Object.fromEntries(
+      streamMock.mock.calls.map((c) => [(c[1] as { sectionType?: string }).sectionType, c[0]])
+    )
+    expect(callMap['Production']).toBe('guided-writing')
+    expect(callMap['Practice']).toBe('exercises')
+    expect(callMap['WarmUp']).toBe('conversation')
+    expect(callMap['WrapUp']).toBe('conversation')
+  })
+
+  it('Exam Prep template: WarmUp/WrapUp use conversation, Production uses exercises', async () => {
+    const user = userEvent.setup()
+    const streamMock = vi.mocked(streamText)
+    streamMock.mockResolvedValue('{}')
+    vi.mocked(generateApi.saveContentBlock).mockImplementation((_lessonId, req) =>
+      Promise.resolve(makeBlock(req.lessonSectionId!, req.blockType as string))
+    )
+
+    renderWithQuery(
+      <FullLessonGenerateButton
+        lessonId="lesson-1"
+        sections={SECTIONS}
+        lessonContext={{ ...LESSON_CONTEXT, templateName: 'Exam Prep' }}
+        onBlockSaved={vi.fn()}
+      />
+    )
+    await user.click(screen.getByTestId('generate-full-lesson-btn'))
+    await user.click(screen.getByTestId('confirm-generate-full-lesson'))
+    await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(5), { timeout: 3000 })
+
+    const callMap = Object.fromEntries(
+      streamMock.mock.calls.map((c) => [(c[1] as { sectionType?: string }).sectionType, c[0]])
+    )
+    expect(callMap['WarmUp']).toBe('conversation')
+    expect(callMap['WrapUp']).toBe('conversation')
+    expect(callMap['Production']).toBe('exercises')
+    expect(callMap['Practice']).toBe('exercises')
   })
 
   it('error in one section does not stop other sections from completing', async () => {

--- a/frontend/src/components/lesson/FullLessonGenerateButton.tsx
+++ b/frontend/src/components/lesson/FullLessonGenerateButton.tsx
@@ -19,6 +19,12 @@ import { useQueryClient } from '@tanstack/react-query'
 import type { LessonSection } from '../../api/lessons'
 import type { ContentBlockType } from '../../types/contentTypes'
 
+// NOTE: These per-template task maps are intentionally maintained here as frontend-only config.
+// The backend template-overrides.json captures `preferredContentType` for selected sections,
+// but the full-lesson generation flow is a UI concern: this component drives which content
+// type to stream per section. Deriving these from the backend config would require an API
+// change to expose template section defaults. Until then, keep this in sync with
+// data/pedagogy/template-overrides.json (see `preferredContentType` fields per section).
 const SECTION_TASK_MAP: Record<string, ContentBlockType> = {
   WarmUp: 'conversation',
   Presentation: 'grammar',
@@ -27,13 +33,42 @@ const SECTION_TASK_MAP: Record<string, ContentBlockType> = {
   WrapUp: 'conversation',
 }
 
-// Exam prep uses written tasks for WarmUp (briefing) and Production (written exam task)
+// Exam Prep: WarmUp/WrapUp are briefing/self-assessment conversations; Production is a written exam task
+// (template-overrides.json: practice.preferredContentType="exercises", production.preferredContentType="exercises")
 const EXAM_PREP_SECTION_TASK_MAP: Record<string, ContentBlockType> = {
-  WarmUp: 'free-text',
+  WarmUp: 'conversation',
   Presentation: 'grammar',
   Practice: 'exercises',
-  Production: 'free-text',
-  WrapUp: 'free-text',
+  Production: 'exercises',
+  WrapUp: 'conversation',
+}
+
+// Reading & Comprehension: Presentation must contain the reading passage
+// (template-overrides.json: presentation.preferredContentType="reading")
+const READING_COMPREHENSION_SECTION_TASK_MAP: Record<string, ContentBlockType> = {
+  WarmUp: 'conversation',
+  Presentation: 'reading',
+  Practice: 'exercises',
+  Production: 'conversation',
+  WrapUp: 'conversation',
+}
+
+// Writing Skills: Production must be an independent writing task
+// (guided-writing; template-overrides.json production section has EE- writing exercise priority types)
+const WRITING_SKILLS_SECTION_TASK_MAP: Record<string, ContentBlockType> = {
+  WarmUp: 'conversation',
+  Presentation: 'grammar',
+  Practice: 'exercises',
+  Production: 'guided-writing',
+  WrapUp: 'conversation',
+}
+
+// Map from lowercase template name to its section task map.
+// Keys must match the `name` field in data/pedagogy/template-overrides.json (lowercased).
+const TEMPLATE_TASK_MAPS: Record<string, Record<string, ContentBlockType>> = {
+  'exam prep': EXAM_PREP_SECTION_TASK_MAP,
+  'reading & comprehension': READING_COMPREHENSION_SECTION_TASK_MAP,
+  'writing skills': WRITING_SKILLS_SECTION_TASK_MAP,
 }
 
 const SECTION_ORDER = ['WarmUp', 'Presentation', 'Practice', 'Production', 'WrapUp']
@@ -107,9 +142,12 @@ export function FullLessonGenerateButton({
 
     const errors: string[] = []
 
-    const taskMap = lessonContext.templateName?.toLowerCase() === 'exam prep'
-      ? EXAM_PREP_SECTION_TASK_MAP
-      : SECTION_TASK_MAP
+    const tName = lessonContext.templateName?.toLowerCase() ?? ''
+    const resolvedMap = tName ? TEMPLATE_TASK_MAPS[tName] : undefined
+    if (tName && !resolvedMap) {
+      console.warn(`FullLessonGenerateButton: unknown template "${lessonContext.templateName}", using default task map`)
+    }
+    const taskMap = resolvedMap ?? SECTION_TASK_MAP
 
     await Promise.allSettled(activeSections.map(async (sectionType) => {
       const section = sections.find(s => s.sectionType === sectionType)!

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -113,3 +113,10 @@ A1-B2 use `vocabularyPerLesson: { productive: {min,max}, receptive: {min,max} }`
 | PR#338 | 2026-03-28 | low | PedagogyConfig.cs ExerciseTypeEntry: `bool Available = false` uses value-type default while other optional fields use nullable types. Functionally correct; minor style divergence. |
 
 | PR#360 | 2026-03-28 | low | PromptService.cs BuildRequest: StudentName and other PII are logged via named structured parameters ({SystemPrompt}, {UserPrompt}). Structured logging backends (Seq, App Insights) index these as searchable fields. Currently safe (Debug only in test/QA compose files), but worth switching to unstructured embedding or documenting as a known constraint to prevent accidental production enablement. |
+
+## PR task-t429-template-propagation (2026-04-02) -- #429 template propagation bug
+
+| Severity | File | Note |
+|---|---|---|
+| Minor | `FullLessonGenerateButton.tsx` | The four `*_SECTION_TASK_MAP` objects share identical WarmUp/WrapUp/Practice entries; only Presentation and Production vary. Minor duplication across 4 maps. Could be refactored as a base + per-template overrides if maps grow. |
+| Minor | `PromptServiceTests.cs` | `BuildReadingPrompt_LogsTemplateName` Theory only covers "Reading & Comprehension" but not "Writing Skills"/"Exam Prep". Asymmetric compared to the other Theory tests. Low risk since reading is R&C-specific. |

--- a/plan/langteach-beta/task429-template-propagation.md
+++ b/plan/langteach-beta/task429-template-propagation.md
@@ -1,0 +1,75 @@
+# Task 429: Fix template type not propagating to block-level generation
+
+## Problem
+
+Full lesson generation ignores template type when selecting content types per section:
+
+1. **R&C template (Carmen B2)**: `FullLessonGenerateButton` uses `SECTION_TASK_MAP.Presentation = 'grammar'` for all templates, so Presentation generates a grammar block instead of a reading passage. Practice then generates comprehension exercises referencing a phantom reading text.
+
+2. **Writing Skills template (Isabel B1)**: `SECTION_TASK_MAP.Production = 'conversation'`, so Production generates a conversation instead of a guided-writing task.
+
+3. **Exam Prep template (Ana B2)**: `EXAM_PREP_SECTION_TASK_MAP` maps WarmUp/WrapUp/Production to `free-text`, but WarmUp and WrapUp section profiles only allow `conversation`, causing HTTP 400 for those sections.
+
+Secondary: Several `PromptService.BuildRequest` calls pass `null` for the template param, producing misleading `template=(none)` in debug logs even though user prompt methods correctly use `ctx.TemplateName`.
+
+## Root cause
+
+`FullLessonGenerateButton.tsx` only has one special-case map (`EXAM_PREP_SECTION_TASK_MAP`) and that map itself contains invalid content types for WarmUp/WrapUp (section profiles only allow `conversation`).
+
+## Fix
+
+### 1. `frontend/src/components/lesson/FullLessonGenerateButton.tsx`
+
+- Fix `EXAM_PREP_SECTION_TASK_MAP`:
+  - WarmUp: `free-text` -> `conversation` (WarmUp only allows `conversation`)
+  - Production: `free-text` -> `exercises` (Exam Prep prefers `exercises`; allowed at B1+)
+  - WrapUp: `free-text` -> `conversation` (WrapUp only allows `conversation`)
+
+- Add `READING_COMPREHENSION_SECTION_TASK_MAP`:
+  - Presentation: `reading` (was `grammar`)
+  - All others same as `SECTION_TASK_MAP`
+
+- Add `WRITING_SKILLS_SECTION_TASK_MAP`:
+  - Production: `guided-writing` (was `conversation`)
+  - All others same as `SECTION_TASK_MAP`
+
+- Update template selection (lines 110-112):
+  ```ts
+  const tName = lessonContext.templateName?.toLowerCase() ?? ''
+  const taskMap =
+    tName === 'exam prep' ? EXAM_PREP_SECTION_TASK_MAP :
+    tName === 'reading & comprehension' ? READING_COMPREHENSION_SECTION_TASK_MAP :
+    tName === 'writing skills' ? WRITING_SKILLS_SECTION_TASK_MAP :
+    SECTION_TASK_MAP
+  ```
+
+### 2. `backend/LangTeach.Api/AI/PromptService.cs`
+
+Fix `BuildRequest` calls that pass `null` for template to pass `ctx.TemplateName` instead, so debug logs accurately show the active template:
+- `BuildVocabularyPrompt`, `BuildGrammarPrompt`, `BuildExercisesPrompt`, `BuildConversationPrompt`, `BuildReadingPrompt`, `BuildHomeworkPrompt`, `BuildFreeTextPrompt`, `BuildErrorCorrectionPrompt`
+
+No behavioral change - prompts already use `ctx.TemplateName` directly in user prompt methods.
+
+## Tests
+
+### Frontend (`FullLessonGenerateButton.test.tsx`)
+- Add test: R&C template uses `reading` for Presentation and `exercises` for Practice
+- Add test: Writing Skills template uses `guided-writing` for Production
+- Add test: Exam Prep template uses `conversation` for WarmUp/WrapUp and `exercises` for Production
+
+### Backend (`PromptServiceTests.cs`)
+- Add test cases for R&C template context to verify `template=` log param matches `ctx.TemplateName`
+- These can be simple: verify `BuildRequest` receives the expected template name
+
+## What is NOT changed
+
+- `GenerateController.cs` already correctly resolves `lesson.TemplateId -> templateName` and passes it to `GenerationContext`.
+- `PromptService` user prompt methods (`ExercisesUserPrompt`, `ReadingUserPrompt`, etc.) already correctly use `ctx.TemplateName` for template guidance and scope constraints.
+- `SectionProfileService.IsAllowed` is NOT changed - the content types in the task maps are selected to be within the section profiles' allowed lists.
+
+## Affected files
+
+- `frontend/src/components/lesson/FullLessonGenerateButton.tsx`
+- `frontend/src/components/lesson/FullLessonGenerateButton.test.tsx`
+- `backend/LangTeach.Api/AI/PromptService.cs`
+- `backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs`


### PR DESCRIPTION
## Summary

- R&C template full-lesson generation now uses `reading` for Presentation (was `grammar`), so the reading passage appears in the right section
- Writing Skills template now uses `guided-writing` for Production (was `conversation`), so writing tasks are generated
- Exam Prep template fixes: WarmUp/WrapUp `free-text` replaced with `conversation` (section profiles only allow `conversation`, causing HTTP 400); Production `free-text` replaced with `exercises`
- Extracts `TEMPLATE_TASK_MAPS` lookup object to avoid a separate `KNOWN_TEMPLATES` drift array
- Fixes 8 `PromptService.BuildRequest` calls that passed `null` for the template param (debug logging only, no behavioral change)

Closes #429. Follow-up: #435 (extend maps to Thematic Vocabulary and Culture & Society templates).

## Test plan

- [ ] All 57 frontend tests pass (`npm test`)
- [ ] All backend tests pass (`dotnet test`)
- [ ] Run `/teacher-qa carmen` and verify reading passage in Presentation, comprehension questions in Practice
- [ ] Run `/teacher-qa isabel` and verify at least one writing task in Production
- [ ] Run `/teacher-qa ana-exam` and verify all 5 sections generate without HTTP 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage validating prompt generation, template context propagation, and section-specific mappings across lesson templates

* **Refactor**
  * Enhanced template name propagation in prompt builders to maintain context throughout generation pipelines
  * Introduced template-specific section task mappings to improve alignment between lesson templates (Exam Prep, Reading & Comprehension, Writing Skills) and appropriate section types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->