### PR TITLE
feat: student profile additive scalar fields (backend prep) (#625)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs
@@ -88,4 +88,77 @@ public class StudentServiceTests : IDisposable
 
         result.NativeLanguage.Should().Be(language);
     }
+
+    [Fact]
+    public async Task CreateAsync_ShortTermObjectives_RoundTrip()
+    {
+        var objectives = new List<ShortTermObjectiveDto>
+        {
+            new("o1", "Pass B2 exam", new DateOnly(2026, 6, 30)),
+            new("o2", "Read a novel in Spanish", null),
+        };
+        var request = BaseRequest();
+        request.ShortTermObjectives = objectives;
+
+        var result = await _sut.CreateAsync(_teacherId, request);
+
+        result.ShortTermObjectives.Should().HaveCount(2);
+        result.ShortTermObjectives[0].Id.Should().Be("o1");
+        result.ShortTermObjectives[0].Text.Should().Be("Pass B2 exam");
+        result.ShortTermObjectives[0].TargetDate.Should().Be(new DateOnly(2026, 6, 30));
+        result.ShortTermObjectives[1].Id.Should().Be("o2");
+        result.ShortTermObjectives[1].TargetDate.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ClearsShortTermObjectives()
+    {
+        var createRequest = BaseRequest();
+        createRequest.ShortTermObjectives = [new("o1", "Initial objective", null)];
+        var created = await _sut.CreateAsync(_teacherId, createRequest);
+
+        var updateRequest = new UpdateStudentRequest
+        {
+            Name = created.Name,
+            LearningLanguage = created.LearningLanguage,
+            CefrLevel = created.CefrLevel,
+            ShortTermObjectives = [],
+        };
+        var updated = await _sut.UpdateAsync(_teacherId, created.Id, updateRequest);
+
+        updated!.ShortTermObjectives.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateAsync_SpokenLanguages_RoundTrip()
+    {
+        var request = BaseRequest();
+        request.SpokenLanguages = ["French", "Italian"];
+
+        var result = await _sut.CreateAsync(_teacherId, request);
+
+        result.SpokenLanguages.Should().BeEquivalentTo(["French", "Italian"]);
+    }
+
+    [Fact]
+    public async Task CreateAsync_BirthYearOutOfRange_ThrowsValidationException()
+    {
+        var request = BaseRequest();
+        request.BirthYear = 1900;
+
+        var act = () => _sut.CreateAsync(_teacherId, request);
+
+        await act.Should().ThrowAsync<ValidationException>();
+    }
+
+    [Fact]
+    public async Task CreateAsync_BirthYearFuture_ThrowsValidationException()
+    {
+        var request = BaseRequest();
+        request.BirthYear = DateTime.UtcNow.Year + 1;
+
+        var act = () => _sut.CreateAsync(_teacherId, request);
+
+        await act.Should().ThrowAsync<ValidationException>();
+    }
 }

--- a/backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs
@@ -90,6 +90,50 @@ public class StudentServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetByIdAsync_ReturnsNewProfileFields()
+    {
+        var request = BaseRequest();
+        request.BirthYear = 1990;
+        request.Profession = "Engineer";
+        request.CountryOfOrigin = "Brazil";
+        request.CountryOfResidence = "Spain";
+        request.IsActive = true;
+        request.IsCorporate = true;
+        request.Rate = "25 euros";
+        request.SpokenLanguages = ["French"];
+        var created = await _sut.CreateAsync(_teacherId, request);
+
+        var result = await _sut.GetByIdAsync(_teacherId, created.Id);
+
+        result.Should().NotBeNull();
+        result!.BirthYear.Should().Be(1990);
+        result.Profession.Should().Be("Engineer");
+        result.CountryOfOrigin.Should().Be("Brazil");
+        result.CountryOfResidence.Should().Be("Spain");
+        result.IsActive.Should().BeTrue();
+        result.IsCorporate.Should().BeTrue();
+        result.Rate.Should().Be("25 euros");
+        result.SpokenLanguages.Should().BeEquivalentTo(["French"]);
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsIsActiveIsCorporateRate()
+    {
+        var request = BaseRequest();
+        request.IsActive = false;
+        request.IsCorporate = true;
+        request.Rate = "40 euros";
+        await _sut.CreateAsync(_teacherId, request);
+
+        var result = await _sut.ListAsync(_teacherId, new LangTeach.Api.DTOs.StudentListQuery());
+
+        var student = result.Items.Single();
+        student.IsActive.Should().BeFalse();
+        student.IsCorporate.Should().BeTrue();
+        student.Rate.Should().Be("40 euros");
+    }
+
+    [Fact]
     public async Task CreateAsync_ShortTermObjectives_RoundTrip()
     {
         var objectives = new List<ShortTermObjectiveDto>

--- a/backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs
@@ -227,4 +227,17 @@ public class StudentServiceTests : IDisposable
 
         await act.Should().ThrowAsync<ValidationException>();
     }
+
+    [Fact]
+    public async Task CreateAsync_ShortTermObjectives_ExceedsCap_ThrowsValidationException()
+    {
+        var request = BaseRequest();
+        request.ShortTermObjectives = Enumerable.Range(1, 11)
+            .Select(i => new ShortTermObjectiveDto($"o{i}", $"Objective {i}", null))
+            .ToList();
+
+        var act = () => _sut.CreateAsync(_teacherId, request);
+
+        await act.Should().ThrowAsync<ValidationException>();
+    }
 }

--- a/backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs
@@ -205,4 +205,26 @@ public class StudentServiceTests : IDisposable
 
         await act.Should().ThrowAsync<ValidationException>();
     }
