### PR TITLE
feat: student TeachingTodos field - backend prep (#627)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs
@@ -240,4 +240,124 @@ public class StudentServiceTests : IDisposable
 
         await act.Should().ThrowAsync<ValidationException>();
     }
+
+    // TeachingTodos tests
+
+    private static TeachingTodoDto MakeTodo(string id, string text = "Work on ser/estar", string status = "pending") =>
+        new(id, text, DateTime.UtcNow, null, status, null);
+
+    [Fact]
+    public async Task TeachingTodos_JsonRoundTrip_Succeeds()
+    {
+        var created = await _sut.CreateAsync(_teacherId, BaseRequest());
+        var updateRequest = new UpdateStudentRequest
+        {
+            Name = created.Name,
+            LearningLanguage = created.LearningLanguage,
+            CefrLevel = created.CefrLevel,
+            TeachingTodos = [MakeTodo("todo-1", "Repasar pretérito"), MakeTodo("todo-2", "Artículo determinado")],
+        };
+
+        var updated = await _sut.UpdateAsync(_teacherId, created.Id, updateRequest);
+
+        updated!.TeachingTodos.Should().HaveCount(2);
+        updated.TeachingTodos[0].Id.Should().Be("todo-1");
+        updated.TeachingTodos[0].Text.Should().Be("Repasar pretérito");
+        updated.TeachingTodos[1].Id.Should().Be("todo-2");
+    }
+
+    [Fact]
+    public async Task TeachingTodos_StatusTransition_Covered_Succeeds()
+    {
+        var created = await _sut.CreateAsync(_teacherId, BaseRequest());
+        await _sut.UpdateAsync(_teacherId, created.Id, new UpdateStudentRequest
+        {
+            Name = created.Name, LearningLanguage = created.LearningLanguage, CefrLevel = created.CefrLevel,
+            TeachingTodos = [MakeTodo("todo-1")],
+        });
+
+        var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "todo-1", new UpdateTeachingTodoDto("covered", null));
+
+        result!.TeachingTodos.Single().Status.Should().Be("covered");
+    }
+
+    [Fact]
+    public async Task TeachingTodos_StatusTransition_Dismissed_Succeeds()
+    {
+        var created = await _sut.CreateAsync(_teacherId, BaseRequest());
+        await _sut.UpdateAsync(_teacherId, created.Id, new UpdateStudentRequest
+        {
+            Name = created.Name, LearningLanguage = created.LearningLanguage, CefrLevel = created.CefrLevel,
+            TeachingTodos = [MakeTodo("todo-1")],
+        });
+
+        var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "todo-1", new UpdateTeachingTodoDto("dismissed", null));
+
+        result!.TeachingTodos.Single().Status.Should().Be("dismissed");
+    }
+
+    [Fact]
+    public async Task TeachingTodos_MaxEnforced_ThrowsValidation()
+    {
+        var created = await _sut.CreateAsync(_teacherId, BaseRequest());
+        var todos = Enumerable.Range(1, 51).Select(i => MakeTodo($"t{i}", $"Todo {i}")).ToList();
+        var updateRequest = new UpdateStudentRequest
+        {
+            Name = created.Name, LearningLanguage = created.LearningLanguage, CefrLevel = created.CefrLevel,
+            TeachingTodos = todos,
+        };
+
+        var act = () => _sut.UpdateAsync(_teacherId, created.Id, updateRequest);
+
+        await act.Should().ThrowAsync<ValidationException>();
+    }
+
+    [Fact]
+    public async Task TeachingTodos_InvalidStatus_ThrowsValidation()
+    {
+        var created = await _sut.CreateAsync(_teacherId, BaseRequest());
+        var updateRequest = new UpdateStudentRequest
+        {
+            Name = created.Name, LearningLanguage = created.LearningLanguage, CefrLevel = created.CefrLevel,
+            TeachingTodos = [MakeTodo("todo-1", "Some text", "invalid-status")],
+        };
+
+        var act = () => _sut.UpdateAsync(_teacherId, created.Id, updateRequest);
+
+        await act.Should().ThrowAsync<ValidationException>();
+    }
+
+    [Fact]
+    public async Task UpdateTeachingTodoAsync_UnknownTodoId_ReturnsNull()
+    {
+        var created = await _sut.CreateAsync(_teacherId, BaseRequest());
+
+        var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "nonexistent-id", new UpdateTeachingTodoDto("covered", null));
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AppendTeachingTodoAsync_WrongTeacher_ReturnsNull()
+    {
+        var otherTeacherId = Guid.NewGuid();
+        var created = await _sut.CreateAsync(_teacherId, BaseRequest());
+
+        var result = await _sut.AppendTeachingTodoAsync(otherTeacherId, created.Id, new CreateTeachingTodoDto("Some text", null));
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AppendTeachingTodoAsync_AppendsEntryWithPendingStatus()
+    {
+        var created = await _sut.CreateAsync(_teacherId, BaseRequest());
+
+        var result = await _sut.AppendTeachingTodoAsync(_teacherId, created.Id, new CreateTeachingTodoDto("Trabajar ser/estar", null));
+
+        result!.TeachingTodos.Should().HaveCount(1);
+        result.TeachingTodos[0].Text.Should().Be("Trabajar ser/estar");
+        result.TeachingTodos[0].Status.Should().Be("pending");
+        result.TeachingTodos[0].Id.Should().NotBeNullOrEmpty();
+    }
 }

