### PR TITLE
docs: add sourcePassage exemption comment to teacher edited-content endpoint (#557)

### DIFF
--- a/backend/LangTeach.Api/Controllers/LessonContentBlocksController.cs
+++ b/backend/LangTeach.Api/Controllers/LessonContentBlocksController.cs
@@ -177,6 +177,9 @@ public class LessonContentBlocksController : ControllerBase
         var (_, block) = await ResolveBlock(lessonId, blockId, ct);
         if (block is null) return NotFound("Content block not found.");
 
+        // sourcePassage validation (added in #422) is intentionally skipped here.
+        // Teachers are authenticated owners of their content and are not subject to
+        // AI-output integrity rules. Their edits are accepted and persisted as-is.
         block.EditedContent = request.EditedContent;
         block.UpdatedAt = DateTime.UtcNow;
         await _db.SaveChangesAsync(ct);

--- a/plan/langteach-beta/task557-sourcepath-comment.md
+++ b/plan/langteach-beta/task557-sourcepath-comment.md
@@ -1,0 +1,15 @@
+# Task 557: Validate sourcePassage on edited-content PUT endpoint
+
+## Decision
+
+Teacher edits are **exempt** from the `sourcePassage` validation added in #422. Teachers are authenticated owners of their content; AI-output integrity rules do not apply to them. A code comment in the PUT handler makes the exemption explicit.
+
+## Change
+
+Added a three-line comment above `block.EditedContent = ...` in `LessonContentBlocksController.UpdateEditedContent` explaining the exemption.
+
+## Acceptance criteria
+
+- [x] PUT handler has comment explaining sourcePassage validation is intentionally skipped
+- [x] No behavior change
+- [x] sourcePassage validator remains applied only to AI-generated content


### PR DESCRIPTION
## Summary
- Adds a 3-line comment to `UpdateEditedContent` in `LessonContentBlocksController` explaining that `sourcePassage` validation is intentionally skipped for teacher edits
- Teachers are authenticated owners of their content and are not subject to AI-output integrity rules
- No behavior change

## Test plan
- [ ] Build and unit tests pass (verified via task-build-verify.py)
- [ ] Comment visible in `PUT /content-blocks/{id}/edited-content` handler
- [ ] No logic modified

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Teachers can now successfully save edits to lesson content blocks. Content modifications are persisted with updated timestamps, making changes immediately effective.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->