### PR TITLE
feat(#581): show NextSessionTopics as "Planned for next class" on session card

### DIFF
--- a/e2e/tests/session-log.spec.ts
+++ b/e2e/tests/session-log.spec.ts
@@ -507,6 +507,15 @@ test('summary header appears on history tab after logging a session', async ({ b
   await expect(page.getByTestId('session-summary-action-items-list')).toBeVisible()
   await expect(page.getByTestId('session-summary-action-items-list')).toContainText('Work on para/por')
 
+  // Session card should show nextSessionTopics collapsed preview and expanded section
+  await expect(page.getByTestId('next-session-topics-preview')).toBeVisible()
+  await expect(page.getByTestId('next-session-topics-preview')).toContainText('Work on para/por')
+
+  await page.getByTestId('session-entry-toggle').click()
+  await expect(page.getByTestId('next-session-topics-section')).toBeVisible()
+  await expect(page.getByTestId('next-session-topics-section')).toContainText('Planned for next class')
+  await expect(page.getByTestId('next-session-topics-section')).toContainText('Work on para/por')
+
   await context.close()
 })
 

--- a/frontend/src/components/session/SessionHistoryTab.test.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.test.tsx
@@ -325,4 +325,44 @@ describe('SessionHistoryTab', () => {
     const badge = screen.getByTestId('general-note-count')
     expect(badge.querySelector('svg')).not.toBeNull()
   })
+
+  it('shows next session topics preview line in collapsed state when nextSessionTopics is set', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    const preview = screen.getByTestId('next-session-topics-preview')
+    expect(preview).toBeInTheDocument()
+    expect(preview).toHaveTextContent('Next:')
+    expect(preview).toHaveTextContent('Review irregular verbs')
+  })
+
+  it('does not show next session topics preview when nextSessionTopics is null', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SESSION_BASE, nextSessionTopics: null },
+    ])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    expect(screen.queryByTestId('next-session-topics-preview')).not.toBeInTheDocument()
+  })
+
+  it('shows next session topics section with amber styling in expanded state', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    fireEvent.click(screen.getByTestId('session-entry-toggle'))
+    const section = screen.getByTestId('next-session-topics-section')
+    expect(section).toBeInTheDocument()
+    expect(section).toHaveTextContent('Planned for next class')
+    expect(section).toHaveTextContent('Review irregular verbs')
+  })
+
+  it('does not show next session topics section when nextSessionTopics is null', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SESSION_BASE, nextSessionTopics: null },
+    ])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    fireEvent.click(screen.getByTestId('session-entry-toggle'))
+    expect(screen.queryByTestId('next-session-topics-section')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/session/SessionHistoryTab.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { ChevronDown, ChevronUp, Trash2, Pencil, ExternalLink, BookOpen } from 'lucide-react'
+import { ChevronDown, ChevronUp, Trash2, Pencil, ExternalLink, BookOpen, CalendarDays } from 'lucide-react'
 import { SessionSummaryHeader } from './SessionSummaryHeader'
 import { SessionLogDialog } from './SessionLogDialog'
 import { logger } from '../../lib/logger'
@@ -161,6 +161,13 @@ function SessionEntry({
               </p>
             )}
 
+            {!expanded && session.nextSessionTopics && (
+              <p className="text-xs text-amber-700 line-clamp-1" data-testid="next-session-topics-preview">
+                <span className="font-medium">Next:</span>{' '}
+                {session.nextSessionTopics}
+              </p>
+            )}
+
             {/* Homework + status badges */}
             <div className="flex flex-wrap gap-1.5 items-center">
               {session.homeworkAssigned && (
@@ -218,9 +225,15 @@ function SessionEntry({
           )}
 
           {session.nextSessionTopics && (
-            <div>
-              <p className="text-xs font-medium text-zinc-500 mb-0.5">Topics for next session</p>
-              <p className="text-sm text-zinc-800 whitespace-pre-wrap">{session.nextSessionTopics}</p>
+            <div
+              className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2"
+              data-testid="next-session-topics-section"
+            >
+              <p className="text-xs font-medium text-amber-700 mb-0.5 flex items-center gap-1">
+                <CalendarDays className="h-3 w-3" />
+                Planned for next class
+              </p>
+              <p className="text-sm text-amber-900 whitespace-pre-wrap">{session.nextSessionTopics}</p>
             </div>
           )}
 

--- a/plan/langteach-beta/task581-next-session-topics.md
+++ b/plan/langteach-beta/task581-next-session-topics.md
@@ -1,0 +1,54 @@
+# Task 581: Show "Planned for next class" (NextSessionTopics) on Session Detail Card
+
+## Issue
+https://github.com/Robert-Freire/langTeachSaaS/issues/581
+
+## Goal
+Make `NextSessionTopics` visually prominent and distinct on the session card so Jordi can quickly see what he planned for next class.
+
+## Current State
+- `nextSessionTopics` already exists in the backend and in `SessionLogDto`
+- In expanded detail: rendered as "Topics for next session" with the same neutral styling as other fields (no visual distinction)
+- In collapsed preview: shows an amber "1 action item" dot+badge but not the actual content
+- Editing: done via the "Edit" button which opens `SessionLogDialog` (has a nextSessionTopics textarea)
+
+## What Needs to Change
+
+### 1. Visual distinction in expanded detail (`SessionHistoryTab.tsx` ~line 220)
+Wrap the `nextSessionTopics` block in a visually distinct container:
+- Background: `bg-amber-50` border `border-amber-200` rounded
+- Label: rename from "Topics for next session" to "Planned for next class"
+- Label color: `text-amber-700` (vs `text-zinc-500` for other fields)
+- Add a small arrow/calendar icon (e.g. `ArrowRight` or `CalendarDays` from lucide-react) next to the label
+- `data-testid="next-session-topics-section"`
+
+### 2. Show content preview in collapsed row (`SessionHistoryTab.tsx` ~line 149)
+Add a collapsed preview line for `nextSessionTopics` alongside the existing Planned/Done lines:
+```tsx
+{!expanded && session.nextSessionTopics && (
+  <p className="text-xs text-amber-700 line-clamp-1">
+    <span className="font-medium">Next:</span>{' '}
+    {session.nextSessionTopics}
+  </p>
+)}
+```
+Place it after the `actualContent` line (before the homework row).
+
+### 3. No backend changes needed
+The field is already editable via the existing "Edit" button / `SessionLogDialog`.
+
+## Files to Change
+- `frontend/src/components/session/SessionHistoryTab.tsx` — display changes (visual treatment + collapsed preview)
+- `frontend/src/components/session/SessionHistoryTab.test.tsx` — update existing tests for new label/testid, add tests for:
+  - nextSessionTopics section is visually distinct (has `data-testid="next-session-topics-section"`)
+  - collapsed preview shows "Next: {content}" when nextSessionTopics is set
+  - collapsed preview does not show "Next:" when nextSessionTopics is null
+
+## E2E Coverage
+Add assertion in `e2e/tests/session-log.spec.ts` that the `next-session-topics-section` is visible when a session has `nextSessionTopics` data (the fixture at line 492 already sets this field).
+
+## Acceptance Criteria Check
+- [x] `NextSessionTopics` displayed with clear label "Planned for next class"
+- [x] Visually distinct: amber background separates it from the current session's planned/actual sections
+- [x] Editable: via existing Edit button -> SessionLogDialog (no change needed)
+- [x] No backend changes required


### PR DESCRIPTION
## Summary

- Wraps `nextSessionTopics` in an amber-bordered section ("Planned for next class" + calendar icon) in the expanded session card, making it visually distinct from current-session content
- Adds a collapsed preview line ("Next: ...") in amber so Jordi sees the next-class plan without expanding
- No backend changes (field already existed in `SessionLogDto`)

## Test plan

- [ ] Open a student with a session that has `nextSessionTopics` set
- [ ] Verify collapsed card shows amber "Next: ..." preview line
- [ ] Expand the card and verify amber-bordered "Planned for next class" section appears with the correct content
- [ ] Verify editing still works via the Edit button
- [ ] Verify sessions without `nextSessionTopics` show neither element

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Added a collapsed preview for next session topics in session history and enhanced the expanded view with a calendar icon and improved styling for better visual clarity.

* **Tests**
  * Added comprehensive tests for next session topics display in both collapsed and expanded states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->