### PR TITLE
fix(seeder): remove Excel import header from Marco Seed notes

### DIFF
--- a/backend/LangTeach.Api/Data/DemoSeeder.cs
+++ b/backend/LangTeach.Api/Data/DemoSeeder.cs
@@ -261,7 +261,7 @@ public static class DemoSeeder
             Interests        = "[]",
             Difficulties     = "[]",
             Weaknesses       = "[]",
-            Notes            = "[Excel import 2026-01-15]\nCurrent level: A2\nObjectives: Business English, travel vocabulary\nDifficulties: Pronunciation, articles",
+            Notes            = "Current level: A2\nObjectives: Business English, travel vocabulary\nDifficulties: Pronunciation, articles",
         }, now);
 
         // Clara Seed — minimal scenario


### PR DESCRIPTION
## Summary
- Removes the `[Excel import 2026-01-15]` prefix from Marco Seed's notes in `DemoSeeder.cs`
- This tag was a demo artifact that made it look like a real import had occurred; seed data should show clean notes

## Test plan
- [ ] Re-run demo seeder and verify Marco Seed's notes no longer show the import header

🤖 Generated with [Claude Code](https://claude.com/claude-code)