### PR TITLE
feat: add VoiceNoteApplication table for voice note traceability (#656)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
@@ -323,7 +323,20 @@ public class ReflectionExtractionServiceTests
 
         var result = sut.ParseResponse(json);
 
+        // RawExtractionJson stores the fence-stripped (cleaned) content, which equals json when no fences present
         result.RawExtractionJson.Should().Be(json);
+    }
+
+    [Fact]
+    public void ParseResponse_StripsFencesBeforeStoringRawExtractionJson()
+    {
+        var sut = CreateSut("{}");
+        var fenced = "```json\n{\"whatWasCovered\":\"ser vs estar\"}\n```";
+        var expected = "{\"whatWasCovered\":\"ser vs estar\"}";
+
+        var result = sut.ParseResponse(fenced);
+
+        result.RawExtractionJson.Should().Be(expected);
     }
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
@@ -314,4 +314,40 @@ public class ReflectionExtractionServiceTests
 
         result.SessionDate.Should().BeNull();
     }
+
+    [Fact]
+    public void ParseResponse_ReturnsRawExtractionJson()
+    {
+        var sut = CreateSut("{}");
+        var json = """{"whatWasCovered":"ser vs estar"}""";
+
+        var result = sut.ParseResponse(json);
+
+        result.RawExtractionJson.Should().Be(json);
+    }
+
+    [Fact]
+    public void ParseResponse_InvalidJson_ReturnsNullRawExtractionJson()
+    {
+        var sut = CreateSut("{}");
+
+        var result = sut.ParseResponse("not valid json");
+
+        result.RawExtractionJson.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ClaudeApiSuccess_RawExtractionJsonMatchesResponse()
+    {
+        var rawJson = """{"whatWasCovered":"verbos irregulares"}""";
+        var sut = new ReflectionExtractionService(
+            new ReflectionClaudeClient(rawJson),
+            FakePrompts,
+            PedagogyService,
+            NullLogger<ReflectionExtractionService>.Instance);
+
+        var result = await sut.ExtractAsync("Hoy trabajamos los verbos", CancellationToken.None);
+
+        result.RawExtractionJson.Should().Be(rawJson);
+    }
 }

--- a/backend/LangTeach.Api.Tests/Services/SessionLogServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/SessionLogServiceTests.cs
@@ -827,6 +827,34 @@ public class SessionLogServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateAsync_VoiceNoteIdBelongsToOtherTeacher_ThrowsKeyNotFoundException()
+    {
+        var otherVoiceNoteId = Guid.NewGuid();
+        _db.VoiceNotes.Add(new VoiceNote
+        {
+            Id = otherVoiceNoteId,
+            TeacherId = _otherTeacherId,
+            BlobPath = "teachers/other/file.webm",
+            OriginalFileName = "file.webm",
+            ContentType = "audio/webm",
+            SizeBytes = 512,
+            DurationSeconds = 0,
+            CreatedAt = DateTime.UtcNow
+        });
+        await _db.SaveChangesAsync();
+
+        var request = new CreateSessionLogRequest
+        {
+            SessionDate = new DateTime(2026, 4, 1, 10, 0, 0, DateTimeKind.Utc),
+            PreviousHomeworkStatus = HomeworkStatus.Done,
+            VoiceNoteId = otherVoiceNoteId
+        };
+
+        var act = () => _sut.CreateAsync(_teacherId, _studentId, request);
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
     public async Task CreateAsync_TelegramFlow_WritesVoiceNoteApplicationWithNullVoiceNoteId()
     {
         var request = new CreateSessionLogRequest

--- a/backend/LangTeach.Api.Tests/Services/SessionLogServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/SessionLogServiceTests.cs
@@ -778,6 +778,73 @@ public class SessionLogServiceTests : IDisposable
         result.Should().NotBeNull();
         result!.IsCancelled.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task CreateAsync_WithVoiceNoteFields_WritesVoiceNoteApplicationRow()
+    {
+        var voiceNoteId = Guid.NewGuid();
+        _db.VoiceNotes.Add(new VoiceNote
+        {
+            Id = voiceNoteId,
+            TeacherId = _teacherId,
+            BlobPath = "teachers/test/file.webm",
+            OriginalFileName = "file.webm",
+            ContentType = "audio/webm",
+            SizeBytes = 1024,
+            DurationSeconds = 0,
+            CreatedAt = DateTime.UtcNow
+        });
+        await _db.SaveChangesAsync();
+
+        var request = new CreateSessionLogRequest
+        {
+            SessionDate = new DateTime(2026, 4, 1, 10, 0, 0, DateTimeKind.Utc),
+            PreviousHomeworkStatus = HomeworkStatus.Done,
+            VoiceNoteId = voiceNoteId,
+            VoiceNoteTranscription = "Hoy trabajamos los verbos irregulares",
+            RawExtractionJson = "{\"whatWasCovered\":\"verbos irregulares\"}"
+        };
+
+        var result = await _sut.CreateAsync(_teacherId, _studentId, request);
+
+        var application = await _db.VoiceNoteApplications
+            .SingleAsync(a => a.SessionLogId == result.Id);
+        application.VoiceNoteId.Should().Be(voiceNoteId);
+        application.Transcription.Should().Be("Hoy trabajamos los verbos irregulares");
+        application.RawExtractionJson.Should().Be("{\"whatWasCovered\":\"verbos irregulares\"}");
+        application.ApplicationType.Should().Be(ApplicationType.Create);
+        application.AppliedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithoutVoiceNoteFields_WritesNoVoiceNoteApplicationRow()
+    {
+        var result = await _sut.CreateAsync(_teacherId, _studentId, BaseRequest());
+
+        var count = await _db.VoiceNoteApplications
+            .CountAsync(a => a.SessionLogId == result.Id);
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CreateAsync_TelegramFlow_WritesVoiceNoteApplicationWithNullVoiceNoteId()
+    {
+        var request = new CreateSessionLogRequest
+        {
+            SessionDate = new DateTime(2026, 4, 1, 10, 0, 0, DateTimeKind.Utc),
+            PreviousHomeworkStatus = HomeworkStatus.Done,
+            VoiceNoteTranscription = "Marco hizo los deberes y repasamos el subjuntivo",
+            RawExtractionJson = "{\"whatWasCovered\":\"subjuntivo\"}"
+        };
+
+        var result = await _sut.CreateAsync(_teacherId, _studentId, request);
+
+        var application = await _db.VoiceNoteApplications
+            .SingleAsync(a => a.SessionLogId == result.Id);
+        application.VoiceNoteId.Should().BeNull();
+        application.Transcription.Should().Be("Marco hizo los deberes y repasamos el subjuntivo");
+        application.ApplicationType.Should().Be(ApplicationType.Create);
+    }
 }
 
 file class NullDifficultyTrendService : IDifficultyTrendService

--- a/backend/LangTeach.Api.Tests/Services/TelegramConversationServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/TelegramConversationServiceTests.cs
@@ -299,7 +299,8 @@ public class TelegramConversationServiceTests : IDisposable
             SuggestedDifficulties: new List<SuggestedDifficultyDto>
             {
                 new("confuses ser and estar", "Grammar", "Copulas", "Medium")
-            });
+            },
+            RawExtractionJson: null);
 
         await _sut.HandleUpdateAsync(TextUpdate(_chatId, "Marco worked on ser/estar today"), CancellationToken.None);
 
