### PR TITLE
fix(#473): aggregate open action items across last 2-3 sessions

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/SessionLogServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/SessionLogServiceTests.cs
@@ -660,6 +660,87 @@ public class SessionLogServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetSummary_AggregatesTopicsFromLast3Sessions()
+    {
+        var baseDate = new DateTime(2026, 3, 30, 0, 0, 0, DateTimeKind.Utc);
+        _db.SessionLogs.AddRange(
+            new SessionLog { Id = Guid.NewGuid(), StudentId = _studentId, TeacherId = _teacherId, SessionDate = baseDate, PreviousHomeworkStatus = HomeworkStatus.NotApplicable, NextSessionTopics = "Topic A", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow },
+            new SessionLog { Id = Guid.NewGuid(), StudentId = _studentId, TeacherId = _teacherId, SessionDate = baseDate.AddDays(-1), PreviousHomeworkStatus = HomeworkStatus.NotApplicable, NextSessionTopics = "Topic B", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow },
+            new SessionLog { Id = Guid.NewGuid(), StudentId = _studentId, TeacherId = _teacherId, SessionDate = baseDate.AddDays(-2), PreviousHomeworkStatus = HomeworkStatus.NotApplicable, NextSessionTopics = "Topic C", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow }
+        );
+        await _db.SaveChangesAsync();
+
+        var result = await _sut.GetSummaryAsync(_teacherId, _studentId);
+
+        result.OpenActionItems.Should().Contain("Topic A");
+        result.OpenActionItems.Should().Contain("Topic B");
+        result.OpenActionItems.Should().Contain("Topic C");
+        result.OpenActionItems.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task GetSummary_DeduplicatesTopicsCaseInsensitive()
+    {
+        var baseDate = new DateTime(2026, 3, 30, 0, 0, 0, DateTimeKind.Utc);
+        _db.SessionLogs.AddRange(
+            new SessionLog { Id = Guid.NewGuid(), StudentId = _studentId, TeacherId = _teacherId, SessionDate = baseDate, PreviousHomeworkStatus = HomeworkStatus.NotApplicable, NextSessionTopics = "Repasar subjuntivo", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow },
+            new SessionLog { Id = Guid.NewGuid(), StudentId = _studentId, TeacherId = _teacherId, SessionDate = baseDate.AddDays(-1), PreviousHomeworkStatus = HomeworkStatus.NotApplicable, NextSessionTopics = "repasar subjuntivo", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow }
+        );
+        await _db.SaveChangesAsync();
+
+        var result = await _sut.GetSummaryAsync(_teacherId, _studentId);
+
+        result.OpenActionItems.Should().HaveCount(1);
+        result.OpenActionItems[0].Should().Be("Repasar subjuntivo");
+    }
+
+    [Fact]
+    public async Task GetSummary_EmptyMiddleSession_DoesNotEraseEarlierTopics()
+    {
+        var baseDate = new DateTime(2026, 3, 30, 0, 0, 0, DateTimeKind.Utc);
+        _db.SessionLogs.AddRange(
+            new SessionLog { Id = Guid.NewGuid(), StudentId = _studentId, TeacherId = _teacherId, SessionDate = baseDate, PreviousHomeworkStatus = HomeworkStatus.NotApplicable, NextSessionTopics = null, CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow },
+            new SessionLog { Id = Guid.NewGuid(), StudentId = _studentId, TeacherId = _teacherId, SessionDate = baseDate.AddDays(-1), PreviousHomeworkStatus = HomeworkStatus.NotApplicable, NextSessionTopics = "Old topic", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow }
+        );
+        await _db.SaveChangesAsync();
+
+        var result = await _sut.GetSummaryAsync(_teacherId, _studentId);
+
+        result.OpenActionItems.Should().BeEquivalentTo(new[] { "Old topic" });
+    }
+
+    [Fact]
+    public async Task GetSummary_TopicsOrderedMostRecentFirst()
+    {
+        var baseDate = new DateTime(2026, 3, 30, 0, 0, 0, DateTimeKind.Utc);
+        _db.SessionLogs.AddRange(
+            new SessionLog { Id = Guid.NewGuid(), StudentId = _studentId, TeacherId = _teacherId, SessionDate = baseDate, PreviousHomeworkStatus = HomeworkStatus.NotApplicable, NextSessionTopics = "Recent topic", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow },
+            new SessionLog { Id = Guid.NewGuid(), StudentId = _studentId, TeacherId = _teacherId, SessionDate = baseDate.AddDays(-1), PreviousHomeworkStatus = HomeworkStatus.NotApplicable, NextSessionTopics = "Older topic", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow }
+        );
+        await _db.SaveChangesAsync();
+
+        var result = await _sut.GetSummaryAsync(_teacherId, _studentId);
+
+        result.OpenActionItems[0].Should().Be("Recent topic");
+        result.OpenActionItems[1].Should().Be("Older topic");
+    }
+
+    [Fact]
+    public async Task GetSummary_MultilineTopicsInMultipleSessionsAggregatedCorrectly()
+    {
+        var baseDate = new DateTime(2026, 3, 30, 0, 0, 0, DateTimeKind.Utc);
+        _db.SessionLogs.AddRange(
+            new SessionLog { Id = Guid.NewGuid(), StudentId = _studentId, TeacherId = _teacherId, SessionDate = baseDate, PreviousHomeworkStatus = HomeworkStatus.NotApplicable, NextSessionTopics = "Line A1\nLine A2", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow },
+            new SessionLog { Id = Guid.NewGuid(), StudentId = _studentId, TeacherId = _teacherId, SessionDate = baseDate.AddDays(-1), PreviousHomeworkStatus = HomeworkStatus.NotApplicable, NextSessionTopics = "Line B1\nLine A1", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow }
+        );
+        await _db.SaveChangesAsync();
+
+        var result = await _sut.GetSummaryAsync(_teacherId, _studentId);
+
+        result.OpenActionItems.Should().BeEquivalentTo(new[] { "Line A1", "Line A2", "Line B1" });
+    }
+
+    [Fact]
     public async Task CreateAsync_SetsIsCancelledFromRequest()
     {
         var request = BaseRequest();

--- a/backend/LangTeach.Api/Services/SessionLogService.cs
+++ b/backend/LangTeach.Api/Services/SessionLogService.cs
@@ -286,26 +286,32 @@ public class SessionLogService : ISessionLogService
         var totalSessions = await _db.SessionLogs
             .CountAsync(sl => sl.StudentId == studentId && sl.TeacherId == teacherId && !sl.IsDeleted && !sl.IsCancelled && sl.Status == SessionLogStatus.Confirmed, cancellationToken);
 
-        var mostRecent = await _db.SessionLogs
+        var recentSessions = await _db.SessionLogs
             .Where(sl => sl.StudentId == studentId && sl.TeacherId == teacherId && !sl.IsDeleted && !sl.IsCancelled && sl.Status == SessionLogStatus.Confirmed && sl.SessionDate.HasValue)
             .OrderByDescending(sl => sl.SessionDate)
-            .FirstOrDefaultAsync(cancellationToken);
+            .Take(3)
+            .ToListAsync(cancellationToken);
 
         string? lastSessionDate = null;
         int? daysSinceLastSession = null;
         var openActionItems = new List<string>();
 
-        if (mostRecent is not null)
+        if (recentSessions.Count > 0)
         {
+            var mostRecent = recentSessions[0];
             lastSessionDate = mostRecent.SessionDate!.Value.ToString("yyyy-MM-dd");
             daysSinceLastSession = (int)(DateTime.UtcNow.Date - mostRecent.SessionDate.Value.Date).TotalDays;
-            if (!string.IsNullOrWhiteSpace(mostRecent.NextSessionTopics))
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var session in recentSessions)
             {
-                openActionItems = mostRecent.NextSessionTopics
-                    .Split('\n', StringSplitOptions.RemoveEmptyEntries)
-                    .Select(l => l.Trim())
-                    .Where(l => l.Length > 0)
-                    .ToList();
+                if (string.IsNullOrWhiteSpace(session.NextSessionTopics)) continue;
+                foreach (var line in session.NextSessionTopics.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+                {
+                    var item = line.Trim();
+                    if (item.Length > 0 && seen.Add(item))
+                        openActionItems.Add(item);
+                }
             }
         }
 

--- a/plan/langteach-beta/task473-aggregate-action-items.md
+++ b/plan/langteach-beta/task473-aggregate-action-items.md
@@ -1,0 +1,63 @@
+# Task 473: Aggregate open action items across last 2-3 sessions
+
+## Problem
+`GetSummaryAsync` in `SessionLogService.cs` (line 277) reads `openActionItems` only from `mostRecent.NextSessionTopics`. If a teacher logs session N+1 with no new topics, the items from session N disappear.
+
+## Fix
+
+### `SessionLogService.cs` (lines 289-310)
+
+Replace the single `FirstOrDefaultAsync` query with a query for the last 3 confirmed sessions. Use the first (most recent) for date/days logic. Aggregate `NextSessionTopics` from all three, deduplicated case-insensitively.
+
+```csharp
+var recentSessions = await _db.SessionLogs
+    .Where(sl => sl.StudentId == studentId && sl.TeacherId == teacherId
+              && !sl.IsDeleted && !sl.IsCancelled
+              && sl.Status == SessionLogStatus.Confirmed && sl.SessionDate.HasValue)
+    .OrderByDescending(sl => sl.SessionDate)
+    .Take(3)
+    .ToListAsync(cancellationToken);
+
+string? lastSessionDate = null;
+int? daysSinceLastSession = null;
+var openActionItems = new List<string>();
+
+if (recentSessions.Count > 0)
+{
+    var mostRecent = recentSessions[0];
+    lastSessionDate = mostRecent.SessionDate!.Value.ToString("yyyy-MM-dd");
+    daysSinceLastSession = (int)(DateTime.UtcNow.Date - mostRecent.SessionDate.Value.Date).TotalDays;
+
+    var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    foreach (var session in recentSessions)
+    {
+        if (string.IsNullOrWhiteSpace(session.NextSessionTopics)) continue;
+        foreach (var line in session.NextSessionTopics.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var item = line.Trim();
+            if (item.Length > 0 && seen.Add(item))
+                openActionItems.Add(item);
+        }
+    }
+}
+```
+
+## Unit tests to add (SessionLogServiceTests.cs)
+
+1. **`GetSummary_AggregatesTopicsFromLast3Sessions`** - 3 sessions each with different topics: all 3 appear in result.
+2. **`GetSummary_DeduplicatesTopicsCaseInsensitive`** - same topic in session N and N-1 (different casing): appears once.
+3. **`GetSummary_EmptyMiddleSession_DoesNotEraseEarlierTopics`** - session N+1 has null topics, session N has topics: topics still appear.
+4. **`GetSummary_TopicsOrderedMostRecentFirst`** - most recent session's topics appear before older session's topics.
+
+## Acceptance criteria checklist
+- [x] Open action items aggregate from last 2-3 sessions
+- [x] Duplicates removed (case-insensitive)
+- [x] Empty `NextSessionTopics` sessions do not erase items from previous sessions
+- [x] Unit tests cover multi-session aggregation
+
+## Files changed
+- `backend/LangTeach.Api/Services/SessionLogService.cs` (lines ~289-310)
+- `backend/LangTeach.Api.Tests/Services/SessionLogServiceTests.cs` (4 new tests)
+
+## E2E
+No e2e required: this is a pure backend service change with no new endpoints. The existing `session-log.spec.ts` covers the summary endpoint at a higher level; no new scenario needed for the internal aggregation logic.


### PR DESCRIPTION
## Summary
- `GetSummaryAsync` now queries the last 3 confirmed sessions (`Take(3)`) instead of only the most recent
- Topics from all 3 sessions are aggregated and deduplicated case-insensitively via `HashSet<string>(OrdinalIgnoreCase)`
- Sessions with null/empty `NextSessionTopics` are skipped without erasing earlier items

## Test plan
- [x] `GetSummary_AggregatesTopicsFromLast3Sessions` - all 3 sessions' topics appear
- [x] `GetSummary_DeduplicatesTopicsCaseInsensitive` - same topic different casing = one entry
- [x] `GetSummary_EmptyMiddleSession_DoesNotEraseEarlierTopics` - null middle session doesn't wipe older topics
- [x] `GetSummary_TopicsOrderedMostRecentFirst` - most recent session's topics come first
- [x] `GetSummary_MultilineTopicsInMultipleSessionsAggregatedCorrectly` - newline-split within session + cross-session dedup
- [x] All 14 GetSummary tests pass, full suite green

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)