--- a/backend/LangTeach.Api/Controllers/StudentsController.cs
+++ b/backend/LangTeach.Api/Controllers/StudentsController.cs
@@ -127,6 +127,48 @@ public class StudentsController : ControllerBase
         return Ok(history);
     }
 
+    [HttpPost("{id:guid}/teaching-todos")]
+    public async Task<IActionResult> AppendTeachingTodo(Guid id, [FromBody] CreateTeachingTodoDto request, CancellationToken cancellationToken)
+    {
+        if (Auth0Id is null) return Unauthorized();
+        var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
+        try
+        {
+            var student = await _studentService.AppendTeachingTodoAsync(teacherId, id, request, cancellationToken);
+            if (student is null)
+            {
+                _logger.LogWarning("POST /api/students/{StudentId}/teaching-todos not found or forbidden. TeacherId={TeacherId}", id, teacherId);
+                return NotFound();
+            }
+            return Ok(student);
+        }
+        catch (System.ComponentModel.DataAnnotations.ValidationException ex)
+        {
+            return ValidationProblem(ex.Message);
+        }
+    }
+
+    [HttpPatch("{id:guid}/teaching-todos/{todoId}")]
+    public async Task<IActionResult> UpdateTeachingTodo(Guid id, string todoId, [FromBody] UpdateTeachingTodoDto request, CancellationToken cancellationToken)
+    {
+        if (Auth0Id is null) return Unauthorized();
+        var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
+        try
+        {
+            var student = await _studentService.UpdateTeachingTodoAsync(teacherId, id, todoId, request, cancellationToken);
+            if (student is null)
+            {
+                _logger.LogWarning("PATCH /api/students/{StudentId}/teaching-todos/{TodoId} not found or forbidden. TeacherId={TeacherId}", id, todoId, teacherId);
+                return NotFound();
+            }
+            return Ok(student);
+        }
+        catch (System.ComponentModel.DataAnnotations.ValidationException ex)
+        {
+            return ValidationProblem(ex.Message);
+        }
+    }
+
     [HttpDelete("{id:guid}")]
     public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {

--- a/backend/LangTeach.Api/DTOs/CreateStudentRequest.cs
+++ b/backend/LangTeach.Api/DTOs/CreateStudentRequest.cs
@@ -80,4 +80,8 @@ public class CreateStudentRequest
     [MaxCollectionCount(20)]
     [MaxStringLengthEach(64)]
     public List<string> SpokenLanguages { get; set; } = [];
+
+    // Teaching fields
+    [MaxCollectionCount(50)]
+    public List<TeachingTodoDto> TeachingTodos { get; set; } = [];
 }

--- a/backend/LangTeach.Api/DTOs/StudentDto.cs
+++ b/backend/LangTeach.Api/DTOs/StudentDto.cs
@@ -31,5 +31,7 @@ public record StudentDto(
     bool IsCorporate,
     string? Rate,
     // Language fields
-    List<string> SpokenLanguages
+    List<string> SpokenLanguages,
+    // Teaching fields
+    List<TeachingTodoDto> TeachingTodos
 );

