### PR TITLE
fix: add workflow_dispatch to frontend CI/CD workflow

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -6,6 +6,7 @@ on:
     paths: ['frontend/**', '.github/workflows/frontend.yml']
   pull_request:
     paths: ['frontend/**', '.github/workflows/frontend.yml']
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -47,7 +48,7 @@ jobs:
   deploy:
     name: Deploy to Azure SWA
     needs: ci
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && vars.DEPLOY_FROZEN != 'true'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && vars.DEPLOY_FROZEN != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch:` to `frontend.yml` `on:` block so deploys can be triggered manually
- Updates deploy job condition to allow `workflow_dispatch` event alongside `push`
- Backend workflow already had `workflow_dispatch` and correct conditions (no change needed)

## Test plan

- [ ] Merge PR
- [ ] Run `gh workflow run frontend.yml --ref main` and confirm frontend deploys to Azure SWA
- [ ] Verify the two sprints of stale frontend work (Pedagogical Quality, Post-Class Tracking) are now live

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow to support manual triggering in addition to automatic deployments, enabling faster deployment cycles while maintaining deployment freeze controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->