### PR TITLE
fix: add difficulties and session log for Ana Visual in DemoSeeder (#603)

### DIFF
--- a/backend/LangTeach.Api/Data/DemoSeeder.cs
+++ b/backend/LangTeach.Api/Data/DemoSeeder.cs
@@ -133,6 +133,7 @@ public static class DemoSeeder
         {
             await db.SaveChangesAsync(); // persist any approval/onboarding updates
             await SeedScenarioStudentsAsync(db, teacher.Id, logger);
+            await SeedAnaVisualSessionLogAsync(db, teacher.Id, logger);
             logger.LogInformation("Visual seed data already exists for teacher {Email}; scenario students refreshed.", teacher.Email);
             return true;
         }
@@ -156,7 +157,7 @@ public static class DemoSeeder
 
         var students = new List<Student>
         {
-            new() { Id = Guid.NewGuid(), TeacherId = teacher.Id, Name = "Ana Visual",   LearningLanguage = "English", CefrLevel = "B2", PersonalNotes = VisualTag, Weaknesses = """[{"description":"Phrasal verbs","weaknessType":"grammatical"},{"description":"Travel vocabulary gaps","weaknessType":"lexical"}]""", CreatedAt = now, UpdatedAt = now },
+            new() { Id = Guid.NewGuid(), TeacherId = teacher.Id, Name = "Ana Visual",   LearningLanguage = "English", CefrLevel = "B2", PersonalNotes = VisualTag, Weaknesses = """[{"description":"Phrasal verbs","weaknessType":"grammatical"},{"description":"Travel vocabulary gaps","weaknessType":"lexical"}]""", Difficulties = """[{"id":"av1","description":"Separable vs inseparable phrasal verbs","competency":"Grammar","subcategory":"Phrasal verbs","severity":"medium","status":"Active","trend":"stable"},{"id":"av2","description":"Travel collocations","competency":"Vocabulary","subcategory":"Travel","severity":"low","status":"Active","trend":"improving"},{"id":"av3","description":"Word stress in multi-syllable words","competency":"Pronunciation","subcategory":"Word stress","severity":"medium","status":"Active","trend":"stable"}]""", CreatedAt = now, UpdatedAt = now },
             new() { Id = Guid.NewGuid(), TeacherId = teacher.Id, Name = "Marco Visual", LearningLanguage = "English", CefrLevel = "A2", PersonalNotes = VisualTag, CreatedAt = now, UpdatedAt = now },
         };
         db.Students.AddRange(students);
@@ -226,6 +227,7 @@ public static class DemoSeeder
             students.Count, entries.Count);
 
         await SeedScenarioStudentsAsync(db, teacher.Id, logger);
+        await SeedAnaVisualSessionLogAsync(db, teacher.Id, logger);
 
         return true;
     }
@@ -418,6 +420,39 @@ public static class DemoSeeder
         }
 
         logger.LogInformation("Scenario students seeded (Ana Seed, Marco Seed, Clara Seed, Diego Seed).");
+    }
+
+    private static async Task SeedAnaVisualSessionLogAsync(AppDbContext db, Guid teacherId, ILogger logger)
+    {
+        var anaVisual = await db.Students.FirstOrDefaultAsync(
+            s => s.TeacherId == teacherId && s.Name == "Ana Visual" && !s.IsDeleted);
+        if (anaVisual is null) return;
+
+        var logExists = await db.SessionLogs.AnyAsync(s => s.StudentId == anaVisual.Id && !s.IsDeleted);
+        if (logExists) return;
+
+        var now = DateTime.UtcNow;
+        db.SessionLogs.Add(new SessionLog
+        {
+            Id                       = Guid.NewGuid(),
+            StudentId                = anaVisual.Id,
+            TeacherId                = teacherId,
+            SessionDate              = now.AddDays(-7),
+            PlannedContent           = "Phrasal verbs in travel contexts and reading comprehension.",
+            ActualContent            = "Practised 12 travel phrasal verbs; read a passage about airport experiences.",
+            HomeworkAssigned         = "Write a short paragraph using at least 5 phrasal verbs from today.",
+            PreviousHomeworkStatus   = HomeworkStatus.Done,
+            NextSessionTopics        = "Collocations with travel vocabulary",
+            GeneralNotes             = "Student struggles with separable vs inseparable phrasal verbs. Good effort overall.",
+            TopicTags                = """["vocabulary","phrasal verbs"]""",
+            MentionedDifficultyPairs = """[{"competency":"Grammar","subcategory":"Phrasal verbs"},{"competency":"Vocabulary","subcategory":"Travel"}]""",
+            SuggestedDifficulties    = """[{"description":"Confuses separable and inseparable phrasal verbs","competency":"Grammar","subcategory":"Phrasal verbs","severity":"medium"}]""",
+            IsDeleted                = false,
+            CreatedAt                = now.AddDays(-7),
+            UpdatedAt                = now.AddDays(-7),
+        });
+        await db.SaveChangesAsync();
+        logger.LogInformation("Ana Visual session log seeded.");
     }
 
     private static async Task<Student> UpsertStudentAsync(AppDbContext db, Guid teacherId, Student incoming, DateTime now)

