### PR TITLE
fix: Telegram bot splits notes into structured session-log fields (#623)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/TelegramConversationServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/TelegramConversationServiceTests.cs
@@ -16,6 +16,7 @@ public class TelegramConversationServiceTests : IDisposable
     private readonly TelegramStateStore _stateStore;
     private readonly StubTelegramBotService _botService;
     private readonly StubTranscriptionService _transcriptionService;
+    private readonly FakeReflectionExtractionService _extractionService;
     private readonly TelegramConversationService _sut;
     private readonly IMemoryCache _cache;
 
@@ -33,6 +34,7 @@ public class TelegramConversationServiceTests : IDisposable
         _stateStore = new TelegramStateStore(_cache);
         _botService = new StubTelegramBotService();
         _transcriptionService = new StubTranscriptionService();
+        _extractionService = new FakeReflectionExtractionService();
 
         var difficultyService = new DifficultyTrendService(_db, NullLogger<DifficultyTrendService>.Instance);
         var sessionLogService = new SessionLogService(_db, difficultyService, NullLogger<SessionLogService>.Instance);
@@ -45,6 +47,7 @@ public class TelegramConversationServiceTests : IDisposable
             _transcriptionService,
             sessionLogService,
             studentService,
+            _extractionService,
             NullLogger<TelegramConversationService>.Instance);
     }
 
@@ -265,7 +268,7 @@ public class TelegramConversationServiceTests : IDisposable
         var studentService = new StudentService(_db, NullLogger<StudentService>.Instance);
         var sut = new TelegramConversationService(
             _db, _stateStore, _botService, throwingTranscription,
-            sessionLogService, studentService,
+            sessionLogService, studentService, _extractionService,
             NullLogger<TelegramConversationService>.Instance);
 
         await sut.HandleUpdateAsync(VoiceUpdate(_chatId), CancellationToken.None);
@@ -274,9 +277,83 @@ public class TelegramConversationServiceTests : IDisposable
         _stateStore.GetConversationState(_chatId).Should().BeNull();
     }
 
+    // --- Structured field extraction ---
+
+    [Fact]
+    public async Task TextMessage_MatchedStudent_MapsExtractedFieldsOntoSessionLog()
+    {
+        LinkTeacher();
+        var student = await CreateStudentAsync("Marco");
+
+        _extractionService.Result = new ExtractedReflectionDto(
+            WhatWasCovered: "ser vs estar",
+            AreasToImprove: "needs more practice with preterite",
+            EmotionalSignals: "engaged",
+            HomeworkAssigned: "complete exercises 3 and 4",
+            NextLessonIdeas: "past tenses review",
+            SuggestedDifficulties: new List<SuggestedDifficultyDto>
+            {
+                new("confuses ser and estar", "Grammar", "Copulas", "Medium")
+            });
+
+        await _sut.HandleUpdateAsync(TextUpdate(_chatId, "Marco worked on ser/estar today"), CancellationToken.None);
+
+        var log = await _db.SessionLogs.SingleAsync(s => s.StudentId == student.Id);
+        log.ActualContent.Should().Be("ser vs estar");
+        log.HomeworkAssigned.Should().Be("complete exercises 3 and 4");
+        log.NextSessionTopics.Should().Be("past tenses review");
+        log.GeneralNotes.Should().Be("needs more practice with preterite\nengaged");
+        _extractionService.LastInput.Should().Be("Marco worked on ser/estar today");
+    }
+
+    [Fact]
+    public async Task TextMessage_ExtractionFailure_FallsBackToRawGeneralNotes()
+    {
+        LinkTeacher();
+        var student = await CreateStudentAsync("Marco");
+
+        _extractionService.ThrowOnNext = new InvalidOperationException("AI unavailable");
+
+        await _sut.HandleUpdateAsync(TextUpdate(_chatId, "Marco did great today"), CancellationToken.None);
+
+        var log = await _db.SessionLogs.SingleAsync(s => s.StudentId == student.Id);
+        log.GeneralNotes.Should().Be("Marco did great today");
+        log.ActualContent.Should().BeNull();
+        log.HomeworkAssigned.Should().BeNull();
+        log.NextSessionTopics.Should().BeNull();
+        _botService.LastSentMessage.Should().Contain("Logged for Marco");
+    }
+
     private class ThrowingTranscriptionService : ITranscriptionService
     {
         public Task<string> TranscribeAsync(Stream audio, string fileName, string contentType, CancellationToken ct = default)
             => throw new InvalidOperationException("Transcription service unavailable");
+    }
+
+    private class FakeReflectionExtractionService : IReflectionExtractionService
+    {
+        public ExtractedReflectionDto? Result { get; set; }
+        public Exception? ThrowOnNext { get; set; }
+        public string? LastInput { get; private set; }
+
+        public Task<ExtractedReflectionDto> ExtractAsync(string text, CancellationToken ct = default)
+        {
+            LastInput = text;
+            if (ThrowOnNext is not null)
+            {
+                var ex = ThrowOnNext;
+                ThrowOnNext = null;
+                throw ex;
+            }
+            // Default: echo input into AreasToImprove so existing tests asserting GeneralNotes == raw text keep passing.
+            var result = Result ?? new ExtractedReflectionDto(
+                WhatWasCovered: null,
+                AreasToImprove: text,
+                EmotionalSignals: null,
+                HomeworkAssigned: null,
+                NextLessonIdeas: null,
+                SuggestedDifficulties: new List<SuggestedDifficultyDto>());
+            return Task.FromResult(result);
+        }
     }
 }