+
+    [Fact]
+    public async Task CreateAsync_ShortTermObjective_EmptyId_ThrowsValidationException()
+    {
+        var request = BaseRequest();
+        request.ShortTermObjectives = [new("", "Some text", null)];
+
+        var act = () => _sut.CreateAsync(_teacherId, request);
+
+        await act.Should().ThrowAsync<ValidationException>();
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShortTermObjective_TextTooLong_ThrowsValidationException()
+    {
+        var request = BaseRequest();
+        request.ShortTermObjectives = [new("o1", new string('x', 201), null)];
+
+        var act = () => _sut.CreateAsync(_teacherId, request);
+
+        await act.Should().ThrowAsync<ValidationException>();
+    }
 }

--- a/backend/LangTeach.Api/DTOs/CreateStudentRequest.cs
+++ b/backend/LangTeach.Api/DTOs/CreateStudentRequest.cs
@@ -36,7 +36,6 @@ public class CreateStudentRequest
     public string? Notes { get; set; }
 
     // Identity fields
-    [Range(1920, 2100)]
     public int? BirthYear { get; set; }
 
     [MaxLength(128)]

--- a/backend/LangTeach.Api/DTOs/CreateStudentRequest.cs
+++ b/backend/LangTeach.Api/DTOs/CreateStudentRequest.cs
@@ -36,6 +36,7 @@ public class CreateStudentRequest
     public string? Notes { get; set; }
 
     // Identity fields
+    [Range(1920, 2100)]
     public int? BirthYear { get; set; }
 
     [MaxLength(128)]

--- a/backend/LangTeach.Api/DTOs/CreateStudentRequest.cs
+++ b/backend/LangTeach.Api/DTOs/CreateStudentRequest.cs
@@ -34,4 +34,45 @@ public class CreateStudentRequest
 
     [MaxLength(2000)]
     public string? Notes { get; set; }
+
+    // Identity fields
+    public int? BirthYear { get; set; }
+
+    [MaxLength(128)]
+    public string? Profession { get; set; }
+
+    [MaxLength(64)]
+    public string? CountryOfOrigin { get; set; }
+
+    [MaxLength(64)]
+    public string? CityOfOrigin { get; set; }
+
+    [MaxLength(64)]
+    public string? CountryOfResidence { get; set; }
+
+    [MaxLength(64)]
+    public string? CityOfResidence { get; set; }
+
+    [MaxLength(512)]
+    public string? ReasonForStudying { get; set; }
+
+    // Level fields
+    [RegularExpression(@"^(A1|A2|B1|B2|C1|C2)$", ErrorMessage = "OfficialCefrLevel must be one of: A1, A2, B1, B2, C1, C2.")]
+    public string? OfficialCefrLevel { get; set; }
+
+    // Plan fields
+    [MaxCollectionCount(10)]
+    public List<ShortTermObjectiveDto> ShortTermObjectives { get; set; } = [];
+
+    // Commercial fields
+    public bool IsActive { get; set; } = true;
+    public bool IsCorporate { get; set; }
+
+    [MaxLength(32)]
+    public string? Rate { get; set; }
+
+    // Language fields
+    [MaxCollectionCount(20)]
+    [MaxStringLengthEach(64)]
+    public List<string> SpokenLanguages { get; set; } = [];
 }