@@ -309,6 +310,32 @@ public class TelegramConversationServiceTests : IDisposable
         log.NextSessionTopics.Should().Be("past tenses review");
         log.GeneralNotes.Should().Be("needs more practice with preterite\nengaged");
         _extractionService.LastInput.Should().Be("Marco worked on ser/estar today");
+    }
+
+    [Fact]
+    public async Task TextMessage_MatchedStudent_WritesVoiceNoteApplicationRow()
+    {
+        LinkTeacher();
+        var student = await CreateStudentAsync("Marco");
+
+        _extractionService.Result = new ExtractedReflectionDto(
+            WhatWasCovered: "ser vs estar",
+            AreasToImprove: null,
+            EmotionalSignals: null,
+            HomeworkAssigned: null,
+            NextLessonIdeas: null,
+            SessionDate: null,
+            SuggestedDifficulties: new List<SuggestedDifficultyDto>(),
+            RawExtractionJson: "{\"whatWasCovered\":\"ser vs estar\"}");
+
+        await _sut.HandleUpdateAsync(TextUpdate(_chatId, "Marco trabajamos ser vs estar"), CancellationToken.None);
+
+        var log = await _db.SessionLogs.SingleAsync(s => s.StudentId == student.Id);
+        var application = await _db.VoiceNoteApplications.SingleAsync(a => a.SessionLogId == log.Id);
+        application.VoiceNoteId.Should().BeNull();
+        application.Transcription.Should().Be("Marco trabajamos ser vs estar");
+        application.RawExtractionJson.Should().Be("{\"whatWasCovered\":\"ser vs estar\"}");
+        application.ApplicationType.Should().Be(ApplicationType.Create);
     }
 
     [Fact]
@@ -324,7 +351,8 @@ public class TelegramConversationServiceTests : IDisposable
             HomeworkAssigned: null,
             NextLessonIdeas: null,
             SessionDate: "2026-04-06",
-            SuggestedDifficulties: new List<SuggestedDifficultyDto>());
+            SuggestedDifficulties: new List<SuggestedDifficultyDto>(),
+            RawExtractionJson: null);
 
         await _sut.HandleUpdateAsync(TextUpdate(_chatId, "Marco el pasado lunes trabajamos los condicionales"), CancellationToken.None);
 
