### PR TITLE
fix: accept RunningAtMaxScale as healthy revision state

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -172,8 +172,8 @@ jobs:
 
             echo "  Attempt ${i}/24: runningState=${STATE}"
 
-            if [ "${STATE}" = "Running" ]; then
-              echo "Revision ${NEW_REVISION} is running and serving traffic."
+            if [ "${STATE}" = "Running" ] || [ "${STATE}" = "RunningAtMaxScale" ]; then
+              echo "Revision ${NEW_REVISION} is running and serving traffic (${STATE})."
               exit 0
             elif [ "${STATE}" = "ActivationFailed" ] || [ "${STATE}" = "Failed" ]; then
               echo "ERROR: Revision ${NEW_REVISION} entered ${STATE} state."


### PR DESCRIPTION
## Summary

`RunningAtMaxScale` is a healthy Azure Container App revision state (container is running at max scale). The deploy job was only checking for `Running`, causing the deploy to time out and fail even when the revision was healthy.

Closes #499 (final fix)

## Test plan

- [ ] Merge and trigger deploy via Actions > Backend CI/CD > Run workflow
- [ ] Confirm job succeeds at attempt 7 with `RunningAtMaxScale`

🤖 Generated with [Claude Code](https://claude.com/claude-code)