--- a/backend/LangTeach.Api/DTOs/ShortTermObjectiveDto.cs
+++ b/backend/LangTeach.Api/DTOs/ShortTermObjectiveDto.cs
@@ -1,0 +1,3 @@
+namespace LangTeach.Api.DTOs;
+
+public record ShortTermObjectiveDto(string Id, string Text, DateOnly? TargetDate);

--- a/backend/LangTeach.Api/DTOs/StudentDto.cs
+++ b/backend/LangTeach.Api/DTOs/StudentDto.cs
@@ -12,5 +12,23 @@ public record StudentDto(
     List<StudentWeaknessDto> Weaknesses,
     List<DifficultyDto> Difficulties,
     DateTime CreatedAt,
-    DateTime UpdatedAt
+    DateTime UpdatedAt,
+    // Identity fields
+    int? BirthYear,
+    string? Profession,
+    string? CountryOfOrigin,
+    string? CityOfOrigin,
+    string? CountryOfResidence,
+    string? CityOfResidence,
+    string? ReasonForStudying,
+    // Level fields
+    string? OfficialCefrLevel,
+    // Plan fields
+    List<ShortTermObjectiveDto> ShortTermObjectives,
+    // Commercial fields
+    bool IsActive,
+    bool IsCorporate,
+    string? Rate,
+    // Language fields
+    List<string> SpokenLanguages
 );

--- a/backend/LangTeach.Api/DTOs/UpdateStudentRequest.cs
+++ b/backend/LangTeach.Api/DTOs/UpdateStudentRequest.cs
@@ -36,6 +36,7 @@ public class UpdateStudentRequest
     public string? Notes { get; set; }
 
     // Identity fields
+    [Range(1920, 2100)]
     public int? BirthYear { get; set; }
 
     [MaxLength(128)]

--- a/backend/LangTeach.Api/DTOs/UpdateStudentRequest.cs
+++ b/backend/LangTeach.Api/DTOs/UpdateStudentRequest.cs
@@ -36,7 +36,6 @@ public class UpdateStudentRequest
     public string? Notes { get; set; }
 
     // Identity fields
-    [Range(1920, 2100)]
     public int? BirthYear { get; set; }
 
     [MaxLength(128)]

--- a/backend/LangTeach.Api/DTOs/UpdateStudentRequest.cs
+++ b/backend/LangTeach.Api/DTOs/UpdateStudentRequest.cs
@@ -34,4 +34,45 @@ public class UpdateStudentRequest
 
     [MaxLength(2000)]
     public string? Notes { get; set; }
+
+    // Identity fields
+    public int? BirthYear { get; set; }
+
+    [MaxLength(128)]
+    public string? Profession { get; set; }
+
+    [MaxLength(64)]
+    public string? CountryOfOrigin { get; set; }
+
+    [MaxLength(64)]
+    public string? CityOfOrigin { get; set; }
+
+    [MaxLength(64)]
+    public string? CountryOfResidence { get; set; }
+
+    [MaxLength(64)]
+    public string? CityOfResidence { get; set; }
+
+    [MaxLength(512)]
+    public string? ReasonForStudying { get; set; }
+
+    // Level fields
+    [RegularExpression(@"^(A1|A2|B1|B2|C1|C2)$", ErrorMessage = "OfficialCefrLevel must be one of: A1, A2, B1, B2, C1, C2.")]
+    public string? OfficialCefrLevel { get; set; }
+
+    // Plan fields
+    [MaxCollectionCount(10)]
+    public List<ShortTermObjectiveDto> ShortTermObjectives { get; set; } = [];
+
+    // Commercial fields
+    public bool IsActive { get; set; } = true;
+    public bool IsCorporate { get; set; }
+
+    [MaxLength(32)]
+    public string? Rate { get; set; }
+
+    // Language fields
+    [MaxCollectionCount(20)]
+    [MaxStringLengthEach(64)]
+    public List<string> SpokenLanguages { get; set; } = [];
 }

