### PR TITLE
refactor(#585): move lesson-plan weakness profile guidance to config

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs
@@ -817,4 +817,26 @@ public class PedagogyConfigServiceTests
         result.Should().Contain("{weaknesses}",
             because: "practice guidance must contain {weaknesses} placeholder for interpolation");
     }
+
+    // --- GetLessonWeaknessProfileGuidance ---
+
+    [Fact]
+    public void GetLessonWeaknessProfileGuidance_ReturnsNonEmpty()
+    {
+        var result = _sut.GetLessonWeaknessProfileGuidance();
+
+        result.Should().NotBeNullOrWhiteSpace(
+            because: "course-rules.json must define lessonWeaknessProfileGuidance");
+    }
+
+    [Fact]
+    public void GetLessonWeaknessProfileGuidance_MentionsPracticeAndProduction()
+    {
+        var result = _sut.GetLessonWeaknessProfileGuidance().ToLowerInvariant();
+
+        result.Should().Contain("practice",
+            because: "the guidance must direct the model to address weaknesses in Practice");
+        result.Should().Contain("production",
+            because: "the guidance must direct the model to address weaknesses in Production");
+    }
 }

--- a/backend/LangTeach.Api/AI/PedagogyConfig.cs
+++ b/backend/LangTeach.Api/AI/PedagogyConfig.cs
@@ -126,7 +126,8 @@ public record CourseRulesFile(
     CourseVarietyRules VarietyRules,
     Dictionary<string, Dictionary<string, SkillRange>> SkillDistribution,
     GrammarProgression GrammarProgression,
-    string[]? SectionCoherenceRules = null
+    string[]? SectionCoherenceRules = null,
+    string? LessonWeaknessProfileGuidance = null
 );
 
 public record CourseVarietyRules(

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1145,7 +1145,7 @@ public class PromptService : IPromptService
             var profileSb = new StringBuilder("\n\nSTUDENT ERROR PROFILE — top documented error patterns for this student:\n");
             for (var i = 0; i < weaknesses.Length; i++)
                 profileSb.AppendLine($"{i + 1}. {weaknesses[i]}");
-            profileSb.Append("Design at least one Practice exercise and one Production task that directly address these patterns.");
+            profileSb.Append(_pedagogy.GetLessonWeaknessProfileGuidance());
             baseInstruction += profileSb.ToString();
 
             var sb = new StringBuilder("\n\nDECLARED WEAKNESSES (max 1-2 targeted exercises per lesson):\n");

--- a/backend/LangTeach.Api/Services/IPedagogyConfigService.cs
+++ b/backend/LangTeach.Api/Services/IPedagogyConfigService.cs
@@ -144,6 +144,12 @@ public interface IPedagogyConfigService
     string? GetWeaknessTargetingGuidance(string sectionType);
 
     /// <summary>
+    /// Returns the lesson-plan design instruction appended to the STUDENT ERROR PROFILE block
+    /// when the student has documented weaknesses. Backed by course-rules.json.
+    /// </summary>
+    string GetLessonWeaknessProfileGuidance();
+
+    /// <summary>
     /// Returns a contrastive note result for the given native language, grammar topic, and CEFR level.
     /// Looks up contrastive patterns for the native language (specific-language patterns take priority
     /// over family-level patterns). Matches the first pattern whose Pattern value is a case-insensitive

--- a/backend/LangTeach.Api/Services/PedagogyConfigService.cs
+++ b/backend/LangTeach.Api/Services/PedagogyConfigService.cs
@@ -326,6 +326,10 @@ public class PedagogyConfigService : IPedagogyConfigService
     public string? GetWeaknessTargetingGuidance(string sectionType) =>
         _sectionProfileService.GetWeaknessTargetingGuidance(sectionType);
 
+    public string GetLessonWeaknessProfileGuidance() =>
+        _courseRules.LessonWeaknessProfileGuidance
+        ?? "Design at least one Practice exercise and one Production task that directly address these patterns.";
+
     public StyleSubstitution[] GetStyleSubstitutions(string[] rejectedTypes)
     {
         var rejectedSet = rejectedTypes.ToHashSet(StringComparer.OrdinalIgnoreCase);

--- a/data/pedagogy/course-rules.json
+++ b/data/pedagogy/course-rules.json
@@ -1,4 +1,5 @@
 {
+  "lessonWeaknessProfileGuidance": "Design at least one Practice exercise and one Production task that directly address these patterns.",
   "sectionCoherenceRules": [
     "The THEME of Warm Up must relate to the THEME of Presentation (same field, not identical).",
     "Practice MUST use EXCLUSIVELY content from Presentation. No new grammar or vocabulary.",

--- a/plan/langteach-beta/task585-weakness-guidance-to-config.md
+++ b/plan/langteach-beta/task585-weakness-guidance-to-config.md
@@ -1,0 +1,34 @@
+# Task 585: Move lesson-plan weakness design instruction from C# to config
+
+## Issue
+https://github.com/Robert-Freire/langTeachSaaS/issues/585
+
+## Problem
+`LessonPlanUserPrompt` in `PromptService.cs` (line 1148) has this hardcoded string:
+```
+"Design at least one Practice exercise and one Production task that directly address these patterns."
+```
+Pedagogical prompt strings should live in config, not C#.
+
+## Changes
+
+### 1. `data/pedagogy/course-rules.json`
+Add field `"lessonWeaknessProfileGuidance"` with the current hardcoded value.
+
+### 2. `backend/LangTeach.Api/AI/PedagogyConfig.cs`
+Add `string? LessonWeaknessProfileGuidance = null` to `CourseRulesFile` record.
+
+### 3. `backend/LangTeach.Api/Services/IPedagogyConfigService.cs`
+Add `string GetLessonWeaknessProfileGuidance();` method declaration.
+
+### 4. `backend/LangTeach.Api/Services/PedagogyConfigService.cs`
+Implement: return `_courseRules.LessonWeaknessProfileGuidance` with a hardcoded fallback so behavior never regresses.
+
+### 5. `backend/LangTeach.Api/AI/PromptService.cs`
+Replace hardcoded string at line 1148 with `_pedagogy.GetLessonWeaknessProfileGuidance()`.
+
+### 6. `backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs`
+Add test: `GetLessonWeaknessProfileGuidance_ReturnsNonEmpty`.
+
+## No e2e test needed
+This is a pure config refactor with no observable behavior change. Unit test is sufficient.


### PR DESCRIPTION
## Summary
- Extracts the hardcoded design instruction in `LessonPlanUserPrompt` ("Design at least one Practice exercise and one Production task...") from `PromptService.cs` into `data/pedagogy/course-rules.json`
- Adds `GetLessonWeaknessProfileGuidance()` to `IPedagogyConfigService` / `PedagogyConfigService` with a null-coalescing fallback
- Two unit tests cover non-empty return and Practice/Production content

Closes #585

## Test plan
- [ ] `dotnet test` passes (all existing + 2 new unit tests)
- [ ] `npm test` passes
- [ ] Behavior unchanged: lesson plan prompt still includes the weakness design instruction when student weaknesses are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lesson planning now uses configurable guidance to instruct creation of practice exercises and production tasks that directly address identified student weakness patterns, enabling personalized pedagogy.

* **Tests**
  * Added unit tests for lesson weakness guidance functionality, validating content accuracy and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->