### PR TITLE
fix: inject today's date so hoy/ayer resolve to real dates in reflection extraction

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
@@ -234,17 +234,24 @@ public class ReflectionExtractionServiceTests
     }
 
     [Fact]
-    public void SystemPrompt_ContainsLanguagePreservationInstruction()
+    public void BuildSystemPrompt_ContainsLanguagePreservationInstruction()
     {
-        // Verify the prompt instructs Claude not to translate teacher input.
-        // Uses reflection to access the private const for a compile-time-safe smoke check.
-        var promptField = typeof(ReflectionExtractionService)
-            .GetField("SystemPrompt", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-        var prompt = (string?)promptField?.GetValue(null);
+        var today = new DateOnly(2026, 4, 11);
+        var prompt = ReflectionExtractionService.BuildSystemPrompt(today);
 
-        prompt.Should().NotBeNull();
-        prompt.Should().Contain("translate", Exactly.Once());
+        prompt.Should().Contain("translate");
         prompt.Should().Contain("sessionDate");
+        prompt.Should().Contain("2026-04-11");
+    }
+
+    [Fact]
+    public void BuildSystemPrompt_InjectsTodayForRelativeDateResolution()
+    {
+        var today = new DateOnly(2026, 4, 11);
+        var prompt = ReflectionExtractionService.BuildSystemPrompt(today);
+
+        prompt.Should().Contain("hoy");
+        prompt.Should().Contain("ayer");
     }
 
     [Fact]

--- a/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
@@ -11,11 +11,13 @@ public class ReflectionExtractionService : IReflectionExtractionService
     private readonly IClaudeClient _claude;
     private readonly ILogger<ReflectionExtractionService> _logger;
 
-    private const string SystemPrompt = """
+    internal static string BuildSystemPrompt(DateOnly today) => $"""
         You are a tool that helps language teachers structure their post-class notes.
         Extract structured information from a teacher's free-form reflection text.
 
         IMPORTANT: Preserve the original language of the teacher's text. Do not translate any field value into another language.
+
+        Today's date is {today:yyyy-MM-dd}.
 
         Respond ONLY with a valid JSON object using these exact keys:
         - whatWasCovered: string or null
@@ -23,7 +25,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
         - emotionalSignals: string or null (student attitude, mood, motivation, engagement signals)
         - homeworkAssigned: string or null
         - nextLessonIdeas: string or null
-        - sessionDate: string or null — ISO 8601 date (YYYY-MM-DD) if the teacher mentions a specific session date or a resolvable relative reference ("ayer", "el martes pasado", "last Tuesday"); null if no date is mentioned or the reference cannot be resolved to a specific date
+        - sessionDate: string or null — ISO 8601 date (YYYY-MM-DD) resolved from today's date and any date reference the teacher mentions ("hoy"/"today" = today, "ayer"/"yesterday" = yesterday, "el martes pasado" = last Tuesday, etc.); null if no date is mentioned
         - suggestedDifficulties: array of objects (can be empty []) — structured breakdown of the same difficulties mentioned in areasToImprove
 
         For suggestedDifficulties, each object must have:
@@ -46,7 +48,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
     public async Task<ExtractedReflectionDto> ExtractAsync(string text, CancellationToken ct = default)
     {
         var request = new ClaudeRequest(
-            SystemPrompt: SystemPrompt,
+            SystemPrompt: BuildSystemPrompt(DateOnly.FromDateTime(DateTime.UtcNow)),
             UserPrompt: text,
             Model: ClaudeModel.Haiku,
             MaxTokens: 1024


### PR DESCRIPTION
## Summary
- Follow-up to #650: the `sessionDate` field was added but "hoy"/"ayer" returned null because Claude had no date anchor
- `BuildSystemPrompt(DateOnly today)` now injects today's UTC date into the prompt, enabling Claude to resolve all relative references ("hoy", "ayer", "el martes pasado", "last Tuesday") to ISO 8601 dates
- Tests updated to call `BuildSystemPrompt` directly instead of via reflection

## Test plan
- [ ] 15/15 reflection extraction unit tests pass
- [ ] Voice note saying "hoy" now returns today's date in `sessionDate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced language extraction to dynamically incorporate today's date and improve recognition of relative date references (such as "today," "yesterday," and Spanish expressions like "hoy" and "ayer") when analyzing teaching session content and user interactions, enabling more accurate and contextual interpretation of temporal language and date references in educational language learning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->