### PR TITLE
fix(#536): skip blank/template sheets in Excel importer

### DIFF
--- a/backend/LangTeach.MigrationTool.Tests/ExcelImporterTests.cs
+++ b/backend/LangTeach.MigrationTool.Tests/ExcelImporterTests.cs
@@ -17,6 +17,59 @@ public class ExcelImporterTests
         return ws;
     }
 
+    private static IXLWorksheet BuildEmptyWorksheet()
+    {
+        var wb = new XLWorkbook();
+        return wb.AddWorksheet("Libre");
+    }
+
+    private static IXLWorksheet BuildWorksheetWithDate(DateTime date)
+    {
+        var wb = new XLWorkbook();
+        var ws = wb.AddWorksheet("Test");
+        ws.Cell(1, 1).Value = "Fecha"; // header
+        ws.Cell(2, 1).Value = date;
+        ws.Cell(2, 3).Value = "some content";
+        return ws;
+    }
+
+    // --- IsBlankSheet ---
+
+    [Fact]
+    public void IsBlankSheet_TrulyEmptySheet_ReturnsTrue()
+    {
+        var ws = BuildEmptyWorksheet();
+        ExcelImporter.IsBlankSheet(ws, ("", "")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsBlankSheet_HeaderOnlyNoData_ReturnsTrue()
+    {
+        var ws = BuildWorksheet(); // only header row, no data rows
+        ExcelImporter.IsBlankSheet(ws, ("", "")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsBlankSheet_SheetWithSessionDate_ReturnsFalse()
+    {
+        var ws = BuildWorksheetWithDate(new DateTime(2024, 3, 15));
+        ExcelImporter.IsBlankSheet(ws, ("", "")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsBlankSheet_SheetWithPreplyNote_ReturnsFalse()
+    {
+        var ws = BuildEmptyWorksheet();
+        ExcelImporter.IsBlankSheet(ws, ("A2", "")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsBlankSheet_SheetWithInfoNote_ReturnsFalse()
+    {
+        var ws = BuildEmptyWorksheet();
+        ExcelImporter.IsBlankSheet(ws, ("", "Some background info")).Should().BeFalse();
+    }
+
     // Helpers for TryParseDate tests
     private static IXLCell BuildNumericCell(double value)
     {

--- a/backend/LangTeach.MigrationTool/ExcelImporter.cs
+++ b/backend/LangTeach.MigrationTool/ExcelImporter.cs
@@ -44,6 +44,14 @@ internal sealed class ExcelImporter
             result.SheetsProcessed++;
             var sheetName = worksheet.Name;
 
+            var profileNotes = CollectProfileNotes(worksheet);
+
+            if (IsBlankSheet(worksheet, profileNotes))
+            {
+                Console.WriteLine($"SKIP (blank sheet): {sheetName}");
+                continue;
+            }
+
             var student = StudentMatcher.FindStudent(sheetName, students);
             if (student is null)
             {
@@ -54,8 +62,6 @@ internal sealed class ExcelImporter
 
             Console.WriteLine($"Processing sheet: {sheetName} -> student: {student.Name}");
             result.SheetsMatched++;
-
-            var profileNotes = CollectProfileNotes(worksheet);
 
             var sessionsImported = await ImportSessionsAsync(worksheet, student);
             result.SessionsImported += sessionsImported.imported;
@@ -69,6 +75,23 @@ internal sealed class ExcelImporter
         }
 
         return result;
+    }
+
+    // A sheet is blank when it has no session dates and no profile notes.
+    // Used to skip template sheets like "Libre" that would otherwise create empty students.
+    internal static bool IsBlankSheet(IXLWorksheet worksheet, (string preply, string info) profileNotes)
+    {
+        if (profileNotes.preply.Length > 0 || profileNotes.info.Length > 0)
+            return false;
+
+        foreach (var row in worksheet.RowsUsed())
+        {
+            if (row.RowNumber() == 1) continue; // header
+            if (TryParseDate(row.Cell(1), out _))
+                return false;
+        }
+
+        return true;
     }
 
     private static (string preply, string info) CollectProfileNotes(IXLWorksheet worksheet)

--- a/plan/langteach-beta/task536-jordi-student-import.md
+++ b/plan/langteach-beta/task536-jordi-student-import.md
@@ -1,0 +1,112 @@
+# Task 536: Import Jordi's Student Data (Alumnos actuales.xlsx)
+
+## Issue
+https://github.com/Robert-Freire/langTeachSaaS/issues/536
+
+## Branch
+`hotfix/jordi-onboarding` -> PR to `main`
+
+## Context
+
+The `LangTeach.MigrationTool` was built in PR #444. It already handles:
+- Parsing all sheets as students
+- Date formats: DateTime, OA numeric serials, text strings
+- Skipping rows with no valid date or all-empty content columns
+- Extracting CEFR level from sheet name or column F
+- Appending profile notes (Preply test result, student info) to student Notes field
+- Idempotency: skips duplicate session dates on re-run
+- Dry-run mode
+
+**One gap**: the "Libre" blank/template sheet would create a spurious empty student because `CreateStudentAsync` is called before checking whether the sheet has any meaningful content (sessions or profile notes).
+
+## Acceptance Criteria
+
+- [ ] Running the tool against Jordi's Excel in dry-run mode shows 34 students, no "Libre" student, and correct session counts
+- [ ] Running live creates all 34 students and their session history in Jordi's production account
+- [ ] Re-running is idempotent (no duplicates)
+
+## Code Changes
+
+### 1. Fix: Skip blank/template sheets in ExcelImporter
+
+**File**: `backend/LangTeach.MigrationTool/ExcelImporter.cs`
+
+Restructure `ImportAsync` to peek at content before creating the student:
+- Collect profile notes first
+- Scan for valid session rows (without inserting) to get a count
+- If sessions == 0 AND profile notes are empty, skip the sheet with a log message
+- Only then call `CreateStudentAsync` if needed
+
+This avoids creating "Libre" (completely blank) while still creating students that have profile notes but no sessions yet.
+
+Sketch:
+```csharp
+var profileNotes = CollectProfileNotes(worksheet);
+var peekSessions = PeekSessionCount(worksheet);
+
+if (peekSessions == 0 && profileNotes.preply.Length == 0 && profileNotes.info.Length == 0)
+{
+    Console.WriteLine($"SKIP (blank sheet): {sheetName}");
+    continue;
+}
+```
+
+Extract a `PeekSessionCount(IXLWorksheet)` helper that walks rows without touching the DB.
+
+### 2. Test: blank sheet is skipped
+
+**File**: `backend/LangTeach.MigrationTool.Tests/ExcelImporterTests.cs`
+
+Add a unit test for the blank-sheet skip path (no rows beyond header -> skip). Cannot test via `ExcelImporter.ImportAsync` without a DB, so test the logic through the public/internal surface indirectly, or expose `ShouldSkipSheet` as an internal helper.
+
+Actually: `ExcelImporter` is not easily unit-testable without a DB. The simplest approach is to add an `internal static bool ShouldSkipSheet(IXLWorksheet)` helper and test it directly.
+
+### 3. Build and run tests locally
+```
+cd backend && dotnet test LangTeach.MigrationTool.Tests
+```
+
+## Operational Steps (for Robert to run)
+
+These are not code changes, but must be confirmed before closing the issue.
+
+### Step A: Get Jordi's teacher ID from production
+
+Query the production DB via Azure CLI:
+```
+MSYS_NO_PATHCONV=1 az containerapp exec --name langteach-api --resource-group langteach-prod --command "sqlcmd -S <server> -U <user> -P <pass> -Q \"SELECT Id FROM Teachers WHERE Auth0Id LIKE '%jordi%'\""
+```
+
+Or use the Azure portal Query Editor on the production SQL database:
+```sql
+SELECT Id, Auth0Id, CreatedAt FROM Teachers ORDER BY CreatedAt DESC;
+```
+
+### Step B: Get production DB connection string
+
+Available in Azure Key Vault or as an app setting in the Container App environment.
+
+### Step C: Dry run
+```bash
+cd backend
+dotnet run --project LangTeach.MigrationTool -- \
+  --file "../../feedback/raw/2026-03-29_jordi_excel_alumnos_actuales.xlsx" \
+  --teacher-id <JORDI_TEACHER_GUID> \
+  --connection "<PROD_CONNECTION_STRING>" \
+  --dry-run
+```
+
+Expected output: ~34 students, ~200+ sessions, 0 "Libre" entries.
+
+### Step D: Live run
+
+Same command without `--dry-run`.
+
+### Step E: Validate
+
+Ask Jordi to log in and confirm all students and session history are visible.
+
+## Files Changed
+
+- `backend/LangTeach.MigrationTool/ExcelImporter.cs` - blank sheet skip logic
+- `backend/LangTeach.MigrationTool.Tests/ExcelImporterTests.cs` - test for blank sheet skip


### PR DESCRIPTION
## Summary

- Moves `CollectProfileNotes` before `CreateStudentAsync` in `ImportAsync` so blank-sheet detection runs before any DB write
- Adds `IsBlankSheet` guard: sheets with no session dates and no profile notes are skipped entirely (fixes the "Libre" template sheet creating a spurious empty student)
- 5 new unit tests for `IsBlankSheet`

## Operational steps (Robert must run after merge)

1. Get Jordi's teacher GUID from production DB:
   ```sql
   SELECT Id, Auth0Id FROM Teachers ORDER BY CreatedAt DESC;
   ```

2. Dry run (no DB writes):
   ```bash
   cd backend
   dotnet run --project LangTeach.MigrationTool -- --file "../feedback/raw/2026-03-29_jordi_excel_alumnos_actuales.xlsx" --teacher-id <JORDI_TEACHER_GUID> --connection "<PROD_CONN_STRING>" --dry-run
   ```
   Expected: ~34 students, no "Libre" entry.

3. Live run: same command without `--dry-run`

4. Confirm with Jordi that all students and session history are visible.

## Test plan

- [x] `dotnet test LangTeach.MigrationTool.Tests` - 67 passed
- [x] Full build verify PASS
- [ ] Dry run against production (Robert)
- [ ] Live run and Jordi validation (Robert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The Excel import process now automatically skips blank worksheets, reducing unnecessary processing and preventing empty student records from being created.

* **Tests**
  * Added tests to verify correct identification and skipping of blank worksheets during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->