@@ -379,7 +407,8 @@ public class TelegramConversationServiceTests : IDisposable
                 HomeworkAssigned: null,
                 NextLessonIdeas: null,
                 SessionDate: null,
-                SuggestedDifficulties: new List<SuggestedDifficultyDto>());
+                SuggestedDifficulties: new List<SuggestedDifficultyDto>(),
+                RawExtractionJson: null);
             return Task.FromResult(result);
         }
     }

--- a/backend/LangTeach.Api/DTOs/ReflectionExtractionDtos.cs
+++ b/backend/LangTeach.Api/DTOs/ReflectionExtractionDtos.cs
@@ -23,5 +23,6 @@ public record ExtractedReflectionDto(
     string? HomeworkAssigned,
     string? NextLessonIdeas,
     string? SessionDate,
-    List<SuggestedDifficultyDto> SuggestedDifficulties
+    List<SuggestedDifficultyDto> SuggestedDifficulties,
+    string? RawExtractionJson
 );

--- a/backend/LangTeach.Api/DTOs/SessionLogDtos.cs
+++ b/backend/LangTeach.Api/DTOs/SessionLogDtos.cs
@@ -71,6 +71,13 @@ public class CreateSessionLogRequest
 
     public List<DifficultyPairDto>? MentionedDifficultyPairs { get; set; }
     public List<SuggestedDifficultyDto>? SuggestedDifficulties { get; set; }
+
+    // Voice note traceability -- written to VoiceNoteApplication when provided.
+    // VoiceNoteId is null for Telegram (no VoiceNote entity). No MaxLength because
+    // transcriptions and raw Claude JSON can be arbitrarily large.
+    public Guid? VoiceNoteId { get; set; }
+    public string? VoiceNoteTranscription { get; set; }
+    public string? RawExtractionJson { get; set; }
 }
 
 public record StudentSessionSummaryDto(

--- a/backend/LangTeach.Api/DTOs/SessionLogDtos.cs
+++ b/backend/LangTeach.Api/DTOs/SessionLogDtos.cs
@@ -73,10 +73,13 @@ public class CreateSessionLogRequest
     public List<SuggestedDifficultyDto>? SuggestedDifficulties { get; set; }
 
     // Voice note traceability -- written to VoiceNoteApplication when provided.
-    // VoiceNoteId is null for Telegram (no VoiceNote entity). No MaxLength because
-    // transcriptions and raw Claude JSON can be arbitrarily large.
+    // VoiceNoteId is null for Telegram (no VoiceNote entity).
     public Guid? VoiceNoteId { get; set; }
+
+    [MaxLength(100000)]
     public string? VoiceNoteTranscription { get; set; }
+
+    [MaxLength(100000)]
     public string? RawExtractionJson { get; set; }
 }
 

--- a/backend/LangTeach.Api/Data/AppDbContext.cs
+++ b/backend/LangTeach.Api/Data/AppDbContext.cs
@@ -21,6 +21,7 @@ public class AppDbContext : DbContext
     public DbSet<GenerationUsage> GenerationUsages => Set<GenerationUsage>();
     public DbSet<SessionLog> SessionLogs => Set<SessionLog>();
     public DbSet<VoiceNote> VoiceNotes => Set<VoiceNote>();
+    public DbSet<VoiceNoteApplication> VoiceNoteApplications => Set<VoiceNoteApplication>();
     public DbSet<CourseSuggestion> CourseSuggestions => Set<CourseSuggestion>();
     public DbSet<TelegramLink> TelegramLinks => Set<TelegramLink>();
 
@@ -218,6 +219,24 @@ public class AppDbContext : DbContext
              .HasForeignKey(v => v.TeacherId)
              .OnDelete(DeleteBehavior.Cascade);
             // TranscribedAt: null = not transcribed, non-null = transcription complete (timestamp provides timing)
+        });
+
+        // VoiceNoteApplication — cascade delete from SessionLog; SetNull on VoiceNote delete.
+        // VoiceNoteId is nullable: Telegram applications have no VoiceNote entity.
+        // No multi-cascade-path conflict: SessionLog->Teacher is NoAction; VoiceNote->Teacher is Cascade.
+        modelBuilder.Entity<VoiceNoteApplication>(e =>
+        {
+            e.HasKey(a => a.Id);
+            e.HasIndex(a => a.SessionLogId);
+            e.HasOne(a => a.SessionLog)
+             .WithMany()
+             .HasForeignKey(a => a.SessionLogId)
+             .OnDelete(DeleteBehavior.Cascade);
+            e.HasOne(a => a.VoiceNote)
+             .WithMany()
+             .HasForeignKey(a => a.VoiceNoteId)
+             .IsRequired(false)
+             .OnDelete(DeleteBehavior.SetNull);
         });
 
         // CourseSuggestion — cascade delete from Course, no-action from CurriculumEntry (nullable)