--- a/backend/LangTeach.Api/Data/DemoSeeder.cs
+++ b/backend/LangTeach.Api/Data/DemoSeeder.cs
@@ -237,16 +237,26 @@ public static class DemoSeeder
         // Ana Seed — rich-profile scenario
         await UpsertStudentAsync(db, teacherId, new Student
         {
-            TeacherId        = teacherId,
-            Name             = "Ana Seed",
-            LearningLanguage = "English",
-            CefrLevel        = "B1",
-            NativeLanguage   = "Portuguese",
-            LearningGoals    = """["Improve conversational fluency","Prepare for job interviews in English"]""",
-            Interests        = """["literature","travel","photography"]""",
-            Difficulties     = """["False friends with Portuguese","Subjunctive mood"]""",
-            Weaknesses       = """["Listening to fast native speech","Idiomatic expressions"]""",
-            Notes            = "[scenario-seed]",
+            TeacherId          = teacherId,
+            Name               = "Ana Seed",
+            LearningLanguage   = "English",
+            CefrLevel          = "B1",
+            NativeLanguage     = "Portuguese",
+            LearningGoals      = """["Improve conversational fluency","Prepare for job interviews in English"]""",
+            Interests          = """["literature","travel","photography"]""",
+            Difficulties       = """["False friends with Portuguese","Subjunctive mood"]""",
+            Weaknesses         = """["Listening to fast native speech","Idiomatic expressions"]""",
+            Notes              = "[scenario-seed]",
+            BirthYear          = 1992,
+            Profession         = "Marketing Manager",
+            CountryOfOrigin    = "Brazil",
+            CityOfOrigin       = "São Paulo",
+            CountryOfResidence = "Spain",
+            CityOfResidence    = "Barcelona",
+            ReasonForStudying  = "Career advancement and relocation to an English-speaking country",
+            IsActive           = true,
+            SpokenLanguages    = """["Portuguese","Spanish"]""",
+            ShortTermObjectives = """[{"id":"o1","text":"Pass B2 Cambridge exam","targetDate":"2026-06-30"},{"id":"o2","text":"Prepare for job interview in English","targetDate":null}]""",
         }, now);
 
         // Marco Seed — excel-imported scenario
@@ -282,16 +292,25 @@ public static class DemoSeeder
         // Diego Seed — with-history scenario
         var diego = await UpsertStudentAsync(db, teacherId, new Student
         {
-            TeacherId        = teacherId,
-            Name             = "Diego Seed",
-            LearningLanguage = "English",
-            CefrLevel        = "B2",
-            NativeLanguage   = "Spanish",
-            LearningGoals    = """["Achieve C1 certification","Improve academic writing"]""",
-            Interests        = """["history","cinema","chess"]""",
-            Difficulties     = """[{"id":"d1","description":"Third conditional structures","competency":"Grammar","subcategory":"Conditionals","severity":"medium","status":"Active","trend":"stable"},{"id":"d2","description":"Academic vocabulary range","competency":"Vocabulary","subcategory":"Academic","severity":"high","status":"Active","trend":"worsening"},{"id":"d3","description":"Reading speed","competency":"Reading","subcategory":"Comprehension","severity":"low","status":"Covered","trend":"improving"}]""",
-            Weaknesses       = "[]",
-            Notes            = "[scenario-seed]",
+            TeacherId           = teacherId,
+            Name                = "Diego Seed",
+            LearningLanguage    = "English",
+            CefrLevel           = "B2",
+            NativeLanguage      = "Spanish",
+            LearningGoals       = """["Achieve C1 certification","Improve academic writing"]""",
+            Interests           = """["history","cinema","chess"]""",
+            Difficulties        = """[{"id":"d1","description":"Third conditional structures","competency":"Grammar","subcategory":"Conditionals","severity":"medium","status":"Active","trend":"stable"},{"id":"d2","description":"Academic vocabulary range","competency":"Vocabulary","subcategory":"Academic","severity":"high","status":"Active","trend":"worsening"},{"id":"d3","description":"Reading speed","competency":"Reading","subcategory":"Comprehension","severity":"low","status":"Covered","trend":"improving"}]""",
+            Weaknesses          = "[]",
+            Notes               = "[scenario-seed]",
+            BirthYear           = 1988,
+            Profession          = "University Professor",
+            CountryOfOrigin     = "Argentina",
+            CountryOfResidence  = "Spain",
+            IsActive            = true,
+            IsCorporate         = true,
+            Rate                = "30 euros",
+            SpokenLanguages     = """["French"]""",
+            ShortTermObjectives = """[{"id":"o1","text":"Complete C1 exam preparation course","targetDate":"2026-09-01"}]""",
         }, now);
 
         // Flush all upserted student updates before checking session logs
