### PR TITLE
fix(#558): return 400 on malformed exercises JSON

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/LessonContentBlocksControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/LessonContentBlocksControllerTests.cs
@@ -312,6 +312,28 @@ public class LessonContentBlocksControllerTests
         reset.GeneratedContent.Should().Be("Original AI content.");
     }
 
+    // --- Exercises malformed JSON validation (#558) ---
+
+    [Fact]
+    public async Task Post_ExercisesWithMalformedJson_Returns400()
+    {
+        var auth0Id = "auth0|cb-exercises-malformed-json";
+        var email = "cb-exercises-malformed-json@example.com";
+        var (lessonId, _) = await SeedTeacherLessonAndSection(auth0Id, email);
+        var client = _factory.CreateAuthenticatedClient(auth0Id, email);
+
+        var request = new SaveContentBlockRequest
+        {
+            BlockType = ContentBlockType.Exercises,
+            GeneratedContent = "this is not json {{{",
+        };
+
+        var response = await client.PostAsJsonAsync($"/api/lessons/{lessonId}/content-blocks", request, TestJsonOptions.Default);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            because: "exercises with malformed JSON must be rejected at write time (#558)");
+    }
+
     // --- Exercises sourcePassage validation (#422 AC6) ---
 
     [Fact]

--- a/backend/LangTeach.Api/Services/ContentValidationService.cs
+++ b/backend/LangTeach.Api/Services/ContentValidationService.cs
@@ -27,7 +27,7 @@ public class ContentValidationService : IContentValidationService
         }
         catch (JsonException)
         {
-            return null;
+            return "Exercises content is not valid JSON";
         }
     }
 }

--- a/plan/langteach-beta/task558-validate-exercises-json.md
+++ b/plan/langteach-beta/task558-validate-exercises-json.md
@@ -1,0 +1,23 @@
+# Task 558: ValidateExercisesContent - Return error on malformed JSON
+
+## Problem
+
+`ContentValidationService.ValidateExercisesContent` catches `JsonException` and returns `null` (treated as valid). This means a save request with `exercises` blockType and malformed JSON content is persisted without validation. Observed in code review of #422.
+
+## Fix
+
+**`ContentValidationService.cs`** - change the `catch (JsonException)` block to return `"Exercises content is not valid JSON"` instead of `null`.
+
+**`LessonContentBlocksControllerTests.cs`** - add `Post_ExercisesWithMalformedJson_Returns400` integration test.
+
+## Acceptance Criteria
+
+- [x] `ValidateExercisesContent` returns `"Exercises content is not valid JSON"` when `JsonException` is thrown
+- [x] Controller returns `400 Bad Request` with that error message instead of persisting malformed content
+- [x] Unit test covers the `JsonException` path: malformed JSON input -> `400` response
+- [x] Valid exercises JSON still passes validation and is persisted normally (pre-existing test covers this)
+
+## Files Changed
+
+- `backend/LangTeach.Api/Services/ContentValidationService.cs` - line 30: `null` -> error string
+- `backend/LangTeach.Api.Tests/Controllers/LessonContentBlocksControllerTests.cs` - new test added


### PR DESCRIPTION
## Summary

- `ValidateExercisesContent` now returns `"Exercises content is not valid JSON"` when `JsonException` is thrown instead of silently returning `null`
- Controller correctly returns `400 Bad Request` for malformed exercises JSON
- Integration test `Post_ExercisesWithMalformedJson_Returns400` added

Closes #558

## Test plan

- [x] `dotnet test` passes (new test + all existing exercises validation tests green)
- [x] `task-build-verify.py` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced exercise content validation with improved error handling. The API now properly detects and reports malformed JSON with a 400 Bad Request response.

* **Tests**
  * Added test coverage for validating API responses when exercise content contains malformed JSON.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->