--- a/backend/LangTeach.Api/Data/Models/ApplicationType.cs
+++ b/backend/LangTeach.Api/Data/Models/ApplicationType.cs
@@ -1,0 +1,7 @@
+namespace LangTeach.Api.Data.Models;
+
+public enum ApplicationType
+{
+    Create = 0,
+    Update = 1
+}

--- a/backend/LangTeach.Api/Data/Models/VoiceNoteApplication.cs
+++ b/backend/LangTeach.Api/Data/Models/VoiceNoteApplication.cs
@@ -1,0 +1,21 @@
+namespace LangTeach.Api.Data.Models;
+
+public enum ApplicationType
+{
+    Create,
+    Update
+}
+
+public class VoiceNoteApplication
+{
+    public Guid Id { get; set; }
+    public Guid SessionLogId { get; set; }
+    public Guid? VoiceNoteId { get; set; }
+    public string? Transcription { get; set; }
+    public string? RawExtractionJson { get; set; }
+    public ApplicationType ApplicationType { get; set; }
+    public DateTime AppliedAt { get; set; }
+
+    public SessionLog SessionLog { get; set; } = null!;
+    public VoiceNote? VoiceNote { get; set; }
+}

--- a/backend/LangTeach.Api/Data/Models/VoiceNoteApplication.cs
+++ b/backend/LangTeach.Api/Data/Models/VoiceNoteApplication.cs
@@ -1,11 +1,5 @@
 namespace LangTeach.Api.Data.Models;
 
-public enum ApplicationType
-{
-    Create,
-    Update
-}
-
 public class VoiceNoteApplication
 {
     public Guid Id { get; set; }

--- a/backend/LangTeach.Api/Migrations/20260411060443_AddVoiceNoteApplication.Designer.cs
+++ b/backend/LangTeach.Api/Migrations/20260411060443_AddVoiceNoteApplication.Designer.cs
@@ -4,6 +4,7 @@ using LangTeach.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LangTeach.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411060443_AddVoiceNoteApplication")]
+    partial class AddVoiceNoteApplication
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/LangTeach.Api/Migrations/20260411060443_AddVoiceNoteApplication.cs
+++ b/backend/LangTeach.Api/Migrations/20260411060443_AddVoiceNoteApplication.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LangTeach.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddVoiceNoteApplication : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "VoiceNoteApplications",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    SessionLogId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    VoiceNoteId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Transcription = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    RawExtractionJson = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    ApplicationType = table.Column<int>(type: "int", nullable: false),
+                    AppliedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_VoiceNoteApplications", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_VoiceNoteApplications_SessionLogs_SessionLogId",
+                        column: x => x.SessionLogId,
+                        principalTable: "SessionLogs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_VoiceNoteApplications_VoiceNotes_VoiceNoteId",
+                        column: x => x.VoiceNoteId,
+                        principalTable: "VoiceNotes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VoiceNoteApplications_SessionLogId",
+                table: "VoiceNoteApplications",
+                column: "SessionLogId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_VoiceNoteApplications_VoiceNoteId",
+                table: "VoiceNoteApplications",
+                column: "VoiceNoteId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "VoiceNoteApplications");
+        }
+    }
+}

--- a/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
@@ -37,7 +37,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Claude API call failed during reflection extraction");
-            return new ExtractedReflectionDto(null, null, null, null, null, null, []);
+            return new ExtractedReflectionDto(null, null, null, null, null, null, [], null);
         }
 
         return ParseResponse(response.Content);
@@ -58,14 +58,15 @@ public class ReflectionExtractionService : IReflectionExtractionService
                 HomeworkAssigned: GetStringOrNull(root, "homeworkAssigned"),
                 NextLessonIdeas: GetStringOrNull(root, "nextLessonIdeas"),
                 SessionDate: GetIsoDateOrNull(root, "sessionDate"),
-                SuggestedDifficulties: ParseSuggestedDifficulties(root)
+                SuggestedDifficulties: ParseSuggestedDifficulties(root),
+                RawExtractionJson: json
             );
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to parse reflection extraction JSON (length: {Length})", json?.Length ?? 0);
         _logger.LogDebug("Unparseable Claude response: {Json}", json);
-            return new ExtractedReflectionDto(null, null, null, null, null, null, []);
+            return new ExtractedReflectionDto(null, null, null, null, null, null, [], null);
         }
     }
 

--- a/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
@@ -59,7 +59,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
                 NextLessonIdeas: GetStringOrNull(root, "nextLessonIdeas"),
                 SessionDate: GetIsoDateOrNull(root, "sessionDate"),
                 SuggestedDifficulties: ParseSuggestedDifficulties(root),
-                RawExtractionJson: json
+                RawExtractionJson: cleaned
             );
         }
         catch (Exception ex)

