### PR TITLE
fix(#496): eliminate content-blocks waitForResponse race condition in navigation.ts

### DIFF
--- a/.claude/skills/teacher-qa/playwright/helpers/navigation.ts
+++ b/.claude/skills/teacher-qa/playwright/helpers/navigation.ts
@@ -251,22 +251,22 @@ export async function extractLessonContent(
 ): Promise<LessonContent> {
   const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5175'
 
-  // Navigate to lesson editor and intercept the lesson data response
-  const [lessonResponse] = await Promise.all([
+  // Navigate to lesson editor and intercept both the lesson metadata and content-blocks responses.
+  // Both waitForResponse listeners must be registered before page.goto fires to avoid a race
+  // condition where the response arrives before the listener is active.
+  const [lessonResponse, blocksResponse] = await Promise.all([
     page.waitForResponse(
       resp => resp.url().includes(`/api/lessons/${lessonId}`) && !resp.url().includes('/content-blocks') && resp.status() === 200 && resp.request().resourceType() === 'xhr',
+      { timeout: 30000 }
+    ),
+    page.waitForResponse(
+      resp => resp.url().includes(`/api/lessons/${lessonId}/content-blocks`) && resp.status() === 200 && resp.request().resourceType() === 'xhr',
       { timeout: 30000 }
     ),
     page.goto(`${baseURL}/lessons/${lessonId}`),
   ])
 
   const lessonData = await lessonResponse.json()
-
-  // Fetch content blocks separately (not included in the lesson GET response)
-  const blocksResponse = await page.waitForResponse(
-    resp => resp.url().includes(`/api/lessons/${lessonId}/content-blocks`) && resp.status() === 200 && resp.request().resourceType() === 'xhr',
-    { timeout: 30000 }
-  )
   const blocksData: Array<{ lessonSectionId: string | null; blockType: string; generatedContent: string; editedContent: string | null }> = await blocksResponse.json()
 
   // Group blocks by section ID

--- a/plan/langteach-beta/task496-fix-navigation-race-condition.md
+++ b/plan/langteach-beta/task496-fix-navigation-race-condition.md
@@ -1,0 +1,50 @@
+# Task 496 — Fix Playwright race condition in navigation.ts
+
+## Issue
+#496: Fix Playwright race condition in navigation.ts: content-blocks wait registered after response fires
+
+## Problem
+
+In `extractLessonContent` (`.claude/skills/teacher-qa/playwright/helpers/navigation.ts`, line 266), the
+`waitForResponse` for `/content-blocks` is registered AFTER `page.goto()` completes. When the page
+loads, both `/api/lessons/{id}` and `/api/lessons/{id}/content-blocks` fire nearly simultaneously.
+By the time we await the second `waitForResponse`, the response may have already fired, causing an
+intermittent timeout.
+
+## Root Cause
+
+```typescript
+// BEFORE (race condition)
+const [lessonResponse] = await Promise.all([
+  page.waitForResponse(resp => ...lessonId..., { timeout: 30000 }),
+  page.goto(`${baseURL}/lessons/${lessonId}`),
+])
+// goto already completed above — content-blocks may have already fired
+const blocksResponse = await page.waitForResponse(
+  resp => ...content-blocks...,
+  { timeout: 30000 }
+)
+```
+
+## Fix
+
+Register both `waitForResponse` calls inside the same `Promise.all` as `page.goto`, so both listeners
+are active before the navigation action triggers any network requests.
+
+```typescript
+// AFTER (race-free)
+const [lessonResponse, blocksResponse] = await Promise.all([
+  page.waitForResponse(resp => ...lessonId..., { timeout: 30000 }),
+  page.waitForResponse(resp => ...content-blocks..., { timeout: 30000 }),
+  page.goto(`${baseURL}/lessons/${lessonId}`),
+])
+```
+
+## File Changed
+
+- `.claude/skills/teacher-qa/playwright/helpers/navigation.ts` (lines 254-270)
+
+## Acceptance Criteria
+
+- Teacher QA content generation tests do not fail due to this race condition
+- No intermittent navigation.ts timing failures in CI


### PR DESCRIPTION
## Summary
- Moves the `waitForResponse` listener for `/api/lessons/{id}/content-blocks` into the same `Promise.all` as the lesson metadata listener and `page.goto()`
- Eliminates the race condition where the response could fire before the listener was registered

## Test plan
- [ ] Teacher QA runs pass without intermittent content-blocks timeout failures
- [ ] CI nightly e2e shows no navigation.ts timing failures

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lesson content loading performance by retrieving lesson metadata and content blocks simultaneously instead of sequentially.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->