### PR TITLE
fix: reflection extraction preserves original language and extracts session date

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
@@ -281,6 +281,26 @@ public class ReflectionExtractionServiceTests
     }
 
     [Fact]
+    public void ParseResponse_SessionDateIsNullWhenNotIsoFormat()
+    {
+        var sut = CreateSut("{}");
+        var json = """
+            {
+              "whatWasCovered": null,
+              "areasToImprove": null,
+              "emotionalSignals": null,
+              "homeworkAssigned": null,
+              "nextLessonIdeas": null,
+              "sessionDate": "martes pasado"
+            }
+            """;
+
+        var result = sut.ParseResponse(json);
+
+        result.SessionDate.Should().BeNull();
+    }
+
+    [Fact]
     public void ParseResponse_SessionDateIsNullWhenExplicitlyNull()
     {
         var sut = CreateSut("{}");

--- a/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
@@ -63,6 +63,7 @@ public class ReflectionExtractionServiceTests
         result.EmotionalSignals.Should().Be("Very engaged");
         result.HomeworkAssigned.Should().Be("Exercises 1-5");
         result.NextLessonIdeas.Should().Be("Present perfect");
+        result.SessionDate.Should().BeNull();
         result.SuggestedDifficulties.Should().BeEmpty();
     }
 
@@ -229,5 +230,73 @@ public class ReflectionExtractionServiceTests
 
         result.WhatWasCovered.Should().BeNull();
         result.AreasToImprove.Should().BeNull();
+        result.SessionDate.Should().BeNull();
+    }
+
+    [Fact]
+    public void SystemPrompt_ContainsLanguagePreservationInstruction()
+    {
+        // Verify the prompt instructs Claude not to translate teacher input.
+        // Uses reflection to access the private const for a compile-time-safe smoke check.
+        var promptField = typeof(ReflectionExtractionService)
+            .GetField("SystemPrompt", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        var prompt = (string?)promptField?.GetValue(null);
+
+        prompt.Should().NotBeNull();
+        prompt.Should().Contain("translate", Exactly.Once());
+        prompt.Should().Contain("sessionDate");
+    }
+
+    [Fact]
+    public void ParseResponse_ExtractsSessionDate()
+    {
+        var sut = CreateSut("{}");
+        var json = """
+            {
+              "whatWasCovered": "los condicionales",
+              "areasToImprove": null,
+              "emotionalSignals": null,
+              "homeworkAssigned": null,
+              "nextLessonIdeas": null,
+              "sessionDate": "2026-04-08",
+              "suggestedDifficulties": []
+            }
+            """;
+
+        var result = sut.ParseResponse(json);
+
+        result.SessionDate.Should().Be("2026-04-08");
+        result.WhatWasCovered.Should().Be("los condicionales");
+    }
+
+    [Fact]
+    public void ParseResponse_SessionDateIsNullWhenAbsent()
+    {
+        var sut = CreateSut("{}");
+        var json = """{"whatWasCovered": "Vocabulary", "areasToImprove": null, "emotionalSignals": null, "homeworkAssigned": null, "nextLessonIdeas": null}""";
+
+        var result = sut.ParseResponse(json);
+
+        result.SessionDate.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseResponse_SessionDateIsNullWhenExplicitlyNull()
+    {
+        var sut = CreateSut("{}");
+        var json = """
+            {
+              "whatWasCovered": null,
+              "areasToImprove": null,
+              "emotionalSignals": null,
+              "homeworkAssigned": null,
+              "nextLessonIdeas": null,
+              "sessionDate": null
+            }
+            """;
+
+        var result = sut.ParseResponse(json);
+
+        result.SessionDate.Should().BeNull();
     }
 }

--- a/backend/LangTeach.Api.Tests/Services/TelegramConversationServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/TelegramConversationServiceTests.cs
@@ -291,6 +291,7 @@ public class TelegramConversationServiceTests : IDisposable
             EmotionalSignals: "engaged",
             HomeworkAssigned: "complete exercises 3 and 4",
             NextLessonIdeas: "past tenses review",
+            SessionDate: null,
             SuggestedDifficulties: new List<SuggestedDifficultyDto>
             {
                 new("confuses ser and estar", "Grammar", "Copulas", "Medium")
@@ -352,6 +353,7 @@ public class TelegramConversationServiceTests : IDisposable
                 EmotionalSignals: null,
                 HomeworkAssigned: null,
                 NextLessonIdeas: null,
+                SessionDate: null,
                 SuggestedDifficulties: new List<SuggestedDifficultyDto>());
             return Task.FromResult(result);
         }