--- a/backend/LangTeach.Api/Data/DemoSeeder.cs
+++ b/backend/LangTeach.Api/Data/DemoSeeder.cs
@@ -132,6 +132,7 @@ public static class DemoSeeder
         if (studentsSeeded && coursesSeeded)
         {
             await db.SaveChangesAsync(); // persist any approval/onboarding updates
+            await EnsureAnaVisualDifficultiesAsync(db, teacher.Id, logger);
             await SeedScenarioStudentsAsync(db, teacher.Id, logger);
             await SeedAnaVisualSessionLogAsync(db, teacher.Id, logger);
             logger.LogInformation("Visual seed data already exists for teacher {Email}; scenario students refreshed.", teacher.Email);
@@ -157,7 +158,7 @@ public static class DemoSeeder
 
         var students = new List<Student>
         {
-            new() { Id = Guid.NewGuid(), TeacherId = teacher.Id, Name = "Ana Visual",   LearningLanguage = "English", CefrLevel = "B2", PersonalNotes = VisualTag, Weaknesses = """[{"description":"Phrasal verbs","weaknessType":"grammatical"},{"description":"Travel vocabulary gaps","weaknessType":"lexical"}]""", Difficulties = """[{"id":"av1","description":"Separable vs inseparable phrasal verbs","competency":"Grammar","subcategory":"Phrasal verbs","severity":"medium","status":"Active","trend":"stable"},{"id":"av2","description":"Travel collocations","competency":"Vocabulary","subcategory":"Travel","severity":"low","status":"Active","trend":"improving"},{"id":"av3","description":"Word stress in multi-syllable words","competency":"Pronunciation","subcategory":"Word stress","severity":"medium","status":"Active","trend":"stable"}]""", CreatedAt = now, UpdatedAt = now },
+            new() { Id = Guid.NewGuid(), TeacherId = teacher.Id, Name = "Ana Visual",   LearningLanguage = "English", CefrLevel = "B2", PersonalNotes = VisualTag, Weaknesses = """[{"description":"Phrasal verbs","weaknessType":"grammatical"},{"description":"Travel vocabulary gaps","weaknessType":"lexical"}]""", Difficulties = AnaVisualDifficulties, CreatedAt = now, UpdatedAt = now },
             new() { Id = Guid.NewGuid(), TeacherId = teacher.Id, Name = "Marco Visual", LearningLanguage = "English", CefrLevel = "A2", PersonalNotes = VisualTag, CreatedAt = now, UpdatedAt = now },
         };
         db.Students.AddRange(students);
@@ -420,6 +421,21 @@ public static class DemoSeeder
         }
 
         logger.LogInformation("Scenario students seeded (Ana Seed, Marco Seed, Clara Seed, Diego Seed).");
+    }
+
+    private const string AnaVisualDifficulties =
+        """[{"id":"av1","description":"Separable vs inseparable phrasal verbs","competency":"Grammar","subcategory":"Phrasal verbs","severity":"medium","status":"Active","trend":"stable"},{"id":"av2","description":"Travel collocations","competency":"Vocabulary","subcategory":"Travel","severity":"low","status":"Active","trend":"improving"},{"id":"av3","description":"Word stress in multi-syllable words","competency":"Pronunciation","subcategory":"Word stress","severity":"medium","status":"Active","trend":"stable"}]""";
+
+    private static async Task EnsureAnaVisualDifficultiesAsync(AppDbContext db, Guid teacherId, ILogger logger)
+    {
+        var anaVisual = await db.Students.FirstOrDefaultAsync(
+            s => s.TeacherId == teacherId && s.Name == "Ana Visual" && !s.IsDeleted);
+        if (anaVisual is null || anaVisual.Difficulties == AnaVisualDifficulties) return;
+
+        anaVisual.Difficulties = AnaVisualDifficulties;
+        anaVisual.UpdatedAt = DateTime.UtcNow;
+        await db.SaveChangesAsync();
+        logger.LogInformation("Ana Visual difficulties backfilled.");
     }
 
     private static async Task SeedAnaVisualSessionLogAsync(AppDbContext db, Guid teacherId, ILogger logger)

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -20,6 +20,13 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 | architecture-reviewer | minor | `TelegramBotServiceTests.cs` uses static `BuildService` factory instead of constructor + `IDisposable` (sibling pattern in `VoiceNoteServiceTests`/`TelegramConversationServiceTests`). Matches the closer reference `ClaudeApiClientUnitTests.cs`, which also uses a static `BuildClient` factory for HttpClient-based service tests. No cleanup needed. |
 
 
+## #643 — 2026-04-10
+
+| Reviewer | Severity | Note |
+|---|---|---|
+| review | info | `SeedAnaVisualSessionLogAsync` is called after the early-return `SaveChangesAsync`; any unsaved tracked changes before that line would be committed by the helper's own `SaveChangesAsync`. Verified safe: no mutations precede the call in the early-return path. |
+| architecture-reviewer | info | New helper method diverges from Diego Seed's inline guard style. Helper is the correct choice because Ana Visual belongs to a different method scope. |
+
 ## #627 — 2026-04-10
 
 | Reviewer | Severity | Note |

