### PR TITLE
fix(#448): CEFR scope gaps - C1 optional stage, ojalá haber, A1.1 gustar singular

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -716,6 +716,17 @@ public class PromptServiceTests
     }
 
     [Fact]
+    public void ExercisesPrompt_C1_IncludesOptionalControlledStageNote()
+    {
+        var ctx = BaseCtx() with { CefrLevel = "C1" };
+
+        var req = _sut.BuildExercisesPrompt(ctx);
+
+        req.UserPrompt.Should().Contain("optional");
+        req.UserPrompt.Should().Contain("controlled");
+    }
+
+    [Fact]
     public void LessonPlanPrompt_A1_MentionsWordBankInPractice()
     {
         var ctx = BaseCtx() with { CefrLevel = "A1" };
@@ -2068,6 +2079,17 @@ public class PromptServiceTests
 
         req.UserPrompt.Should().Contain("GRAMMAR SCOPE",
             because: "exercises must include the CEFR grammar scope block to prevent level overreach (e.g. imperfect subjunctive at B1.1)");
+    }
+
+    [Fact]
+    public void GrammarPrompt_A1_GustarConstrainedToSingular()
+    {
+        var ctx = BaseCtx() with { CefrLevel = "A1" };
+
+        var req = _sut.BuildGrammarPrompt(ctx);
+
+        req.UserPrompt.Should().Contain("singular",
+            because: "A1.1 grammar scope must constrain gustar to singular form only per PCIC A1.1 p.38");
     }
 
     // --- Sentence transformation format ---

--- a/backend/LangTeach.Api.Tests/Services/GrammarValidationServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/GrammarValidationServiceTests.cs
@@ -97,6 +97,15 @@ public class GrammarValidationServiceTests
     }
 
     [Fact]
+    public void Validate_OjalaPresentPerfectIndicative_TriggersRule()
+    {
+        var svc = CreateService();
+        // "ojalá ha llegado" uses indicative present perfect — rule should catch it at B1+
+        var warnings = svc.Validate("Ojalá ha llegado a tiempo.", "Spanish", "B1", null);
+        Assert.Contains(warnings, w => w.RuleId == "ojala-indicative");
+    }
+
+    [Fact]
     public void Validate_LanguageCaseInsensitive_SpanishEquals()
     {
         var svc = CreateService();

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -273,6 +273,20 @@ public class PromptService : IPromptService
                 sb.AppendLine($"  Suitable types: {string.Join(", ", def.AllowedExerciseCategories)}");
         }
 
+        if (req.OptionalStages is { Length: > 0 })
+        {
+            sb.AppendLine("Optional stage(s) — include only when additional mechanical consolidation is needed; omit entirely if not needed:");
+            foreach (var stageId in req.OptionalStages)
+            {
+                if (!defs.TryGetValue(stageId, out var def))
+                    continue;
+                var optRange = req.ItemsPerStage.TryGetValue(stageId, out var optBounds) && optBounds.Length >= 2
+                    ? $"{optBounds[0]}-{optBounds[1]}"
+                    : "0-2";
+                sb.AppendLine($"- \"{stageId}\" ({def.NameLong} / {def.NameEs}): {def.Description} Items: {optRange} (optional).");
+            }
+        }
+
         sb.AppendLine("IMPORTANT: Each stage MUST use a different exercise format (fillInBlank / multipleChoice / matching / trueFalse / sentenceOrdering / sentenceTransformation). Do not repeat the same format across stages.");
         return sb.ToString().TrimEnd();
     }

--- a/data/pedagogy/cefr-levels/a1.json
+++ b/data/pedagogy/cefr-levels/a1.json
@@ -9,7 +9,7 @@
     "Pronombres personales sujeto",
     "Interrogativos (que, quien, donde, como, cuando, cuanto, por que)",
     "Hay vs esta/estan",
-    "Gustar + infinitivo / sustantivo (A1.2)",
+    "Gustar + infinitivo / sustantivo singular (A1.2): at A1.1 restrict to 'me gusta' + infinitive or singular noun only; plural agreement 'gustan' not introduced until A1.2 per PCIC Nociones especificas > Actividades y situaciones > Gustos y preferencias",
     "Demostrativos (este, ese, aquel) (A1.2)",
     "Tambien/tampoco (A1.2)",
     "Verbos reflexivos frecuentes (llamarse, levantarse) (A1.2)",

--- a/data/pedagogy/grammar-validation-rules.json
+++ b/data/pedagogy/grammar-validation-rules.json
@@ -39,8 +39,8 @@
       "id": "ojala-indicative",
       "targetLanguage": "spanish",
       "category": "mood-selection",
