### PR TITLE
feat: adopt Stitch sidebar design (#635)

### DIFF
--- a/e2e/tests/dashboard.spec.ts
+++ b/e2e/tests/dashboard.spec.ts
@@ -147,13 +147,17 @@ test('sidebar nav links navigate to correct routes', async ({ browser }) => {
   await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
   await expect(page.locator('h1')).toHaveText('Students', { timeout: UI_TIMEOUT })
 
+  // Nav -> Courses
+  await nav.getByRole('link', { name: 'Courses', exact: true }).click()
+  await expect(page).toHaveURL('/courses', { timeout: UI_TIMEOUT })
+
   // Nav -> Lessons
   await nav.getByRole('link', { name: 'Lessons', exact: true }).click()
   await expect(page).toHaveURL('/lessons', { timeout: UI_TIMEOUT })
   await expect(page.locator('h1')).toHaveText('Lessons', { timeout: UI_TIMEOUT })
 
-  // Nav -> My Profile
-  await nav.getByRole('link', { name: 'My Profile', exact: true }).click()
+  // Nav -> Settings
+  await nav.getByRole('link', { name: 'Settings', exact: true }).click()
   await expect(page).toHaveURL('/settings', { timeout: UI_TIMEOUT })
 
   // Nav -> Dashboard

--- a/e2e/tests/dashboard.spec.ts
+++ b/e2e/tests/dashboard.spec.ts
@@ -160,6 +160,7 @@ test('sidebar nav links navigate to correct routes', async ({ browser }) => {
   // Nav -> Settings
   await nav.getByRole('link', { name: 'Settings', exact: true }).click()
   await expect(page).toHaveURL('/settings', { timeout: UI_TIMEOUT })
+  await expect(page.locator('h1')).toHaveText('My Profile', { timeout: UI_TIMEOUT })
 
   // Nav -> Dashboard
   await nav.getByRole('link', { name: 'Dashboard', exact: true }).click()

--- a/e2e/tests/dashboard.spec.ts
+++ b/e2e/tests/dashboard.spec.ts
@@ -150,6 +150,7 @@ test('sidebar nav links navigate to correct routes', async ({ browser }) => {
   // Nav -> Courses
   await nav.getByRole('link', { name: 'Courses', exact: true }).click()
   await expect(page).toHaveURL('/courses', { timeout: UI_TIMEOUT })
+  await expect(page.locator('h1')).toHaveText('Courses', { timeout: UI_TIMEOUT })
 
   // Nav -> Lessons
   await nav.getByRole('link', { name: 'Lessons', exact: true }).click()

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LangTeach</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Manrope:wght@400;700;800&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,9 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LangTeach</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Manrope:wght@400;700;800&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,8 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@fontsource-variable/geist": "^5.2.8",
+        "@fontsource-variable/inter": "^5.2.8",
+        "@fontsource-variable/manrope": "^5.2.8",
         "@tailwindcss/vite": "^4.2.1",
         "@tanstack/react-query": "^5.90.21",
         "axios": "^1.13.6",
@@ -1268,6 +1270,24 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.2.8.tgz",
       "integrity": "sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/manrope": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/manrope/-/manrope-5.2.8.tgz",
+      "integrity": "sha512-nc9lOuCRz73UHnovDE2bwXUdghE2SEOc7Aii0qGe3CLyE03W1a7VnY5Z6euRiapiKbCkGS+eXbY3s/kvWeGeSw==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,8 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/geist": "^5.2.8",
+    "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource-variable/manrope": "^5.2.8",
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/react-query": "^5.90.21",
     "axios": "^1.13.6",

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -78,6 +78,30 @@ describe('AppShell', () => {
     expect(allDashboardLinks.length).toBeGreaterThanOrEqual(2)
   })
 
+  it('renders nav items in correct order: Dashboard, Students, Courses, Lessons, Settings', () => {
+    renderShell()
+    const links = document.querySelector('aside')?.querySelectorAll('a')
+    const labels = Array.from(links ?? []).map(a => a.textContent?.trim())
+    expect(labels).toEqual(['Dashboard', 'Students', 'Courses', 'Lessons', 'Settings'])
+  })
+
+  it('does not render a My Profile nav item', () => {
+    renderShell()
+    expect(screen.queryByText('My Profile')).not.toBeInTheDocument()
+  })
+
+  it('renders LANGUAGE CURATOR subtitle below logo', () => {
+    renderShell()
+    const subtitles = screen.getAllByText(/language curator/i)
+    expect(subtitles.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders Teacher label in user card', () => {
+    renderShell()
+    const teacherLabels = screen.getAllByText(/^teacher$/i)
+    expect(teacherLabels.length).toBeGreaterThanOrEqual(1)
+  })
+
   it('renders the mobile top bar with logo text', () => {
     renderShell()
     const logoTexts = screen.getAllByText('LangTeach')

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Link, Outlet, useLocation } from 'react-router-dom'
 import { useAuth0 } from '@auth0/auth0-react'
-import { LayoutDashboard, UserCircle, Users, BookOpen, GraduationCap, LogOut, Menu } from 'lucide-react'
+import { LayoutDashboard, Users, BookOpen, GraduationCap, Settings, LogOut, Menu } from 'lucide-react'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { cn } from '@/lib/utils'
 import LangTeachLogo from '@/components/LangTeachLogo'
@@ -11,10 +11,10 @@ import { UsageIndicator } from '@/components/UsageIndicator'
 
 const navItems = [
   { to: '/', label: 'Dashboard', icon: LayoutDashboard },
-  { to: '/settings', label: 'My Profile', icon: UserCircle },
   { to: '/students', label: 'Students', icon: Users },
-  { to: '/lessons', label: 'Lessons', icon: BookOpen },
   { to: '/courses', label: 'Courses', icon: GraduationCap },
+  { to: '/lessons', label: 'Lessons', icon: BookOpen },
+  { to: '/settings', label: 'Settings', icon: Settings },
 ]
 
 function SidebarContent({ user, initials, logout, location }: {
@@ -25,49 +25,57 @@ function SidebarContent({ user, initials, logout, location }: {
 }) {
   return (
     <>
-      {/* Logo */}
-      <div className="px-6 py-5 border-b border-zinc-100 flex items-center gap-2.5">
-        <LangTeachLogo size={28} />
-        <span className="text-indigo-600 font-bold text-lg tracking-tight">LangTeach</span>
+      {/* Logo + subtitle */}
+      <div className="px-6 pt-7 pb-8">
+        <div className="flex items-center gap-2.5">
+          <LangTeachLogo size={28} />
+          <span className="text-indigo-600 font-extrabold text-xl tracking-tight font-manrope">LangTeach</span>
+        </div>
+        <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 mt-1 ml-[38px] font-inter">
+          Language Curator
+        </p>
       </div>
 
       {/* Nav */}
-      <nav className="flex-1 overflow-y-auto px-3 py-4 space-y-0.5">
+      <nav className="flex-1 overflow-y-auto px-3 space-y-0.5">
         {navItems.map(({ to, label, icon: Icon }) => {
-          const active = location.pathname === to
+          const active = location.pathname === to || (to !== '/' && location.pathname.startsWith(to))
           return (
             <Link
               key={to}
               to={to}
               className={cn(
-                'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                'flex items-center gap-3 py-2.5 pl-4 pr-3 text-base font-medium font-inter transition-colors',
                 active
-                  ? 'bg-indigo-50 text-indigo-700'
-                  : 'text-muted-foreground hover:bg-zinc-100 hover:text-foreground'
+                  ? 'bg-white border-l-[3px] border-l-indigo-600 text-indigo-700 rounded-r-md'
+                  : 'text-zinc-500 hover:bg-[#E6E0F8] hover:text-zinc-900 rounded-md border-l-[3px] border-l-transparent'
               )}
             >
-              <Icon className={cn('h-5 w-5 shrink-0', active ? 'text-indigo-600' : 'text-muted-foreground/60')} />
+              <Icon className={cn('h-5 w-5 shrink-0', active ? 'text-indigo-600' : 'text-zinc-400')} />
               {label}
             </Link>
           )
         })}
       </nav>
 
-      {/* Usage + User + Logout */}
-      <div className="border-t border-border px-3 py-4 mt-2 space-y-0.5">
+      {/* Usage + User card + Logout */}
+      <div className="px-3 py-4 mt-2 space-y-3">
         <UsageIndicator />
-        <div className="flex items-center gap-3 px-3 py-2">
-          <Avatar className="h-7 w-7">
+        <div className="bg-white rounded-xl p-3 flex items-center gap-3">
+          <Avatar className="h-9 w-9 shrink-0">
             <AvatarImage src={user?.picture} alt={user?.name} />
-            <AvatarFallback className="bg-indigo-600 text-white text-xs">{initials}</AvatarFallback>
+            <AvatarFallback className="bg-indigo-600 text-white text-xs font-semibold">{initials}</AvatarFallback>
           </Avatar>
-          <span className="text-sm text-muted-foreground truncate" title={user?.email}>{user?.name ?? user?.email}</span>
+          <div className="flex flex-col overflow-hidden min-w-0">
+            <span className="text-sm font-bold text-zinc-900 truncate font-inter">{user?.name ?? user?.email}</span>
+            <span className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter">Teacher</span>
+          </div>
         </div>
         <button
           onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}
-          className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-zinc-100 hover:text-foreground transition-colors"
+          className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-zinc-400 hover:bg-[#E6E0F8] hover:text-zinc-700 transition-colors font-inter"
         >
-          <LogOut className="h-5 w-5 shrink-0 text-zinc-400" />
+          <LogOut className="h-5 w-5 shrink-0" />
           Log out
         </button>
       </div>
@@ -80,7 +88,6 @@ export default function AppShell() {
   const location = useLocation()
   const [drawerOpen, setDrawerOpen] = useState(false)
 
-  // Auto-close drawer on navigation (sync with router state)
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { setDrawerOpen(false) }, [location.pathname])
 
@@ -91,7 +98,7 @@ export default function AppShell() {
   return (
     <div className="flex h-screen overflow-hidden bg-zinc-50">
       {/* Desktop sidebar */}
-      <aside className="hidden lg:flex w-60 flex-col bg-white border-r border-border">
+      <aside className="hidden lg:flex w-64 flex-col bg-[#F4F2FD]">
         <SidebarContent user={user} initials={initials} logout={logout} location={location} />
       </aside>
 
@@ -109,7 +116,7 @@ export default function AppShell() {
         </Button>
         <div className="flex items-center gap-2">
           <LangTeachLogo size={24} />
-          <span className="text-indigo-600 font-bold text-base tracking-tight">LangTeach</span>
+          <span className="text-indigo-600 font-bold text-base tracking-tight font-manrope">LangTeach</span>
         </div>
         <Avatar className="h-8 w-8">
           <AvatarImage src={user?.picture} alt={user?.name} />
@@ -119,7 +126,7 @@ export default function AppShell() {
 
       {/* Mobile drawer */}
       <Sheet open={drawerOpen} onOpenChange={setDrawerOpen}>
-        <SheetContent>
+        <SheetContent className="bg-[#F4F2FD] p-0">
           <div className="flex flex-col h-full">
             <SidebarContent user={user} initials={initials} logout={logout} location={location} />
           </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,6 +5,11 @@
 
 @custom-variant dark (&:is(.dark *));
 
+@theme {
+  --font-inter: 'Inter', sans-serif;
+  --font-manrope: 'Manrope', sans-serif;
+}
+
 :root {
     --background: oklch(1 0 0);
     --foreground: oklch(0.145 0 0);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,12 +2,14 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/geist";
+@import "@fontsource-variable/inter";
+@import "@fontsource-variable/manrope";
 
 @custom-variant dark (&:is(.dark *));
 
 @theme {
-  --font-inter: 'Inter', sans-serif;
-  --font-manrope: 'Manrope', sans-serif;
+  --font-inter: 'Inter Variable', sans-serif;
+  --font-manrope: 'Manrope Variable', sans-serif;
 }
 
 :root {

--- a/plan/langteach-beta/task635-stitch-sidebar.md
+++ b/plan/langteach-beta/task635-stitch-sidebar.md
@@ -1,0 +1,67 @@
+# Task 635: Adopt Stitch Sidebar Design
+
+## Goal
+Replace `AppShell.tsx` sidebar with the Stitch "Academic Atelier" visual style: tonal layering, left border active indicator, Inter typography, logo header with subtitle, and user card at bottom.
+
+## Acceptance criteria (from issue)
+- Sidebar background `#F4F2FD` (surface-container-low), no 1px border against main content
+- Active item: 3px left indigo border bar + white (`#FFFFFF`) background
+- Hover: `#E6E0F8` (surface-container-highest), no border
+- Nav order: Dashboard, Students, Courses, Lessons, Settings
+- "LANGUAGE CURATOR" subtitle below logo (0.6875rem, uppercase, 0.05em tracking)
+- User card: avatar + name + "TEACHER" label at bottom
+- Manrope + Inter fonts loaded via Google Fonts and applied
+- Mobile responsive (Sheet drawer preserved)
+- E2E: navigation still works
+
+## Files to change
+
+### 1. `frontend/index.html`
+Add Google Fonts `<link>` tags for Manrope (400,700,800) and Inter (400,500,600) using preconnect + stylesheet pattern.
+
+### 2. `frontend/src/index.css`
+Add an `@theme` block to register the font families as named Tailwind utilities (Tailwind v4 pattern):
+```css
+@theme {
+  --font-inter: 'Inter', sans-serif;
+  --font-manrope: 'Manrope', sans-serif;
+}
+```
+This enables `font-inter` and `font-manrope` utility classes.
+
+### 3. `frontend/src/components/AppShell.tsx`
+- Replace `UserCircle` import with `Settings` in lucide-react import line
+- **Sidebar bg**: `bg-[#F4F2FD]` (remove `bg-white`, remove `border-r`)
+- **Main content bg**: keep `bg-zinc-50` -- tonal difference creates natural separation without borders
+- **Nav items** (updated order and styles):
+  - Remove "My Profile" item; keep Settings at position 5
+  - Order: Dashboard `/`, Students `/students`, Courses `/courses`, Lessons `/lessons`, Settings `/settings`
+  - Icon additions: import `Settings` from lucide (already imported in mockup); drop `UserCircle`
+  - Active class: `bg-white border-l-[3px] border-l-indigo-600 text-indigo-700 font-medium`
+  - Inactive class: `text-zinc-500 hover:bg-[#E6E0F8] hover:text-zinc-900 font-medium`
+  - Remove `rounded-md` from active (left border needs flush left); use `rounded-r-md` only
+  - Typography: `text-base font-medium font-['Inter']` on nav labels
+- **Header area**:
+  - Remove `border-b` from logo section
+  - Add subtitle `<p>` "LANGUAGE CURATOR" styled: `text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400`
+- **User card** (bottom):
+  - Keep `UsageIndicator`
+  - Replace bare flex row with a contained card: `bg-white rounded-xl p-3` wrapping avatar + name column + "TEACHER" label
+  - Add `<span className="text-[0.6875rem] font-bold uppercase tracking-wider text-zinc-400">Teacher</span>` below name
+  - Remove standalone logout button; integrate a subtle logout icon or keep as is (issue doesn't explicitly redesign logout)
+- **Mobile top bar**: minimal change -- keep hamburger + LangTeach logo wordmark
+
+### 3. `frontend/src/components/AppShell.test.tsx`
+- Update nav order test: verify Courses appears before Lessons
+- Update `renders nav items` test if it checks specific items by order
+
+### E2E
+- `navigation-flow.spec.ts` already uses `page.goto()` direct navigation -- no change needed
+- No new e2e test required: existing navigation coverage satisfies the AC
+
+## Out of scope (per issue)
+- Dashboard content, student pages, CSS variable tokens, Sessions nav item (#640)
+
+## Risk
+- The `aside` desktop sidebar currently uses `hidden lg:flex` -- unit test checks this. Preserve that class structure.
+- `font-['Inter']` Tailwind syntax requires v3 arbitrary values. Confirm it works or use `style={{ fontFamily: 'Inter, sans-serif' }}` inline if needed.


### PR DESCRIPTION
## Summary

- Replace `AppShell.tsx` sidebar with Stitch "Academic Atelier" visual design: `#F4F2FD` tonal background (no border against main content), 3px left indigo active indicator, white active item background
- Nav reordered to: Dashboard, Students, Courses, Lessons, Settings
- "LANGUAGE CURATOR" subtitle below logo in Label-SM style
- User card at bottom with avatar, name, and uppercase "TEACHER" label
- Inter Variable + Manrope Variable fonts loaded via `@fontsource-variable` packages (consistent with existing Geist convention)

## Test plan

- [ ] Run `npm test` in `frontend/` — 68 unit tests pass including new AppShell tests for nav order, LANGUAGE CURATOR subtitle, and TEACHER label
- [ ] Run `e2e/tests/dashboard.spec.ts` — sidebar nav test covers all 5 routes (Dashboard, Students, Courses, Lessons, Settings) with h1 assertions
- [ ] Visual: check sidebar on `/`, `/students`, `/courses`, `/lessons`, `/settings` at desktop viewport
- [ ] Visual: verify no hard border between sidebar and main content (tonal separation only)
- [ ] Visual: confirm active nav item shows 3px left indigo bar
- [ ] Mobile: hamburger opens Sheet drawer with same sidebar content

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Settings" navigation option to the sidebar.

* **Style**
  * Redesigned sidebar navigation menu with updated "Language Curator" subtitle and "Teacher" user label.
  * Integrated new variable fonts (Inter and Manrope) for enhanced typography throughout the app.

* **Tests**
  * Added comprehensive test coverage for navigation links, sidebar layout, and user profile display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->