--- a/backend/LangTeach.Api/DTOs/TeachingTodoDto.cs
+++ b/backend/LangTeach.Api/DTOs/TeachingTodoDto.cs
@@ -1,0 +1,13 @@
+namespace LangTeach.Api.DTOs;
+
+public record TeachingTodoDto(
+    string Id,
+    string Text,
+    DateTime CreatedAt,
+    string? SourceSessionLogId,
+    string Status,
+    string? CoveredInSessionLogId);
+
+public record CreateTeachingTodoDto(string Text, string? SourceSessionLogId);
+
+public record UpdateTeachingTodoDto(string Status, string? CoveredInSessionLogId);

--- a/backend/LangTeach.Api/DTOs/TeachingTodoDto.cs
+++ b/backend/LangTeach.Api/DTOs/TeachingTodoDto.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace LangTeach.Api.DTOs;
 
 public record TeachingTodoDto(
@@ -8,6 +10,10 @@ public record TeachingTodoDto(
     string Status,
     string? CoveredInSessionLogId);
 
-public record CreateTeachingTodoDto(string Text, string? SourceSessionLogId);
+public record CreateTeachingTodoDto(
+    [MaxLength(500)] string Text,
+    string? SourceSessionLogId);
 
-public record UpdateTeachingTodoDto(string Status, string? CoveredInSessionLogId);
+public record UpdateTeachingTodoDto(
+    [Required] string Status,
+    string? CoveredInSessionLogId);

--- a/backend/LangTeach.Api/DTOs/UpdateStudentRequest.cs
+++ b/backend/LangTeach.Api/DTOs/UpdateStudentRequest.cs
@@ -80,4 +80,8 @@ public class UpdateStudentRequest
     [MaxCollectionCount(20)]
     [MaxStringLengthEach(64)]
     public List<string> SpokenLanguages { get; set; } = [];
+
+    // Teaching fields
+    [MaxCollectionCount(50)]
+    public List<TeachingTodoDto> TeachingTodos { get; set; } = [];
 }

--- a/backend/LangTeach.Api/Data/DemoSeeder.cs
+++ b/backend/LangTeach.Api/Data/DemoSeeder.cs
@@ -46,7 +46,7 @@ public static class DemoSeeder
 
         var students = new List<Student>
         {
-            new() { Id = Guid.NewGuid(), TeacherId = teacher.Id, Name = "Ana Souza",        LearningLanguage = "English", CefrLevel = "B2", Interests = """["travel","cooking"]""",    PersonalNotes = DemoTag, CreatedAt = now, UpdatedAt = now },
+            new() { Id = Guid.NewGuid(), TeacherId = teacher.Id, Name = "Ana Souza",        LearningLanguage = "English", CefrLevel = "B2", Interests = """["travel","cooking"]""",    PersonalNotes = DemoTag, TeachingTodos = """[{"id":"a1b2c3d4-0000-0000-0000-000000000001","text":"Trabajar la diferencia entre artículo determinado e indeterminado","createdAt":"2026-04-09T10:00:00Z","sourceSessionLogId":null,"status":"pending","coveredInSessionLogId":null},{"id":"a1b2c3d4-0000-0000-0000-000000000002","text":"Repasar pretérito en narraciones personales","createdAt":"2026-04-09T10:05:00Z","sourceSessionLogId":null,"status":"pending","coveredInSessionLogId":null}]""", CreatedAt = now, UpdatedAt = now },
             new() { Id = Guid.NewGuid(), TeacherId = teacher.Id, Name = "Marco Rossi",      LearningLanguage = "English", CefrLevel = "A2", Interests = """["football","music"]""",    PersonalNotes = DemoTag, CreatedAt = now, UpdatedAt = now },
             new() { Id = Guid.NewGuid(), TeacherId = teacher.Id, Name = "Yuki Tanaka",      LearningLanguage = "English", CefrLevel = "B1", Interests = """["technology","anime"]""",  PersonalNotes = DemoTag, CreatedAt = now, UpdatedAt = now },
             new() { Id = Guid.NewGuid(), TeacherId = teacher.Id, Name = "Fatima Al-Hassan", LearningLanguage = "English", CefrLevel = "C1", Interests = """["literature","history"]""", PersonalNotes = DemoTag, CreatedAt = now, UpdatedAt = now },

--- a/backend/LangTeach.Api/Data/Models/Student.cs
+++ b/backend/LangTeach.Api/Data/Models/Student.cs
@@ -29,6 +29,7 @@ public class Student
 
     // Plan fields
     public string ShortTermObjectives { get; set; } = "[]";
+    public string TeachingTodos { get; set; } = "[]";
 
     // Commercial fields
     public bool IsActive { get; set; } = true;

--- a/backend/LangTeach.Api/Migrations/20260410081359_AddTeachingTodos.Designer.cs
+++ b/backend/LangTeach.Api/Migrations/20260410081359_AddTeachingTodos.Designer.cs
@@ -4,6 +4,7 @@ using LangTeach.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LangTeach.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410081359_AddTeachingTodos")]
+    partial class AddTeachingTodos
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/LangTeach.Api/Migrations/20260410081359_AddTeachingTodos.cs
+++ b/backend/LangTeach.Api/Migrations/20260410081359_AddTeachingTodos.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LangTeach.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTeachingTodos : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "TeachingTodos",
+                table: "Students",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TeachingTodos",
+                table: "Students");
+        }
+    }
+}

