### PR TITLE
fix(#536): remove [Excel import] marker from student notes

### DIFF
--- a/backend/LangTeach.MigrationTool/ExcelImporter.cs
+++ b/backend/LangTeach.MigrationTool/ExcelImporter.cs
@@ -253,7 +253,7 @@ internal sealed class ExcelImporter
 
     private async Task<bool> AppendStudentNotesAsync(Student student, string preply, string info)
     {
-        const string marker = "[Excel import";
+        const string marker = "Preply test:";
 
         // Idempotency: do not append if already imported
         if (student.Notes?.Contains(marker) == true)
@@ -263,7 +263,7 @@ internal sealed class ExcelImporter
         if (preply.Length > 0) parts.Add($"Preply test: {preply}");
         if (info.Length > 0) parts.Add($"Student info: {info}");
 
-        var appendBlock = $"\n[Excel import {DateTime.UtcNow:yyyy-MM-dd}]\n{string.Join("\n", parts)}";
+        var appendBlock = $"\n{string.Join("\n", parts)}";
 
         Console.WriteLine($"  Appending profile notes for {student.Name}");
 


### PR DESCRIPTION
Removes the `[Excel import YYYY-MM-DD]` header line from the notes block appended during Excel import. The Preply test and student info data are kept as-is.

Idempotency guard updated to use `Preply test:` as the marker instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated student notes formatting to use a new prefix marker and remove date headers from appended note blocks, ensuring proper note deduplication and consistent note display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->