### PR TITLE
fix(#497): session badge expand affordance and date locale format

### DIFF
--- a/frontend/src/components/session/SessionHistoryTab.test.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.test.tsx
@@ -309,4 +309,20 @@ describe('SessionHistoryTab', () => {
     await screen.findByTestId('session-entry')
     expect(screen.queryByTestId('draft-badge')).not.toBeInTheDocument()
   })
+
+  it('action item badge contains a chevron icon for expand affordance', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    const badge = screen.getByTestId('action-item-count')
+    expect(badge.querySelector('svg')).not.toBeNull()
+  })
+
+  it('general note badge contains a chevron icon for expand affordance', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    const badge = screen.getByTestId('general-note-count')
+    expect(badge.querySelector('svg')).not.toBeNull()
+  })
 })

--- a/frontend/src/components/session/SessionHistoryTab.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.tsx
@@ -126,12 +126,22 @@ function SessionEntry({
                 <span className="inline-flex items-center gap-1 text-xs text-amber-600" data-testid="action-item-count">
                   <span className="bg-amber-400 rounded-full w-1.5 h-1.5 shrink-0" />
                   1 action item
+                  {expanded ? (
+                    <ChevronUp className="h-3 w-3 shrink-0" />
+                  ) : (
+                    <ChevronDown className="h-3 w-3 shrink-0" />
+                  )}
                 </span>
               )}
               {hasNote && (
                 <span className="inline-flex items-center gap-1 text-xs text-zinc-400" data-testid="general-note-count">
                   <span className="bg-zinc-300 rounded-full w-1.5 h-1.5 shrink-0" />
                   1 note
+                  {expanded ? (
+                    <ChevronUp className="h-3 w-3 shrink-0" />
+                  ) : (
+                    <ChevronDown className="h-3 w-3 shrink-0" />
+                  )}
                 </span>
               )}
             </div>

--- a/frontend/src/components/session/SessionLogDialog.test.tsx
+++ b/frontend/src/components/session/SessionLogDialog.test.tsx
@@ -513,6 +513,37 @@ describe('SessionLogDialog', () => {
     expect(vi.mocked(sessionLogsApi.createSession)).not.toHaveBeenCalled()
   })
 
+  it('shows ISO date helper text when a date is entered', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([])
+
+    wrapper(
+      <SessionLogDialog studentId={STUDENT_ID} open={true} onOpenChange={vi.fn()} />
+    )
+
+    await waitFor(() => expect(screen.getByTestId('session-date')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByTestId('session-date'), { target: { value: '2026-04-06' } })
+
+    expect(screen.getByTestId('session-date-iso')).toHaveTextContent('2026-04-06')
+  })
+
+  it('shows ISO date helper text pre-populated in edit mode', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([])
+
+    wrapper(
+      <SessionLogDialog
+        studentId={STUDENT_ID}
+        open={true}
+        onOpenChange={vi.fn()}
+        initialSession={SAMPLE_SESSION}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-date-iso')).toHaveTextContent('2026-03-15')
+    })
+  })
+
   it('accepts a future session date without validation error', async () => {
     vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([])
     vi.mocked(sessionLogsApi.createSession).mockResolvedValue({

--- a/frontend/src/components/session/SessionLogDialog.tsx
+++ b/frontend/src/components/session/SessionLogDialog.tsx
@@ -412,6 +412,9 @@ export function SessionLogDialog({
                 data-testid="session-date"
                 className="text-sm"
               />
+              {sessionDate && (
+                <p className="text-xs text-zinc-400" data-testid="session-date-iso">{sessionDate}</p>
+              )}
               {errors.sessionDate && <p className="text-xs text-red-600">{errors.sessionDate}</p>}
             </div>
 

--- a/plan/langteach-beta/task497-session-history-polish.md
+++ b/plan/langteach-beta/task497-session-history-polish.md
@@ -1,0 +1,27 @@
+# Task 497: Session history minor polish
+
+## Issue
+Session history minor polish: badge expand affordance and date field locale format
+
+## Acceptance Criteria
+1. Session timeline badge has a clear expand affordance (chevron or equivalent)
+2. Date field in session log edit dialog displays in a fixed, unambiguous format across locales
+
+## Changes
+
+### 1. SessionHistoryTab.tsx — Badge expand affordance
+The "1 action item" span (line ~126) inside the toggle button has no visual cue that it is expandable.
+Fix: add a small `ChevronDown`/`ChevronUp` icon (already imported) after the badge text, toggled by the `expanded` state.
+Same for "1 note" badge for visual consistency.
+
+### 2. SessionLogDialog.tsx — Date field locale format
+`<input type="date">` renders the date in the OS/browser locale (MM/DD/YYYY in US, DD/MM/YYYY in EU).
+The stored value is always YYYY-MM-DD but the displayed format is ambiguous.
+Fix: add a `text-xs text-zinc-400` helper text showing the stored value in explicit `YYYY-MM-DD` format when a date is set.
+
+## Tests
+- SessionHistoryTab.test.tsx: add assertion that the action-item-count element contains a chevron icon (or SVG child)
+- SessionLogDialog.test.tsx: add assertion that when a date is pre-filled in edit mode, the YYYY-MM-DD value is shown as helper text
+
+## E2E
+No new e2e needed — purely visual/affordance change, covered by existing session-log.spec.ts and visual spec.


### PR DESCRIPTION
## Summary
- Session timeline badges ("1 action item", "1 note") now include a `ChevronDown`/`ChevronUp` icon so users can tell the card is expandable at a glance
- Date input in session log edit dialog shows a `YYYY-MM-DD` ISO helper text below it, making the stored date unambiguous regardless of browser locale

Closes #497

## Test plan
- [x] Unit: `SessionHistoryTab.test.tsx` - 2 new tests verify SVG chevron presence in action-item and note badges
- [x] Unit: `SessionLogDialog.test.tsx` - 2 new tests verify ISO helper text in create and edit mode
- [x] UI review: badges look clean with chevrons in both collapsed/expanded states; date helper text renders correctly in edit dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chevron icons now appear next to action item and note counts in session history entries, dynamically toggling between up and down states based on section expansion.
  * ISO date format is now displayed in session creation and edit dialogs, appearing beneath the date input field for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->