### PR TITLE
feat(#494): add studentId filter to GET /api/lessons

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/LessonsControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/LessonsControllerTests.cs
@@ -371,6 +371,94 @@ public class LessonsControllerTests
         lesson!.StudentName.Should().Be("Alice Johnson");
     }
 
+    [Fact]
+    public async Task ListLessons_WithStudentId_ReturnsOnlyStudentLessons()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var teacher = new Teacher
+        {
+            Id = Guid.NewGuid(),
+            Auth0UserId = "auth0|lesson-studentfilter",
+            Email = "lesson-studentfilter@example.com",
+            DisplayName = "Student Filter Test",
+            IsApproved = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        db.Teachers.Add(teacher);
+
+        var studentA = new Student
+        {
+            Id = Guid.NewGuid(),
+            TeacherId = teacher.Id,
+            Name = "Alice",
+            LearningLanguage = "English",
+            CefrLevel = "A1",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        var studentB = new Student
+        {
+            Id = Guid.NewGuid(),
+            TeacherId = teacher.Id,
+            Name = "Bob",
+            LearningLanguage = "English",
+            CefrLevel = "B1",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        db.Students.AddRange(studentA, studentB);
+        await db.SaveChangesAsync();
+
+        var client = _factory.CreateAuthenticatedClient("auth0|lesson-studentfilter", "lesson-studentfilter@example.com");
+
+        var lessonA = await CreateLessonWithStudentAsync(client, "Lesson for Alice", studentA.Id);
+        var lessonB = await CreateLessonWithStudentAsync(client, "Lesson for Bob", studentB.Id);
+        var lessonNone = await CreateLessonAsync(client, "Unassigned Lesson");
+
+        var response = await client.GetAsync($"/api/lessons?studentId={studentA.Id}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<PagedResult<LessonDto>>();
+        result!.Items.Should().Contain(l => l.Id == lessonA.Id);
+        result.Items.Should().NotContain(l => l.Id == lessonB.Id);
+        result.Items.Should().NotContain(l => l.Id == lessonNone.Id);
+    }
+
+    [Fact]
+    public async Task ListLessons_WithoutStudentId_ReturnsAllLessons()
+    {
+        var client = _factory.CreateAuthenticatedClient("auth0|lesson-nofilter", "lesson-nofilter@example.com");
+
+        var lesson1 = await CreateLessonAsync(client, "No-filter Lesson 1");
+        var lesson2 = await CreateLessonAsync(client, "No-filter Lesson 2");
+
+        var response = await client.GetAsync("/api/lessons");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<PagedResult<LessonDto>>();
+        result!.Items.Should().Contain(l => l.Id == lesson1.Id);
+        result.Items.Should().Contain(l => l.Id == lesson2.Id);
+    }
+
+    private static async Task<LessonDto> CreateLessonWithStudentAsync(HttpClient client, string title, Guid studentId)
+    {
+        var request = new CreateLessonRequest
+        {
+            Title = title,
+            Language = "English",
+            CefrLevel = "B1",
+            Topic = "Test topic",
+            DurationMinutes = 60,
+            StudentId = studentId,
+        };
+        var response = await client.PostAsJsonAsync("/api/lessons", request);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<LessonDto>())!;
+    }
+
     private static async Task<LessonDto> CreateLessonAsync(
         HttpClient client,
         string title,

--- a/backend/LangTeach.Api/DTOs/LessonListQuery.cs
+++ b/backend/LangTeach.Api/DTOs/LessonListQuery.cs
@@ -24,6 +24,7 @@ public class LessonListQuery : IValidatableObject
 
     public DateTime? ScheduledFrom { get; set; }
     public DateTime? ScheduledTo { get; set; }
+    public Guid? StudentId { get; set; }
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {

--- a/backend/LangTeach.Api/Services/LessonService.cs
+++ b/backend/LangTeach.Api/Services/LessonService.cs
@@ -49,6 +49,9 @@ public class LessonService : ILessonService
             q = q.Where(l => l.ScheduledAt.HasValue && l.ScheduledAt.Value < scheduledToExclusive);
         }
 
+        if (query.StudentId.HasValue)
+            q = q.Where(l => l.StudentId == query.StudentId.Value);
+
         if (!string.IsNullOrWhiteSpace(query.Search))
         {
             var term = $"%{query.Search}%";

--- a/e2e/tests/session-log.spec.ts
+++ b/e2e/tests/session-log.spec.ts
@@ -603,3 +603,49 @@ test('confirming session updates existing difficulty in profile', async ({ brows
 
   await context.close()
 })
+
+test('lesson dropdown in session log shows only lessons for the selected student', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  const ts = Date.now()
+
+  // Create two students
+  const createStudentA = await page.request.post(`${API_BASE}/api/students`, {
+    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
+    data: { name: `Student A ${ts}`, learningLanguage: 'Spanish', cefrLevel: 'B1', interests: [], learningGoals: [], weaknesses: [], difficulties: [] },
+  })
+  const studentA = await createStudentA.json() as { id: string }
+
+  const createStudentB = await page.request.post(`${API_BASE}/api/students`, {
+    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
+    data: { name: `Student B ${ts}`, learningLanguage: 'French', cefrLevel: 'A2', interests: [], learningGoals: [], weaknesses: [], difficulties: [] },
+  })
+  const studentB = await createStudentB.json() as { id: string }
+
+  // Create one lesson per student
+  await page.request.post(`${API_BASE}/api/lessons`, {
+    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
+    data: { title: `Lesson for A ${ts}`, language: 'Spanish', cefrLevel: 'B1', topic: 'Subjunctive', durationMinutes: 60, studentId: studentA.id },
+  })
+  await page.request.post(`${API_BASE}/api/lessons`, {
+    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
+    data: { title: `Lesson for B ${ts}`, language: 'French', cefrLevel: 'A2', topic: 'Articles', durationMinutes: 60, studentId: studentB.id },
+  })
+
+  // Open session log dialog for student A
+  await page.goto(`/students/${studentA.id}`)
+  await expect(page.getByTestId('student-detail-name')).toHaveText(`Student A ${ts}`, { timeout: 15000 })
+  await page.getByTestId('log-session-button').click()
+  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('linked-lesson')).toBeVisible({ timeout: 8000 })
+
+  // Open the lesson dropdown
+  await page.getByTestId('linked-lesson').click()
+
+  // Student A's lesson should be visible; Student B's lesson should not
+  await expect(page.getByRole('option', { name: `Lesson for A ${ts}` })).toBeVisible()
+  await expect(page.getByRole('option', { name: `Lesson for B ${ts}` })).not.toBeVisible()
+
+  await context.close()
+})

--- a/frontend/src/api/lessons.ts
+++ b/frontend/src/api/lessons.ts
@@ -87,6 +87,7 @@ export interface LessonListQuery {
   pageSize?: number
   scheduledFrom?: string
   scheduledTo?: string
+  studentId?: string
 }
 
 export async function getLessons(query?: LessonListQuery): Promise<LessonListResponse> {

--- a/frontend/src/components/session/SessionLogDialog.test.tsx
+++ b/frontend/src/components/session/SessionLogDialog.test.tsx
@@ -217,6 +217,20 @@ describe('SessionLogDialog', () => {
     })
   })
 
+  it('fetches lessons with studentId to avoid client-side filtering', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([])
+
+    wrapper(
+      <SessionLogDialog studentId={STUDENT_ID} open={true} onOpenChange={vi.fn()} />
+    )
+
+    await waitFor(() => {
+      expect(vi.mocked(lessonsApi.getLessons)).toHaveBeenCalledWith(
+        expect.objectContaining({ studentId: STUDENT_ID })
+      )
+    })
+  })
+
   it('sends linkedLessonId in payload when lesson is selected', async () => {
     const user = userEvent.setup()
 

--- a/frontend/src/components/session/SessionLogDialog.tsx
+++ b/frontend/src/components/session/SessionLogDialog.tsx
@@ -196,11 +196,11 @@ export function SessionLogDialog({
 
   // Fetch lessons for linked lesson selector
   const { data: lessonsData } = useQuery({
-    queryKey: ['lessons', { pageSize: 100 }],
-    queryFn: () => getLessons({ pageSize: 100 }),
+    queryKey: ['lessons', { pageSize: 100, studentId }],
+    queryFn: () => getLessons({ pageSize: 100, studentId }),
     enabled: open,
   })
-  const studentLessons = lessonsData?.items.filter(l => l.studentId === studentId) ?? []
+  const studentLessons = lessonsData?.items ?? []
 
   const { data: studentData } = useQuery({
     queryKey: ['student', studentId],

--- a/plan/langteach-beta/task494-studentid-filter-lessons.md
+++ b/plan/langteach-beta/task494-studentid-filter-lessons.md
@@ -1,0 +1,23 @@
+# Task 494: Add studentId filter to GET /api/lessons
+
+## Problem
+`SessionLogDialog` fetches lessons via `GET /api/lessons?pageSize=100` and filters by `studentId` client-side. No `studentId` filter exists on `LessonListQuery`.
+
+## Changes
+
+### Backend
+1. `DTOs/LessonListQuery.cs` - add `Guid? StudentId { get; set; }`
+2. `Services/LessonService.cs` - add filter clause when `query.StudentId.HasValue`
+
+### Frontend
+3. `api/lessons.ts` - add `studentId?: string` to `LessonListQuery` interface
+4. `components/session/SessionLogDialog.tsx` - pass `studentId` in query, remove client-side filter
+
+### Tests
+5. `LangTeach.Api.Tests/Controllers/LessonsControllerTests.cs` - add test verifying studentId filter returns only matching lessons
+6. `components/session/SessionLogDialog.test.tsx` - verify lessons query includes studentId param
+
+## Acceptance Criteria
+- `GET /api/lessons?studentId={id}` returns only lessons for that student
+- `SessionLogDialog` passes studentId in the lessons request
+- Calls without studentId return all lessons (backward compatible)


### PR DESCRIPTION
## Summary
- Adds optional `studentId` query parameter to `LessonListQuery` and filters server-side in `LessonService.ListAsync`
- Updates `SessionLogDialog` to pass `studentId` when fetching lessons, removing client-side post-filter
- Backward compatible: calls without `studentId` continue to return all lessons

Closes #494

## Test plan
- [x] Backend unit test: `GET /api/lessons?studentId={id}` returns only that student's lessons
- [x] Backend unit test: `GET /api/lessons` (no filter) returns all lessons
- [x] Frontend unit test: `SessionLogDialog` calls `getLessons` with `studentId` param
- [x] E2e test: lesson dropdown in session log shows only the selected student's lessons

🤖 Generated with [Claude Code](https://claude.com/claude-code)