@@ -408,15 +427,28 @@ public static class DemoSeeder
 
         if (existing is not null)
         {
-            existing.LearningLanguage = incoming.LearningLanguage;
-            existing.CefrLevel        = incoming.CefrLevel;
-            existing.NativeLanguage   = incoming.NativeLanguage;
-            existing.LearningGoals    = incoming.LearningGoals;
-            existing.Interests        = incoming.Interests;
-            existing.Difficulties     = incoming.Difficulties;
-            existing.Weaknesses       = incoming.Weaknesses;
-            existing.Notes            = incoming.Notes;
-            existing.UpdatedAt        = now;
+            existing.LearningLanguage      = incoming.LearningLanguage;
+            existing.CefrLevel             = incoming.CefrLevel;
+            existing.NativeLanguage        = incoming.NativeLanguage;
+            existing.LearningGoals         = incoming.LearningGoals;
+            existing.Interests             = incoming.Interests;
+            existing.Difficulties          = incoming.Difficulties;
+            existing.Weaknesses            = incoming.Weaknesses;
+            existing.Notes                 = incoming.Notes;
+            existing.BirthYear             = incoming.BirthYear;
+            existing.Profession            = incoming.Profession;
+            existing.CountryOfOrigin       = incoming.CountryOfOrigin;
+            existing.CityOfOrigin          = incoming.CityOfOrigin;
+            existing.CountryOfResidence    = incoming.CountryOfResidence;
+            existing.CityOfResidence       = incoming.CityOfResidence;
+            existing.ReasonForStudying     = incoming.ReasonForStudying;
+            existing.OfficialCefrLevel     = incoming.OfficialCefrLevel;
+            existing.ShortTermObjectives   = incoming.ShortTermObjectives;
+            existing.IsActive              = incoming.IsActive;
+            existing.IsCorporate           = incoming.IsCorporate;
+            existing.Rate                  = incoming.Rate;
+            existing.SpokenLanguages       = incoming.SpokenLanguages;
+            existing.UpdatedAt             = now;
             return existing;
         }
 

--- a/backend/LangTeach.Api/Data/Models/Student.cs
+++ b/backend/LangTeach.Api/Data/Models/Student.cs
@@ -14,6 +14,29 @@ public class Student
     public string Difficulties { get; set; } = "[]";
     public string? Notes { get; set; }
     public string SkillLevelOverrides { get; set; } = "{}";
+    // Identity fields
+    public int? BirthYear { get; set; }
+    public string? Profession { get; set; }
+    public string? CountryOfOrigin { get; set; }
+    public string? CityOfOrigin { get; set; }
+    public string? CountryOfResidence { get; set; }
+    public string? CityOfResidence { get; set; }
+    public string? ReasonForStudying { get; set; }
+
+    // Level fields
+    public string? OfficialCefrLevel { get; set; }
+
+    // Plan fields
+    public string ShortTermObjectives { get; set; } = "[]";
+
+    // Commercial fields
+    public bool IsActive { get; set; } = true;
+    public bool IsCorporate { get; set; }
+    public string? Rate { get; set; }
+
+    // Language fields
+    public string SpokenLanguages { get; set; } = "[]";
+
     public bool IsDeleted { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }

