### PR TITLE
fix: apply extracted sessionDate to form and draft payload

### DIFF
--- a/frontend/src/api/sessionLogs.ts
+++ b/frontend/src/api/sessionLogs.ts
@@ -42,6 +42,7 @@ export interface ExtractedReflection {
   emotionalSignals: string | null
   homeworkAssigned: string | null
   nextLessonIdeas: string | null
+  sessionDate?: string | null
   suggestedDifficulties: SuggestedDifficulty[]
 }
 

--- a/frontend/src/components/session/SessionLogDialog.test.tsx
+++ b/frontend/src/components/session/SessionLogDialog.test.tsx
@@ -629,6 +629,7 @@ describe('SessionLogDialog', () => {
       emotionalSignals: 'Student was enthusiastic',
       homeworkAssigned: 'Exercise 4A',
       nextLessonIdeas: 'Review preterito',
+      sessionDate: '2026-04-11',
       suggestedDifficulties: [] as { description: string; competency: string; subcategory: string; severity: string }[],
     }
 
@@ -685,6 +686,31 @@ describe('SessionLogDialog', () => {
         expect((screen.getByTestId('actual-content') as HTMLTextAreaElement).value).toBe('Covered ser vs estar')
         expect((screen.getByTestId('homework-assigned') as HTMLInputElement).value).toBe('Exercise 4A')
         expect((screen.getByTestId('next-session-topics') as HTMLTextAreaElement).value).toBe('Review preterito')
+      })
+    })
+
+    it('pre-fills session date field from extracted sessionDate when form date is empty', async () => {
+      wrapper(<SessionLogDialog studentId={STUDENT_ID} open={true} onOpenChange={vi.fn()} />)
+      await waitFor(() => expect(screen.getByTestId('mock-audio-recorder-trigger')).toBeInTheDocument())
+
+      fireEvent.click(screen.getByTestId('mock-audio-recorder-trigger'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('session-date-iso')).toHaveTextContent('2026-04-11')
+      })
+    })
+
+    it('includes extracted sessionDate in the draft payload', async () => {
+      wrapper(<SessionLogDialog studentId={STUDENT_ID} open={true} onOpenChange={vi.fn()} />)
+      await waitFor(() => expect(screen.getByTestId('mock-audio-recorder-trigger')).toBeInTheDocument())
+
+      fireEvent.click(screen.getByTestId('mock-audio-recorder-trigger'))
+
+      await waitFor(() => {
+        expect(vi.mocked(sessionLogsApi.createSession)).toHaveBeenCalledWith(
+          STUDENT_ID,
+          expect.objectContaining({ sessionDate: '2026-04-11' }),
+        )
       })
     })
 

--- a/frontend/src/components/session/SessionLogDialog.tsx
+++ b/frontend/src/components/session/SessionLogDialog.tsx
@@ -116,6 +116,8 @@ export function SessionLogDialog({
   const [draftSessionId, setDraftSessionId] = useState<string | null>(null)
   const [extractionFailed, setExtractionFailed] = useState(false)
   const voiceRunRef = useRef(0)
+  const sessionDateRef = useRef(sessionDate)
+  useEffect(() => { sessionDateRef.current = sessionDate }, [sessionDate])
 
   // Pre-populate fields when editing an existing session
   /* eslint-disable react-hooks/set-state-in-effect */
@@ -325,11 +327,11 @@ export function SessionLogDialog({
       setNextSessionTopics(extracted.nextLessonIdeas ?? '')
       setGeneralNotes(notes)
       setSuggestedDifficulties(extracted.suggestedDifficulties ?? [])
-      if (!sessionDate && extracted.sessionDate) setSessionDate(extracted.sessionDate)
+      if (!sessionDateRef.current && extracted.sessionDate) setSessionDate(extracted.sessionDate)
       /* eslint-enable react-hooks/set-state-in-effect */
       if (runId !== voiceRunRef.current) return
       // Auto-save as Draft using full current form state + extracted fields
-      const resolvedDate = sessionDate || extracted.sessionDate || null
+      const resolvedDate = sessionDateRef.current || extracted.sessionDate || null
       const draft = await createSession(studentId, {
         sessionDate: resolvedDate,
         plannedContent: plannedContent || null,

--- a/frontend/src/components/session/SessionLogDialog.tsx
+++ b/frontend/src/components/session/SessionLogDialog.tsx
@@ -325,11 +325,13 @@ export function SessionLogDialog({
       setNextSessionTopics(extracted.nextLessonIdeas ?? '')
       setGeneralNotes(notes)
       setSuggestedDifficulties(extracted.suggestedDifficulties ?? [])
+      if (!sessionDate && extracted.sessionDate) setSessionDate(extracted.sessionDate)
       /* eslint-enable react-hooks/set-state-in-effect */
       if (runId !== voiceRunRef.current) return
       // Auto-save as Draft using full current form state + extracted fields
+      const resolvedDate = sessionDate || extracted.sessionDate || null
       const draft = await createSession(studentId, {
-        sessionDate: sessionDate || null,
+        sessionDate: resolvedDate,
         plannedContent: plannedContent || null,
         actualContent: extracted.whatWasCovered ?? null,
         homeworkAssigned: extracted.homeworkAssigned ?? null,


### PR DESCRIPTION
## Summary
- The backend was returning `sessionDate` from voice note extraction (e.g. "hoy" → today's ISO date) but the frontend never read it
- Now pre-fills the session date field when the form is empty and passes the resolved date in the auto-saved draft
- Two new unit tests verify the field is populated and the draft payload includes the date

## Test plan
- [ ] 890/890 frontend tests pass
- [ ] After saying "hoy" in a voice note, the session date field shows today's date

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session date extraction from voice recordings - dates extracted from voice notes are now properly preserved in session drafts even when the form date field is initially empty, ensuring session dates are not lost during the voice extraction process.

* **Tests**
  * Added test cases to verify correct session date extraction and handling behavior from voice recordings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->