### PR TITLE
refactor: IVoiceNoteService accepts Stream instead of IFormFile (#553)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/VoiceNoteServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/VoiceNoteServiceTests.cs
@@ -3,7 +3,6 @@ using LangTeach.Api.Data;
 using LangTeach.Api.Data.Models;
 using LangTeach.Api.Services;
 using LangTeach.Api.Tests.Helpers;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -48,11 +47,11 @@ public class VoiceNoteServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task UploadAsync_ValidFile_ReturnsTranscribedNote()
+    public async Task UploadAsync_ValidStream_ReturnsTranscribedNote()
     {
-        var file = MakeFormFile("recording.webm", "audio/webm", 1024);
+        using var stream = MakeStream(1024);
 
-        var result = await _sut.UploadAsync(_teacherId, file);
+        var result = await _sut.UploadAsync(_teacherId, stream, "recording.webm", "audio/webm", 1024);
 
         result.Should().NotBeNull();
         result.TranscribedAt.Should().NotBeNull();
@@ -62,11 +61,12 @@ public class VoiceNoteServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task UploadAsync_FileTooLarge_ThrowsInvalidOperation()
+    public async Task UploadAsync_StreamTooLarge_ThrowsInvalidOperation()
     {
-        var oversizeFile = MakeFormFile("big.webm", "audio/webm", sizeBytes: 51 * 1024 * 1024);
+        using var stream = MakeStream(1024);
+        var oversizeBytes = 51L * 1024 * 1024;
 
-        var act = () => _sut.UploadAsync(_teacherId, oversizeFile);
+        var act = () => _sut.UploadAsync(_teacherId, stream, "big.webm", "audio/webm", oversizeBytes);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*exceeds maximum*");
@@ -75,9 +75,9 @@ public class VoiceNoteServiceTests : IDisposable
     [Fact]
     public async Task UploadAsync_UnsupportedContentType_ThrowsInvalidOperation()
     {
-        var file = MakeFormFile("video.mp4", "video/mp4", 1024);
+        using var stream = MakeStream(1024);
 
-        var act = () => _sut.UploadAsync(_teacherId, file);
+        var act = () => _sut.UploadAsync(_teacherId, stream, "video.mp4", "video/mp4", 1024);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*not supported*");
@@ -86,8 +86,8 @@ public class VoiceNoteServiceTests : IDisposable
     [Fact]
     public async Task GetByIdAsync_ExistingNote_ReturnsNote()
     {
-        var file = MakeFormFile("recording.webm", "audio/webm", 1024);
-        var created = await _sut.UploadAsync(_teacherId, file);
+        using var stream = MakeStream(1024);
+        var created = await _sut.UploadAsync(_teacherId, stream, "recording.webm", "audio/webm", 1024);
 
         var result = await _sut.GetByIdAsync(_teacherId, created.Id);
 
@@ -98,8 +98,8 @@ public class VoiceNoteServiceTests : IDisposable
     [Fact]
     public async Task GetByIdAsync_OtherTeacherNote_ReturnsNull()
     {
-        var file = MakeFormFile("recording.webm", "audio/webm", 1024);
-        var created = await _sut.UploadAsync(_teacherId, file);
+        using var stream = MakeStream(1024);
+        var created = await _sut.UploadAsync(_teacherId, stream, "recording.webm", "audio/webm", 1024);
         var otherTeacherId = Guid.NewGuid();
 
         var result = await _sut.GetByIdAsync(otherTeacherId, created.Id);
@@ -110,8 +110,8 @@ public class VoiceNoteServiceTests : IDisposable
     [Fact]
     public async Task UpdateTranscriptionAsync_ValidNote_UpdatesText()
     {
-        var file = MakeFormFile("recording.webm", "audio/webm", 1024);
-        var created = await _sut.UploadAsync(_teacherId, file);
+        using var stream = MakeStream(1024);
+        var created = await _sut.UploadAsync(_teacherId, stream, "recording.webm", "audio/webm", 1024);
 
         var updated = await _sut.UpdateTranscriptionAsync(_teacherId, created.Id, "Edited text");
 
@@ -129,17 +129,8 @@ public class VoiceNoteServiceTests : IDisposable
 
     public void Dispose() => _db.Dispose();
 
-    private static IFormFile MakeFormFile(string fileName, string contentType, long sizeBytes)
-    {
-        var bytes = new byte[sizeBytes];
-        var stream = new MemoryStream(bytes);
-        var file = new FormFile(stream, 0, sizeBytes, "file", fileName)
-        {
-            Headers = new HeaderDictionary(),
-            ContentType = contentType,
-        };
-        return file;
-    }
+    private static MemoryStream MakeStream(int sizeBytes) =>
+        new(new byte[sizeBytes]);
 
     /// <summary>
     /// Simple IDbContextFactory implementation that creates contexts with pre-built options.

--- a/backend/LangTeach.Api/Controllers/VoiceNotesController.cs
+++ b/backend/LangTeach.Api/Controllers/VoiceNotesController.cs
@@ -37,7 +37,8 @@ public class VoiceNotesController : ControllerBase
 
         try
         {
-            var note = await _voiceNoteService.UploadAsync(teacherId, file, ct);
+            using var stream = file.OpenReadStream();
+            var note = await _voiceNoteService.UploadAsync(teacherId, stream, file.FileName, file.ContentType, file.Length, ct);
             _logger.LogInformation("POST voice-note uploaded. TeacherId={TeacherId} Id={Id}", teacherId, note.Id);
             return CreatedAtAction(nameof(GetById), new { id = note.Id }, note);
         }

--- a/backend/LangTeach.Api/Services/IVoiceNoteService.cs
+++ b/backend/LangTeach.Api/Services/IVoiceNoteService.cs
@@ -1,11 +1,10 @@
 using LangTeach.Api.DTOs;
-using Microsoft.AspNetCore.Http;
 
 namespace LangTeach.Api.Services;
 
 public interface IVoiceNoteService
 {
-    Task<VoiceNoteDto> UploadAsync(Guid teacherId, IFormFile file, CancellationToken ct = default);
+    Task<VoiceNoteDto> UploadAsync(Guid teacherId, Stream audio, string fileName, string contentType, long sizeBytes, CancellationToken ct = default);
     Task<VoiceNoteDto?> GetByIdAsync(Guid teacherId, Guid id, CancellationToken ct = default);
     Task<VoiceNoteDto?> UpdateTranscriptionAsync(Guid teacherId, Guid id, string transcription, CancellationToken ct = default);
     Task<string?> GetAudioUrlAsync(Guid teacherId, Guid id, CancellationToken ct = default);

--- a/backend/LangTeach.Api/Services/VoiceNoteService.cs
+++ b/backend/LangTeach.Api/Services/VoiceNoteService.cs
@@ -1,7 +1,6 @@
 using LangTeach.Api.Data;
 using LangTeach.Api.Data.Models;
 using LangTeach.Api.DTOs;
-using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 
 namespace LangTeach.Api.Services;
@@ -37,28 +36,28 @@ public class VoiceNoteService : IVoiceNoteService
         _logger = logger;
     }
 
-    public async Task<VoiceNoteDto> UploadAsync(Guid teacherId, IFormFile file, CancellationToken ct = default)
+    public async Task<VoiceNoteDto> UploadAsync(Guid teacherId, Stream audio, string fileName, string contentType, long sizeBytes, CancellationToken ct = default)
     {
-        if (file.Length == 0)
+        if (sizeBytes == 0)
             throw new InvalidOperationException("An audio file is required and cannot be empty.");
 
-        if (file.Length > MaxFileSizeBytes)
+        if (sizeBytes > MaxFileSizeBytes)
             throw new InvalidOperationException($"File exceeds maximum allowed size of {MaxFileSizeBytes / (1024 * 1024)} MB.");
 
         // Browsers send MIME types with codec parameters (e.g. "audio/webm;codecs=opus").
         // Strip parameters before validation and storage so the base type matches AllowedContentTypes.
-        var baseContentType = file.ContentType.Split(';')[0].Trim();
+        var baseContentType = contentType.Split(';')[0].Trim();
 
         if (!AllowedContentTypes.Contains(baseContentType))
             throw new InvalidOperationException($"File type '{baseContentType}' is not supported. Supported types: webm, mp4, mpeg, wav, ogg.");
 
         var id = Guid.NewGuid();
-        var ext = Path.GetExtension(file.FileName);
+        var ext = Path.GetExtension(fileName);
         var blobPath = $"teachers/{teacherId}/{id}{ext}";
 
-        // Buffer the file so we can reuse the bytes for blob upload and transcription
+        // Buffer the stream so we can reuse the bytes for blob upload and transcription
         using var buffer = new MemoryStream();
-        await file.CopyToAsync(buffer, ct);
+        await audio.CopyToAsync(buffer, ct);
         buffer.Position = 0;
 
         // Upload audio to blob storage
@@ -67,16 +66,16 @@ public class VoiceNoteService : IVoiceNoteService
         _logger.LogInformation("Voice note uploaded to blob. TeacherId={TeacherId} BlobPath={BlobPath}", teacherId, blobPath);
 
         buffer.Position = 0;
-        var transcription = await _transcription.TranscribeAsync(buffer, file.FileName, baseContentType, ct);
+        var transcription = await _transcription.TranscribeAsync(buffer, fileName, baseContentType, ct);
 
         var note = new VoiceNote
         {
             Id = id,
             TeacherId = teacherId,
             BlobPath = blobPath,
-            OriginalFileName = Path.GetFileName(file.FileName),
+            OriginalFileName = Path.GetFileName(fileName),
             ContentType = baseContentType,
-            SizeBytes = file.Length,
+            SizeBytes = sizeBytes,
             DurationSeconds = 0, // Duration extraction not yet implemented; field reserved for future use
             Transcription = transcription,
             TranscribedAt = DateTime.UtcNow,

--- a/plan/langteach-beta/task553-transcription-stream-refactor.md
+++ b/plan/langteach-beta/task553-transcription-stream-refactor.md
@@ -1,0 +1,98 @@
+# Task 553 — refactor: ITranscriptionService — accept Stream instead of IFormFile
+
+## Status
+In progress
+
+## Issue
+[#553](https://github.com/Robert-Freire/langTeachSaaS/issues/553)
+
+## Current State (after sprint/adaptive-replanning sync)
+
+`ITranscriptionService.TranscribeAsync` already uses the Stream-based signature:
+```csharp
+Task<string> TranscribeAsync(Stream audio, string fileName, string contentType, CancellationToken ct = default);
+```
+
+Both `AzureSpeechTranscriptionService` and `StubTranscriptionService` already implement this.
+
+**What remains:**
+- `IVoiceNoteService.UploadAsync` and `VoiceNoteService.UploadAsync` still accept `IFormFile` (web-transport concern)
+- `VoiceNoteServiceTests` still use `MakeFormFile` helper (IFormFile mocks), not streams
+- AC 4 ("New signature tested with a stream-based unit test, not IFormFile mock") is unmet
+
+## Acceptance Criteria
+
+1. ✅ `ITranscriptionService` signature takes `Stream, fileName, contentType` — no `IFormFile`
+2. `VoiceNoteService` compiles and passes all existing tests
+3. No behaviour change: upload flow (browser voice input) works identically
+4. New signature tested with a stream-based unit test (not `IFormFile` mock)
+
+## Changes Required
+
+### 1. `IVoiceNoteService` — new signature
+
+```csharp
+Task<VoiceNoteDto> UploadAsync(
+    Guid teacherId,
+    Stream audio,
+    string fileName,
+    string contentType,
+    long sizeBytes,
+    CancellationToken ct = default);
+```
+
+Remove `using Microsoft.AspNetCore.Http;` from the interface file.
+
+### 2. `VoiceNoteService.UploadAsync` — update implementation
+
+- Accept `Stream audio, string fileName, string contentType, long sizeBytes` instead of `IFormFile`
+- Validation: use `sizeBytes` for size check, use `contentType` for allowed-type check (strip codec params)
+- Buffering: copy `audio` to `MemoryStream` buffer (needed for two reads: blob upload + transcription)
+- Remove `file.CopyToAsync`, `file.Length`, `file.FileName`, `file.ContentType` references
+- Remove `using Microsoft.AspNetCore.Http;`
+
+### 3. `VoiceNotesController.Upload` — extract from IFormFile
+
+The controller is the HTTP boundary — it still accepts `IFormFile` from ASP.NET:
+```csharp
+[HttpPost]
+[RequestSizeLimit(51 * 1024 * 1024)]
+public async Task<IActionResult> Upload(IFormFile file, CancellationToken ct)
+{
+    // ...
+    using var stream = file.OpenReadStream();
+    var note = await _voiceNoteService.UploadAsync(
+        teacherId, stream, file.FileName, file.ContentType, file.Length, ct);
+    // ...
+}
+```
+
+No change to the endpoint contract (same HTTP multipart upload).
+
+### 4. `VoiceNoteServiceTests` — update to stream-based
+
+Replace `MakeFormFile(...)` helper with `MakeStream(sizeBytes)` that returns `(Stream, string fileName, string contentType, long sizeBytes)`.
+
+All calls to `_sut.UploadAsync(_teacherId, file)` become `_sut.UploadAsync(_teacherId, stream, "recording.webm", "audio/webm", sizeBytes)`.
+
+Remove `MakeFormFile` helper and `using Microsoft.AspNetCore.Http;` from the test file.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `backend/LangTeach.Api/Services/IVoiceNoteService.cs` | New UploadAsync signature, remove IFormFile import |
+| `backend/LangTeach.Api/Services/VoiceNoteService.cs` | Update UploadAsync to accept Stream+metadata, remove IFormFile |
+| `backend/LangTeach.Api/Controllers/VoiceNotesController.cs` | Extract from IFormFile, call service with stream |
+| `backend/LangTeach.Api.Tests/Services/VoiceNoteServiceTests.cs` | Replace IFormFile helpers with stream helpers |
+
+## E2E Impact
+
+None — endpoint contract unchanged. Existing `session-log-voice.spec.ts` and `voice-note.spec.ts` e2e tests cover the HTTP upload path end-to-end; no new e2e tests needed.
+
+## Out of Scope
+
+- No blob storage logic changes
+- No transcription logic changes
+- No migration changes
+- No new endpoints


### PR DESCRIPTION
## Summary

- Changes `IVoiceNoteService.UploadAsync` and `VoiceNoteService.UploadAsync` to accept `(Stream audio, string fileName, string contentType, long sizeBytes)` instead of `IFormFile`
- Controller extracts stream/metadata from `IFormFile` at the HTTP boundary (no endpoint contract change)
- Unit tests updated to pass streams directly — no `IFormFile` mocks remaining

Closes #553. Prerequisite for Telegram bot integration (#545).

## Test plan

- [x] All 849 unit tests pass
- [x] `VoiceNoteServiceTests` uses `MakeStream` / `MemoryStream` throughout (no `IFormFile`)
- [x] Build verify: PASS (dotnet build, dotnet test, npm lint, npm build, npm test)
- [x] Code review: PASS
- [x] Architecture review: PASS

🤖 Generated with [Claude Code](https://claude.ai/claude-code)