--- a/backend/LangTeach.Api/Migrations/20260410031048_AddStudentProfileFields.Designer.cs
+++ b/backend/LangTeach.Api/Migrations/20260410031048_AddStudentProfileFields.Designer.cs
@@ -4,6 +4,7 @@ using LangTeach.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LangTeach.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410031048_AddStudentProfileFields")]
+    partial class AddStudentProfileFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/LangTeach.Api/Migrations/20260410031048_AddStudentProfileFields.cs
+++ b/backend/LangTeach.Api/Migrations/20260410031048_AddStudentProfileFields.cs
@@ -1,0 +1,152 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LangTeach.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStudentProfileFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "BirthYear",
+                table: "Students",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CityOfOrigin",
+                table: "Students",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CityOfResidence",
+                table: "Students",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CountryOfOrigin",
+                table: "Students",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CountryOfResidence",
+                table: "Students",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                table: "Students",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsCorporate",
+                table: "Students",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "OfficialCefrLevel",
+                table: "Students",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Profession",
+                table: "Students",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Rate",
+                table: "Students",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ReasonForStudying",
+                table: "Students",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShortTermObjectives",
+                table: "Students",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "SpokenLanguages",
+                table: "Students",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BirthYear",
+                table: "Students");
+
+            migrationBuilder.DropColumn(
+                name: "CityOfOrigin",
+                table: "Students");
+
+            migrationBuilder.DropColumn(
+                name: "CityOfResidence",
+                table: "Students");
+
+            migrationBuilder.DropColumn(
+                name: "CountryOfOrigin",
+                table: "Students");
+
+            migrationBuilder.DropColumn(
+                name: "CountryOfResidence",
+                table: "Students");
+
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                table: "Students");
+
+            migrationBuilder.DropColumn(
+                name: "IsCorporate",
+                table: "Students");
+
+            migrationBuilder.DropColumn(
+                name: "OfficialCefrLevel",
+                table: "Students");
+
+            migrationBuilder.DropColumn(
+                name: "Profession",
+                table: "Students");
+
+            migrationBuilder.DropColumn(
+                name: "Rate",
+                table: "Students");
+
+            migrationBuilder.DropColumn(
+                name: "ReasonForStudying",
+                table: "Students");
+
+            migrationBuilder.DropColumn(
+                name: "ShortTermObjectives",
+                table: "Students");
+
+            migrationBuilder.DropColumn(
+                name: "SpokenLanguages",
+                table: "Students");
+        }
+    }
+}

--- a/backend/LangTeach.Api/Migrations/20260410031048_AddStudentProfileFields.cs
+++ b/backend/LangTeach.Api/Migrations/20260410031048_AddStudentProfileFields.cs
@@ -45,7 +45,7 @@ namespace LangTeach.Api.Migrations
                 table: "Students",
                 type: "bit",
                 nullable: false,
-                defaultValue: false);
+                defaultValue: true);
 
             migrationBuilder.AddColumn<bool>(
                 name: "IsCorporate",

--- a/backend/LangTeach.Api/Migrations/20260410031048_AddStudentProfileFields.cs
+++ b/backend/LangTeach.Api/Migrations/20260410031048_AddStudentProfileFields.cs
@@ -83,14 +83,14 @@ namespace LangTeach.Api.Migrations
                 table: "Students",
                 type: "nvarchar(max)",
                 nullable: false,
-                defaultValue: "");
+                defaultValue: "[]");
 
             migrationBuilder.AddColumn<string>(
                 name: "SpokenLanguages",
                 table: "Students",
                 type: "nvarchar(max)",
                 nullable: false,
-                defaultValue: "");
+                defaultValue: "[]");
         }
 
         /// <inheritdoc />

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -87,6 +87,8 @@ public class StudentService : IStudentService
         ValidateWeaknesses(normalizedWeaknessesCreate);
         ValidateDifficulties(request.Difficulties);
         var normalizedDifficulties = NormalizeSystemFields(request.Difficulties);
+        ValidateBirthYear(request.BirthYear);
+        ValidateShortTermObjectives(request.ShortTermObjectives);
 
         var student = new Student
         {
@@ -101,6 +103,19 @@ public class StudentService : IStudentService
             Weaknesses = Serialize(normalizedWeaknessesCreate),
             Difficulties = Serialize(normalizedDifficulties),
             Notes = request.Notes,
+            BirthYear = request.BirthYear,
+            Profession = request.Profession,
+            CountryOfOrigin = request.CountryOfOrigin,
+            CityOfOrigin = request.CityOfOrigin,
+            CountryOfResidence = request.CountryOfResidence,
+            CityOfResidence = request.CityOfResidence,
+            ReasonForStudying = request.ReasonForStudying,
+            OfficialCefrLevel = request.OfficialCefrLevel,
+            ShortTermObjectives = Serialize(request.ShortTermObjectives),
+            IsActive = request.IsActive,
+            IsCorporate = request.IsCorporate,
+            Rate = request.Rate,
+            SpokenLanguages = Serialize(request.SpokenLanguages),
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow,
         };
@@ -126,6 +141,8 @@ public class StudentService : IStudentService
         ValidateWeaknesses(normalizedWeaknessesUpdate);
         ValidateDifficulties(request.Difficulties);
         var normalizedDifficulties = NormalizeSystemFields(request.Difficulties);
+        ValidateBirthYear(request.BirthYear);
+        ValidateShortTermObjectives(request.ShortTermObjectives);
 
         student.Name = request.Name;
         student.LearningLanguage = request.LearningLanguage;
