### PR TITLE
fix(#535): make session date optional, default to today if blank

### DIFF
--- a/frontend/src/components/session/SessionLogDialog.tsx
+++ b/frontend/src/components/session/SessionLogDialog.tsx
@@ -167,7 +167,7 @@ export function SessionLogDialog({
   const { mutate: submitLog, isPending } = useMutation({
     mutationFn: () => {
       const payload = {
-        sessionDate,
+        sessionDate: sessionDate || todayIso(),
         plannedContent: plannedContent || null,
         actualContent: actualContent || null,
         homeworkAssigned: homeworkAssigned || null,
@@ -206,7 +206,6 @@ export function SessionLogDialog({
 
   function validate(): boolean {
     const errs: Record<string, string> = {}
-    if (!sessionDate) errs.sessionDate = 'Date is required.'
     if (!plannedContent && !actualContent) {
       errs.content = 'At least one of "What was planned" or "What was actually done" is required.'
     }
@@ -265,7 +264,6 @@ export function SessionLogDialog({
                 type="date"
                 value={sessionDate}
                 onChange={(e) => setSessionDate(e.target.value)}
-                required
                 data-testid="session-date"
                 className="text-sm"
               />


### PR DESCRIPTION
## Summary

- Remove `required` attribute from the session date input
- Remove the "Date is required" frontend validation
- If date is left blank on submit, defaults to today (no backend change needed)

This is a follow-up to #535 — the native date picker still blocked users who cleared the field. Now the field is fully optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session date field handling. The date now defaults to today when not provided, and validation no longer requires users to manually set a date before submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->