### PR TITLE
fix: strip markdown fences before deserializing AI response in CurriculumGenerationService

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/CurriculumGenerationServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/CurriculumGenerationServiceTests.cs
@@ -481,4 +481,94 @@ public class CurriculumGenerationServiceTests
         var notes0 = JsonSerializer.Deserialize<PersonalizationNotesData>(entries[0].PersonalizationNotes!, opts);
         notes0!.EmphasisAreas.Should().ContainMatch("*ser/estar*");
     }
+
+    // -------------------------------------------------------------------------
+    // StripFences: markdown-fenced responses are accepted
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task FreePath_FenceWrappedJson_IsDeserializedCorrectly()
+    {
+        var fencedJson = """
+            ```json
+            [
+                {"orderIndex":1,"topic":"Greetings","grammarFocus":"ser/estar","competencies":["speaking"],"lessonType":"Communicative"}
+            ]
+            ```
+            """;
+        var sut = BuildService(new FakeTemplateService(), new ConfigurableClaudeClient(fencedJson));
+
+        var ctx = new CurriculumContext(
+            Language: "Spanish", Mode: "general", SessionCount: 1,
+            TargetCefrLevel: null, TargetExam: null, ExamDate: null,
+            StudentName: null, StudentNativeLanguage: null,
+            StudentInterests: null, StudentGoals: null);
+
+        var (entries, _) = await sut.GenerateAsync(ctx);
+
+        entries.Should().HaveCount(1);
+        entries[0].Topic.Should().Be("Greetings");
+    }
+
+    [Fact]
+    public async Task FreePath_NonJsonResponse_ThrowsCurriculumGenerationException()
+    {
+        var sut = BuildService(new FakeTemplateService(), new ConfigurableClaudeClient("Sorry, I cannot generate that."));
+
+        var ctx = new CurriculumContext(
+            Language: "Spanish", Mode: "general", SessionCount: 1,
+            TargetCefrLevel: null, TargetExam: null, ExamDate: null,
+            StudentName: null, StudentNativeLanguage: null,
+            StudentInterests: null, StudentGoals: null);
+
+        await sut.Invoking(s => s.GenerateAsync(ctx))
+            .Should().ThrowAsync<CurriculumGenerationException>();
+    }
+
+    [Fact]
+    public async Task TemplatePath_PersonalizationFenceWrappedJson_IsAppliedCorrectly()
+    {
+        var fencedPersonalization = """
+            ```json
+            [{"orderIndex":1,"topic":"Marco meets his football team"},{"orderIndex":2,"topic":"Marco explains why he loves football"}]
+            ```
+            """;
+        var sut = BuildService(
+            new FakeTemplateService(FakeTemplates.TwoUnitTemplate()),
+            new ConfigurableClaudeClient(fencedPersonalization));
+
+        var ctx = new CurriculumContext(
+            Language: "Spanish", Mode: "general", SessionCount: 2,
+            TargetCefrLevel: "A1", TargetExam: null, ExamDate: null,
+            StudentName: "Marco", StudentNativeLanguage: "Italian",
+            StudentInterests: ["football"], StudentGoals: null,
+            TemplateLevel: "A1.1");
+
+        var (entries, _) = await sut.GenerateAsync(ctx);
+
+        entries[0].Topic.Should().Be("Marco meets his football team");
+        entries[1].Topic.Should().Be("Marco explains why he loves football");
+    }
+
+    [Fact]
+    public async Task TemplatePath_PersonalizationNonJsonResponse_KeepsOriginalTopics()
+    {
+        var sut = BuildService(
+            new FakeTemplateService(FakeTemplates.TwoUnitTemplate()),
+            new ConfigurableClaudeClient("Sorry, I cannot generate personalization."));
+
+        var ctx = new CurriculumContext(
+            Language: "Spanish", Mode: "general", SessionCount: 2,
+            TargetCefrLevel: "A1", TargetExam: null, ExamDate: null,
+            StudentName: "Marco", StudentNativeLanguage: "Italian",
+            StudentInterests: null, StudentGoals: null,
+            TemplateLevel: "A1.1");
+
+        // Should not throw; original template entries are preserved
+        var (entries, _) = await sut.GenerateAsync(ctx);
+
+        entries.Should().HaveCount(2);
+        entries[0].TemplateUnitRef.Should().Be("Nosotros");
+        entries[1].TemplateUnitRef.Should().Be("Quiero aprender español");
+    }
 }

--- a/backend/LangTeach.Api/Services/CurriculumGenerationService.cs
+++ b/backend/LangTeach.Api/Services/CurriculumGenerationService.cs
@@ -107,11 +107,15 @@ public class CurriculumGenerationService : ICurriculumGenerationService
         var aiRequest = _prompts.BuildCurriculumPrompt(ctx);
         var aiResponse = await _claude.CompleteAsync(aiRequest, ct);
 