--- a/backend/LangTeach.Api/Services/IStudentService.cs
+++ b/backend/LangTeach.Api/Services/IStudentService.cs
@@ -9,4 +9,6 @@ public interface IStudentService
     Task<StudentDto> CreateAsync(Guid teacherId, CreateStudentRequest request, CancellationToken cancellationToken = default);
     Task<StudentDto?> UpdateAsync(Guid teacherId, Guid studentId, UpdateStudentRequest request, CancellationToken cancellationToken = default);
     Task<bool> DeleteAsync(Guid teacherId, Guid studentId, CancellationToken cancellationToken = default);
+    Task<StudentDto?> AppendTeachingTodoAsync(Guid teacherId, Guid studentId, CreateTeachingTodoDto request, CancellationToken cancellationToken = default);
+    Task<StudentDto?> UpdateTeachingTodoAsync(Guid teacherId, Guid studentId, string todoId, UpdateTeachingTodoDto request, CancellationToken cancellationToken = default);
 }

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -31,6 +31,11 @@ public class StudentService : IStudentService
         "Active", "Covered"
     ];
 
+    private static readonly HashSet<string> AllowedTodoStatuses =
+    [
+        "pending", "covered", "dismissed"
+    ];
+
     private static readonly HashSet<string> AllowedWeaknessTypes =
         new(StringComparer.OrdinalIgnoreCase) { "grammatical", "lexical", "orthographic" };
 
@@ -89,6 +94,7 @@ public class StudentService : IStudentService
         var normalizedDifficulties = NormalizeSystemFields(request.Difficulties);
         ValidateBirthYear(request.BirthYear);
         ValidateShortTermObjectives(request.ShortTermObjectives);
+        ValidateTeachingTodos(request.TeachingTodos);
 
         var student = new Student
         {
@@ -113,6 +119,7 @@ public class StudentService : IStudentService
             ReasonForStudying = request.ReasonForStudying,
             OfficialCefrLevel = request.OfficialCefrLevel,
             ShortTermObjectives = Serialize(request.ShortTermObjectives),
+            TeachingTodos = Serialize(request.TeachingTodos),
             IsActive = request.IsActive,
             IsCorporate = request.IsCorporate,
             Rate = request.Rate,
@@ -144,6 +151,7 @@ public class StudentService : IStudentService
         var normalizedDifficulties = NormalizeSystemFields(request.Difficulties);
         ValidateBirthYear(request.BirthYear);
         ValidateShortTermObjectives(request.ShortTermObjectives);
+        ValidateTeachingTodos(request.TeachingTodos);
 
         student.Name = request.Name;
         student.LearningLanguage = request.LearningLanguage;
@@ -164,6 +172,7 @@ public class StudentService : IStudentService
         student.ReasonForStudying = request.ReasonForStudying;
         student.OfficialCefrLevel = request.OfficialCefrLevel;
         student.ShortTermObjectives = Serialize(request.ShortTermObjectives);
+        student.TeachingTodos = Serialize(request.TeachingTodos);
         student.IsActive = request.IsActive;
         student.IsCorporate = request.IsCorporate;
         student.Rate = request.Rate;
@@ -222,7 +231,8 @@ public class StudentService : IStudentService
         s.IsActive,
         s.IsCorporate,
         s.Rate,
-        JsonStorageHelper.DeserializeList<string>(s.SpokenLanguages)
+        JsonStorageHelper.DeserializeList<string>(s.SpokenLanguages),
+        JsonStorageHelper.DeserializeList<TeachingTodoDto>(s.TeachingTodos)
     );
 
     private static List<StudentWeaknessDto> NormalizeWeaknesses(List<StudentWeaknessDto> weaknesses) =>