--- a/backend/LangTeach.Api/Services/TelegramConversationService.cs
+++ b/backend/LangTeach.Api/Services/TelegramConversationService.cs
@@ -15,6 +15,7 @@ public class TelegramConversationService : ITelegramConversationService
     private readonly ITranscriptionService _transcriptionService;
     private readonly ISessionLogService _sessionLogService;
     private readonly IStudentService _studentService;
+    private readonly IReflectionExtractionService _extractionService;
     private readonly ILogger<TelegramConversationService> _logger;
 
     public TelegramConversationService(
@@ -24,6 +25,7 @@ public class TelegramConversationService : ITelegramConversationService
         ITranscriptionService transcriptionService,
         ISessionLogService sessionLogService,
         IStudentService studentService,
+        IReflectionExtractionService extractionService,
         ILogger<TelegramConversationService> logger)
     {
         _db = db;
@@ -32,6 +34,7 @@ public class TelegramConversationService : ITelegramConversationService
         _transcriptionService = transcriptionService;
         _sessionLogService = sessionLogService;
         _studentService = studentService;
+        _extractionService = extractionService;
         _logger = logger;
     }
 
@@ -187,11 +190,7 @@ public class TelegramConversationService : ITelegramConversationService
         long chatId, Guid teacherId, Guid studentId, string studentName,
         string notes, CancellationToken ct)
     {
-        var request = new CreateSessionLogRequest
-        {
-            SessionDate = DateTime.UtcNow.Date,
-            GeneralNotes = notes
-        };
+        var request = await BuildSessionLogRequestAsync(chatId, teacherId, studentId, notes, ct);
 
         await _sessionLogService.CreateAsync(teacherId, studentId, request, ct);
         _logger.LogInformation("TelegramBot created session log for TeacherId={TeacherId} StudentId={StudentId}", teacherId, studentId);
@@ -199,6 +198,53 @@ public class TelegramConversationService : ITelegramConversationService
         await _botService.SendMessageAsync(chatId,
             $"Logged for {studentName}. Summary saved.",
             ct);
+    }
+
+    private async Task<CreateSessionLogRequest> BuildSessionLogRequestAsync(
+        long chatId, Guid teacherId, Guid studentId, string notes, CancellationToken ct)
+    {
+        ExtractedReflectionDto? extracted = null;
+        try
+        {
+            extracted = await _extractionService.ExtractAsync(notes, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "TelegramBot reflection extraction failed; falling back to GeneralNotes. ChatId={ChatId} TeacherId={TeacherId} StudentId={StudentId}",
+                chatId, teacherId, studentId);
+        }
+
+        if (extracted is null)
+        {
+            return new CreateSessionLogRequest
+            {
+                SessionDate = DateTime.UtcNow.Date,
+                GeneralNotes = notes
+            };
+        }
+
+        // Mirror of SessionLogDialog.tsx:316-346 — join AreasToImprove + EmotionalSignals into GeneralNotes,
+        // map the rest onto their structured fields.
+        var generalNotes = string.Join("\n",
+            new[] { extracted.AreasToImprove, extracted.EmotionalSignals }
+                .Where(s => !string.IsNullOrWhiteSpace(s)));
+
+        return new CreateSessionLogRequest
+        {
+            SessionDate = DateTime.UtcNow.Date,
+            ActualContent = extracted.WhatWasCovered,
+            HomeworkAssigned = extracted.HomeworkAssigned,
+            NextSessionTopics = extracted.NextLessonIdeas,
+            GeneralNotes = string.IsNullOrEmpty(generalNotes) ? null : generalNotes,
+            SuggestedDifficulties = extracted.SuggestedDifficulties.Count > 0
+                ? extracted.SuggestedDifficulties
+                : null
+        };
     }
 
     public async Task<TelegramStatusResponse> GetLinkStatusAsync(Guid teacherId, CancellationToken ct)

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -6,6 +6,12 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 
 *Cleared 2026-04-08 during Adaptive Replanning sprint close. All entries deleted (low/info severity, all already deferred with sound reasoning) or batched into #603-#609.*
 