+        var strippedAiContent = ContentJsonHelper.StripFences(aiResponse.Content);
+        if (strippedAiContent is null)
+            throw new CurriculumGenerationException("AI response is not valid JSON.");
+
         List<AiEntryDto>? aiEntries;
         try
         {
             aiEntries = JsonSerializer.Deserialize<List<AiEntryDto>>(
-                aiResponse.Content.Trim(),
+                strippedAiContent,
                 new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
         }
         catch (JsonException ex)
@@ -180,11 +184,18 @@ public class CurriculumGenerationService : ICurriculumGenerationService
 
     private void ApplyPersonalization(List<CurriculumEntry> skeletons, string aiContent)
     {
+        var strippedPersonalization = ContentJsonHelper.StripFences(aiContent);
+        if (strippedPersonalization is null)
+        {
+            _logger.LogWarning("AI personalization response is not valid JSON; keeping original topics.");
+            return;
+        }
+
         List<PersonalizationDto>? personalization;
         try
         {
             personalization = JsonSerializer.Deserialize<List<PersonalizationDto>>(
-                aiContent.Trim(),
+                strippedPersonalization,
                 new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
         }
         catch (JsonException ex)

--- a/plan/langteach-beta/task562-strip-fences-curriculum.md
+++ b/plan/langteach-beta/task562-strip-fences-curriculum.md
@@ -1,0 +1,49 @@
+# Task 562 — CurriculumGenerationService: call StripFences before deserializing AI response
+
+## Issue
+#562 — P2, area:backend
+
+## Problem
+`CurriculumGenerationService` has two deserialization sites that call `.Trim()` directly on AI content without stripping markdown code fences first. If the model wraps JSON in triple-backtick fences, `JsonSerializer.Deserialize` throws `JsonException`.
+
+## Sites to fix
+
+### Site 1 — Free generation path (line 113)
+```csharp
+// BEFORE
+aiEntries = JsonSerializer.Deserialize<List<AiEntryDto>>(
+    aiResponse.Content.Trim(), ...);
+
+// AFTER
+var stripped = ContentJsonHelper.StripFences(aiResponse.Content);
+if (stripped is null)
+    throw new CurriculumGenerationException("AI response is not valid JSON.");
+aiEntries = JsonSerializer.Deserialize<List<AiEntryDto>>(stripped, ...);
+```
+
+### Site 2 — ApplyPersonalization method (line 186)
+```csharp
+// BEFORE
+personalization = JsonSerializer.Deserialize<List<PersonalizationDto>>(
+    aiContent.Trim(), ...);
+
+// AFTER
+var stripped = ContentJsonHelper.StripFences(aiContent);
+if (stripped is null)
+{
+    _logger.LogWarning("AI personalization response is not valid JSON; keeping original topics.");
+    return;
+}
+personalization = JsonSerializer.Deserialize<List<PersonalizationDto>>(stripped, ...);
+```
+
+## Changes
+- `backend/LangTeach.Api/Services/CurriculumGenerationService.cs`: apply StripFences at both sites
+
+## Tests
+- Existing unit tests in `CurriculumGenerationServiceTests.cs` cover the happy path
+- Add tests for fence-wrapped JSON at both sites (free generation throws on bad JSON; personalization logs+returns gracefully)
+
+## Acceptance criteria
+- Both sites use `ContentJsonHelper.StripFences` before deserializing
+- Null return from `StripFences` is handled: hard throw at site 1, graceful return at site 2


### PR DESCRIPTION
## Summary

- Applies `ContentJsonHelper.StripFences` before both `JsonSerializer.Deserialize` calls in `CurriculumGenerationService` (free generation path and personalization path)
- Free generation: throws `CurriculumGenerationException("AI response is not valid JSON.")` if `StripFences` returns null
- Personalization: logs a warning and keeps original topics if `StripFences` returns null
- Adds 4 unit tests covering fenced-valid and non-JSON responses at both sites

Closes #562

## Test plan

- [x] `FreePath_FenceWrappedJson_IsDeserializedCorrectly` - fence-wrapped JSON succeeds
- [x] `FreePath_NonJsonResponse_ThrowsCurriculumGenerationException` - plain text throws
- [x] `TemplatePath_PersonalizationFenceWrappedJson_IsAppliedCorrectly` - personalization fence-wrapped JSON succeeds
- [x] `TemplatePath_PersonalizationNonJsonResponse_KeepsOriginalTopics` - non-JSON personalization keeps originals
- [x] All 16 `CurriculumGenerationServiceTests` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced curriculum generation service with improved error handling and graceful fallback behavior for edge cases in AI-generated responses.

* **Tests**
  * Added unit tests verifying curriculum generation response parsing and fallback behavior across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->