### PR TITLE
fix(#486): verify topic tag category dropdown has all four curriculum categories

### DIFF
--- a/e2e/tests/session-log.spec.ts
+++ b/e2e/tests/session-log.spec.ts
@@ -221,6 +221,49 @@ test('delete session requires confirmation dialog', async ({ browser }) => {
   await context.close()
 })
 
+test('topic tag category dropdown has all four curriculum-aligned options', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  const studentName = `Tag Category Test ${Date.now()}`
+  const createRes = await page.request.post(`${API_BASE}/api/students`, {
+    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
+    data: {
+      name: studentName,
+      learningLanguage: 'Spanish',
+      cefrLevel: 'B1',
+      interests: [],
+      learningGoals: [],
+      weaknesses: [],
+      difficulties: [],
+    },
+  })
+  const student = await createRes.json() as { id: string }
+
+  await page.goto(`/students/${student.id}`)
+  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
+  await page.getByTestId('log-session-button').click()
+  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
+
+  // Open the category dropdown and verify all four options exist
+  await page.getByTestId('topic-tag-category').click()
+  await expect(page.getByRole('option', { name: 'Grammar' })).toBeVisible()
+  await expect(page.getByRole('option', { name: 'Vocabulary' })).toBeVisible()
+  await expect(page.getByRole('option', { name: 'Competency' })).toBeVisible()
+  await expect(page.getByRole('option', { name: 'Communicative function' })).toBeVisible()
+
+  // Select Grammar and add a tag
+  await page.getByRole('option', { name: 'Grammar' }).click()
+  await page.getByTestId('topic-tag-name').fill('preterito indefinido')
+  await page.getByTestId('topic-tag-add').click()
+
+  // Badge should display tag with category label
+  await expect(page.getByTestId('topic-tags-input')).toContainText('preterito indefinido')
+  await expect(page.getByTestId('topic-tags-input')).toContainText('(Grammar)')
+
+  await context.close()
+})
+
 test('summary header appears on history tab after logging a session', async ({ browser }) => {
   const context = await createMockAuthContext(browser)
   const page = await context.newPage()

--- a/frontend/src/components/session/TopicTagsInput.test.tsx
+++ b/frontend/src/components/session/TopicTagsInput.test.tsx
@@ -66,4 +66,15 @@ describe('TopicTagsInput', () => {
     expect(screen.getByText('viajes')).toBeInTheDocument()
     expect(screen.getByText('(Vocabulary)')).toBeInTheDocument()
   })
+
+  it('renders all four curriculum-aligned category options', () => {
+    const { container } = render(<TopicTagsInput value={[]} onChange={vi.fn()} />)
+    const items = container.querySelectorAll('[data-value]')
+    const values = Array.from(items).map((el) => el.getAttribute('data-value'))
+    expect(values).toContain('grammar')
+    expect(values).toContain('vocabulary')
+    expect(values).toContain('competency')
+    expect(values).toContain('communicativeFunction')
+    expect(values).toHaveLength(4)
+  })
 })

--- a/plan/langteach-beta/task486-topic-tag-category-dropdown.md
+++ b/plan/langteach-beta/task486-topic-tag-category-dropdown.md
@@ -1,0 +1,39 @@
+# Task 486: Verify topic tag category dropdown options
+
+## Issue
+GitHub #486 - Verify: topic tag category dropdown contains all required curriculum-aligned options
+
+## Current state (verified)
+
+`TopicTagsInput.tsx` lines 9-14 already define all four required categories:
+```ts
+const CATEGORIES = [
+  { value: 'grammar', label: 'Grammar' },
+  { value: 'vocabulary', label: 'Vocabulary' },
+  { value: 'competency', label: 'Competency' },
+  { value: 'communicativeFunction', label: 'Communicative function' },
+]
+```
+
+Free-text without category also works correctly (lines 28-29).
+
+Backend (`SessionLogDtos.cs`) stores `TopicTags` as a freeform JSON string with no enum validation, so the frontend values are the canonical source of truth. The `CoveredTopicEntry` record uses `string? Category` (nullable, unconstrained).
+
+## Acceptance criteria status
+
+- [x] AC1: Dropdown has exactly Grammar, Vocabulary, Competency, Communicative function - ALREADY DONE
+- [x] AC2: Values match backend tag category constants - backend has no enum; frontend values are authoritative
+- [x] AC3: Free-text works with no category - ALREADY DONE
+
+## Work needed
+
+The existing unit test (`TopicTagsInput.test.tsx`) does not explicitly assert that all four category options exist. An e2e test for the session log topic tag flow with a category is also missing.
+
+### Changes
+
+1. **`frontend/src/components/session/TopicTagsInput.test.tsx`** - Add test that verifies all four category options are rendered (using the `SelectItem` mock's `data-value` attribute).
+
+2. **`e2e/tests/session-log.spec.ts`** - Add a test that selects a category from the dropdown and verifies the badge displays it.
+
+## No backend changes needed
+The backend category field is freeform. No enum or constant to add.


### PR DESCRIPTION
## Summary

- The `TopicTagsInput` dropdown already had all four required curriculum categories (Grammar, Vocabulary, Competency, Communicative function). No production code change needed.
- Added unit test asserting all four `SelectItem` `data-value` attributes are present and count is exactly 4.
- Added e2e test that opens the session log dialog, verifies all four options via `getByRole('option')`, selects Grammar, adds a tag, and confirms the badge displays `(Grammar)`.

## Test plan

- [ ] Unit tests pass: `npx vitest run src/components/session/TopicTagsInput.test.tsx` (7 tests)
- [ ] Build verify passes: all steps green
- [ ] E2E: session log dialog category dropdown shows all four options and tagged badge renders correctly

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)