### PR TITLE
docs: add Claude in Chrome extension guidance for frontend dev loop (#392)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -63,6 +63,7 @@ GitHub Issues is the single source of truth. Run `python3 .claude/scripts/task-p
 - **If milestone doesn't match active sprint**: STOP and ask the user.
 - **Self-assign immediately** when picking: `gh issue edit <N> --add-assignee "@me"`
 - **At most one `area:frontend` task in flight at a time.** Docker frontend runs on a fixed port (5173); concurrent frontend worktrees conflict. If a frontend task is already assigned, pick a backend or config task instead.
+- **Chrome extension for UI work:** When implementing frontend UI, launch Claude Code with `claude --chrome` to get live visual feedback via the Claude in Chrome extension. This improves first-pass output quality. It does NOT replace Playwright e2e tests or the `review-ui` agent (which runs before every push regardless). See `docs/dev-workflow.md` for setup steps.
 
 For issue creation, editing, board management, and labels: see `.claude/procedures/issue-management.md`.
 

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -177,6 +177,27 @@ When an agent enters a worktree via `EnterWorktree`, a post-creation hook (`.cla
 
 If builds fail in a worktree despite the hook, verify dependencies manually.
 
+## Chrome Extension for Frontend Development
+
+The [Claude in Chrome extension](https://chromewebstore.google.com/detail/bjfgambnhccakkhmkepdoekmckoijdlc) gives Claude Code a live browser connection during active UI work. Instead of generating code blindly, Claude can take screenshots, observe the rendered UI, and self-correct visual issues before handing back to the developer.
+
+**Setup (one-time, on the developer's machine):**
+1. Install the extension from the Chrome Web Store (works on Chrome and Edge, not Brave).
+2. Launch a Claude Code session with `claude --chrome`.
+3. Open `localhost:5173` (Docker frontend must be running) and confirm Claude can take a screenshot.
+
+**When to use:**
+- During active frontend task implementation, when writing or iterating on UI components.
+- The extension shares the browser's existing login session, so Auth0-authenticated pages are accessible without extra setup.
+
+**What it does NOT replace:**
+- Playwright e2e tests: those verify correctness in CI and run regardless.
+- The `review-ui` agent: that runs as a structured quality gate before every push, whether or not the Chrome extension was used during development.
+
+**Scope:** This is a local dev machine tool only. Agents running in CI or on remote machines do not have access to the Chrome session.
+
+**Serialization note:** At most one `area:frontend` task may be in flight at a time (Docker frontend port 5173 is fixed; parallel frontend worktrees conflict). The Chrome extension is only useful when the Docker frontend is running for the current task.
+
 ## Windows / Git Bash Notes
 
 The Bash tool runs in Git Bash on Windows. Git Bash automatically translates Unix absolute paths to Windows paths (e.g., `/opt/bin/tool` becomes `C:/Program Files/Git/opt/bin/tool`). This breaks `docker exec` commands with paths meant for inside containers. Fix: prefix with `MSYS_NO_PATHCONV=1`.

--- a/plan/langteach-beta/t392-chrome-extension/task392-chrome-extension-setup.md
+++ b/plan/langteach-beta/t392-chrome-extension/task392-chrome-extension-setup.md
@@ -1,0 +1,33 @@
+# Task 392: Set up Claude in Chrome Extension for Frontend Dev Loop
+
+## Issue
+https://github.com/Robert-Freire/langTeachSaaS/issues/392
+
+## Goal
+Document the Chrome extension setup and usage guidance so future frontend tasks use it automatically.
+
+## Acceptance Criteria
+- [x] AC#1: Extension installed and verified (done by user)
+- [ ] AC#2: `docs/dev-workflow.md` documents setup and when to use it
+- [ ] AC#3: `CLAUDE.md` references Chrome extension for frontend tasks
+- [ ] AC#4: (covered by the PR + this task being the first to note usage)
+
+## Changes
+
+### `docs/dev-workflow.md`
+Add a "Chrome Extension for Frontend Development" section after the "Worktree Setup" section (currently line 178).
+
+Content:
+- How to activate: launch Claude Code with `claude --chrome`, verify extension is running in Chrome/Edge
+- The extension shares the browser session so Auth0-authenticated pages work without extra setup
+- Use during active UI implementation to get visual feedback before handing back to the developer
+- Does NOT replace Playwright e2e tests (correctness in CI) or the `review-ui` agent (structured visual QA before push)
+- Not a CI concern: only available when running Claude Code CLI interactively on the developer's machine
+
+### `.claude/CLAUDE.md`
+Add a bullet after the `area:frontend` serialization rule (line 65):
+- When implementing frontend UI, use `claude --chrome` if available to get live visual feedback.
+- Pairs with the `review-ui` agent (which runs before push regardless).
+
+## Scope
+Docs-only. No code changes. No e2e tests needed. No build checks needed.


### PR DESCRIPTION
## Summary

- Adds a "Chrome Extension for Frontend Development" section to `docs/dev-workflow.md` with setup steps, when to use it, and what it does not replace (Playwright tests, `review-ui` agent)
- Adds a reference bullet to `.claude/CLAUDE.md` under the `area:frontend` task rules so agents know to launch with `--chrome` during UI implementation
- Includes plan file for the task

## Notes

- Extension was installed and verified by the user against `localhost:5173` (AC#1 done manually)
- This PR itself is the first frontend task completed with the extension active (AC#4)
- Sprint branch (`sprint/pedagogical-quality`) was already merged to main, so this PR targets main directly

## Test plan

- [ ] Review `docs/dev-workflow.md` Chrome extension section for accuracy
- [ ] Review `.claude/CLAUDE.md` bullet for clarity
- [ ] No code changes; no build or test steps required

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)