--- a/plan/langteach-beta/task603-demo-seeder-difficulties.md
+++ b/plan/langteach-beta/task603-demo-seeder-difficulties.md
@@ -1,0 +1,40 @@
+# Task 603 — Add student with difficulties to DemoSeeder
+
+## Problem
+`SeedVisualAsync` seeds Ana Visual with `Weaknesses` but no `Difficulties`. The difficulty chips
+on the student detail page and the "Difficulties mentioned" section of the SessionLogDialog cannot
+be visually verified during review-ui runs.
+
+## Approach
+
+### 1. Add `Difficulties` to Ana Visual (in `SeedVisualAsync`)
+Add 3 difficulties using the rich `DifficultyDto` format (id, description, competency, subcategory,
+severity, status, trend) covering 3 different valid competencies: Grammar, Vocabulary, Pronunciation.
+
+```json
+[
+  {"id":"av1","description":"Separable vs inseparable phrasal verbs","competency":"Grammar","subcategory":"Phrasal verbs","severity":"medium","status":"Active","trend":"stable"},
+  {"id":"av2","description":"Travel collocations","competency":"Vocabulary","subcategory":"Travel","severity":"low","status":"Active","trend":"improving"},
+  {"id":"av3","description":"Word stress in multi-syllable words","competency":"Pronunciation","subcategory":"Word stress","severity":"medium","status":"Active","trend":"stable"}
+]
+```
+
+### 2. Add a session log for Ana Visual with `MentionedDifficultyPairs` and `SuggestedDifficulties`
+This covers the SessionLogDialog "Difficulties mentioned" section. Add via a new private helper
+`SeedAnaVisualSessionLogAsync` with an idempotency guard (`AnyAsync` on StudentId).
+
+The helper is called from both:
+- The early-return path (already seeded, scenario students refreshed)
+- The normal seeding path (after `SaveChangesAsync`)
+
+The session log will contain:
+- `MentionedDifficultyPairs`: Grammar/Phrasal verbs, Vocabulary/Travel collocations
+- `SuggestedDifficulties`: one suggestion (Grammar, Phrasal verbs, medium)
+
+## Files changed
+- `backend/LangTeach.Api/Data/DemoSeeder.cs`
+
+## Acceptance criteria
+- Ana Visual has 3 non-empty difficulties with distinct competencies
+- One confirmed session log exists for Ana Visual with non-empty `MentionedDifficultyPairs` and `SuggestedDifficulties`
+- Seeder is idempotent: re-running on an existing seed does not duplicate data


### PR DESCRIPTION
## Summary
- Adds 3 pre-populated difficulties to Ana Visual (Grammar/Phrasal verbs, Vocabulary/Travel, Pronunciation/Word stress), enabling difficulty chips on the student detail page to render during review-ui runs
- Seeds one confirmed session log for Ana Visual with `MentionedDifficultyPairs` and `SuggestedDifficulties` populated, enabling the SessionLogDialog "Difficulties mentioned" section to be visually verified
- New `SeedAnaVisualSessionLogAsync` helper uses the same idempotency pattern (`AnyAsync` guard) as Diego Seed's session log seeding; called from both the early-return and normal paths of `SeedVisualAsync`

## Test plan
- [ ] Run visual seeder against a fresh DB; confirm Ana Visual has 3 difficulty chips on student detail page
- [ ] Open Ana Visual's session log dialog; confirm "Difficulties mentioned" section shows Grammar/Phrasal verbs and Vocabulary/Travel entries
- [ ] Re-run seeder on existing data; confirm no duplicate session logs are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced demo student profiles with new profile attributes
  * Added session history examples to demo scenarios for improved preview experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->