### PR TITLE
fix(#493): session history UX polish - optional label and word-boundary truncation

### DIFF
--- a/frontend/src/components/session/SessionHistoryTab.test.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.test.tsx
@@ -94,12 +94,16 @@ describe('SessionHistoryTab', () => {
     expect(await screen.findAllByTestId('session-entry')).toHaveLength(1)
   })
 
-  it('shows inline preview with truncated planned and actual content', async () => {
+  it('shows inline preview with word-boundary-truncated planned and actual content', async () => {
     vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
     wrapper()
     await screen.findByTestId('session-entry')
-    expect(screen.getByText(/Preterito indefinido intro/)).toBeInTheDocument()
-    expect(screen.getByText(/Covered basics and exercises/)).toBeInTheDocument()
+    const plannedEl = screen.getByText(/Preterito indefinido intro/)
+    const actualEl = screen.getByText(/Covered basics and exercises/)
+    expect(plannedEl).toBeInTheDocument()
+    expect(actualEl).toBeInTheDocument()
+    expect(plannedEl.closest('p')).toHaveClass('line-clamp-1')
+    expect(actualEl.closest('p')).toHaveClass('line-clamp-1')
   })
 
   it('hides planned and actual preview when expanded to avoid duplication', async () => {

--- a/frontend/src/components/session/SessionHistoryTab.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.tsx
@@ -138,14 +138,14 @@ function SessionEntry({
 
             {/* Planned and actual — hidden when expanded to avoid duplication with detail section */}
             {!expanded && session.plannedContent && (
-              <p className="text-xs text-zinc-500 truncate">
+              <p className="text-xs text-zinc-500 line-clamp-1">
                 <span className="font-medium text-zinc-700">Planned:</span>{' '}
                 {session.plannedContent}
               </p>
             )}
 
             {!expanded && session.actualContent && (
-              <p className="text-xs text-zinc-600 truncate">
+              <p className="text-xs text-zinc-600 line-clamp-1">
                 <span className="font-medium text-zinc-700">Done:</span>{' '}
                 {session.actualContent}
               </p>
@@ -154,7 +154,7 @@ function SessionEntry({
             {/* Homework + status badges */}
             <div className="flex flex-wrap gap-1.5 items-center">
               {session.homeworkAssigned && (
-                <span className="text-xs text-zinc-500 truncate max-w-[160px]">
+                <span className="text-xs text-zinc-500 line-clamp-1 max-w-[160px]">
                   HW: {session.homeworkAssigned}
                 </span>
               )}

--- a/frontend/src/components/session/SessionLogDialog.test.tsx
+++ b/frontend/src/components/session/SessionLogDialog.test.tsx
@@ -148,6 +148,21 @@ describe('SessionLogDialog', () => {
     expect(screen.getByTestId('reassessment-level')).toBeInTheDocument()
   })
 
+  it('shows (optional) label on "What was actually done" field', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([])
+
+    wrapper(
+      <SessionLogDialog studentId={STUDENT_ID} open={true} onOpenChange={vi.fn()} />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('actual-content')).toBeInTheDocument()
+    })
+
+    const label = screen.getByText(/What was actually done/i).closest('label')
+    expect(label).toHaveTextContent('(optional)')
+  })
+
   it('auto-populates planned content when lessonObjectives provided', async () => {
     vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([])
 

--- a/frontend/src/components/session/SessionLogDialog.tsx
+++ b/frontend/src/components/session/SessionLogDialog.tsx
@@ -451,6 +451,7 @@ export function SessionLogDialog({
             <div className="space-y-1">
               <Label htmlFor="actual-content" className="text-sm">
                 What was actually done
+                <span className="text-zinc-400 font-normal ml-1">(optional)</span>
               </Label>
               <Textarea
                 id="actual-content"

--- a/plan/langteach-beta/task493-session-history-ux-polish.md
+++ b/plan/langteach-beta/task493-session-history-ux-polish.md
@@ -1,0 +1,25 @@
+# Task 493 - Session history UX polish
+
+## Issue
+#493 - Missing `(optional)` label on "What was actually done" field; mid-word truncation in timeline cards.
+
+## Changes
+
+### 1. SessionLogDialog.tsx (line 453)
+Add `(optional)` span to "What was actually done" label, consistent with other optional fields.
+- File: `frontend/src/components/session/SessionLogDialog.tsx`
+- The field is optional per validation (only one of planned/actual is required).
+
+### 2. SessionHistoryTab.tsx (lines 141, 147, 157)
+Replace Tailwind `truncate` with `line-clamp-1` for word-boundary truncation.
+- `truncate` = `overflow:hidden; text-overflow:ellipsis; white-space:nowrap` -- cuts at character level
+- `line-clamp-1` = `-webkit-line-clamp:1` -- respects word boundaries
+- Affects: Planned preview, Done preview, HW preview spans
+
+### Tests
+Update `SessionLogDialog.test.tsx` to assert `(optional)` text on "actual content" label.
+Update `SessionHistoryTab.test.tsx` to assert `line-clamp-1` class (or no `truncate`) on preview elements -- or just verify rendering doesn't break.
+
+## Acceptance criteria
+- "What was actually done" shows `(optional)` label
+- HW preview text truncates at word boundary (uses `line-clamp-1`)


### PR DESCRIPTION
Closes #493

## Summary
- **SessionLogDialog**: adds `(optional)` label to the "What was actually done" field, consistent with adjacent optional fields (planned content, homework, topics, general notes)
- **SessionHistoryTab**: replaces CSS `truncate` with `line-clamp-1` on the planned content, actual content, and HW preview elements in collapsed timeline cards, so text truncates at word boundaries

## Test plan
- [x] Unit test added: `SessionLogDialog` asserts `(optional)` appears in the actual-content label
- [x] Unit test updated: `SessionHistoryTab` asserts `line-clamp-1` class on preview paragraph elements
- [x] All 60 tests pass; build clean
- [x] UI review: verified dialog labels and truncation visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved text truncation in session preview displays for better consistency.

* **New Features**
  * Added "(optional)" indicator to the "What was actually done" field for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->