+## #623 — 2026-04-09
+
+| Reviewer | Severity | Note |
+|---|---|---|
+| architecture-reviewer | minor | `FakeReflectionExtractionService` is a private inner class in `TelegramConversationServiceTests`; project convention is top-level stub files in `Services/` folder (`StubReflectionExtractionService.cs`, `StubTelegramBotService.cs`, etc.). Single-class scope for now; extract if another test class needs it. |
+
 ## #620 — 2026-04-09
 
 | Reviewer | Severity | Note |

--- a/plan/langteach-beta/task623-telegram-extract-fields.md
+++ b/plan/langteach-beta/task623-telegram-extract-fields.md
@@ -1,0 +1,85 @@
+# Task 623: Telegram bot — extract structured fields
+
+**Issue:** Robert-Freire/langTeachSaaS#623
+**Type:** Hotfix (branch from `main`, PR to `main`)
+**Branch:** `hotfix/t623-telegram-extract-fields`
+
+## Problem
+
+`TelegramConversationService.CreateSessionLogAndConfirmAsync` at `backend/LangTeach.Api/Services/TelegramConversationService.cs:186` builds `CreateSessionLogRequest` with only `SessionDate` and `GeneralNotes = notes`. Every other field is left null.
+
+The in-app voice flow (`frontend/src/components/session/SessionLogDialog.tsx:316`) calls `extractSessionReflection()` (`POST /api/students/{id}/sessions/extract`) which runs `IReflectionExtractionService` and returns an `ExtractedReflectionDto`. The frontend then maps those fields onto the session-log request.
+
+The Telegram path skips extraction entirely, so the two entry points produce very different records for identical input.
+
+## Solution
+
+Inject `IReflectionExtractionService` into `TelegramConversationService` and call it from `CreateSessionLogAndConfirmAsync` before building the request. Map the returned `ExtractedReflectionDto` onto `CreateSessionLogRequest` using the exact same mapping the frontend uses.
+
+### Field mapping (mirror of `SessionLogDialog.tsx:316-346`)
+
+| Extracted field | CreateSessionLogRequest field |
+|---|---|
+| `WhatWasCovered` | `ActualContent` |
+| `HomeworkAssigned` | `HomeworkAssigned` |
+| `NextLessonIdeas` | `NextSessionTopics` |
+| `AreasToImprove` + `EmotionalSignals` (joined with `\n`, empties filtered) | `GeneralNotes` |
+| `SuggestedDifficulties` (non-null list, may be empty) | `SuggestedDifficulties` (nullable list; pass the list if non-empty, else `null` — matches frontend `extracted.suggestedDifficulties?.length ? ... : undefined`) |
+
+`PlannedContent`, `PreviousHomeworkStatus`, `LevelReassessmentSkill/Level`, `LinkedLessonId`, `TopicTags`, `IsCancelled`, `Status` stay at defaults (same as current Telegram behavior — the bot has no UI for them).
+
+Session status stays at the default `Confirmed` (current Telegram behavior). The in-app flow auto-saves as `Draft`, but Telegram teachers just dropped a note and expect it logged; holding it as a draft would hide it from their history.
+
+### Fallback on extraction failure
+
+If `_extractionService.ExtractAsync` throws (AI unavailable, timeout, etc.), log a warning and fall back to the current behavior: put the raw text in `GeneralNotes` only. The teacher still gets a record instead of a swallowed message.
+
+`OperationCanceledException` must re-throw (standard cancellation hygiene, matches the transcription block above).
+
+## Changes
+
+### `backend/LangTeach.Api/Services/TelegramConversationService.cs`
+
+1. Add `IReflectionExtractionService _extractionService` field and constructor parameter.
+2. In `CreateSessionLogAndConfirmAsync`, before building `CreateSessionLogRequest`:
+   - Call `_extractionService.ExtractAsync(notes, ct)` in a try/catch.
+   - On success, build the request using the mapping above.
+   - On failure, log a warning with `chatId`, `teacherId`, `studentId` and fall back to `GeneralNotes = notes` only.
+3. No changes to any other method.
+
+### `backend/LangTeach.Api.Tests/Services/TelegramConversationServiceTests.cs`
+
+The existing test constructor instantiates `TelegramConversationService` with 7 positional args. Adding `IReflectionExtractionService` will break the build unless the test constructor is updated in the same commit.
+
+1. Add a `FakeReflectionExtractionService` (or equivalent stub) that returns a configurable `ExtractedReflectionDto` and is injected at the correct constructor position (append as the new last parameter in `TelegramConversationService`, or slot logically before `ILogger` — pick one and be consistent; prefer appending before `ILogger` so logger stays last as in most services in the codebase).
+2. Add test: `HandleUpdateAsync_TextMessage_MatchedStudent_UsesExtractionResult` — given a text message that matches a student name, verifies the created session log has fields populated from the extraction stub.
+3. Add test: `HandleUpdateAsync_ExtractionFailure_FallsBackToGeneralNotes` — extraction service throws, session log is still created with `GeneralNotes = rawText` and other fields null, warning logged.
+4. Update existing happy-path tests that assert on `GeneralNotes` to also account for the (stubbed) extraction output, or configure the stub to echo input into `GeneralNotes` so existing assertions still pass.
+
+No DI registration change needed: `IReflectionExtractionService` is already registered (used by `SessionsController`).
+
+No migration. No frontend changes. No API contract changes.
+
+## Acceptance criteria (from #623)
+
+- [x] A Telegram voice note or text message creates a session log whose fields are split the same way as a session logged via the in-app voice flow for the same transcription.
+- [x] If AI extraction fails, the session log is still created with the raw text in `GeneralNotes` and a warning is logged.
+- [x] `TelegramConversationServiceTests` updated to cover the extraction call and the fallback.
+
+## Out of scope
+
+- Changing the in-app extraction logic.
+- Parsing student names out of the transcription (the bot already matches by token).
+- Persisting the extracted difficulties anywhere beyond what `SessionLogService.CreateAsync` already does with `SuggestedDifficulties` on the request.
+- `Draft` vs `Confirmed` status change for Telegram-created logs (explicit decision above).
+
+## Test plan
+
+- Unit: new + updated `TelegramConversationServiceTests` cases above.
+- Build verify: `task-build-verify.py`.
+- No e2e added: the existing `e2e/tests/telegram-connect.spec.ts` covers the link flow; the extraction path is a backend-only behavior change and is fully covered by unit tests that mock `IReflectionExtractionService`. Adding a real-AI e2e would be flaky and out of proportion for a hotfix.
+
+## Rollout
+
+- Hotfix PR targets `main`.
+- After merge, sync sprint branch: `git checkout sprint/ui-redesign-student-polish && git merge main && git push`.