@@ -136,6 +153,19 @@ public class StudentService : IStudentService
         student.Weaknesses = Serialize(normalizedWeaknessesUpdate);
         student.Difficulties = Serialize(normalizedDifficulties);
         student.Notes = request.Notes;
+        student.BirthYear = request.BirthYear;
+        student.Profession = request.Profession;
+        student.CountryOfOrigin = request.CountryOfOrigin;
+        student.CityOfOrigin = request.CityOfOrigin;
+        student.CountryOfResidence = request.CountryOfResidence;
+        student.CityOfResidence = request.CityOfResidence;
+        student.ReasonForStudying = request.ReasonForStudying;
+        student.OfficialCefrLevel = request.OfficialCefrLevel;
+        student.ShortTermObjectives = Serialize(request.ShortTermObjectives);
+        student.IsActive = request.IsActive;
+        student.IsCorporate = request.IsCorporate;
+        student.Rate = request.Rate;
+        student.SpokenLanguages = Serialize(request.SpokenLanguages);
         student.UpdatedAt = DateTime.UtcNow;
 
         await _db.SaveChangesAsync(cancellationToken);
@@ -176,7 +206,20 @@ public class StudentService : IStudentService
             str => new StudentWeaknessDto(str, "grammatical")),
         JsonStorageHelper.DeserializeList<DifficultyDto>(s.Difficulties),
         s.CreatedAt,
-        s.UpdatedAt
+        s.UpdatedAt,
+        s.BirthYear,
+        s.Profession,
+        s.CountryOfOrigin,
+        s.CityOfOrigin,
+        s.CountryOfResidence,
+        s.CityOfResidence,
+        s.ReasonForStudying,
+        s.OfficialCefrLevel,
+        JsonStorageHelper.DeserializeList<ShortTermObjectiveDto>(s.ShortTermObjectives),
+        s.IsActive,
+        s.IsCorporate,
+        s.Rate,
+        JsonStorageHelper.DeserializeList<string>(s.SpokenLanguages)
     );
 
     private static List<StudentWeaknessDto> NormalizeWeaknesses(List<StudentWeaknessDto> weaknesses) =>