@@ -299,6 +309,82 @@ public class StudentService : IStudentService
     // so the server is always authoritative after the next session log confirm.
     private static List<DifficultyDto> NormalizeSystemFields(List<DifficultyDto> difficulties) =>
         difficulties.Select(d => d with { Trend = "stable" }).ToList();
+
+    public async Task<StudentDto?> AppendTeachingTodoAsync(Guid teacherId, Guid studentId, CreateTeachingTodoDto request, CancellationToken cancellationToken = default)
+    {
+        var student = await _db.Students
+            .FirstOrDefaultAsync(s => s.Id == studentId && s.TeacherId == teacherId && !s.IsDeleted, cancellationToken);
+
+        if (student is null)
+            return null;
+
+        var todos = JsonStorageHelper.DeserializeList<TeachingTodoDto>(student.TeachingTodos);
+
+        if (todos.Count >= 50)
+            throw new ValidationException("Cannot have more than 50 teaching todos.");
+
+        if (string.IsNullOrWhiteSpace(request.Text) || request.Text.Length > 500)
+            throw new ValidationException("Todo text must be between 1 and 500 characters.");
+
+        var newTodo = new TeachingTodoDto(
+            Guid.NewGuid().ToString(),
+            request.Text,
+            DateTime.UtcNow,
+            request.SourceSessionLogId,
+            "pending",
+            null);
+
+        todos.Add(newTodo);
+        student.TeachingTodos = Serialize(todos);
+        student.UpdatedAt = DateTime.UtcNow;
+
+        await _db.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("Teaching todo appended. TeacherId={TeacherId} StudentId={StudentId} TodoId={TodoId}",
+            teacherId, student.Id, newTodo.Id);
+
+        return MapToDto(student);
+    }
+
+    public async Task<StudentDto?> UpdateTeachingTodoAsync(Guid teacherId, Guid studentId, string todoId, UpdateTeachingTodoDto request, CancellationToken cancellationToken = default)
+    {
+        var student = await _db.Students
+            .FirstOrDefaultAsync(s => s.Id == studentId && s.TeacherId == teacherId && !s.IsDeleted, cancellationToken);
+
+        if (student is null)
+            return null;
+
+        if (!AllowedTodoStatuses.Contains(request.Status))
+            throw new ValidationException($"Todo status '{request.Status}' is not valid. Allowed: {string.Join(", ", AllowedTodoStatuses)}.");
+
+        var todos = JsonStorageHelper.DeserializeList<TeachingTodoDto>(student.TeachingTodos);
+        var index = todos.FindIndex(t => t.Id == todoId);
+
+        if (index < 0)
+            return null;
+
+        todos[index] = todos[index] with { Status = request.Status, CoveredInSessionLogId = request.CoveredInSessionLogId };
+        student.TeachingTodos = Serialize(todos);
+        student.UpdatedAt = DateTime.UtcNow;
+
+        await _db.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("Teaching todo updated. TeacherId={TeacherId} StudentId={StudentId} TodoId={TodoId} Status={Status}",
+            teacherId, student.Id, todoId, request.Status);
+
+        return MapToDto(student);
+    }
+
+    private static void ValidateTeachingTodos(List<TeachingTodoDto> todos)
+    {
+        if (todos.Count > 50)
+            throw new ValidationException("TeachingTodos cannot contain more than 50 entries.");
+        foreach (var t in todos)
+        {
+            if (string.IsNullOrWhiteSpace(t.Text) || t.Text.Length > 500)
+                throw new ValidationException("Each teaching todo Text must be between 1 and 500 characters.");
+            if (string.IsNullOrWhiteSpace(t.Status) || !AllowedTodoStatuses.Contains(t.Status))
+                throw new ValidationException($"Teaching todo status '{t.Status}' is not valid. Allowed: {string.Join(", ", AllowedTodoStatuses)}.");
+        }
+    }
 
     private static string Serialize<T>(List<T> list) =>
         JsonStorageHelper.Serialize(list);

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -377,8 +377,13 @@ public class StudentService : IStudentService
     {
         if (todos.Count > 50)
             throw new ValidationException("TeachingTodos cannot contain more than 50 entries.");
+        var seenIds = new HashSet<string>(StringComparer.Ordinal);
         foreach (var t in todos)
         {
+            if (string.IsNullOrWhiteSpace(t.Id) || t.Id.Length > 100)
+                throw new ValidationException("Each teaching todo must have an Id (max 100 characters).");
+            if (!seenIds.Add(t.Id))
+                throw new ValidationException($"Duplicate teaching todo Id '{t.Id}'.");
             if (string.IsNullOrWhiteSpace(t.Text) || t.Text.Length > 500)
                 throw new ValidationException("Each teaching todo Text must be between 1 and 500 characters.");
             if (string.IsNullOrWhiteSpace(t.Status) || !AllowedTodoStatuses.Contains(t.Status))

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -19,3 +19,12 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 | review | minor | `TelegramBotService.DownloadFileAsync:45` interpolates Telegram-supplied `file_path` into a URL without `Uri.EscapeDataString`. Defensive only — Telegram's documented file_path format is safe. |
 | architecture-reviewer | minor | `TelegramBotServiceTests.cs` uses static `BuildService` factory instead of constructor + `IDisposable` (sibling pattern in `VoiceNoteServiceTests`/`TelegramConversationServiceTests`). Matches the closer reference `ClaudeApiClientUnitTests.cs`, which also uses a static `BuildClient` factory for HttpClient-based service tests. No cleanup needed. |
 
+
+## #627 — 2026-04-10
+
+| Reviewer | Severity | Note |
+|---|---|---|
+| review | minor | `AllowedTodoStatuses` uses case-sensitive comparer. Client sending `"Pending"` gets a validation error. Consistent with `AllowedStatuses` (difficulties) which also omits `OrdinalIgnoreCase`. |
+| architecture-reviewer | minor | Same case-sensitivity note as above. |
+| Sophy | minor | Dual mutation path (PUT full-replace + POST/PATCH sub-resource) -- intentional per issue spec. Sophy asked to document intent. Both paths are valid: PUT for import/sync, POST/PATCH for incremental UI. |
+| Sophy | info | `UpdateTeachingTodoAsync` returns null for both student-not-found and todo-not-found; controller maps both to 404. Minor ambiguity for callers; consistent with existing not-found handling. |

--- a/plan/langteach-beta/task627-teaching-todos-backend.md
+++ b/plan/langteach-beta/task627-teaching-todos-backend.md
@@ -1,0 +1,130 @@
+# Task 627: Student TeachingTodos field (backend prep)
+
+## Issue
+https://github.com/Robert-Freire/langTeachSaaS/issues/627
+
+## Goal
+Add a `TeachingTodos` JSON column to `Student`, expose it via the existing GET/PUT `/api/students/{id}` endpoints, and add convenience POST/PATCH sub-resource endpoints for append and status update.
+
+## JSON shape (stored on Student)
+```json
+[
+  {
+    "id": "uuid",
+    "text": "Trabajar ser/estar en contextos de pasado",
+    "createdAt": "2026-04-09T10:15:00Z",
+    "sourceSessionLogId": "uuid-or-null",
+    "status": "pending",
+    "coveredInSessionLogId": null
+  }
+]
+```
+Status values: `pending | covered | dismissed`
+
+## Implementation steps
+
+### 1. DTOs
+Create `backend/LangTeach.Api/DTOs/TeachingTodoDto.cs`:
+```csharp
+public record TeachingTodoDto(
+    string Id,
+    string Text,
+    DateTime CreatedAt,
+    string? SourceSessionLogId,
+    string Status,
+    string? CoveredInSessionLogId);
+
+public record CreateTeachingTodoDto(string Text, string? SourceSessionLogId);
+
+public record UpdateTeachingTodoDto(string Status, string? CoveredInSessionLogId);
+```
+
+### 2. Student model
+Add to `Student.cs`:
+```csharp
+public string TeachingTodos { get; set; } = "[]";
+```
+
+### 3. EF migration
+Run:
+```bash
+dotnet ef migrations add AddTeachingTodos --project backend/LangTeach.Api --startup-project backend/LangTeach.Api
+```
+Migration sets NOT NULL default `'[]'`.
+
+### 4. StudentDto
+Append `List<TeachingTodoDto> TeachingTodos` as the **last parameter** of the positional record (after `SpokenLanguages`). Update `MapToDto` to pass `JsonStorageHelper.DeserializeList<TeachingTodoDto>(s.TeachingTodos)` as the final argument.
+
+### 5. StudentService
+- `MapToDto`: add `JsonStorageHelper.DeserializeList<TeachingTodoDto>(s.TeachingTodos)`
+- `CreateAsync`: initialize `TeachingTodos = "[]"` (already default, but explicit for clarity)
+- `UpdateAsync`: accept `TeachingTodos` from request (full replacement), validate max 50 entries and each `Text` non-empty, length <= 500; validate `Status` is one of `pending | covered | dismissed`
+- Add `ValidateTeachingTodos(List<TeachingTodoDto> todos)` private method
+- Add `IStudentService` method stubs: `AppendTeachingTodoAsync`, `UpdateTeachingTodoAsync`
+- Implement both in `StudentService`:
+  - `AppendTeachingTodoAsync(teacherId, studentId, CreateTeachingTodoDto)`: deserialize current list, append new entry with generated Guid + UtcNow + status=pending, enforce max 50, save, return updated StudentDto
+  - `UpdateTeachingTodoAsync(teacherId, studentId, todoId, UpdateTeachingTodoDto)`: find todo by id (return null if not found -- controller returns 404), update status and coveredInSessionLogId, validate status is one of the allowed values, save, return updated StudentDto
+  - On full PUT replacement (UpdateAsync), caller-supplied `Id` values in `TeachingTodos` are trusted as-is (same as `ShortTermObjectives`). Do NOT regenerate IDs.
+
+### 6. CreateStudentRequest / UpdateStudentRequest
+Add to both:
+```csharp
+[MaxCollectionCount(50)]
+public List<TeachingTodoDto> TeachingTodos { get; set; } = [];
+```
+
+### 7. StudentsController
+Add two new endpoints:
+```
+POST  /api/students/{id}/teaching-todos        -> AppendTeachingTodoAsync
+PATCH /api/students/{id}/teaching-todos/{todoId} -> UpdateTeachingTodoAsync
+```
+
+### 8. DemoSeeder
+Add 2-3 teaching todos to Ana Souza seed student:
+- "Trabajar la diferencia entre artículo determinado e indeterminado"
+- "Repasar pretérito en narraciones personales"
+- "Practicar ser/estar en descripciones" (optional third)
+
+Set the `TeachingTodos` JSON column directly in the Ana Souza `new()` inline initializer (line 49 of DemoSeeder.cs), since the student is constructed inside a collection initializer. Post-construction assignment is not possible there. Use a raw JSON string literal identical to the shape above.
+
+### 9. Unit tests
+In `LangTeach.Api.Tests/Services/StudentServiceTests.cs`, add:
+- `TeachingTodo_JsonRoundTrip_Succeeds` -- create student with todos via UpdateAsync, GetById returns correct deserialized list
+- `TeachingTodo_StatusTransition_Covered_Succeeds`
+- `TeachingTodo_StatusTransition_Dismissed_Succeeds`
+- `TeachingTodo_MaxEnforced_ThrowsValidation` -- 51 entries rejected
+- `TeachingTodo_InvalidStatus_ThrowsValidation`
+- `UpdateTeachingTodoAsync_UnknownTodoId_ReturnsNull` -- PATCH with non-existent todoId returns null (controller 404)
+- `AppendTeachingTodoAsync_WrongTeacher_ReturnsNull` -- auth boundary: different teacherId cannot append
+
+## Acceptance criteria checklist
+- [ ] EF migration adds `TeachingTodos` column (NOT NULL, default `[]`)
+- [ ] `GET /api/students/{id}` returns teaching todos array
+- [ ] `PUT /api/students/{id}` accepts full-replacement todos array
+- [ ] `POST /api/students/{id}/teaching-todos` appends a new todo
+- [ ] `PATCH /api/students/{id}/teaching-todos/{todoId}` updates status
+- [ ] `sourceSessionLogId` stored and returned (nullable, no FK constraint)
+- [ ] Seeder adds 2-3 todos for Ana Souza seed student
+- [ ] Unit tests: JSON round-trip, status transitions, max-50 enforcement
+- [ ] Max 50 entries validation enforced
+
+## Out of scope
+- Frontend UI (separate issues)
+- TeacherFollowup / dashboard bandeja (different entity)
+- dueHint / urgency field
+
+## Files to modify
+- `backend/LangTeach.Api/Data/Models/Student.cs`
+- `backend/LangTeach.Api/DTOs/StudentDto.cs`
+- `backend/LangTeach.Api/DTOs/CreateStudentRequest.cs`
+- `backend/LangTeach.Api/DTOs/UpdateStudentRequest.cs`
+- `backend/LangTeach.Api/Services/IStudentService.cs`
+- `backend/LangTeach.Api/Services/StudentService.cs`
+- `backend/LangTeach.Api/Controllers/StudentsController.cs`
+- `backend/LangTeach.Api/Data/DemoSeeder.cs`
+- `backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs`
+
+## Files to create
+- `backend/LangTeach.Api/DTOs/TeachingTodoDto.cs`
+- EF migration files (auto-generated)

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -4,5 +4,6 @@ Out-of-scope observations logged by agents during implementation. Each row is so
 
 | Source issue | Date | Severity | Observation |
 | #626 | 2026-04-10 | medium | DemoSeeder uses PersonalNotes as seed-detection marker; if teacher edits that field the seeder loses track and may create duplicates. Pre-existing pattern (was Notes before this PR). Should use a dedicated IsDemo flag or deterministic seed name matching. |
+| #627 | 2026-04-10 | low | CodeRabbit suggested validating sourceSessionLogId/coveredInSessionLogId against DB. Dismissed: issue spec explicitly chose soft-backlink (stored UUID, no FK), Sophy approved. If referential integrity becomes a requirement, it can be added later. |
 
 *Cleared 2026-04-08 during Adaptive Replanning sprint close. Actionable entries batched into #603 (DemoSeeder difficulties), #604 (StudentForm partial rows), #605 (VoiceNote MaxLength + AudioRecorder), #606 (exercises block cap), #607 (ExcelImporter date validation), #608 (trend thresholds config), #609 (e2e test hygiene). Remaining entries deleted (acceptable limitations, pre-existing patterns, or covered by previously filed issues).*


### PR DESCRIPTION
## Summary

- Adds `TeachingTodos` JSON column to `Student` (NOT NULL, default `[]`) via EF migration, following the same pattern as `ShortTermObjectives`
- Exposes teaching todos via `GET /api/students/{id}` and `PUT /api/students/{id}` (full replacement)
- Adds `POST /api/students/{id}/teaching-todos` (append) and `PATCH /api/students/{id}/teaching-todos/{todoId}` (status update)
- Validates: max 50 entries, text 1-500 chars, status `pending|covered|dismissed`, no duplicate IDs on PUT
- Seeds 2 example todos for Ana Souza in DemoSeeder

## Test plan

- [x] `dotnet test` -- 8 new unit tests (round-trip, status transitions, max-50, invalid status, unknown todo id, auth boundary, append)
- [x] Build verify PASS (dotnet, npm lint, npm build, npm test)
- [x] No conflicts with sprint branch

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added teaching todos management for student records.
  * Teachers can now create and update teaching todos with status tracking (pending, covered, dismissed).
  * Teaching todos support automatic timestamping and optional session log linking.
  * Enforced limit of 50 teaching todos per student with text length validation (max 500 characters).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->