-      "pattern": "\\bojalá\\s+(que\\s+)?(él|ella|tú|yo|nosotros|vosotros|ellos|ellas|usted|ustedes)?\\s*(tiene|tienen|tengo|tienes|tenemos|tenéis|viene|vienen|vengo|vienes|venimos|puede|pueden|puedo|puedes|podemos|sabe|saben|sé|sabes|sabemos|es|son|soy|eres|somos|está|están|estoy|estás|estamos|va|van|voy|vas|vamos|hace|hacen|hago|haces|hacemos|habla|hablan|hablo|hablas|hablamos)\\b",
-      "correction": "After 'ojalá', use the subjunctive, not the indicative. Correct: ojalá (que) tenga/venga/pueda/sepa/esté/vaya/haga/hable.",
+      "pattern": "\\bojalá\\s+(que\\s+)?(él|ella|tú|yo|nosotros|vosotros|ellos|ellas|usted|ustedes)?\\s*(tiene|tienen|tengo|tienes|tenemos|tenéis|viene|vienen|vengo|vienes|venimos|puede|pueden|puedo|puedes|podemos|sabe|saben|sé|sabes|sabemos|es|son|soy|eres|somos|está|están|estoy|estás|estamos|va|van|voy|vas|vamos|hace|hacen|hago|haces|hacemos|habla|hablan|hablo|hablas|hablamos|ha|has|han|hemos|habéis|he)\\b",
+      "correction": "After 'ojalá', use the subjunctive, not the indicative. Correct: ojalá (que) tenga/venga/pueda/sepa/esté/vaya/haga/hable. For present perfect: ojalá haya llegado (not 'ha llegado').",
       "severity": "high",
       "levels": ["B1", "B2", "C1", "C2"],
       "contextRelevance": {

--- a/plan/beta2-teacher-workflow/task448-cefr-prompt-fixes.md
+++ b/plan/beta2-teacher-workflow/task448-cefr-prompt-fixes.md
@@ -1,0 +1,60 @@
+# Task 448: Pedagogy review findings - CEFR scope gaps in prompts and config
+
+## Goal
+
+Fix three CEFR pedagogy gaps found by Isaac during the Pedagogical Quality sprint review:
+1. C1/C2 prompt does not communicate that "controlled" is an optional practice stage
+2. `ojala-indicative` grammar validation rule misses present perfect indicative forms of haber
+3. A1.1 grammar scope does not constrain gustar to singular form only
+
+## Source files
+
+| Fix | File |
+|-----|------|
+| C1 optionalStages | `backend/LangTeach.Api/AI/PromptService.cs` (`BuildPracticeStageBlock`) |
+| ojalá regex gap | `data/pedagogy/grammar-validation-rules.json` |
+| A1.1 gustar | `data/pedagogy/cefr-levels/a1.json` |
+
+## Implementation
+
+### Fix 1: C1/C2 optionalStages in prompt
+
+`BuildPracticeStageBlock` (PromptService.cs ~L249) already reads `req.OptionalStages` via `CefrStageRequirement.OptionalStages` but never emits it. After the main stages loop, append:
+
+```
+Optional stage(s): controlled (optional, use when mechanical consolidation is needed
+before moving to meaningful practice)
+```
+
+Concretely: after the `foreach` loop over `req.Stages`, if `req.OptionalStages` is non-empty, iterate and emit each one with its definition and a note: `"(optional - include when mechanical consolidation would benefit the learner; omit for advanced/fluent C1 students)"`.
+
+### Fix 2: ojalá present perfect indicative gap
+
+The current `ojala-indicative` pattern only lists present indicative verbs (tiene, viene, etc.).  
+It misses `ha/has/han/hemos/habéis/he` (indicative present of haber used in present perfect: "ojalá ha llegado").  
+The correct form after "ojalá" for present perfect is subjunctive: "haya/hayas/hayan/hayamos/hayáis".
+
+Add the indicative haber forms to the pattern alternation. Also update the `correction` text to mention the present perfect case.
+
+### Fix 3: A1.1 gustar singular constraint
+
+`data/pedagogy/cefr-levels/a1.json` grammarInScope entry:
+- Current: `"Gustar + infinitivo / sustantivo (A1.2)"`
+- New: `"Gustar + infinitivo / sustantivo singular (A1.2): at A1.1 restrict to 'me gusta' + infinitive or singular noun only; plural agreement 'gustan' not introduced until A1.2 per PCIC A1.1 p.38"`
+
+This makes the PCIC constraint explicit in the data so the AI reads it directly from the grammar scope block.
+
+## Tests
+
+- `PromptServiceTests.cs`: add test for `BuildPracticeStageBlock` at C1 level verifying "optional" appears in output.
+- Grammar validation tests: `GrammarValidation.cs` or existing test if present; add a test case "ojalá ha llegado" triggers the rule.
+- No frontend changes.
+
+## Acceptance criteria (from issue)
+
+- [ ] C1 prompt block includes optionalStages note for controlled stage
+- [ ] ojalá grammar validation rule extended to cover present perfect subjunctive [indicative haber]
+- [ ] A1.1 grammar scope constrains gustar to singular form only
+- [ ] All backend tests pass
+- [ ] Teacher QA re-run with Ana A1 confirms gustar fix
+- [ ] `.claude/skills/teacher-qa/output/prior-findings.md` updated with all three findings after merge


### PR DESCRIPTION
## Summary

- C1/C2 exercises prompt now emits optional `controlled` stage with item-count bounds (0-2) and actionable language; uses existing `OptionalStages` data field that was not previously surfaced in prompts
- `ojala-indicative` grammar validation rule extended with haber present indicative forms (`ha|has|han|hemos|habéis|he`) to catch `ojalá ha llegado`-style errors; correction text updated with present perfect example
- A1.1 `grammarInScope` gustar entry explicitly constrains to singular form (`me gusta`) with PCIC section reference; `gustan` deferred to A1.2

Fixes #448. Findings sourced from Isaac's pedagogy review (sprint close, 2026-04-02).

## Test plan

- [ ] `ExercisesPrompt_C1_IncludesOptionalControlledStageNote` passes (C1 prompt contains "optional" and "controlled")
- [ ] `Validate_OjalaPresentPerfectIndicative_TriggersRule` passes ("ojalá ha llegado" triggers rule at B1+)
- [ ] `GrammarPrompt_A1_GustarConstrainedToSingular` passes (A1 grammar scope contains "singular")
- [ ] All 786 backend tests pass
- [ ] Teacher QA re-run with Ana A1 to confirm gustar fix (post-merge AC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional practice stages in lesson content generation.

* **Bug Fixes**
  * Improved detection of incorrect indicative verb forms after "ojalá" (corrects to subjunctive mood).

* **Documentation**
  * Refined A1-level grammar scope documentation to clarify singular form constraints for "gustar" and subjunctive mood requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->