--- a/backend/LangTeach.Api/Services/SessionLogService.cs
+++ b/backend/LangTeach.Api/Services/SessionLogService.cs
@@ -125,6 +125,20 @@ public class SessionLogService : ISessionLogService
 
         _db.SessionLogs.Add(entity);
 
+        if (request.VoiceNoteId.HasValue || request.VoiceNoteTranscription is not null || request.RawExtractionJson is not null)
+        {
+            _db.VoiceNoteApplications.Add(new VoiceNoteApplication
+            {
+                Id = Guid.NewGuid(),
+                SessionLogId = entity.Id,
+                VoiceNoteId = request.VoiceNoteId,
+                Transcription = request.VoiceNoteTranscription,
+                RawExtractionJson = request.RawExtractionJson,
+                ApplicationType = ApplicationType.Create,
+                AppliedAt = now
+            });
+        }
+
         if (request.LevelReassessmentSkill is not null && request.LevelReassessmentLevel is not null)
             PropagateReassessment(student, request.LevelReassessmentSkill, request.LevelReassessmentLevel, _logger);
 

--- a/backend/LangTeach.Api/Services/SessionLogService.cs
+++ b/backend/LangTeach.Api/Services/SessionLogService.cs
@@ -97,6 +97,16 @@ public class SessionLogService : ISessionLogService
                 throw new KeyNotFoundException($"Lesson {request.LinkedLessonId.Value} not found.");
         }
 
+        if (request.VoiceNoteId.HasValue)
+        {
+            var voiceNoteExists = await _db.VoiceNotes.AnyAsync(
+                v => v.Id == request.VoiceNoteId.Value && v.TeacherId == teacherId,
+                cancellationToken);
+
+            if (!voiceNoteExists)
+                throw new KeyNotFoundException($"VoiceNote {request.VoiceNoteId.Value} not found.");
+        }
+
         var now = DateTime.UtcNow;
         var sanitizedDifficulties = SanitizeSuggestedDifficulties(request.SuggestedDifficulties, _logger);
         var entity = new SessionLog

--- a/backend/LangTeach.Api/Services/StubReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/StubReflectionExtractionService.cs
@@ -12,6 +12,7 @@ public class StubReflectionExtractionService : IReflectionExtractionService
             HomeworkAssigned: "[Extracted] Homework assigned",
             NextLessonIdeas: "[Extracted] Next lesson ideas",
             SessionDate: null,
-            SuggestedDifficulties: []
+            SuggestedDifficulties: [],
+            RawExtractionJson: null
         ));
 }

--- a/backend/LangTeach.Api/Services/TelegramConversationService.cs
+++ b/backend/LangTeach.Api/Services/TelegramConversationService.cs
@@ -224,7 +224,8 @@ public class TelegramConversationService : ITelegramConversationService
             return new CreateSessionLogRequest
             {
                 SessionDate = DateTime.UtcNow.Date,
-                GeneralNotes = notes
+                GeneralNotes = notes,
+                VoiceNoteTranscription = notes
             };
         }
 
@@ -243,7 +244,9 @@ public class TelegramConversationService : ITelegramConversationService
             GeneralNotes = string.IsNullOrEmpty(generalNotes) ? null : generalNotes,
             SuggestedDifficulties = extracted.SuggestedDifficulties.Count > 0
                 ? extracted.SuggestedDifficulties
-                : null
+                : null,
+            VoiceNoteTranscription = notes,
+            RawExtractionJson = extracted.RawExtractionJson
         };
     }
 

--- a/frontend/src/api/sessionLogs.ts
+++ b/frontend/src/api/sessionLogs.ts
@@ -44,6 +44,7 @@ export interface ExtractedReflection {
   nextLessonIdeas: string | null
   sessionDate?: string | null
   suggestedDifficulties: SuggestedDifficulty[]
+  rawExtractionJson?: string | null
 }
 
 export interface CreateSessionLogRequest {
@@ -62,6 +63,9 @@ export interface CreateSessionLogRequest {
   status?: 'Draft' | 'Confirmed'
   mentionedDifficultyPairs?: { Competency: string; Subcategory: string }[]
   suggestedDifficulties?: SuggestedDifficulty[]
+  voiceNoteId?: string
+  voiceNoteTranscription?: string
+  rawExtractionJson?: string
 }
 
 export type UpdateSessionLogRequest = CreateSessionLogRequest

--- a/frontend/src/components/session/SessionLogDialog.test.tsx
+++ b/frontend/src/components/session/SessionLogDialog.test.tsx
@@ -714,6 +714,30 @@ describe('SessionLogDialog', () => {
       })
     })
 