### PR DESCRIPTION
## Summary

- The Telegram bot was stuffing every transcription into `GeneralNotes`, while the in-app voice flow runs the text through `IReflectionExtractionService` and maps the result onto structured fields (`ActualContent`, `HomeworkAssigned`, `NextSessionTopics`, `GeneralNotes`, `SuggestedDifficulties`).
- `TelegramConversationService` now calls the same extraction service and mirrors the field mapping in `SessionLogDialog.tsx:308-346`, so both entry points produce identical session-log records for the same input.
- On extraction failure the bot logs a warning and falls back to the previous behavior (raw text in `GeneralNotes`) so teachers still get a record.

Hotfix targeting `main` per project rules for production bug fixes.

Fixes #623

## Test plan

- [x] `dotnet test` — 12 `TelegramConversationServiceTests` pass (10 existing + 2 new: field-mapping happy path + extraction-failure fallback)
- [x] `task-build-verify.py` PASS (bicep, dotnet build/test, npm lint/build/test)
- [x] qa-verify: PASS (all 3 ACs covered)
- [x] code review: PASS
- [x] architecture review: PASS WITH NOTES (minor, logged to backlog)
- [ ] Manual smoke: send a Telegram message once deployed, confirm fields are split

## Post-merge

After merge to `main`, sync the sprint branch:

```powershell
git checkout sprint/ui-redesign-student-polish; git merge main; git push origin sprint/ui-redesign-student-polish
```

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session logs now automatically extract and structure reflection data, including content covered, homework assignments, areas for improvement, and next session topics
  * Improved data organization with graceful fallback to raw text when extraction is unavailable

* **Tests**
  * Added comprehensive test coverage for structured reflection data extraction, including success scenarios and resilience when extraction fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->