### PR TITLE
feat: distinguish action items from general notes in session timeline card (#485)

### DIFF
--- a/frontend/src/components/session/SessionHistoryTab.test.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.test.tsx
@@ -209,11 +209,42 @@ describe('SessionHistoryTab', () => {
     })
   })
 
-  it('shows notes count when generalNotes and nextSessionTopics are set', async () => {
+  it('shows separate action item and note counts when both are set', async () => {
     vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
     wrapper()
     await screen.findByTestId('session-entry')
-    expect(screen.getByText(/2 notes/)).toBeInTheDocument()
+    expect(screen.getByTestId('action-item-count')).toHaveTextContent('1 action item')
+    expect(screen.getByTestId('general-note-count')).toHaveTextContent('1 note')
+  })
+
+  it('shows only action item count when nextSessionTopics is set and generalNotes is null', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SESSION_BASE, generalNotes: null },
+    ])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    expect(screen.getByTestId('action-item-count')).toHaveTextContent('1 action item')
+    expect(screen.queryByTestId('general-note-count')).not.toBeInTheDocument()
+  })
+
+  it('shows only general note count when generalNotes is set and nextSessionTopics is null', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SESSION_BASE, nextSessionTopics: null },
+    ])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    expect(screen.getByTestId('general-note-count')).toHaveTextContent('1 note')
+    expect(screen.queryByTestId('action-item-count')).not.toBeInTheDocument()
+  })
+
+  it('shows no count indicators when both generalNotes and nextSessionTopics are null', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SESSION_BASE, generalNotes: null, nextSessionTopics: null },
+    ])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    expect(screen.queryByTestId('action-item-count')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('general-note-count')).not.toBeInTheDocument()
   })
 
   it('shows relative time label: "today" for same-day session', async () => {

--- a/frontend/src/components/session/SessionHistoryTab.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { ChevronDown, ChevronUp, Trash2, Pencil, ExternalLink, FileText, BookOpen } from 'lucide-react'
+import { ChevronDown, ChevronUp, Trash2, Pencil, ExternalLink, BookOpen } from 'lucide-react'
 import { SessionSummaryHeader } from './SessionSummaryHeader'
 import { SessionLogDialog } from './SessionLogDialog'
 import { logger } from '../../lib/logger'
@@ -50,13 +50,6 @@ function tagCategoryClass(category?: string): string {
   return 'bg-zinc-100 text-zinc-600 border-zinc-200'
 }
 
-function notesCount(session: SessionLog): number {
-  let count = 0
-  if (session.generalNotes) count++
-  if (session.nextSessionTopics) count++
-  return count
-}
-
 function SessionEntry({
   session,
   studentId,
@@ -85,7 +78,8 @@ function SessionEntry({
   })
 
   const topicTags = parseTopicTags(session.topicTags)
-  const notes = notesCount(session)
+  const hasActionItem = Boolean(session.nextSessionTopics)
+  const hasNote = Boolean(session.generalNotes)
   const hwStatus = session.previousHomeworkStatusName
 
   return (
@@ -108,10 +102,16 @@ function SessionEntry({
                 {formatDate(session.sessionDate)}
               </span>
               <span className="text-xs text-zinc-400">{relativeTime(session.sessionDate)}</span>
-              {notes > 0 && (
-                <span className="inline-flex items-center gap-1 text-xs text-zinc-400">
-                  <FileText className="h-3 w-3" />
-                  {notes} {notes === 1 ? 'note' : 'notes'}
+              {hasActionItem && (
+                <span className="inline-flex items-center gap-1 text-xs text-amber-600" data-testid="action-item-count">
+                  <span className="bg-amber-400 rounded-full w-1.5 h-1.5 shrink-0" />
+                  1 action item
+                </span>
+              )}
+              {hasNote && (
+                <span className="inline-flex items-center gap-1 text-xs text-zinc-400" data-testid="general-note-count">
+                  <span className="bg-zinc-300 rounded-full w-1.5 h-1.5 shrink-0" />
+                  1 note
                 </span>
               )}
             </div>

--- a/plan/langteach-beta/task485-timeline-card-counts.md
+++ b/plan/langteach-beta/task485-timeline-card-counts.md
@@ -1,0 +1,53 @@
+# Task 485 — UX: Distinguish actionable vs contextual observations in timeline card count
+
+## Issue
+https://github.com/Robert-Freire/langTeachSaaS/issues/485
+
+## Problem
+Session timeline cards show a generic "N notes" count combining `nextSessionTopics` (action items) and `generalNotes` (contextual). Actionable items deserve more visual prominence.
+
+## Acceptance Criteria
+- [ ] Timeline card shows separate counts for `nextSessionTopics` (action items) and `generalNotes`
+- [ ] Action items use a distinct visual treatment from general notes (amber vs grey)
+- [ ] No count shown for a type if it is null or empty
+- [ ] Unit test covers the count rendering logic
+
+## Scope
+
+**Only `SessionHistoryTab.tsx`** — that is where session timeline cards live.
+
+The `LessonHistoryCard.tsx` is a separate component showing lesson-based notes (not session logs) and is out of scope.
+
+## Changes
+
+### `frontend/src/components/session/SessionHistoryTab.tsx`
+
+1. Remove `notesCount(session)` function (lines 53-58).
+2. In `SessionEntry`, compute two separate booleans:
+   ```ts
+   const hasActionItem = Boolean(session.nextSessionTopics)
+   const hasNote = Boolean(session.generalNotes)
+   ```
+3. Replace the single notes count display (the `{notes > 0 && ...}` block) with:
+   - If `hasActionItem`: amber dot + "1 action item" with `data-testid="action-item-count"`
+   - If `hasNote`: grey dot + "1 note" with `data-testid="general-note-count"`
+   - Render both when both are present (separated by a middot or just side by side)
+   - Use `·` separator between them when both are present, or render independently
+
+   Visual treatment:
+   - Action item: `inline-flex items-center gap-1 text-xs text-amber-600` with an amber dot (filled circle, `bg-amber-400 rounded-full w-1.5 h-1.5`)
+   - General note: `inline-flex items-center gap-1 text-xs text-zinc-400` with grey dot (`bg-zinc-300 rounded-full w-1.5 h-1.5`) or keep `FileText` icon
+
+### `frontend/src/components/session/SessionHistoryTab.test.tsx`
+
+1. Update existing test "shows notes count when generalNotes and nextSessionTopics are set" — it currently asserts `2 notes` (generic), replace with assertions on the two separate elements.
+2. Add tests:
+   - Only nextSessionTopics set: shows "1 action item", no note count
+   - Only generalNotes set: shows "1 note", no action item count
+   - Neither set: neither indicator shown
+
+## Data model note
+`nextSessionTopics` and `generalNotes` are free-text strings (null or non-empty). Each contributes at most 1 count. No plural logic needed beyond "1 action item" / "1 note" (always singular).
+
+## No backend changes needed
+The API already returns both fields on the `SessionLog` DTO.

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -8,6 +8,7 @@ Out-of-scope observations logged by agents during implementation. Each row is so
 | #498 | 2026-04-05 | P2:should | usage-limits.spec.ts times out in nightly CI (real AI generation too slow) — excluded from parallel project, filed #504 |
 | #498 | 2026-04-05 | P3:nice | Nightly notification skips job timeout/cancellation (if:failure() misses timed_out/cancelled) — filed #507 |
 | #498 | 2026-04-05 | dismissed | CodeRabbit: material-upload/usage-limits orphaned in parallel testIgnore — intentional, filed #503/#504 |
+| #485 | 2026-04-05 | P3:nice | task-build-verify.py bicep step fails in worktrees with long paths (Windows path length truncation); pre-existing, not task-specific |
 | #498 | 2026-04-05 | dismissed | CodeRabbit: Conversation template 5 sections false positive — BuildSections includes all sections regardless of required flag |
 
 *Cleared 2026-04-04 during Post-Class Tracking sprint close. 6 entries triaged: #441 lesson filter batched into #494, #450/#442 MaxLength batched into #492, remaining entries deleted (pre-existing patterns, dismissed CodeRabbit notes, stale worktree artifact).*


### PR DESCRIPTION
## Summary
- Replaces generic "N notes" count on session timeline cards with two separate visual indicators
- Amber dot + "1 action item" for `nextSessionTopics` (actionable, drives next lesson)
- Grey dot + "1 note" for `generalNotes` (contextual)
- Neither indicator shown if the respective field is null/empty

## Test plan
- [ ] Session history tab shows amber "1 action item" when `nextSessionTopics` is set
- [ ] Session history tab shows grey "1 note" when `generalNotes` is set
- [ ] Both indicators shown when both fields are set
- [ ] No indicators shown when both fields are null
- [ ] Unit tests: 22 passing (4 new tests added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Separated action items and general notes into distinct status indicators in the session history view, providing clearer visibility of session content types instead of a combined count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->