+    it('includes voiceNoteId, voiceNoteTranscription and rawExtractionJson in draft payload', async () => {
+      const EXTRACTED_WITH_RAW = {
+        ...EXTRACTED,
+        rawExtractionJson: '{"whatWasCovered":"Covered ser vs estar"}',
+      }
+      vi.mocked(sessionLogsApi.extractSessionReflection).mockResolvedValue(EXTRACTED_WITH_RAW)
+
+      wrapper(<SessionLogDialog studentId={STUDENT_ID} open={true} onOpenChange={vi.fn()} />)
+      await waitFor(() => expect(screen.getByTestId('mock-audio-recorder-trigger')).toBeInTheDocument())
+
+      fireEvent.click(screen.getByTestId('mock-audio-recorder-trigger'))
+
+      await waitFor(() => {
+        expect(vi.mocked(sessionLogsApi.createSession)).toHaveBeenCalledWith(
+          STUDENT_ID,
+          expect.objectContaining({
+            voiceNoteId: 'vn-1',
+            voiceNoteTranscription: 'We covered ser vs estar.',
+            rawExtractionJson: '{"whatWasCovered":"Covered ser vs estar"}',
+          }),
+        )
+      })
+    })
+
     it('auto-saves Draft and changes submit button to "Confirm"', async () => {
       wrapper(<SessionLogDialog studentId={STUDENT_ID} open={true} onOpenChange={vi.fn()} />)
       await waitFor(() => expect(screen.getByTestId('mock-audio-recorder-trigger')).toBeInTheDocument())

--- a/frontend/src/components/session/SessionLogDialog.tsx
+++ b/frontend/src/components/session/SessionLogDialog.tsx
@@ -347,6 +347,9 @@ export function SessionLogDialog({
         isCancelled,
         status: 'Draft',
         suggestedDifficulties: extracted.suggestedDifficulties?.length ? extracted.suggestedDifficulties : undefined,
+        voiceNoteId: voiceNote.id,
+        voiceNoteTranscription: voiceNote.transcription ?? undefined,
+        rawExtractionJson: extracted.rawExtractionJson ?? undefined,
       })
       if (runId !== voiceRunRef.current) return
       setDraftSessionId(draft.id)

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -6,6 +6,14 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 
 *Cleared 2026-04-08 during Adaptive Replanning sprint close. All entries deleted (low/info severity, all already deferred with sound reasoning) or batched into #603-#609.*
 
+## #656 — 2026-04-11
+
+| Reviewer | Severity | Note |
+|---|---|---|
+| review | minor | `VoiceNoteApplication.RawExtractionJson` stores the raw Claude response before markdown-fence stripping, so it may contain ````json` fences. Field name implies clean JSON. Rename to `RawExtractionResponse` if it causes confusion in future tooling. |
+| sophy | minor | `SessionLogService` guard writes VoiceNoteApplication if any of three fields is non-null, so half-populated rows (e.g. only RawExtractionJson) are possible. In practice all callers provide at least Transcription; add explicit validation if partial rows become a problem. |
+| sophy | info | `ApplicationType.Update` is unused but retained as the issue AC explicitly requires it for the future update flow. Drop in a future sprint if Update is never wired. |
+
 ## #653 — 2026-04-11
 
 | Reviewer | Severity | Note |

--- a/plan/langteach-beta/task656-voice-note-traceability.md
+++ b/plan/langteach-beta/task656-voice-note-traceability.md
@@ -1,0 +1,178 @@
+# Task 656: Voice Note Traceability via VoiceNoteApplication Table
+
+## Issue
+#656 — Add voice note traceability via VoiceNoteApplication table
+
+## Context
+
+Currently, when a voice note creates a session log (web UI or Telegram), nothing records
+which voice note was used, what transcription was sent to Claude, or what Claude returned.
+This makes it impossible to reproduce failures.
+
+The fix: introduce a `VoiceNoteApplication` table that records every time a voice note is
+applied to a session log. `SessionLog` itself does NOT get `VoiceNoteId` or `RawExtractionJson`
+fields.
+
+## Flows to Cover
+
+**Web UI (SessionLogDialog.tsx):**
+1. User records voice note -> `uploadVoiceNote()` -> returns `VoiceNote { id, transcription }`
+2. `extractSessionReflection(studentId, transcription)` -> POST `/api/students/{id}/sessions/extract`
+   -> returns `ExtractedReflectionDto` (currently no raw JSON)
+3. `createSession(studentId, {...})` -> POST `/api/students/{id}/sessions`
+   -> backend creates `SessionLog`
+
+**Telegram:**
+1. Audio downloaded -> `TranscribeAsync()` -> `notes` string
+2. `_extractionService.ExtractAsync(notes)` -> `ExtractedReflectionDto`
+3. `_sessionLogService.CreateAsync(...)` -> `SessionLog`
+
+## Design
+
+### Capture Raw JSON from Claude
+
+Add `string? RawExtractionJson` to `ExtractedReflectionDto` (as a positional parameter at the end).
+`ReflectionExtractionService.ExtractAsync` captures `response.Content` before parsing and
+includes it in the returned DTO. The stub returns `null`.
+
+This field flows through the extract endpoint back to the frontend, which passes it in the
+create session log request.
+
+### Pass VoiceNote Context Through Create Request
+
+Add three optional fields to `CreateSessionLogRequest`:
+
+```csharp
+public Guid? VoiceNoteId { get; set; }          // null for Telegram
+public string? VoiceNoteTranscription { get; set; }  // text sent to extractor
+public string? RawExtractionJson { get; set; }  // raw Claude response
+```
+
+Only when at least one of these is non-null does `SessionLogService.CreateAsync` write a
+`VoiceNoteApplication` row. `ApplicationType = Create` always (Update is future scope).
+
+### VoiceNoteApplication Model
+
+```csharp
+public class VoiceNoteApplication
+{
+    public Guid Id { get; set; }
+    public Guid SessionLogId { get; set; }
+    public Guid? VoiceNoteId { get; set; }         // null for Telegram
+    public string? Transcription { get; set; }
+    public string? RawExtractionJson { get; set; }
+    public ApplicationType ApplicationType { get; set; }
+    public DateTime AppliedAt { get; set; }
+
+    public SessionLog SessionLog { get; set; } = null!;
+    public VoiceNote? VoiceNote { get; set; }
+}
+
+public enum ApplicationType { Create, Update }
+```
+
+### EF Configuration (AppDbContext)
+
+```csharp
+modelBuilder.Entity<VoiceNoteApplication>(e =>
+{
+    e.HasKey(a => a.Id);
+    e.HasIndex(a => a.SessionLogId);
+    e.HasOne(a => a.SessionLog)
+     .WithMany()
+     .HasForeignKey(a => a.SessionLogId)
+     .OnDelete(DeleteBehavior.Cascade);
+    e.HasOne(a => a.VoiceNote)
+     .WithMany()
+     .HasForeignKey(a => a.VoiceNoteId)
+     .IsRequired(false)
+     .OnDelete(DeleteBehavior.SetNull);
+});
+```
+
+**Note on SQL Server multi-cascade-path:** `VoiceNote` cascades from `Teacher` (Cascade).
+`SessionLog` is NoAction from Teacher/Student. `VoiceNoteApplication.SessionLogId` is Cascade
+(from SessionLog, not from Teacher directly), so no cycle conflict. `VoiceNoteId` is SetNull
+(not Cascade), so also fine.
+
+### Telegram flow change
+
+In `TelegramConversationService.BuildSessionLogRequestAsync`, capture `rawExtractionJson` from
+the extracted DTO and populate the new request fields. Since Telegram voice notes are not
+stored as `VoiceNote` entities, `VoiceNoteId` stays null; `Transcription` is the `notes`
+string passed into the method.
+
+Pass `notes` parameter down to `BuildSessionLogRequestAsync` (already there) and add
+`VoiceNoteTranscription = notes` and `RawExtractionJson = extracted?.RawExtractionJson`
+to the returned `CreateSessionLogRequest`.
+
+### Frontend changes
+
+1. `frontend/src/api/sessionLogs.ts`: Add `rawExtractionJson?: string` to `ExtractedReflection`
+   interface and `voiceNoteId?: string`, `voiceNoteTranscription?: string`,
+   `rawExtractionJson?: string` to `CreateSessionLogRequest` interface.
+2. `frontend/src/components/session/SessionLogDialog.tsx`: In `handleVoiceNote`, after
+   getting `extracted`, pass `voiceNote.id`, `voiceNote.transcription`, and
+   `extracted.rawExtractionJson` in the `createSession` call.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `backend/LangTeach.Api/Data/Models/VoiceNoteApplication.cs` | NEW — entity + enum |
+| `backend/LangTeach.Api/Data/AppDbContext.cs` | Add `VoiceNoteApplications` DbSet + config |
+| `backend/LangTeach.Api/Migrations/<ts>_AddVoiceNoteApplication.cs` | EF migration (generated) |
+| `backend/LangTeach.Api/DTOs/ReflectionExtractionDtos.cs` | Add `RawExtractionJson?` as 8th positional param |
+| `backend/LangTeach.Api/Services/ReflectionExtractionService.cs` | Capture raw JSON; update 2 error-path `new ExtractedReflectionDto(...)` calls (lines 40 and 68) to add `null` as 8th arg |
+| `backend/LangTeach.Api/Services/StubReflectionExtractionService.cs` | Add `null` as 8th arg |
+| `backend/LangTeach.Api/DTOs/SessionLogDtos.cs` | Add 3 optional fields to `CreateSessionLogRequest` |
+| `backend/LangTeach.Api/Services/SessionLogService.cs` | Create `VoiceNoteApplication` row in `CreateAsync` |
+| `backend/LangTeach.Api/Services/TelegramConversationService.cs` | Populate new request fields |
+| `backend/LangTeach.Api.Tests/Services/TelegramConversationServiceTests.cs` | Update 3 `new ExtractedReflectionDto(...)` positional calls (all need 8th `null` arg) |
+| `backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs` | Extend existing tests to assert `RawExtractionJson` |
+| `frontend/src/api/sessionLogs.ts` | Extend interfaces |
+| `frontend/src/components/session/SessionLogDialog.tsx` | Pass voiceNoteId, voiceNoteTranscription, rawExtractionJson in createSession call |
+| `frontend/src/components/session/SessionLogDialog.test.tsx` | NEW — verify 3 new fields flow into createSession |
+
+## Notes on Fields
+
+- `VoiceNoteTranscription` and `RawExtractionJson` on `CreateSessionLogRequest`: intentionally no
+  `[MaxLength]` attribute, because the raw Claude JSON and transcription can be arbitrarily large.
+  SQL Server `nvarchar(max)` columns (no length constraint in EF = max). These are internal fields
+  not exposed via public update endpoints.
+- `voiceNote` is already in scope in `handleVoiceNote` in `SessionLogDialog.tsx`. The three new
+  fields are added directly to the object literal passed to `createSession` at line ~335:
+  `voiceNoteId: voiceNote.id`, `voiceNoteTranscription: voiceNote.transcription ?? undefined`,
+  `rawExtractionJson: extracted.rawExtractionJson ?? undefined`.
+
+## Tests to Write
+
+1. `SessionLogServiceTests`: new test verifies that calling `CreateAsync` with
+   `VoiceNoteTranscription` set writes a `VoiceNoteApplication` row with `ApplicationType=Create`.
+2. `SessionLogServiceTests`: test that calling `CreateAsync` without voice note fields writes NO
+   `VoiceNoteApplication` row.
+3. `TelegramConversationServiceTests`: verify that `CreateAsync` is called with populated
+   `VoiceNoteTranscription` and `RawExtractionJson` when extraction succeeds.
+4. `ReflectionExtractionServiceTests`: verify `RawExtractionJson` on returned DTO matches
+   the raw Claude response content (extend existing `ParseResponse` tests).
+5. `SessionLogDialog.test.tsx`: new test verifies that after `handleVoiceNote`, the
+   `createSession` call includes `voiceNoteId`, `voiceNoteTranscription`, and `rawExtractionJson`.
+
+## Acceptance Criteria Mapping
+
+| AC | Implementation |
+|----|----------------|
+| New `VoiceNoteApplication` entity and EF migration | Model + migration |
+| `ApplicationType` enum: Create, Update | Enum in model file |
+| `VoiceNoteId` nullable FK with SetNull on delete | EF config |
+| `SessionLogId` FK with cascade delete | EF config |
+| Row written on web UI voice note create | SessionLogService + frontend passing voiceNoteId |
+| Row written on Telegram voice note create (VoiceNoteId=null) | TelegramConversationService + SessionLogService |
+| Future Update flow also writes row | ApplicationType enum exists; Update path is future scope (not implemented now) |
+| No new public API endpoints | Confirmed: extending existing DTOs only |
+
+## Out of Scope
+
+- The "update via voice note" flow (AC deliberately deferred)
+- Lesson notes voice note path (LessonNotesCard / LessonNotesController) — not a session log
+- Any read/admin endpoint for VoiceNoteApplication


### PR DESCRIPTION
## Summary

- Introduces `VoiceNoteApplication` join table recording each time a voice note drives a session log creation; stores the transcription sent to Claude and the raw extraction JSON for full failure reproduction
- `ExtractedReflectionDto` now carries `RawExtractionJson` from Claude; `CreateSessionLogRequest` accepts `VoiceNoteId`, `VoiceNoteTranscription`, and `RawExtractionJson`
- Web UI (SessionLogDialog) passes `voiceNoteId` + `rawExtractionJson` on draft save; Telegram flow populates transcription + raw JSON with `VoiceNoteId = null`

## Changes

- `Data/Models/VoiceNoteApplication.cs` + `ApplicationType.cs` (new entity + enum)
- EF migration `20260411060443_AddVoiceNoteApplication`
- `SessionLogService.CreateAsync` writes application row when any voice note field is set
- `TelegramConversationService.BuildSessionLogRequestAsync` populates traceability fields
- `SessionLogDialog.tsx` passes `voiceNoteId`, `voiceNoteTranscription`, `rawExtractionJson`
- 9 new tests across 4 test files

## Test plan

- [x] Backend build: clean
- [x] Backend tests: 1006 passed, 0 failed
- [x] Frontend tests: 939 passed, 0 failed
- [x] QA verify: PASS
- [x] Code review: PASS WITH NOTES (all addressed)
- [x] Architecture review: PASS WITH NOTES (all addressed)
- [x] Sophy: CLEAN

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice notes are now linked to session logs with transcription and extraction data automatically persisted.

* **Tests**
  * Added comprehensive test coverage for voice note data handling across extraction, session logging, and conversation services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->