### PR TITLE
fix: inject day of week and clarify el pasado X date resolution

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
@@ -245,13 +245,17 @@ public class ReflectionExtractionServiceTests
     }
 
     [Fact]
-    public void BuildSystemPrompt_InjectsTodayForRelativeDateResolution()
+    public void BuildSystemPrompt_InjectsDayOfWeekAndDate()
     {
-        var today = new DateOnly(2026, 4, 11);
+        var today = new DateOnly(2026, 4, 11); // Saturday
         var prompt = ReflectionExtractionService.BuildSystemPrompt(today);
 
+        prompt.Should().Contain("Saturday");
+        prompt.Should().Contain("2026-04-11");
         prompt.Should().Contain("hoy");
         prompt.Should().Contain("ayer");
+        prompt.Should().Contain("el pasado lunes");
+        prompt.Should().Contain("el lunes pasado");
     }
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/Services/TelegramConversationServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/TelegramConversationServiceTests.cs
@@ -308,6 +308,27 @@ public class TelegramConversationServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task TextMessage_MatchedStudent_UsesExtractedSessionDate()
+    {
+        LinkTeacher();
+        var student = await CreateStudentAsync("Marco");
+
+        _extractionService.Result = new ExtractedReflectionDto(
+            WhatWasCovered: "condicionales",
+            AreasToImprove: null,
+            EmotionalSignals: null,
+            HomeworkAssigned: null,
+            NextLessonIdeas: null,
+            SessionDate: "2026-04-06",
+            SuggestedDifficulties: new List<SuggestedDifficultyDto>());
+
+        await _sut.HandleUpdateAsync(TextUpdate(_chatId, "Marco el pasado lunes trabajamos los condicionales"), CancellationToken.None);
+
+        var log = await _db.SessionLogs.SingleAsync(s => s.StudentId == student.Id);
+        log.SessionDate.Should().Be(new DateTime(2026, 4, 6, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
     public async Task TextMessage_ExtractionFailure_FallsBackToRawGeneralNotes()
     {
         LinkTeacher();

--- a/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
@@ -17,7 +17,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
 
         IMPORTANT: Preserve the original language of the teacher's text. Do not translate any field value into another language.
 
-        Today's date is {today:yyyy-MM-dd}.
+        Today is {today.DayOfWeek}, {today:yyyy-MM-dd}.
 
         Respond ONLY with a valid JSON object using these exact keys:
         - whatWasCovered: string or null
@@ -25,7 +25,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
         - emotionalSignals: string or null (student attitude, mood, motivation, engagement signals)
         - homeworkAssigned: string or null
         - nextLessonIdeas: string or null
-        - sessionDate: string or null — ISO 8601 date (YYYY-MM-DD) resolved from today's date and any date reference the teacher mentions ("hoy"/"today" = today, "ayer"/"yesterday" = yesterday, "el martes pasado" = last Tuesday, etc.); null if no date is mentioned
+        - sessionDate: string or null — ISO 8601 date (YYYY-MM-DD) of the session being described. Resolve date references using today's date and day of week: "hoy"/"today" = today, "ayer"/"yesterday" = yesterday, "el lunes pasado"/"el pasado lunes" = the most recent Monday before today (not the Monday of this week if today is Monday), "el martes pasado"/"el pasado martes" = the most recent Tuesday before today, and so on for any weekday. Always pick the last occurrence of the named weekday strictly before today. Null if no date is mentioned.
         - suggestedDifficulties: array of objects (can be empty []) — structured breakdown of the same difficulties mentioned in areasToImprove
 
         For suggestedDifficulties, each object must have:

--- a/backend/LangTeach.Api/Services/TelegramConversationService.cs
+++ b/backend/LangTeach.Api/Services/TelegramConversationService.cs
@@ -236,7 +236,7 @@ public class TelegramConversationService : ITelegramConversationService
 
         return new CreateSessionLogRequest
         {
-            SessionDate = DateTime.UtcNow.Date,
+            SessionDate = ParseSessionDate(extracted.SessionDate),
             ActualContent = extracted.WhatWasCovered,
             HomeworkAssigned = extracted.HomeworkAssigned,
             NextSessionTopics = extracted.NextLessonIdeas,
@@ -302,5 +302,16 @@ public class TelegramConversationService : ITelegramConversationService
         await _botService.SendMessageAsync(chatId,
             "Connected! You can now send voice notes or text to log session notes. I'll ask which student after each message.",
             ct);
+    }
+
+    private static DateTime ParseSessionDate(string? isoDate)
+    {
+        if (isoDate is not null &&
+            DateOnly.TryParseExact(isoDate, "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.None, out var parsed))
+        {
+            return parsed.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+        }
+        return DateTime.UtcNow.Date;
     }
 }


### PR DESCRIPTION
## Summary
- Prompt was only giving Claude the ISO date, not the weekday — Claude had to infer the day of week from the number, making relative arithmetic unreliable
- "el pasado lunes" and "el lunes pasado" were not both covered as examples; Claude was returning the day after the named weekday consistently
- Now injects "Today is Saturday, 2026-04-11" and explicitly covers both Spanish word orders with the rule: pick the last occurrence of the named weekday strictly before today

## Test plan
- [ ] 15/15 backend tests pass
- [ ] "el pasado lunes" returns the correct Monday, not Tuesday

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy in resolving weekday-based date references when describing sessions.
  * Enhanced system prompts to provide weekday context information for more precise session date matching.
  * Refined handling of relative weekday references to ensure sessions are correctly associated with their proper dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->