@@ -197,6 +240,25 @@ public class StudentService : IStudentService
     {
         if (nativeLanguage is not null && !AllowedNativeLanguages.Contains(nativeLanguage))
             throw new ValidationException($"NativeLanguage '{nativeLanguage}' is not in the allowed list.");
+    }
+
+    private static void ValidateBirthYear(int? birthYear)
+    {
+        if (birthYear is null) return;
+        var currentYear = DateTime.UtcNow.Year;
+        if (birthYear < 1920 || birthYear > currentYear)
+            throw new ValidationException($"BirthYear must be between 1920 and {currentYear}.");
+    }
+
+    private static void ValidateShortTermObjectives(List<ShortTermObjectiveDto> objectives)
+    {
+        foreach (var o in objectives)
+        {
+            if (string.IsNullOrWhiteSpace(o.Id) || o.Id.Length > 50)
+                throw new ValidationException("Each ShortTermObjective must have an Id (max 50 characters).");
+            if (string.IsNullOrWhiteSpace(o.Text) || o.Text.Length > 200)
+                throw new ValidationException("Each ShortTermObjective Text must be between 1 and 200 characters.");
+        }
     }
 
     private static void ValidateDifficulties(List<DifficultyDto> difficulties)

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -252,6 +252,8 @@ public class StudentService : IStudentService
 
     private static void ValidateShortTermObjectives(List<ShortTermObjectiveDto> objectives)
     {
+        if (objectives.Count > 10)
+            throw new ValidationException("ShortTermObjectives cannot contain more than 10 entries.");
         foreach (var o in objectives)
         {
             if (string.IsNullOrWhiteSpace(o.Id) || o.Id.Length > 50)

--- a/plan/langteach-beta/task625-student-profile-backend.md
+++ b/plan/langteach-beta/task625-student-profile-backend.md
@@ -1,0 +1,73 @@
+# Task 625: Student Profile Additive Scalar Fields (Backend Prep)
+
+## Goal
+
+Add ~15 new columns to `Student`, expose via DTOs, validate, seed, and unit-test JSON round-trips.
+
+## Files to change
+
+| File | Change |
+|------|--------|
+| `backend/LangTeach.Api/Data/Models/Student.cs` | Add 15 new properties |
+| `backend/LangTeach.Api/DTOs/ShortTermObjectiveDto.cs` | New record |
+| `backend/LangTeach.Api/DTOs/StudentDto.cs` | Add all new fields |
+| `backend/LangTeach.Api/DTOs/CreateStudentRequest.cs` | Add new fields + validation |
+| `backend/LangTeach.Api/DTOs/UpdateStudentRequest.cs` | Add new fields + validation |
+| `backend/LangTeach.Api/Services/StudentService.cs` | MapToDto, Create, Update |
+| `backend/LangTeach.Api/Data/DemoSeeder.cs` | Populate Ana and Diego new fields |
+| `backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs` | JSON round-trip tests |
+| EF Migration | `dotnet ef migrations add AddStudentProfileFields` |
+
+## New fields
+
+### Identity (nullable, no default)
+- `BirthYear` (int?)
+- `Profession` (string?, max 128)
+- `CountryOfOrigin` (string?, max 64)
+- `CityOfOrigin` (string?, max 64)
+- `CountryOfResidence` (string?, max 64)
+- `CityOfResidence` (string?, max 64)
+- `ReasonForStudying` (string?, max 512)
+
+### Level
+- `OfficialCefrLevel` (string?, nullable, validated as CEFR or null)
+
+### Plan (JSON, NOT NULL, default "[]")
+- `ShortTermObjectives` (string JSON) -> exposed as `List<ShortTermObjectiveDto>`
+- `ShortTermObjectiveDto`: `{ Id: string, Text: string, TargetDate: DateOnly? }`
+
+### Commercial
+- `IsActive` (bool, NOT NULL, default true)
+- `IsCorporate` (bool, NOT NULL, default false)
+- `Rate` (string?, max 32)
+
+### Languages (JSON, NOT NULL, default "[]")
+- `SpokenLanguages` (string JSON) -> exposed as `List<string>`
+
+## Validation
+
+- `BirthYear`: range 1920..current year
+- `Rate`: max 32 chars
+- `ShortTermObjectives`: max 10 entries; each Id max 50, Text max 200
+- `OfficialCefrLevel`: null or one of A1,A2,B1,B2,C1,C2
+- String fields: max-length annotations
+
+## List endpoint
+
+`GET /api/students` must project `IsActive`, `IsCorporate`, `Rate` (already in `StudentDto` which is used for both list and detail).
+
+## Seeder updates
+
+Ana Seed: add profession, countryOfOrigin, isActive, spokenLanguages, shortTermObjectives
+Diego Seed: add rate, isCorporate, isActive, shortTermObjectives
+
+## Tests
+
+Unit tests in `StudentServiceTests.cs` for:
+1. Create with ShortTermObjectives -> round-trip returns same list
+2. Update clears objectives to empty list
+3. Create with SpokenLanguages -> round-trip
+
+## Migration
+
+Run `dotnet ef migrations add AddStudentProfileFields --project backend/LangTeach.Api --startup-project backend/LangTeach.Api` after entity changes.


### PR DESCRIPTION
## Summary
- Adds 15 new columns to `Student` (identity, level, plan, commercial, language fields) with one EF migration
- Extends `StudentDto`, `CreateStudentRequest`, `UpdateStudentRequest` with all new fields and validation
- New `ShortTermObjectiveDto` record for JSON-serialized objectives
- `DemoSeeder` populates Ana Seed and Diego Seed with meaningful new field data
- Unit tests cover ShortTermObjectives/SpokenLanguages round-trips, GetById/List returning new fields, and validation edge cases

## Test plan
- [x] `task-build-verify.py` passes (dotnet build, dotnet test, npm build, npm lint, npm test)
- [x] qa-verify: PASS
- [x] code-review: PASS (fixed IsActive migration default bug, added validation tests)
- [x] architecture-reviewer: PASS (fixed BirthYear dual-layer validation)

Closes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded student profiles with additional biographical and professional information (birth year, profession, origin and residence details, reason for studying).
  * Added support for tracking student short-term objectives (up to 10 per student) with target dates.
  * Introduced spoken languages tracking (up to 20 languages per student).
  * Added student status indicators (active/inactive, corporate flag) and rate information.
  * Integrated official CEFR level field for enhanced proficiency tracking.

* **Tests**
  * Added comprehensive test coverage for new student profile fields and validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->