--- a/backend/LangTeach.Api/DTOs/ReflectionExtractionDtos.cs
+++ b/backend/LangTeach.Api/DTOs/ReflectionExtractionDtos.cs
@@ -22,5 +22,6 @@ public record ExtractedReflectionDto(
     string? EmotionalSignals,
     string? HomeworkAssigned,
     string? NextLessonIdeas,
+    string? SessionDate,
     List<SuggestedDifficultyDto> SuggestedDifficulties
 );

--- a/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
@@ -13,12 +13,16 @@ public class ReflectionExtractionService : IReflectionExtractionService
     private const string SystemPrompt = """
         You are a tool that helps language teachers structure their post-class notes.
         Extract structured information from a teacher's free-form reflection text.
+
+        IMPORTANT: Preserve the original language of the teacher's text. Do not translate any field value into another language.
+
         Respond ONLY with a valid JSON object using these exact keys:
         - whatWasCovered: string or null
         - areasToImprove: string or null (narrative summary of student difficulties and struggles — prose, not a list)
         - emotionalSignals: string or null (student attitude, mood, motivation, engagement signals)
         - homeworkAssigned: string or null
         - nextLessonIdeas: string or null
+        - sessionDate: string or null — ISO 8601 date (YYYY-MM-DD) if the teacher mentions a specific session date or a resolvable relative reference ("ayer", "el martes pasado", "last Tuesday"); null if no date is mentioned or the reference cannot be resolved to a specific date
         - suggestedDifficulties: array of objects (can be empty []) — structured breakdown of the same difficulties mentioned in areasToImprove
 
         For suggestedDifficulties, each object must have:
@@ -55,7 +59,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Claude API call failed during reflection extraction");
-            return new ExtractedReflectionDto(null, null, null, null, null, []);
+            return new ExtractedReflectionDto(null, null, null, null, null, null, []);
         }
 
         return ParseResponse(response.Content);
@@ -75,6 +79,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
                 EmotionalSignals: GetStringOrNull(root, "emotionalSignals"),
                 HomeworkAssigned: GetStringOrNull(root, "homeworkAssigned"),
                 NextLessonIdeas: GetStringOrNull(root, "nextLessonIdeas"),
+                SessionDate: GetStringOrNull(root, "sessionDate"),
                 SuggestedDifficulties: ParseSuggestedDifficulties(root)
             );
         }
@@ -82,7 +87,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
         {
             _logger.LogWarning(ex, "Failed to parse reflection extraction JSON (length: {Length})", json?.Length ?? 0);
         _logger.LogDebug("Unparseable Claude response: {Json}", json);
-            return new ExtractedReflectionDto(null, null, null, null, null, []);
+            return new ExtractedReflectionDto(null, null, null, null, null, null, []);
         }
     }
 

--- a/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using LangTeach.Api.AI;
 using LangTeach.Api.DTOs;
@@ -79,7 +80,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
                 EmotionalSignals: GetStringOrNull(root, "emotionalSignals"),
                 HomeworkAssigned: GetStringOrNull(root, "homeworkAssigned"),
                 NextLessonIdeas: GetStringOrNull(root, "nextLessonIdeas"),
-                SessionDate: GetStringOrNull(root, "sessionDate"),
+                SessionDate: GetIsoDateOrNull(root, "sessionDate"),
                 SuggestedDifficulties: ParseSuggestedDifficulties(root)
             );
         }
@@ -129,5 +130,20 @@ public class ReflectionExtractionService : IReflectionExtractionService
             return string.IsNullOrWhiteSpace(value) ? null : value;
         }
         return null;
+    }
+
+    private static string? GetIsoDateOrNull(JsonElement root, string key)
+    {
+        var raw = GetStringOrNull(root, key);
+        if (raw is null) return null;
+
+        return DateOnly.TryParseExact(
+            raw,
+            "yyyy-MM-dd",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out var parsed)
+            ? parsed.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
+            : null;
     }
 }

--- a/backend/LangTeach.Api/Services/StubReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/StubReflectionExtractionService.cs
@@ -11,6 +11,7 @@ public class StubReflectionExtractionService : IReflectionExtractionService
             EmotionalSignals: "[Extracted] Emotional signals",
             HomeworkAssigned: "[Extracted] Homework assigned",
             NextLessonIdeas: "[Extracted] Next lesson ideas",
+            SessionDate: null,
             SuggestedDifficulties: []
         ));
 }

--- a/plan/langteach-beta/task650-reflection-language-date.md
+++ b/plan/langteach-beta/task650-reflection-language-date.md
@@ -1,0 +1,46 @@
+# Task 650: Reflection Extraction - Preserve Language & Add Session Date
+
+## Issue
+https://github.com/Robert-Freire/langTeachSaaS/issues/650
+
+## Type
+Hotfix. Branch from `main`, PR to `main`.
+
+## Problem
+1. Extraction prompt has no instruction to preserve the teacher's original language, so Claude translates Spanish reflections to English.
+2. No `sessionDate` field in `ExtractedReflectionDto` or the prompt schema, so temporal references ("ayer", "el martes") are discarded.
+
+## Files Changed
+- `backend/LangTeach.Api/DTOs/ReflectionExtractionDtos.cs`
+- `backend/LangTeach.Api/Services/ReflectionExtractionService.cs`
+- `backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs`
+
+## Changes
+
+### 1. `ExtractedReflectionDto` (DTOs file)
+Add `string? SessionDate` as the last positional field before `SuggestedDifficulties`.
+
+### 2. System prompt (ReflectionExtractionService.cs)
+- Add explicit instruction: "Preserve the original language of the teacher's text. Do not translate any field value."
+- Add `sessionDate` to the JSON schema: `string or null - ISO 8601 date (YYYY-MM-DD) if the teacher mentions a specific session date or a resolvable relative reference ("ayer", "el martes pasado", "last Tuesday") relative to today; null if no date is mentioned or cannot be resolved. Today's date is not injected — use null if the reference is ambiguous.`
+
+Note: We do NOT inject today's date into the prompt at runtime. The instruction tells Claude to resolve relative references where it can, but unresolvable ones return null. This is acceptable for now.
+
+### 3. `ParseResponse` (ReflectionExtractionService.cs)
+- Extract `sessionDate` from the JSON element.
+- Add to the `ExtractedReflectionDto` constructor call.
+- Update the fallback return (both in `ExtractAsync` error path and `ParseResponse` exception path) to include `null` for `SessionDate`.
+
+### 4. Tests (ReflectionExtractionServiceTests.cs)
+- All existing tests: add `.SessionDate.Should().BeNull()` where appropriate (fields not set = null).
+- New test `ParseResponse_PreservesOriginalLanguageInPrompt`: verifies the system prompt contains the word "language" and "translate" (smoke check that the instruction is present).
+- New test `ParseResponse_ExtractsSessionDate`: JSON with `sessionDate: "2026-04-08"` is parsed correctly.
+- New test `ParseResponse_SessionDateIsNullWhenAbsent`: JSON without `sessionDate` field returns null.
+- New test `ParseResponse_SessionDateIsNullWhenExplicitlyNull`: JSON with `sessionDate: null` returns null.
+
+## Acceptance Criteria Coverage
+- [x] Prompt includes explicit preserve-language instruction
+- [x] `sessionDate` field added to `ExtractedReflectionDto`
+- [x] Prompt instructs Claude to parse relative date references into ISO 8601, null when none
+- [x] Existing unit tests updated; new test cases for both behaviors
+- [x] No changes to Azure Speech transcription layer


### PR DESCRIPTION
## Summary
- Add explicit language-preservation instruction to the Claude extraction prompt so teacher notes in Spanish (or any language) are not translated to English
- Add `sessionDate` field to `ExtractedReflectionDto` and prompt schema; Claude resolves relative date references ("ayer", "el martes") to ISO 8601 when possible, null otherwise
- Update all constructor call sites (stub, tests); add 4 new unit tests

Closes #650

## Test plan
- [ ] 13/13 reflection extraction unit tests pass (dotnet test verified)
- [ ] All other backend and frontend tests pass (build-verify PASS)
- [ ] Verify a Spanish voice note is returned in Spanish from the reflection endpoint after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reflection extraction now captures a session date (ISO-8601 or null) alongside other fields.
  * Extraction preserves the teacher’s original language for all returned values.

* **Tests**
  * Added comprehensive tests validating session date extraction and related behaviors across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->