### PR TITLE
feat: TeacherFollowup entity and dashboard integration (#671)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
@@ -20,7 +20,8 @@ public class DashboardServiceTests : IDisposable
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
         _db = new AppDbContext(options);
-        _sut = new DashboardService(_db, NullLogger<DashboardService>.Instance);
+        var followupService = new TeacherFollowupService(_db);
+        _sut = new DashboardService(_db, followupService, NullLogger<DashboardService>.Instance);
 
         _db.Teachers.Add(new Teacher
         {

--- a/backend/LangTeach.Api.Tests/Services/TeacherFollowupServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/TeacherFollowupServiceTests.cs
@@ -1,0 +1,150 @@
+using FluentAssertions;
+using LangTeach.Api.Data;
+using LangTeach.Api.Data.Models;
+using LangTeach.Api.DTOs;
+using LangTeach.Api.Services;
+using Microsoft.EntityFrameworkCore;
+
+namespace LangTeach.Api.Tests.Services;
+
+public class TeacherFollowupServiceTests : IDisposable
+{
+    private readonly AppDbContext _db;
+    private readonly TeacherFollowupService _sut;
+    private readonly Guid _teacherId = Guid.NewGuid();
+    private readonly Guid _otherTeacherId = Guid.NewGuid();
+    private readonly Guid _studentId = Guid.NewGuid();
+
+    public TeacherFollowupServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _db = new AppDbContext(options);
+        _sut = new TeacherFollowupService(_db);
+
+        _db.Teachers.AddRange(
+            new Teacher { Id = _teacherId, Auth0UserId = "auth0|t1", Email = "t1@test.com", DisplayName = "Teacher 1", IsApproved = true, CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow },
+            new Teacher { Id = _otherTeacherId, Auth0UserId = "auth0|t2", Email = "t2@test.com", DisplayName = "Teacher 2", IsApproved = true, CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow }
+        );
+        _db.Students.Add(new Student
+        {
+            Id = _studentId,
+            TeacherId = _teacherId,
+            Name = "Ewan McLeod",
+            LearningLanguage = "Spanish",
+            CefrLevel = "A1",
+            NativeLanguages = "[\"English\"]",
+            TeachingTodos = "[]",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        _db.SaveChanges();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task CreateAsync_AddsFollowup_ReturnableViaGetAll()
+    {
+        var request = new CreateTeacherFollowupRequest("Enviar ejercicio de gustar", _studentId.ToString(), null, null);
+
+        var created = await _sut.CreateAsync(_teacherId, request, default);
+
+        created.Text.Should().Be("Enviar ejercicio de gustar");
+        created.Status.Should().Be("pending");
+        created.StudentId.Should().Be(_studentId.ToString());
+        created.StudentName.Should().Be("Ewan McLeod");
+        created.CompletedAt.Should().BeNull();
+
+        var all = await _sut.GetAllAsync(_teacherId, default);
+        all.Should().HaveCount(1);
+        all[0].Id.Should().Be(created.Id);
+    }
+
+    [Fact]
+    public async Task GetByStudentAsync_ReturnsOnlyThatStudentsFollowups()
+    {
+        var otherStudentId = Guid.NewGuid();
+        _db.Students.Add(new Student
+        {
+            Id = otherStudentId,
+            TeacherId = _teacherId,
+            Name = "Bruno Almeida",
+            LearningLanguage = "Spanish",
+            CefrLevel = "B1",
+            NativeLanguages = "[\"Portuguese\"]",
+            TeachingTodos = "[]",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        _db.SaveChanges();
+
+        await _sut.CreateAsync(_teacherId, new CreateTeacherFollowupRequest("Followup for Ewan", _studentId.ToString(), null, null), default);
+        await _sut.CreateAsync(_teacherId, new CreateTeacherFollowupRequest("Followup for Bruno", otherStudentId.ToString(), null, null), default);
+
+        var result = await _sut.GetByStudentAsync(_teacherId, _studentId, default);
+
+        result.Should().HaveCount(1);
+        result[0].Text.Should().Be("Followup for Ewan");
+    }
+
+    [Fact]
+    public async Task UpdateStatusAsync_ToDone_SetsCompletedAt()
+    {
+        var created = await _sut.CreateAsync(_teacherId, new CreateTeacherFollowupRequest("Check notes", null, null, null), default);
+
+        var updated = await _sut.UpdateStatusAsync(_teacherId, Guid.Parse(created.Id), new UpdateTeacherFollowupRequest("done"), default);
+
+        updated.Should().NotBeNull();
+        updated!.Status.Should().Be("done");
+        updated.CompletedAt.Should().NotBeNull();
+        updated.CompletedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task UpdateStatusAsync_BackToPending_ClearsCompletedAt()
+    {
+        var created = await _sut.CreateAsync(_teacherId, new CreateTeacherFollowupRequest("Check notes", null, null, null), default);
+        await _sut.UpdateStatusAsync(_teacherId, Guid.Parse(created.Id), new UpdateTeacherFollowupRequest("done"), default);
+
+        var updated = await _sut.UpdateStatusAsync(_teacherId, Guid.Parse(created.Id), new UpdateTeacherFollowupRequest("pending"), default);
+
+        updated!.Status.Should().Be("pending");
+        updated.CompletedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesFollowup()
+    {
+        var created = await _sut.CreateAsync(_teacherId, new CreateTeacherFollowupRequest("Delete me", null, null, null), default);
+
+        var deleted = await _sut.DeleteAsync(_teacherId, Guid.Parse(created.Id), default);
+
+        deleted.Should().BeTrue();
+        var all = await _sut.GetAllAsync(_teacherId, default);
+        all.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAllAsync_TeacherIsolation_OtherTeacherCannotSeeFollowups()
+    {
+        await _sut.CreateAsync(_teacherId, new CreateTeacherFollowupRequest("Teacher 1 followup", null, null, null), default);
+
+        var otherResult = await _sut.GetAllAsync(_otherTeacherId, default);
+
+        otherResult.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task UpdateStatusAsync_WrongTeacher_ReturnsNull()
+    {
+        var created = await _sut.CreateAsync(_teacherId, new CreateTeacherFollowupRequest("Private followup", null, null, null), default);
+
+        var result = await _sut.UpdateStatusAsync(_otherTeacherId, Guid.Parse(created.Id), new UpdateTeacherFollowupRequest("done"), default);
+
+        result.Should().BeNull();
+    }
+}

--- a/backend/LangTeach.Api.Tests/Services/TeacherFollowupServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/TeacherFollowupServiceTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using FluentAssertions;
 using LangTeach.Api.Data;
 using LangTeach.Api.Data.Models;
@@ -160,5 +161,29 @@ public class TeacherFollowupServiceTests : IDisposable
         pending.Should().HaveCount(1);
         pending[0].Text.Should().Be("Pending one");
         pending[0].Status.Should().Be("pending");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithOtherTeachersStudentId_ThrowsValidationException()
+    {
+        var otherStudent = Guid.NewGuid();
+        _db.Students.Add(new Student
+        {
+            Id = otherStudent,
+            TeacherId = _otherTeacherId,
+            Name = "Other Teacher Student",
+            LearningLanguage = "Spanish",
+            CefrLevel = "A1",
+            NativeLanguages = "[\"English\"]",
+            TeachingTodos = "[]",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        _db.SaveChanges();
+
+        var act = () => _sut.CreateAsync(_teacherId, new CreateTeacherFollowupRequest("Test", otherStudent, null, null), default);
+
+        await act.Should().ThrowAsync<ValidationException>();
     }
 }

--- a/backend/LangTeach.Api.Tests/Services/TeacherFollowupServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/TeacherFollowupServiceTests.cs
@@ -48,7 +48,7 @@ public class TeacherFollowupServiceTests : IDisposable
     [Fact]
     public async Task CreateAsync_AddsFollowup_ReturnableViaGetAll()
     {
-        var request = new CreateTeacherFollowupRequest("Enviar ejercicio de gustar", _studentId.ToString(), null, null);
+        var request = new CreateTeacherFollowupRequest("Enviar ejercicio de gustar", _studentId, null, null);
 
         var created = await _sut.CreateAsync(_teacherId, request, default);
 
@@ -82,8 +82,8 @@ public class TeacherFollowupServiceTests : IDisposable
         });
         _db.SaveChanges();
 
-        await _sut.CreateAsync(_teacherId, new CreateTeacherFollowupRequest("Followup for Ewan", _studentId.ToString(), null, null), default);
-        await _sut.CreateAsync(_teacherId, new CreateTeacherFollowupRequest("Followup for Bruno", otherStudentId.ToString(), null, null), default);
+        await _sut.CreateAsync(_teacherId, new CreateTeacherFollowupRequest("Followup for Ewan", _studentId, null, null), default);
+        await _sut.CreateAsync(_teacherId, new CreateTeacherFollowupRequest("Followup for Bruno", otherStudentId, null, null), default);
 
         var result = await _sut.GetByStudentAsync(_teacherId, _studentId, default);
 
@@ -146,5 +146,19 @@ public class TeacherFollowupServiceTests : IDisposable
         var result = await _sut.UpdateStatusAsync(_otherTeacherId, Guid.Parse(created.Id), new UpdateTeacherFollowupRequest("done"), default);
 
         result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_ReturnsOnlyPendingFollowups()
+    {
+        var created = await _sut.CreateAsync(_teacherId, new CreateTeacherFollowupRequest("Pending one", null, null, null), default);
+        await _sut.CreateAsync(_teacherId, new CreateTeacherFollowupRequest("Done one", null, null, null), default);
+        await _sut.UpdateStatusAsync(_teacherId, Guid.Parse((await _sut.GetAllAsync(_teacherId, default))[1].Id), new UpdateTeacherFollowupRequest("done"), default);
+
+        var pending = await _sut.GetPendingAsync(_teacherId, default);
+
+        pending.Should().HaveCount(1);
+        pending[0].Text.Should().Be("Pending one");
+        pending[0].Status.Should().Be("pending");
     }
 }

--- a/backend/LangTeach.Api/Controllers/TeacherFollowupsController.cs
+++ b/backend/LangTeach.Api/Controllers/TeacherFollowupsController.cs
@@ -36,10 +36,16 @@ public class TeacherFollowupsController : ControllerBase
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
 
         List<TeacherFollowupDto> result;
-        if (studentId is not null && Guid.TryParse(studentId, out var sid))
+        if (studentId is not null)
+        {
+            if (!Guid.TryParse(studentId, out var sid))
+                return ValidationProblem("studentId must be a valid GUID.");
             result = await _followupService.GetByStudentAsync(teacherId, sid, cancellationToken);
+        }
         else
+        {
             result = await _followupService.GetAllAsync(teacherId, cancellationToken);
+        }
 
         return Ok(result);
     }

--- a/backend/LangTeach.Api/Controllers/TeacherFollowupsController.cs
+++ b/backend/LangTeach.Api/Controllers/TeacherFollowupsController.cs
@@ -1,0 +1,81 @@
+using System.Security.Claims;
+using LangTeach.Api.DTOs;
+using LangTeach.Api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LangTeach.Api.Controllers;
+
+[ApiController]
+[Route("api/teacher-followups")]
+[Authorize]
+public class TeacherFollowupsController : ControllerBase
+{
+    private readonly ITeacherFollowupService _followupService;
+    private readonly IProfileService _profileService;
+    private readonly ILogger<TeacherFollowupsController> _logger;
+
+    public TeacherFollowupsController(
+        ITeacherFollowupService followupService,
+        IProfileService profileService,
+        ILogger<TeacherFollowupsController> logger)
+    {
+        _followupService = followupService;
+        _profileService = profileService;
+        _logger = logger;
+    }
+
+    private string? Auth0Id => User.FindFirstValue(ClaimTypes.NameIdentifier);
+    private string Email => User.FindFirstValue(ClaimTypes.Email) ?? "";
+
+    [HttpGet]
+    public async Task<IActionResult> Get([FromQuery] string? studentId, CancellationToken cancellationToken)
+    {
+        if (Auth0Id is null) return Unauthorized();
+        var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
+
+        List<TeacherFollowupDto> result;
+        if (studentId is not null && Guid.TryParse(studentId, out var sid))
+            result = await _followupService.GetByStudentAsync(teacherId, sid, cancellationToken);
+        else
+            result = await _followupService.GetAllAsync(teacherId, cancellationToken);
+
+        return Ok(result);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateTeacherFollowupRequest request, CancellationToken cancellationToken)
+    {
+        if (Auth0Id is null) return Unauthorized();
+        var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
+
+        var dto = await _followupService.CreateAsync(teacherId, request, cancellationToken);
+
+        _logger.LogInformation("POST /api/teacher-followups Id={Id} TeacherId={TeacherId}", dto.Id, teacherId);
+        return CreatedAtAction(nameof(Get), new { }, dto);
+    }
+
+    [HttpPatch("{id}")]
+    public async Task<IActionResult> UpdateStatus(Guid id, [FromBody] UpdateTeacherFollowupRequest request, CancellationToken cancellationToken)
+    {
+        if (Auth0Id is null) return Unauthorized();
+        var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
+
+        var dto = await _followupService.UpdateStatusAsync(teacherId, id, request, cancellationToken);
+        if (dto is null) return NotFound();
+
+        return Ok(dto);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
+    {
+        if (Auth0Id is null) return Unauthorized();
+        var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
+
+        var deleted = await _followupService.DeleteAsync(teacherId, id, cancellationToken);
+        if (!deleted) return NotFound();
+
+        return NoContent();
+    }
+}

--- a/backend/LangTeach.Api/Controllers/TeacherFollowupsController.cs
+++ b/backend/LangTeach.Api/Controllers/TeacherFollowupsController.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
 using LangTeach.Api.DTOs;
 using LangTeach.Api.Services;
@@ -48,11 +49,16 @@ public class TeacherFollowupsController : ControllerBase
     {
         if (Auth0Id is null) return Unauthorized();
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
-
-        var dto = await _followupService.CreateAsync(teacherId, request, cancellationToken);
-
-        _logger.LogInformation("POST /api/teacher-followups Id={Id} TeacherId={TeacherId}", dto.Id, teacherId);
-        return CreatedAtAction(nameof(Get), new { }, dto);
+        try
+        {
+            var dto = await _followupService.CreateAsync(teacherId, request, cancellationToken);
+            _logger.LogInformation("POST /api/teacher-followups Id={Id} TeacherId={TeacherId}", dto.Id, teacherId);
+            return CreatedAtAction(nameof(Get), new { }, dto);
+        }
+        catch (ValidationException ex)
+        {
+            return ValidationProblem(ex.Message);
+        }
     }
 
     [HttpPatch("{id}")]

--- a/backend/LangTeach.Api/DTOs/DashboardDtos.cs
+++ b/backend/LangTeach.Api/DTOs/DashboardDtos.cs
@@ -39,5 +39,6 @@ public record ActiveStudentDto(
 public record DashboardDto(
     NextSessionDto? NextSession,
     List<TodaySessionDto> TodaySessions,
-    List<ActiveStudentDto> ActiveStudents
+    List<ActiveStudentDto> ActiveStudents,
+    List<TeacherFollowupDto> PendingFollowups
 );

--- a/backend/LangTeach.Api/DTOs/TeacherFollowupDto.cs
+++ b/backend/LangTeach.Api/DTOs/TeacherFollowupDto.cs
@@ -15,9 +15,11 @@ public record TeacherFollowupDto(
 
 public record CreateTeacherFollowupRequest(
     [MaxLength(500)] string Text,
-    string? StudentId,
+    Guid? StudentId,
     DateOnly? DueDate,
-    string? SourceSessionLogId);
+    Guid? SourceSessionLogId);
 
 public record UpdateTeacherFollowupRequest(
-    [Required] string Status);
+    [Required]
+    [RegularExpression("^(pending|done)$", ErrorMessage = "Status must be 'pending' or 'done'.")]
+    string Status);

--- a/backend/LangTeach.Api/DTOs/TeacherFollowupDto.cs
+++ b/backend/LangTeach.Api/DTOs/TeacherFollowupDto.cs
@@ -14,7 +14,10 @@ public record TeacherFollowupDto(
     string? SourceSessionLogId);
 
 public record CreateTeacherFollowupRequest(
-    [MaxLength(500)] string Text,
+    [Required]
+    [MaxLength(500)]
+    [RegularExpression(@".*\S.*", ErrorMessage = "Text cannot be blank.")]
+    string Text,
     Guid? StudentId,
     DateOnly? DueDate,
     Guid? SourceSessionLogId);

--- a/backend/LangTeach.Api/DTOs/TeacherFollowupDto.cs
+++ b/backend/LangTeach.Api/DTOs/TeacherFollowupDto.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LangTeach.Api.DTOs;
+
+public record TeacherFollowupDto(
+    string Id,
+    string? StudentId,
+    string? StudentName,
+    string Text,
+    string Status,
+    DateTime CreatedAt,
+    DateOnly? DueDate,
+    DateTime? CompletedAt,
+    string? SourceSessionLogId);
+
+public record CreateTeacherFollowupRequest(
+    [MaxLength(500)] string Text,
+    string? StudentId,
+    DateOnly? DueDate,
+    string? SourceSessionLogId);
+
+public record UpdateTeacherFollowupRequest(
+    [Required] string Status);

--- a/backend/LangTeach.Api/Data/AppDbContext.cs
+++ b/backend/LangTeach.Api/Data/AppDbContext.cs
@@ -24,6 +24,7 @@ public class AppDbContext : DbContext
     public DbSet<VoiceNoteApplication> VoiceNoteApplications => Set<VoiceNoteApplication>();
     public DbSet<CourseSuggestion> CourseSuggestions => Set<CourseSuggestion>();
     public DbSet<TelegramLink> TelegramLinks => Set<TelegramLink>();
+    public DbSet<TeacherFollowup> TeacherFollowups => Set<TeacherFollowup>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -287,6 +288,30 @@ public class AppDbContext : DbContext
              .WithMany()
              .HasForeignKey(t => t.TeacherId)
              .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // TeacherFollowup — cascade delete from Teacher, no-action from Student and SessionLog (nullable)
+        modelBuilder.Entity<TeacherFollowup>(e =>
+        {
+            e.HasKey(f => f.Id);
+            e.HasIndex(f => new { f.TeacherId, f.Status });
+            e.HasIndex(f => new { f.TeacherId, f.StudentId });
+            e.Property(f => f.Text).HasMaxLength(500).IsRequired();
+            e.Property(f => f.Status).HasDefaultValue("pending");
+            e.HasOne(f => f.Teacher)
+             .WithMany()
+             .HasForeignKey(f => f.TeacherId)
+             .OnDelete(DeleteBehavior.Cascade);
+            e.HasOne(f => f.Student)
+             .WithMany()
+             .HasForeignKey(f => f.StudentId)
+             .IsRequired(false)
+             .OnDelete(DeleteBehavior.NoAction);
+            e.HasOne(f => f.SourceSessionLog)
+             .WithMany()
+             .HasForeignKey(f => f.SourceSessionLogId)
+             .IsRequired(false)
+             .OnDelete(DeleteBehavior.NoAction);
         });
     }
 }

--- a/backend/LangTeach.Api/Data/Models/TeacherFollowup.cs
+++ b/backend/LangTeach.Api/Data/Models/TeacherFollowup.cs
@@ -1,0 +1,18 @@
+namespace LangTeach.Api.Data.Models;
+
+public class TeacherFollowup
+{
+    public Guid Id { get; set; }
+    public Guid TeacherId { get; set; }
+    public Guid? StudentId { get; set; }
+    public string Text { get; set; } = string.Empty;
+    public string Status { get; set; } = "pending"; // pending | done
+    public DateTime CreatedAt { get; set; }
+    public DateOnly? DueDate { get; set; }
+    public DateTime? CompletedAt { get; set; }
+    public Guid? SourceSessionLogId { get; set; }
+
+    public Teacher Teacher { get; set; } = null!;
+    public Student? Student { get; set; }
+    public SessionLog? SourceSessionLog { get; set; }
+}

--- a/backend/LangTeach.Api/Migrations/20260411180645_AddTeacherFollowups.Designer.cs
+++ b/backend/LangTeach.Api/Migrations/20260411180645_AddTeacherFollowups.Designer.cs
@@ -4,6 +4,7 @@ using LangTeach.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LangTeach.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411180645_AddTeacherFollowups")]
+    partial class AddTeacherFollowups
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/LangTeach.Api/Migrations/20260411180645_AddTeacherFollowups.cs
+++ b/backend/LangTeach.Api/Migrations/20260411180645_AddTeacherFollowups.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LangTeach.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTeacherFollowups : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TeacherFollowups",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    TeacherId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    StudentId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Text = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: false),
+                    Status = table.Column<string>(type: "nvarchar(450)", nullable: false, defaultValue: "pending"),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DueDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    CompletedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    SourceSessionLogId = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TeacherFollowups", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TeacherFollowups_SessionLogs_SourceSessionLogId",
+                        column: x => x.SourceSessionLogId,
+                        principalTable: "SessionLogs",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_TeacherFollowups_Students_StudentId",
+                        column: x => x.StudentId,
+                        principalTable: "Students",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_TeacherFollowups_Teachers_TeacherId",
+                        column: x => x.TeacherId,
+                        principalTable: "Teachers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeacherFollowups_SourceSessionLogId",
+                table: "TeacherFollowups",
+                column: "SourceSessionLogId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeacherFollowups_StudentId",
+                table: "TeacherFollowups",
+                column: "StudentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeacherFollowups_TeacherId_Status",
+                table: "TeacherFollowups",
+                columns: new[] { "TeacherId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeacherFollowups_TeacherId_StudentId",
+                table: "TeacherFollowups",
+                columns: new[] { "TeacherId", "StudentId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TeacherFollowups");
+        }
+    }
+}

--- a/backend/LangTeach.Api/Program.cs
+++ b/backend/LangTeach.Api/Program.cs
@@ -183,6 +183,7 @@ else
     builder.Services.AddScoped<IReplanSuggestionService, ReplanSuggestionService>();
 builder.Services.AddScoped<IDifficultyTrendService, DifficultyTrendService>();
 builder.Services.AddScoped<ISessionLogService, SessionLogService>();
+builder.Services.AddScoped<ITeacherFollowupService, TeacherFollowupService>();
 builder.Services.AddScoped<IDashboardService, DashboardService>();
 builder.Services.AddScoped<IProgressService, ProgressService>();
 builder.Services.AddScoped<ISessionHistoryService, SessionHistoryService>();

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -8,11 +8,13 @@ namespace LangTeach.Api.Services;
 public class DashboardService : IDashboardService
 {
     private readonly AppDbContext _db;
+    private readonly ITeacherFollowupService _followupService;
     private readonly ILogger<DashboardService> _logger;
 
-    public DashboardService(AppDbContext db, ILogger<DashboardService> logger)
+    public DashboardService(AppDbContext db, ITeacherFollowupService followupService, ILogger<DashboardService> logger)
     {
         _db = db;
+        _followupService = followupService;
         _logger = logger;
     }
 
@@ -24,8 +26,10 @@ public class DashboardService : IDashboardService
         var nextSession = await GetNextSessionAsync(teacherId, now, cancellationToken);
         var todaySessions = await GetTodaySessionsAsync(teacherId, today, cancellationToken);
         var activeStudents = await GetActiveStudentsAsync(teacherId, now, cancellationToken);
+        var allFollowups = await _followupService.GetAllAsync(teacherId, cancellationToken);
+        var pendingFollowups = allFollowups.Where(f => f.Status == "pending").ToList();
 
-        return new DashboardDto(nextSession, todaySessions, activeStudents);
+        return new DashboardDto(nextSession, todaySessions, activeStudents, pendingFollowups);
     }
 
     private async Task<NextSessionDto?> GetNextSessionAsync(Guid teacherId, DateTime now, CancellationToken cancellationToken)

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -26,8 +26,7 @@ public class DashboardService : IDashboardService
         var nextSession = await GetNextSessionAsync(teacherId, now, cancellationToken);
         var todaySessions = await GetTodaySessionsAsync(teacherId, today, cancellationToken);
         var activeStudents = await GetActiveStudentsAsync(teacherId, now, cancellationToken);
-        var allFollowups = await _followupService.GetAllAsync(teacherId, cancellationToken);
-        var pendingFollowups = allFollowups.Where(f => f.Status == "pending").ToList();
+        var pendingFollowups = await _followupService.GetPendingAsync(teacherId, cancellationToken);
 
         return new DashboardDto(nextSession, todaySessions, activeStudents, pendingFollowups);
     }

--- a/backend/LangTeach.Api/Services/ITeacherFollowupService.cs
+++ b/backend/LangTeach.Api/Services/ITeacherFollowupService.cs
@@ -5,6 +5,7 @@ namespace LangTeach.Api.Services;
 public interface ITeacherFollowupService
 {
     Task<List<TeacherFollowupDto>> GetAllAsync(Guid teacherId, CancellationToken cancellationToken);
+    Task<List<TeacherFollowupDto>> GetPendingAsync(Guid teacherId, CancellationToken cancellationToken);
     Task<List<TeacherFollowupDto>> GetByStudentAsync(Guid teacherId, Guid studentId, CancellationToken cancellationToken);
     Task<TeacherFollowupDto> CreateAsync(Guid teacherId, CreateTeacherFollowupRequest request, CancellationToken cancellationToken);
     Task<TeacherFollowupDto?> UpdateStatusAsync(Guid teacherId, Guid followupId, UpdateTeacherFollowupRequest request, CancellationToken cancellationToken);

--- a/backend/LangTeach.Api/Services/ITeacherFollowupService.cs
+++ b/backend/LangTeach.Api/Services/ITeacherFollowupService.cs
@@ -1,0 +1,12 @@
+using LangTeach.Api.DTOs;
+
+namespace LangTeach.Api.Services;
+
+public interface ITeacherFollowupService
+{
+    Task<List<TeacherFollowupDto>> GetAllAsync(Guid teacherId, CancellationToken cancellationToken);
+    Task<List<TeacherFollowupDto>> GetByStudentAsync(Guid teacherId, Guid studentId, CancellationToken cancellationToken);
+    Task<TeacherFollowupDto> CreateAsync(Guid teacherId, CreateTeacherFollowupRequest request, CancellationToken cancellationToken);
+    Task<TeacherFollowupDto?> UpdateStatusAsync(Guid teacherId, Guid followupId, UpdateTeacherFollowupRequest request, CancellationToken cancellationToken);
+    Task<bool> DeleteAsync(Guid teacherId, Guid followupId, CancellationToken cancellationToken);
+}

--- a/backend/LangTeach.Api/Services/TeacherFollowupService.cs
+++ b/backend/LangTeach.Api/Services/TeacherFollowupService.cs
@@ -17,6 +17,16 @@ public class TeacherFollowupService(AppDbContext db) : ITeacherFollowupService
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<List<TeacherFollowupDto>> GetPendingAsync(Guid teacherId, CancellationToken cancellationToken)
+    {
+        return await db.TeacherFollowups
+            .Where(f => f.TeacherId == teacherId && f.Status == "pending")
+            .Include(f => f.Student)
+            .OrderBy(f => f.CreatedAt)
+            .Select(f => ToDto(f, f.Student != null ? f.Student.Name : null))
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task<List<TeacherFollowupDto>> GetByStudentAsync(Guid teacherId, Guid studentId, CancellationToken cancellationToken)
     {
         return await db.TeacherFollowups
@@ -28,29 +38,26 @@ public class TeacherFollowupService(AppDbContext db) : ITeacherFollowupService
 
     public async Task<TeacherFollowupDto> CreateAsync(Guid teacherId, CreateTeacherFollowupRequest request, CancellationToken cancellationToken)
     {
-        Guid? studentId = request.StudentId is not null ? Guid.Parse(request.StudentId) : null;
-        Guid? sourceSessionLogId = request.SourceSessionLogId is not null ? Guid.Parse(request.SourceSessionLogId) : null;
-
         var followup = new TeacherFollowup
         {
             Id = Guid.NewGuid(),
             TeacherId = teacherId,
-            StudentId = studentId,
+            StudentId = request.StudentId,
             Text = request.Text,
             Status = "pending",
             CreatedAt = DateTime.UtcNow,
             DueDate = request.DueDate,
-            SourceSessionLogId = sourceSessionLogId,
+            SourceSessionLogId = request.SourceSessionLogId,
         };
 
         db.TeacherFollowups.Add(followup);
         await db.SaveChangesAsync(cancellationToken);
 
         string? studentName = null;
-        if (studentId.HasValue)
+        if (request.StudentId.HasValue)
         {
             studentName = await db.Students
-                .Where(s => s.Id == studentId.Value)
+                .Where(s => s.Id == request.StudentId.Value)
                 .Select(s => s.Name)
                 .FirstOrDefaultAsync(cancellationToken);
         }
@@ -86,8 +93,7 @@ public class TeacherFollowupService(AppDbContext db) : ITeacherFollowupService
     }
 
     private static TeacherFollowupDto ToDto(TeacherFollowup f, string? studentName) =>
-        new(
-            f.Id.ToString(),
+        new(f.Id.ToString(),
             f.StudentId?.ToString(),
             studentName,
             f.Text,

--- a/backend/LangTeach.Api/Services/TeacherFollowupService.cs
+++ b/backend/LangTeach.Api/Services/TeacherFollowupService.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using LangTeach.Api.Data;
 using LangTeach.Api.Data.Models;
 using LangTeach.Api.DTOs;
@@ -38,6 +39,24 @@ public class TeacherFollowupService(AppDbContext db) : ITeacherFollowupService
 
     public async Task<TeacherFollowupDto> CreateAsync(Guid teacherId, CreateTeacherFollowupRequest request, CancellationToken cancellationToken)
     {
+        string? studentName = null;
+        if (request.StudentId.HasValue)
+        {
+            studentName = await db.Students
+                .Where(s => s.Id == request.StudentId.Value && s.TeacherId == teacherId)
+                .Select(s => s.Name)
+                .FirstOrDefaultAsync(cancellationToken)
+                ?? throw new ValidationException("Student not found.");
+        }
+
+        if (request.SourceSessionLogId.HasValue)
+        {
+            var sessionExists = await db.SessionLogs
+                .AnyAsync(sl => sl.Id == request.SourceSessionLogId.Value && sl.TeacherId == teacherId, cancellationToken);
+            if (!sessionExists)
+                throw new ValidationException("Session log not found.");
+        }
+
         var followup = new TeacherFollowup
         {
             Id = Guid.NewGuid(),
@@ -52,15 +71,6 @@ public class TeacherFollowupService(AppDbContext db) : ITeacherFollowupService
 
         db.TeacherFollowups.Add(followup);
         await db.SaveChangesAsync(cancellationToken);
-
-        string? studentName = null;
-        if (request.StudentId.HasValue)
-        {
-            studentName = await db.Students
-                .Where(s => s.Id == request.StudentId.Value)
-                .Select(s => s.Name)
-                .FirstOrDefaultAsync(cancellationToken);
-        }
 
         return ToDto(followup, studentName);
     }

--- a/backend/LangTeach.Api/Services/TeacherFollowupService.cs
+++ b/backend/LangTeach.Api/Services/TeacherFollowupService.cs
@@ -1,0 +1,99 @@
+using LangTeach.Api.Data;
+using LangTeach.Api.Data.Models;
+using LangTeach.Api.DTOs;
+using Microsoft.EntityFrameworkCore;
+
+namespace LangTeach.Api.Services;
+
+public class TeacherFollowupService(AppDbContext db) : ITeacherFollowupService
+{
+    public async Task<List<TeacherFollowupDto>> GetAllAsync(Guid teacherId, CancellationToken cancellationToken)
+    {
+        return await db.TeacherFollowups
+            .Where(f => f.TeacherId == teacherId)
+            .Include(f => f.Student)
+            .OrderBy(f => f.CreatedAt)
+            .Select(f => ToDto(f, f.Student != null ? f.Student.Name : null))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<List<TeacherFollowupDto>> GetByStudentAsync(Guid teacherId, Guid studentId, CancellationToken cancellationToken)
+    {
+        return await db.TeacherFollowups
+            .Where(f => f.TeacherId == teacherId && f.StudentId == studentId)
+            .OrderBy(f => f.CreatedAt)
+            .Select(f => ToDto(f, null))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<TeacherFollowupDto> CreateAsync(Guid teacherId, CreateTeacherFollowupRequest request, CancellationToken cancellationToken)
+    {
+        Guid? studentId = request.StudentId is not null ? Guid.Parse(request.StudentId) : null;
+        Guid? sourceSessionLogId = request.SourceSessionLogId is not null ? Guid.Parse(request.SourceSessionLogId) : null;
+
+        var followup = new TeacherFollowup
+        {
+            Id = Guid.NewGuid(),
+            TeacherId = teacherId,
+            StudentId = studentId,
+            Text = request.Text,
+            Status = "pending",
+            CreatedAt = DateTime.UtcNow,
+            DueDate = request.DueDate,
+            SourceSessionLogId = sourceSessionLogId,
+        };
+
+        db.TeacherFollowups.Add(followup);
+        await db.SaveChangesAsync(cancellationToken);
+
+        string? studentName = null;
+        if (studentId.HasValue)
+        {
+            studentName = await db.Students
+                .Where(s => s.Id == studentId.Value)
+                .Select(s => s.Name)
+                .FirstOrDefaultAsync(cancellationToken);
+        }
+
+        return ToDto(followup, studentName);
+    }
+
+    public async Task<TeacherFollowupDto?> UpdateStatusAsync(Guid teacherId, Guid followupId, UpdateTeacherFollowupRequest request, CancellationToken cancellationToken)
+    {
+        var followup = await db.TeacherFollowups
+            .Include(f => f.Student)
+            .FirstOrDefaultAsync(f => f.Id == followupId && f.TeacherId == teacherId, cancellationToken);
+
+        if (followup is null) return null;
+
+        followup.Status = request.Status;
+        followup.CompletedAt = request.Status == "done" ? DateTime.UtcNow : null;
+
+        await db.SaveChangesAsync(cancellationToken);
+        return ToDto(followup, followup.Student?.Name);
+    }
+
+    public async Task<bool> DeleteAsync(Guid teacherId, Guid followupId, CancellationToken cancellationToken)
+    {
+        var followup = await db.TeacherFollowups
+            .FirstOrDefaultAsync(f => f.Id == followupId && f.TeacherId == teacherId, cancellationToken);
+
+        if (followup is null) return false;
+
+        db.TeacherFollowups.Remove(followup);
+        await db.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    private static TeacherFollowupDto ToDto(TeacherFollowup f, string? studentName) =>
+        new(
+            f.Id.ToString(),
+            f.StudentId?.ToString(),
+            studentName,
+            f.Text,
+            f.Status,
+            f.CreatedAt,
+            f.DueDate,
+            f.CompletedAt,
+            f.SourceSessionLogId?.ToString());
+}

--- a/e2e/tests/followups.spec.ts
+++ b/e2e/tests/followups.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test'
+import { createMockAuthContext } from '../helpers/auth-helper'
+import { setupMockTeacher } from '../helpers/mock-teacher-helper'
+import { UI_TIMEOUT, NAV_TIMEOUT } from '../helpers/timeouts'
+
+test.beforeAll(async ({ browser }) => {
+  const ctx = await createMockAuthContext(browser)
+  const page = await ctx.newPage()
+  await setupMockTeacher(page)
+  await page.close()
+  await ctx.close()
+})
+
+test('followup happy path: create, appear on dashboard, mark done', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    // Step 1: Create a student to attach the followup to
+    const studentName = `Followup Test ${Date.now()}`
+    await page.goto('/students/new')
+    await expect(page.locator('h1')).toHaveText('Add Student', { timeout: NAV_TIMEOUT })
+    await page.getByTestId('student-name').fill(studentName)
+    await page.getByTestId('student-language').click()
+    await page.getByRole('option', { name: 'Spanish' }).click()
+    await page.getByTestId('student-cefr').click()
+    await page.getByRole('option', { name: 'A1' }).click()
+    await page.getByTestId('student-native-language').click()
+    await page.getByRole('option', { name: 'English' }).click()
+    await page.keyboard.press('Escape')
+    await page.getByRole('button', { name: 'Save Student' }).click()
+
+    await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
+    await expect(page.getByTestId('tab-profile')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // Step 2: Add a followup from the Profile tab
+    const followupText = `Enviar ejercicio de practica ${Date.now()}`
+    await expect(page.getByTestId('student-followups-card')).toBeVisible({ timeout: UI_TIMEOUT })
+    await page.getByTestId('followup-input').fill(followupText)
+    await page.getByTestId('followup-add-btn').click()
+
+    // Followup appears in the card
+    await expect(page.getByText(followupText)).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // Step 3: Navigate to dashboard and verify followup appears in Pending Followups panel
+    await page.goto('/')
+    await expect(page.locator('h1')).toHaveText('Dashboard', { timeout: NAV_TIMEOUT })
+    await expect(page.getByTestId('zone2-pending-followups')).toBeVisible({ timeout: UI_TIMEOUT })
+    await expect(page.getByText(followupText)).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // Step 4: Mark as done from the dashboard (click the amber dot)
+    const followupRows = page.locator(`[data-testid^="followup-dot-"]`)
+    // Find the row with our followup text
+    const ourRow = page.locator('[data-testid="zone2-pending-followups"]').locator(`text="${followupText}"`).locator('..')
+    const dot = ourRow.locator('[aria-label="Mark done"]').first()
+    await dot.click()
+
+    // Followup disappears from pending list (or panel shows "All caught up" if no other followups)
+    await expect(page.getByText(followupText)).not.toBeVisible({ timeout: UI_TIMEOUT })
+  } finally {
+    await page.close()
+    await context.close()
+  }
+})

--- a/e2e/tests/followups.spec.ts
+++ b/e2e/tests/followups.spec.ts
@@ -48,12 +48,10 @@ test('followup happy path: create, appear on dashboard, mark done', async ({ bro
     await expect(page.getByTestId('zone2-pending-followups')).toBeVisible({ timeout: UI_TIMEOUT })
     await expect(page.getByText(followupText)).toBeVisible({ timeout: UI_TIMEOUT })
 
-    // Step 4: Mark as done from the dashboard (click the amber dot)
-    const followupRows = page.locator(`[data-testid^="followup-dot-"]`)
-    // Find the row with our followup text
-    const ourRow = page.locator('[data-testid="zone2-pending-followups"]').locator(`text="${followupText}"`).locator('..')
-    const dot = ourRow.locator('[aria-label="Mark done"]').first()
-    await dot.click()
+    // Step 4: Mark as done from the dashboard - find the dot next to our followup text
+    const panel = page.getByTestId('zone2-pending-followups')
+    const followupRow = panel.locator('div').filter({ hasText: followupText }).first()
+    await followupRow.getByLabel('Mark done').click()
 
     // Followup disappears from pending list (or panel shows "All caught up" if no other followups)
     await expect(page.getByText(followupText)).not.toBeVisible({ timeout: UI_TIMEOUT })

--- a/frontend/src/api/dashboard.ts
+++ b/frontend/src/api/dashboard.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '../lib/apiClient'
+import type { TeacherFollowup } from './followups'
 
 export interface PendingTodo {
   id: string
@@ -49,7 +50,10 @@ export interface DashboardData {
   nextSession: NextSession | null
   todaySessions: TodaySession[]
   activeStudents: ActiveStudent[]
+  pendingFollowups: TeacherFollowup[]
 }
+
+export type { TeacherFollowup }
 
 export async function getDashboard(): Promise<DashboardData> {
   const res = await apiClient.get<DashboardData>('/api/dashboard')

--- a/frontend/src/api/followups.ts
+++ b/frontend/src/api/followups.ts
@@ -1,0 +1,40 @@
+import { apiClient } from '../lib/apiClient'
+
+export interface TeacherFollowup {
+  id: string
+  studentId: string | null
+  studentName: string | null
+  text: string
+  status: 'pending' | 'done'
+  createdAt: string
+  dueDate: string | null
+  completedAt: string | null
+  sourceSessionLogId: string | null
+}
+
+export interface CreateFollowupRequest {
+  text: string
+  studentId?: string | null
+  dueDate?: string | null
+  sourceSessionLogId?: string | null
+}
+
+export async function getFollowups(studentId?: string): Promise<TeacherFollowup[]> {
+  const params = studentId ? { studentId } : {}
+  const res = await apiClient.get<TeacherFollowup[]>('/api/teacher-followups', { params })
+  return res.data
+}
+
+export async function createFollowup(data: CreateFollowupRequest): Promise<TeacherFollowup> {
+  const res = await apiClient.post<TeacherFollowup>('/api/teacher-followups', data)
+  return res.data
+}
+
+export async function updateFollowupStatus(id: string, status: 'pending' | 'done'): Promise<TeacherFollowup> {
+  const res = await apiClient.patch<TeacherFollowup>(`/api/teacher-followups/${id}`, { status })
+  return res.data
+}
+
+export async function deleteFollowup(id: string): Promise<void> {
+  await apiClient.delete(`/api/teacher-followups/${id}`)
+}

--- a/frontend/src/components/dashboard/PendingFollowups.test.tsx
+++ b/frontend/src/components/dashboard/PendingFollowups.test.tsx
@@ -1,53 +1,57 @@
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { PendingFollowups } from './PendingFollowups'
-import type { ActiveStudent } from '@/api/dashboard'
+import type { TeacherFollowup } from '@/api/followups'
 
-function makeStudent(overrides: Partial<ActiveStudent> = {}): ActiveStudent {
+vi.mock('@/api/followups', async () => {
+  const actual = await vi.importActual<typeof import('@/api/followups')>('@/api/followups')
+  return { ...actual, updateFollowupStatus: vi.fn().mockResolvedValue({}) }
+})
+
+function makeFollowup(overrides: Partial<TeacherFollowup> = {}): TeacherFollowup {
   return {
+    id: 'f1',
     studentId: 'student-1',
-    name: 'Ana García',
-    cefrLevel: 'B1',
-    nativeLanguages: ['English'],
-    isActive: true,
-    lastSessionDate: null,
-    nextSessionDate: null,
-    totalSessions: 0,
-    teachingTodosCount: 0,
-    pendingTodos: [],
+    studentName: 'Ana García',
+    text: 'Enviar ejercicio',
+    status: 'pending',
+    createdAt: new Date().toISOString(),
+    dueDate: null,
+    completedAt: null,
+    sourceSessionLogId: null,
     ...overrides,
   }
 }
 
 describe('PendingFollowups', () => {
-  it('shows all caught up when no pending todos', () => {
-    render(<PendingFollowups students={[makeStudent()]} />)
+  it('shows all caught up when no followups', () => {
+    render(<PendingFollowups followups={[]} />)
     expect(screen.getByText(/All caught up/)).toBeInTheDocument()
   })
 
-  it('renders pending todo text and student name', () => {
-    const student = makeStudent({
-      pendingTodos: [
-        { id: 't1', text: 'Review ser/estar', createdAt: new Date().toISOString(), status: 'pending', sourceSessionLogId: null, coveredInSessionLogId: null },
-      ],
-    })
-    render(<PendingFollowups students={[student]} />)
-    expect(screen.getByText('Review ser/estar')).toBeInTheDocument()
+  it('renders followup text and student name', () => {
+    render(<PendingFollowups followups={[makeFollowup()]} />)
+    expect(screen.getByText('Enviar ejercicio')).toBeInTheDocument()
     expect(screen.getByText('Ana García')).toBeInTheDocument()
   })
 
   it('renders zone2-pending-followups testid', () => {
-    render(<PendingFollowups students={[]} />)
+    render(<PendingFollowups followups={[]} />)
     expect(screen.getByTestId('zone2-pending-followups')).toBeInTheDocument()
   })
 
-  it('shows todos from multiple students', () => {
-    const students = [
-      makeStudent({ name: 'Ana', pendingTodos: [{ id: 't1', text: 'Todo A', createdAt: new Date().toISOString(), status: 'pending', sourceSessionLogId: null, coveredInSessionLogId: null }] }),
-      makeStudent({ studentId: 'student-2', name: 'Marco', pendingTodos: [{ id: 't2', text: 'Todo B', createdAt: new Date().toISOString(), status: 'pending', sourceSessionLogId: null, coveredInSessionLogId: null }] }),
+  it('shows followups from multiple students', () => {
+    const followups = [
+      makeFollowup({ id: 'f1', studentName: 'Ana', text: 'Todo A' }),
+      makeFollowup({ id: 'f2', studentName: 'Marco', text: 'Todo B' }),
     ]
-    render(<PendingFollowups students={students} />)
+    render(<PendingFollowups followups={followups} />)
     expect(screen.getByText('Todo A')).toBeInTheDocument()
     expect(screen.getByText('Todo B')).toBeInTheDocument()
+  })
+
+  it('renders mark-done button for each followup', () => {
+    render(<PendingFollowups followups={[makeFollowup({ id: 'f1' })]} />)
+    expect(screen.getByTestId('followup-dot-f1')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/dashboard/PendingFollowups.tsx
+++ b/frontend/src/components/dashboard/PendingFollowups.tsx
@@ -1,15 +1,9 @@
-import type { ActiveStudent } from '@/api/dashboard'
+import type { TeacherFollowup } from '@/api/followups'
+import { updateFollowupStatus } from '@/api/followups'
+import { useState } from 'react'
 
 interface PendingFollowupsProps {
-  students: ActiveStudent[]
-}
-
-interface PendingRow {
-  studentId: string
-  studentName: string
-  todoId: string
-  text: string
-  createdAt: string
+  followups: TeacherFollowup[]
 }
 
 function ageBadge(createdAt: string): { label: string; className: string } {
@@ -20,40 +14,52 @@ function ageBadge(createdAt: string): { label: string; className: string } {
   return { label: `${days}d`, className: 'bg-red-100 text-red-700' }
 }
 
-export function PendingFollowups({ students }: PendingFollowupsProps) {
-  const rows: PendingRow[] = []
-  for (const student of students) {
-    for (const todo of student.pendingTodos) {
-      rows.push({
-        studentId: student.studentId,
-        studentName: student.name,
-        todoId: todo.id,
-        text: todo.text,
-        createdAt: todo.createdAt,
+export function PendingFollowups({ followups }: PendingFollowupsProps) {
+  const [hidden, setHidden] = useState<Set<string>>(new Set())
+
+  async function handleMarkDone(id: string) {
+    setHidden(prev => new Set([...prev, id]))
+    try {
+      await updateFollowupStatus(id, 'done')
+    } catch {
+      setHidden(prev => {
+        const next = new Set(prev)
+        next.delete(id)
+        return next
       })
     }
   }
+
+  const visible = followups.filter(f => !hidden.has(f.id))
 
   return (
     <div className="rounded-2xl bg-white p-5 shadow-[0_12px_40px_rgba(26,27,34,0.06)] ring-1 ring-[#C7C4D8]/20" data-testid="zone2-pending-followups">
       <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22] mb-4">Pending Followups</h3>
 
-      {rows.length === 0 ? (
+      {visible.length === 0 ? (
         <p className="text-sm text-zinc-400 font-inter py-4 text-center">All caught up</p>
       ) : (
         <div className="space-y-2">
-          {rows.map(row => {
-            const badge = ageBadge(row.createdAt)
+          {visible.map(f => {
+            const badge = ageBadge(f.createdAt)
             return (
               <div
-                key={row.todoId}
+                key={f.id}
                 className="flex items-start gap-3 rounded-lg px-3 py-2.5 hover:bg-[#F4F2FD] transition-colors"
               >
+                <button
+                  onClick={() => handleMarkDone(f.id)}
+                  aria-label="Mark done"
+                  className="mt-0.5 shrink-0 w-3.5 h-3.5 rounded-full border-2 border-amber-400 bg-amber-100 hover:bg-amber-400 transition-colors"
+                  data-testid={`followup-dot-${f.id}`}
+                />
                 <div className="flex-1 min-w-0">
-                  <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mb-0.5">
-                    {row.studentName}
-                  </p>
-                  <p className="text-sm text-[#1A1B22] font-inter">{row.text}</p>
+                  {f.studentName && (
+                    <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mb-0.5">
+                      {f.studentName}
+                    </p>
+                  )}
+                  <p className="text-sm text-[#1A1B22] font-inter">{f.text}</p>
                 </div>
                 <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[0.6875rem] font-bold font-inter shrink-0 ${badge.className}`}>
                   {badge.label}

--- a/frontend/src/components/session/SessionLogDialog.test.tsx
+++ b/frontend/src/components/session/SessionLogDialog.test.tsx
@@ -7,6 +7,16 @@ import { SessionLogDialog } from './SessionLogDialog'
 import * as sessionLogsApi from '../../api/sessionLogs'
 import type { SessionLog } from '../../api/sessionLogs'
 import * as lessonsApi from '../../api/lessons'
+import { createFollowup } from '../../api/followups'
+
+vi.mock('../../api/followups', () => ({
+  getFollowups: vi.fn().mockResolvedValue([]),
+  createFollowup: vi.fn().mockResolvedValue({
+    id: 'new-f', text: '', status: 'pending', createdAt: new Date().toISOString(),
+    studentId: 'student-1', studentName: null, dueDate: null, completedAt: null, sourceSessionLogId: null,
+  }),
+  updateFollowupStatus: vi.fn().mockResolvedValue({}),
+}))
 
 vi.mock('../../api/sessionLogs', () => ({
   listSessions: vi.fn(),
@@ -1075,6 +1085,34 @@ describe('SessionLogDialog', () => {
       const plannedField = screen.getByTestId('planned-content') as HTMLTextAreaElement
       fireEvent.change(plannedField, { target: { value: 'Review irregular verbs + ser/estar' } })
       expect(plannedField.value).toBe('Review irregular verbs + ser/estar')
+    })
+  })
+
+  describe('followup quick-add', () => {
+    beforeEach(() => {
+      vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([])
+      vi.mocked(lessonsApi.getLessons).mockResolvedValue({ items: [], totalCount: 0, page: 1, pageSize: 100 })
+    })
+
+    it('renders the new followups quick-add section', async () => {
+      wrapper(
+        <SessionLogDialog studentId={STUDENT_ID} open={true} onOpenChange={vi.fn()} />
+      )
+      await waitFor(() => expect(screen.getByTestId('session-new-followup-section')).toBeInTheDocument())
+    })
+
+    it('calls createFollowup when add button clicked with text', async () => {
+      wrapper(
+        <SessionLogDialog studentId={STUDENT_ID} open={true} onOpenChange={vi.fn()} />
+      )
+      await waitFor(() => expect(screen.getByTestId('session-followup-input')).toBeInTheDocument())
+      fireEvent.change(screen.getByTestId('session-followup-input'), { target: { value: 'Send homework' } })
+      fireEvent.click(screen.getByTestId('session-followup-add-btn'))
+      await waitFor(() =>
+        expect(vi.mocked(createFollowup)).toHaveBeenCalledWith(
+          expect.objectContaining({ text: 'Send homework', studentId: STUDENT_ID })
+        )
+      )
     })
   })
 })

--- a/frontend/src/components/session/SessionLogDialog.tsx
+++ b/frontend/src/components/session/SessionLogDialog.tsx
@@ -115,6 +115,7 @@ export function SessionLogDialog({
 
   // Followup state
   const [newFollowupText, setNewFollowupText] = useState('')
+  const [isAddingFollowup, setIsAddingFollowup] = useState(false)
   const [localFollowups, setLocalFollowups] = useState<TeacherFollowup[]>([])
 
   // Voice extraction state
@@ -228,6 +229,7 @@ export function SessionLogDialog({
       setExtractionFailed(false)
       setLocalFollowups([])
       setNewFollowupText('')
+      setIsAddingFollowup(false)
     }
   }, [open, linkedLessonId])
   /* eslint-enable react-hooks/set-state-in-effect */
@@ -270,13 +272,16 @@ export function SessionLogDialog({
 
   async function handleAddFollowup() {
     const text = newFollowupText.trim()
-    if (!text) return
+    if (!text || isAddingFollowup) return
+    setIsAddingFollowup(true)
     try {
       const created = await createFollowup({ text, studentId, sourceSessionLogId: draftSessionId ?? undefined })
       setLocalFollowups(prev => [...prev, created])
       setNewFollowupText('')
     } catch {
       // API failure - leave input intact so user can retry
+    } finally {
+      setIsAddingFollowup(false)
     }
   }
 
@@ -885,7 +890,7 @@ export function SessionLogDialog({
                 <Button
                   type="button"
                   onClick={handleAddFollowup}
-                  disabled={!newFollowupText.trim()}
+                  disabled={!newFollowupText.trim() || isAddingFollowup}
                   size="sm"
                   className="bg-amber-500 hover:bg-amber-600 text-white"
                   data-testid="session-followup-add-btn"

--- a/frontend/src/components/session/SessionLogDialog.tsx
+++ b/frontend/src/components/session/SessionLogDialog.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { getFollowups, createFollowup, updateFollowupStatus } from '@/api/followups'
+import type { TeacherFollowup } from '@/api/followups'
 import { CheckCircle2, Loader2 } from 'lucide-react'
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
@@ -110,6 +112,10 @@ export function SessionLogDialog({
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const editSnapshotRef = useRef<Record<string, string | boolean>>({})
+
+  // Followup state
+  const [newFollowupText, setNewFollowupText] = useState('')
+  const [localFollowups, setLocalFollowups] = useState<TeacherFollowup[]>([])
 
   // Voice extraction state
   const [isExtracting, setIsExtracting] = useState(false)
@@ -248,6 +254,31 @@ export function SessionLogDialog({
     enabled: open,
   })
   const activeDifficulties = studentData?.difficulties.filter(d => d.status === 'Active') ?? []
+
+  const { data: serverFollowups = [] } = useQuery({
+    queryKey: ['followups', studentId],
+    queryFn: () => getFollowups(studentId),
+    enabled: open,
+  })
+  // Merge server followups with locally-added ones (avoid duplicates by id)
+  const pendingFollowups = [
+    ...serverFollowups.filter(f => f.status === 'pending'),
+    ...localFollowups.filter(lf => !serverFollowups.some(sf => sf.id === lf.id)),
+  ]
+
+  async function handleAddFollowup() {
+    const text = newFollowupText.trim()
+    if (!text) return
+    const created = await createFollowup({ text, studentId, sourceSessionLogId: draftSessionId ?? undefined })
+    setLocalFollowups(prev => [...prev, created])
+    setNewFollowupText('')
+  }
+
+  async function handleToggleFollowup(f: TeacherFollowup) {
+    const next = f.status === 'pending' ? 'done' : 'pending'
+    await updateFollowupStatus(f.id, next)
+    setLocalFollowups(prev => prev.map(lf => lf.id === f.id ? { ...lf, status: next } : lf))
+  }
 
   const { mutate: submitLog, isPending } = useMutation({
     mutationFn: () => {
@@ -806,6 +837,60 @@ export function SessionLogDialog({
                 </Select>
               </div>
             )}
+
+            {/* Pending Followups context panel */}
+            {pendingFollowups.length > 0 && (
+              <div className="space-y-2" data-testid="session-pending-followups">
+                <Label className="text-sm font-medium">Pending Followups</Label>
+                <div className="space-y-1.5 rounded-md border border-amber-200 bg-amber-50/50 p-3">
+                  {pendingFollowups.map(f => (
+                    <div key={f.id} className="flex items-start gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleToggleFollowup(f)}
+                        aria-label="Mark done"
+                        data-testid={`session-followup-toggle-${f.id}`}
+                        className="mt-0.5 shrink-0 w-3 h-3 rounded-full border-2 border-amber-400 bg-amber-100 hover:bg-amber-500 transition-colors"
+                      />
+                      <p className="text-sm text-[#1A1B22]">{f.text}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* New Followups quick-add */}
+            <div className="rounded-md bg-amber-50 p-3 space-y-2" data-testid="session-new-followup-section">
+              <Label className="text-sm font-medium">New Followups</Label>
+              <div className="flex gap-2">
+                <Input
+                  type="text"
+                  value={newFollowupText}
+                  onChange={e => setNewFollowupText(e.target.value)}
+                  onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); handleAddFollowup() } }}
+                  placeholder="Add a followup..."
+                  className="flex-1 text-sm bg-white"
+                  data-testid="session-followup-input"
+                />
+                <Button
+                  type="button"
+                  onClick={handleAddFollowup}
+                  disabled={!newFollowupText.trim()}
+                  size="sm"
+                  className="bg-amber-500 hover:bg-amber-600 text-white"
+                  data-testid="session-followup-add-btn"
+                >
+                  Add
+                </Button>
+              </div>
+              {localFollowups.length > 0 && (
+                <div className="space-y-1">
+                  {localFollowups.map(f => (
+                    <p key={f.id} className="text-xs text-amber-800">+ {f.text}</p>
+                  ))}
+                </div>
+              )}
+            </div>
 
             {submitError && (
               <p className="text-xs text-red-600" data-testid="session-log-error">{submitError}</p>

--- a/frontend/src/components/session/SessionLogDialog.tsx
+++ b/frontend/src/components/session/SessionLogDialog.tsx
@@ -226,6 +226,8 @@ export function SessionLogDialog({
       setIsExtracting(false)
       setDraftSessionId(null)
       setExtractionFailed(false)
+      setLocalFollowups([])
+      setNewFollowupText('')
     }
   }, [open, linkedLessonId])
   /* eslint-enable react-hooks/set-state-in-effect */
@@ -269,15 +271,23 @@ export function SessionLogDialog({
   async function handleAddFollowup() {
     const text = newFollowupText.trim()
     if (!text) return
-    const created = await createFollowup({ text, studentId, sourceSessionLogId: draftSessionId ?? undefined })
-    setLocalFollowups(prev => [...prev, created])
-    setNewFollowupText('')
+    try {
+      const created = await createFollowup({ text, studentId, sourceSessionLogId: draftSessionId ?? undefined })
+      setLocalFollowups(prev => [...prev, created])
+      setNewFollowupText('')
+    } catch {
+      // API failure - leave input intact so user can retry
+    }
   }
 
   async function handleToggleFollowup(f: TeacherFollowup) {
     const next = f.status === 'pending' ? 'done' : 'pending'
-    await updateFollowupStatus(f.id, next)
-    setLocalFollowups(prev => prev.map(lf => lf.id === f.id ? { ...lf, status: next } : lf))
+    try {
+      await updateFollowupStatus(f.id, next)
+      setLocalFollowups(prev => prev.map(lf => lf.id === f.id ? { ...lf, status: next } : lf))
+    } catch {
+      // API failure - leave UI unchanged
+    }
   }
 
   const { mutate: submitLog, isPending } = useMutation({

--- a/frontend/src/components/session/SessionLogDialog.tsx
+++ b/frontend/src/components/session/SessionLogDialog.tsx
@@ -264,10 +264,11 @@ export function SessionLogDialog({
     queryFn: () => getFollowups(studentId),
     enabled: open,
   })
-  // Merge server followups with locally-added ones (avoid duplicates by id)
+  // Merge server followups with locally-added ones; respect status overrides from local toggles
+  const localStatusMap = new Map(localFollowups.map(lf => [lf.id, lf.status]))
   const pendingFollowups = [
-    ...serverFollowups.filter(f => f.status === 'pending'),
-    ...localFollowups.filter(lf => !serverFollowups.some(sf => sf.id === lf.id)),
+    ...serverFollowups.filter(f => (localStatusMap.get(f.id) ?? f.status) === 'pending'),
+    ...localFollowups.filter(lf => !serverFollowups.some(sf => sf.id === lf.id) && lf.status === 'pending'),
   ]
 
   async function handleAddFollowup() {

--- a/frontend/src/components/student/StudentFollowupsCard.test.tsx
+++ b/frontend/src/components/student/StudentFollowupsCard.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { StudentFollowupsCard } from './StudentFollowupsCard'
 import type { TeacherFollowup } from '@/api/followups'
 
@@ -26,6 +27,19 @@ function makeFollowup(overrides: Partial<TeacherFollowup> = {}): TeacherFollowup
   }
 }
 
+function renderCard(props: { followups: TeacherFollowup[]; studentId?: string; onFollowupChange?: () => void }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <StudentFollowupsCard
+        followups={props.followups}
+        studentId={props.studentId ?? 's1'}
+        onFollowupChange={props.onFollowupChange ?? vi.fn()}
+      />
+    </QueryClientProvider>,
+  )
+}
+
 describe('StudentFollowupsCard', () => {
   const onFollowupChange = vi.fn()
 
@@ -36,30 +50,30 @@ describe('StudentFollowupsCard', () => {
   })
 
   it('shows empty state when no followups', () => {
-    render(<StudentFollowupsCard followups={[]} studentId="s1" onFollowupChange={onFollowupChange} />)
+    renderCard({ followups: [], onFollowupChange })
     expect(screen.getByText(/No pending followups/)).toBeInTheDocument()
   })
 
   it('renders pending followup text', () => {
-    render(<StudentFollowupsCard followups={[makeFollowup()]} studentId="s1" onFollowupChange={onFollowupChange} />)
+    renderCard({ followups: [makeFollowup()], onFollowupChange })
     expect(screen.getByText('Enviar ejercicio')).toBeInTheDocument()
   })
 
   it('renders done followup with strikethrough styling', () => {
-    render(<StudentFollowupsCard followups={[makeFollowup({ id: 'f2', status: 'done' })]} studentId="s1" onFollowupChange={onFollowupChange} />)
+    renderCard({ followups: [makeFollowup({ id: 'f2', status: 'done' })], onFollowupChange })
     const doneText = screen.getByText('Enviar ejercicio')
     expect(doneText.className).toContain('line-through')
   })
 
   it('shows overdue indicator for old pending followups', () => {
     const oldDate = new Date(Date.now() - 10 * 86400000).toISOString()
-    render(<StudentFollowupsCard followups={[makeFollowup({ id: 'f1', createdAt: oldDate })]} studentId="s1" onFollowupChange={onFollowupChange} />)
+    renderCard({ followups: [makeFollowup({ id: 'f1', createdAt: oldDate })], onFollowupChange })
     expect(screen.getByTestId('followup-overdue-f1')).toBeInTheDocument()
     expect(screen.getByTestId('followup-overdue-f1').textContent).toMatch(/Overdue \(\d+ days\)/)
   })
 
   it('calls createFollowup when add button clicked', async () => {
-    render(<StudentFollowupsCard followups={[]} studentId="s1" onFollowupChange={onFollowupChange} />)
+    renderCard({ followups: [], onFollowupChange })
     fireEvent.change(screen.getByTestId('followup-input'), { target: { value: 'Nueva tarea' } })
     fireEvent.click(screen.getByTestId('followup-add-btn'))
     await waitFor(() => expect(mockCreate).toHaveBeenCalledWith({ text: 'Nueva tarea', studentId: 's1' }))
@@ -67,20 +81,20 @@ describe('StudentFollowupsCard', () => {
   })
 
   it('calls updateFollowupStatus when done button clicked', async () => {
-    render(<StudentFollowupsCard followups={[makeFollowup({ id: 'f1' })]} studentId="s1" onFollowupChange={onFollowupChange} />)
+    renderCard({ followups: [makeFollowup({ id: 'f1' })], onFollowupChange })
     fireEvent.click(screen.getByTestId('followup-done-btn-f1'))
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith('f1', 'done'))
     expect(onFollowupChange).toHaveBeenCalled()
   })
 
   it('renders add input with amber-50 tint', () => {
-    render(<StudentFollowupsCard followups={[]} studentId="s1" onFollowupChange={onFollowupChange} />)
+    renderCard({ followups: [], onFollowupChange })
     const input = screen.getByTestId('followup-input')
     expect(input.className).toContain('amber-50')
   })
 
   it('renders the student-followups-card testid', () => {
-    render(<StudentFollowupsCard followups={[]} studentId="s1" onFollowupChange={onFollowupChange} />)
+    renderCard({ followups: [], onFollowupChange })
     expect(screen.getByTestId('student-followups-card')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/student/StudentFollowupsCard.test.tsx
+++ b/frontend/src/components/student/StudentFollowupsCard.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { StudentFollowupsCard } from './StudentFollowupsCard'
+import type { TeacherFollowup } from '@/api/followups'
+
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+
+vi.mock('@/api/followups', () => ({
+  createFollowup: (...args: unknown[]) => mockCreate(...args),
+  updateFollowupStatus: (...args: unknown[]) => mockUpdate(...args),
+}))
+
+function makeFollowup(overrides: Partial<TeacherFollowup> = {}): TeacherFollowup {
+  return {
+    id: 'f1',
+    studentId: 'student-1',
+    studentName: null,
+    text: 'Enviar ejercicio',
+    status: 'pending',
+    createdAt: new Date().toISOString(),
+    dueDate: null,
+    completedAt: null,
+    sourceSessionLogId: null,
+    ...overrides,
+  }
+}
+
+describe('StudentFollowupsCard', () => {
+  const onFollowupChange = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreate.mockResolvedValue({ id: 'new-f', text: 'Nueva', status: 'pending', createdAt: new Date().toISOString(), studentId: 'student-1', studentName: null, dueDate: null, completedAt: null, sourceSessionLogId: null })
+    mockUpdate.mockResolvedValue({})
+  })
+
+  it('shows empty state when no followups', () => {
+    render(<StudentFollowupsCard followups={[]} studentId="s1" onFollowupChange={onFollowupChange} />)
+    expect(screen.getByText(/No pending followups/)).toBeInTheDocument()
+  })
+
+  it('renders pending followup text', () => {
+    render(<StudentFollowupsCard followups={[makeFollowup()]} studentId="s1" onFollowupChange={onFollowupChange} />)
+    expect(screen.getByText('Enviar ejercicio')).toBeInTheDocument()
+  })
+
+  it('renders done followup with strikethrough styling', () => {
+    render(<StudentFollowupsCard followups={[makeFollowup({ id: 'f2', status: 'done' })]} studentId="s1" onFollowupChange={onFollowupChange} />)
+    const doneText = screen.getByText('Enviar ejercicio')
+    expect(doneText.className).toContain('line-through')
+  })
+
+  it('shows overdue indicator for old pending followups', () => {
+    const oldDate = new Date(Date.now() - 10 * 86400000).toISOString()
+    render(<StudentFollowupsCard followups={[makeFollowup({ id: 'f1', createdAt: oldDate })]} studentId="s1" onFollowupChange={onFollowupChange} />)
+    expect(screen.getByTestId('followup-overdue-f1')).toBeInTheDocument()
+    expect(screen.getByTestId('followup-overdue-f1').textContent).toMatch(/Overdue \(\d+ days\)/)
+  })
+
+  it('calls createFollowup when add button clicked', async () => {
+    render(<StudentFollowupsCard followups={[]} studentId="s1" onFollowupChange={onFollowupChange} />)
+    fireEvent.change(screen.getByTestId('followup-input'), { target: { value: 'Nueva tarea' } })
+    fireEvent.click(screen.getByTestId('followup-add-btn'))
+    await waitFor(() => expect(mockCreate).toHaveBeenCalledWith({ text: 'Nueva tarea', studentId: 's1' }))
+    expect(onFollowupChange).toHaveBeenCalled()
+  })
+
+  it('calls updateFollowupStatus when done button clicked', async () => {
+    render(<StudentFollowupsCard followups={[makeFollowup({ id: 'f1' })]} studentId="s1" onFollowupChange={onFollowupChange} />)
+    fireEvent.click(screen.getByTestId('followup-done-btn-f1'))
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith('f1', 'done'))
+    expect(onFollowupChange).toHaveBeenCalled()
+  })
+
+  it('renders add input with amber-50 tint', () => {
+    render(<StudentFollowupsCard followups={[]} studentId="s1" onFollowupChange={onFollowupChange} />)
+    const input = screen.getByTestId('followup-input')
+    expect(input.className).toContain('amber-50')
+  })
+
+  it('renders the student-followups-card testid', () => {
+    render(<StudentFollowupsCard followups={[]} studentId="s1" onFollowupChange={onFollowupChange} />)
+    expect(screen.getByTestId('student-followups-card')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/student/StudentFollowupsCard.tsx
+++ b/frontend/src/components/student/StudentFollowupsCard.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from 'react'
+import { useMutation } from '@tanstack/react-query'
 import type { TeacherFollowup } from '@/api/followups'
 import { createFollowup, updateFollowupStatus } from '@/api/followups'
 
@@ -14,30 +15,32 @@ function daysAgo(createdAt: string): number {
 
 export function StudentFollowupsCard({ followups, studentId, onFollowupChange }: StudentFollowupsCardProps) {
   const [newText, setNewText] = useState('')
-  const [adding, setAdding] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  async function handleAdd() {
-    const text = newText.trim()
-    if (!text) return
-    setAdding(true)
-    try {
-      await createFollowup({ text, studentId })
+  const createMutation = useMutation({
+    mutationFn: (text: string) => createFollowup({ text, studentId }),
+    onSuccess: () => {
       setNewText('')
       onFollowupChange()
-    } finally {
-      setAdding(false)
-    }
+    },
+  })
+
+  const toggleMutation = useMutation({
+    mutationFn: ({ id, status }: { id: string; status: 'pending' | 'done' }) =>
+      updateFollowupStatus(id, status),
+    onSuccess: () => onFollowupChange(),
+  })
+
+  function handleAdd() {
+    const text = newText.trim()
+    if (!text || createMutation.isPending) return
+    createMutation.mutate(text)
   }
 
-  async function handleToggle(f: TeacherFollowup) {
+  function handleToggle(f: TeacherFollowup) {
+    if (toggleMutation.isPending) return
     const next = f.status === 'pending' ? 'done' : 'pending'
-    try {
-      await updateFollowupStatus(f.id, next)
-      onFollowupChange()
-    } catch {
-      // API failure - leave UI unchanged
-    }
+    toggleMutation.mutate({ id: f.id, status: next })
   }
 
   const pending = followups.filter(f => f.status === 'pending')
@@ -107,11 +110,11 @@ export function StudentFollowupsCard({ followups, studentId, onFollowupChange }:
           placeholder="Add followup..."
           className="flex-1 rounded-md border border-zinc-200 bg-amber-50 px-3 py-1.5 text-sm text-[#1A1B22] placeholder:text-zinc-400 focus:outline-none focus:ring-1 focus:ring-amber-400"
           data-testid="followup-input"
-          disabled={adding}
+          disabled={createMutation.isPending}
         />
         <button
           onClick={handleAdd}
-          disabled={adding || !newText.trim()}
+          disabled={createMutation.isPending || !newText.trim()}
           className="rounded-md bg-amber-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-600 disabled:opacity-40 transition-colors"
           data-testid="followup-add-btn"
         >

--- a/frontend/src/components/student/StudentFollowupsCard.tsx
+++ b/frontend/src/components/student/StudentFollowupsCard.tsx
@@ -67,6 +67,7 @@ export function StudentFollowupsCard({ followups, studentId, onFollowupChange }:
             return (
               <div key={f.id} className="flex items-start gap-2 group">
                 <button
+                  type="button"
                   onClick={() => handleToggle(f)}
                   aria-label="Mark done"
                   data-testid={`followup-toggle-${f.id}`}
@@ -81,6 +82,7 @@ export function StudentFollowupsCard({ followups, studentId, onFollowupChange }:
                   )}
                 </div>
                 <button
+                  type="button"
                   onClick={() => handleToggle(f)}
                   className="shrink-0 text-[0.6875rem] font-semibold text-zinc-400 hover:text-emerald-600 transition-colors opacity-0 group-hover:opacity-100"
                   data-testid={`followup-done-btn-${f.id}`}
@@ -113,6 +115,7 @@ export function StudentFollowupsCard({ followups, studentId, onFollowupChange }:
           disabled={createMutation.isPending}
         />
         <button
+          type="button"
           onClick={handleAdd}
           disabled={createMutation.isPending || !newText.trim()}
           className="rounded-md bg-amber-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-600 disabled:opacity-40 transition-colors"

--- a/frontend/src/components/student/StudentFollowupsCard.tsx
+++ b/frontend/src/components/student/StudentFollowupsCard.tsx
@@ -1,0 +1,123 @@
+import { useState, useRef } from 'react'
+import type { TeacherFollowup } from '@/api/followups'
+import { createFollowup, updateFollowupStatus } from '@/api/followups'
+
+interface StudentFollowupsCardProps {
+  followups: TeacherFollowup[]
+  studentId: string
+  onFollowupChange: () => void
+}
+
+function daysAgo(createdAt: string): number {
+  return Math.floor(Math.max(0, Date.now() - new Date(createdAt).getTime()) / 86400000)
+}
+
+function overdueDays(createdAt: string): number {
+  return daysAgo(createdAt)
+}
+
+export function StudentFollowupsCard({ followups, studentId, onFollowupChange }: StudentFollowupsCardProps) {
+  const [newText, setNewText] = useState('')
+  const [adding, setAdding] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  async function handleAdd() {
+    const text = newText.trim()
+    if (!text) return
+    setAdding(true)
+    try {
+      await createFollowup({ text, studentId })
+      setNewText('')
+      onFollowupChange()
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  async function handleToggle(f: TeacherFollowup) {
+    const next = f.status === 'pending' ? 'done' : 'pending'
+    await updateFollowupStatus(f.id, next)
+    onFollowupChange()
+  }
+
+  const pending = followups.filter(f => f.status === 'pending')
+  const done = followups.filter(f => f.status === 'done').slice(-3)
+
+  return (
+    <div data-testid="student-followups-card">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-xs font-bold uppercase tracking-[0.06em] text-zinc-400">Pending Followups</h3>
+        {pending.length > 0 && (
+          <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[0.6875rem] font-bold text-amber-700">
+            {pending.length}
+          </span>
+        )}
+      </div>
+
+      {pending.length === 0 && done.length === 0 ? (
+        <p className="text-xs text-zinc-400 py-2">No pending followups</p>
+      ) : (
+        <div className="space-y-1.5">
+          {pending.map(f => {
+            const days = overdueDays(f.createdAt)
+            const isOverdue = days > 7
+            return (
+              <div key={f.id} className="flex items-start gap-2 group">
+                <button
+                  onClick={() => handleToggle(f)}
+                  aria-label="Mark done"
+                  data-testid={`followup-toggle-${f.id}`}
+                  className="mt-0.5 shrink-0 w-3 h-3 rounded-full border-2 border-amber-400 bg-amber-100 hover:bg-amber-500 transition-colors"
+                />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm text-[#1A1B22]">{f.text}</p>
+                  {isOverdue && (
+                    <p className="text-[0.6875rem] font-semibold text-red-600" data-testid={`followup-overdue-${f.id}`}>
+                      Overdue ({days} days)
+                    </p>
+                  )}
+                </div>
+                <button
+                  onClick={() => handleToggle(f)}
+                  className="shrink-0 text-[0.6875rem] font-semibold text-zinc-400 hover:text-emerald-600 transition-colors opacity-0 group-hover:opacity-100"
+                  data-testid={`followup-done-btn-${f.id}`}
+                >
+                  Done
+                </button>
+              </div>
+            )
+          })}
+
+          {done.map(f => (
+            <div key={f.id} className="flex items-start gap-2 opacity-50">
+              <span className="mt-0.5 shrink-0 w-3 h-3 rounded-full bg-emerald-500" />
+              <p className="text-sm text-zinc-500 line-through">{f.text}</p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-3 flex gap-2">
+        <input
+          ref={inputRef}
+          type="text"
+          value={newText}
+          onChange={e => setNewText(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && handleAdd()}
+          placeholder="Add followup..."
+          className="flex-1 rounded-md border border-zinc-200 bg-amber-50 px-3 py-1.5 text-sm text-[#1A1B22] placeholder:text-zinc-400 focus:outline-none focus:ring-1 focus:ring-amber-400"
+          data-testid="followup-input"
+          disabled={adding}
+        />
+        <button
+          onClick={handleAdd}
+          disabled={adding || !newText.trim()}
+          className="rounded-md bg-amber-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-600 disabled:opacity-40 transition-colors"
+          data-testid="followup-add-btn"
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/student/StudentFollowupsCard.tsx
+++ b/frontend/src/components/student/StudentFollowupsCard.tsx
@@ -12,10 +12,6 @@ function daysAgo(createdAt: string): number {
   return Math.floor(Math.max(0, Date.now() - new Date(createdAt).getTime()) / 86400000)
 }
 
-function overdueDays(createdAt: string): number {
-  return daysAgo(createdAt)
-}
-
 export function StudentFollowupsCard({ followups, studentId, onFollowupChange }: StudentFollowupsCardProps) {
   const [newText, setNewText] = useState('')
   const [adding, setAdding] = useState(false)
@@ -36,8 +32,12 @@ export function StudentFollowupsCard({ followups, studentId, onFollowupChange }:
 
   async function handleToggle(f: TeacherFollowup) {
     const next = f.status === 'pending' ? 'done' : 'pending'
-    await updateFollowupStatus(f.id, next)
-    onFollowupChange()
+    try {
+      await updateFollowupStatus(f.id, next)
+      onFollowupChange()
+    } catch {
+      // API failure - leave UI unchanged
+    }
   }
 
   const pending = followups.filter(f => f.status === 'pending')
@@ -59,7 +59,7 @@ export function StudentFollowupsCard({ followups, studentId, onFollowupChange }:
       ) : (
         <div className="space-y-1.5">
           {pending.map(f => {
-            const days = overdueDays(f.createdAt)
+            const days = daysAgo(f.createdAt)
             const isOverdue = days > 7
             return (
               <div key={f.id} className="flex items-start gap-2 group">

--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { StudentProfileTab } from './StudentProfileTab'
 import type { Student } from '@/api/students'
 import type { TeacherFollowup } from '@/api/followups'
@@ -68,10 +69,13 @@ const EMPTY_STUDENT: Student = {
 }
 
 function renderProfile(student: Student, onToggle?: (id: string, status: 'Active' | 'Covered') => void) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
   return render(
-    <MemoryRouter>
-      <StudentProfileTab student={student} onToggleDifficultyStatus={onToggle} />
-    </MemoryRouter>
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <StudentProfileTab student={student} onToggleDifficultyStatus={onToggle} />
+      </MemoryRouter>
+    </QueryClientProvider>
   )
 }
 
@@ -205,10 +209,13 @@ describe('StudentProfileTab', () => {
     })
 
     it('renders a passed followup item', () => {
+      const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
       render(
-        <MemoryRouter>
-          <StudentProfileTab student={FULL_STUDENT} followups={[FOLLOWUP]} onFollowupChange={vi.fn()} />
-        </MemoryRouter>
+        <QueryClientProvider client={qc}>
+          <MemoryRouter>
+            <StudentProfileTab student={FULL_STUDENT} followups={[FOLLOWUP]} onFollowupChange={vi.fn()} />
+          </MemoryRouter>
+        </QueryClientProvider>
       )
       expect(screen.getByText('Enviar ejercicio de subjuntivo')).toBeInTheDocument()
     })

--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -3,6 +3,12 @@ import { describe, it, expect, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { StudentProfileTab } from './StudentProfileTab'
 import type { Student } from '@/api/students'
+import type { TeacherFollowup } from '@/api/followups'
+
+vi.mock('@/api/followups', () => ({
+  createFollowup: vi.fn(),
+  updateFollowupStatus: vi.fn(),
+}))
 
 const FULL_STUDENT: Student = {
   id: 'student-1',
@@ -177,6 +183,39 @@ describe('StudentProfileTab', () => {
       renderProfile(FULL_STUDENT)
       expect(screen.getByTestId('teaching-todos-list')).toBeInTheDocument()
       expect(screen.getByText('Enviar ejercicios de por/para')).toBeInTheDocument()
+    })
+  })
+
+  describe('Pending Followups section', () => {
+    const FOLLOWUP: TeacherFollowup = {
+      id: 'fu-1',
+      studentId: 'student-1',
+      studentName: 'Matteo Russo',
+      text: 'Enviar ejercicio de subjuntivo',
+      status: 'pending',
+      createdAt: new Date().toISOString(),
+      dueDate: null,
+      completedAt: null,
+      sourceSessionLogId: null,
+    }
+
+    it('renders the followups section container', () => {
+      renderProfile(FULL_STUDENT)
+      expect(screen.getByTestId('profile-followups')).toBeInTheDocument()
+    })
+
+    it('renders a passed followup item', () => {
+      render(
+        <MemoryRouter>
+          <StudentProfileTab student={FULL_STUDENT} followups={[FOLLOWUP]} onFollowupChange={vi.fn()} />
+        </MemoryRouter>
+      )
+      expect(screen.getByText('Enviar ejercicio de subjuntivo')).toBeInTheDocument()
+    })
+
+    it('renders empty state when no followups passed', () => {
+      renderProfile(FULL_STUDENT)
+      expect(screen.getByText(/No pending followups/)).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -1,11 +1,15 @@
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import type { Student } from '@/api/students'
+import type { TeacherFollowup } from '@/api/followups'
 import { parseNotes } from './studentNoteUtils'
 import { TeachingTodosCard } from './TeachingTodosCard'
+import { StudentFollowupsCard } from './StudentFollowupsCard'
 
 interface Props {
   student: Student
+  followups?: TeacherFollowup[]
+  onFollowupChange?: () => void
   onToggleDifficultyStatus?: (id: string, status: 'Active' | 'Covered') => void
 }
 
@@ -31,7 +35,7 @@ function EmptyState({ text }: { text: string }) {
   return <p className="text-sm text-zinc-400 italic">{text}</p>
 }
 
-export function StudentProfileTab({ student, onToggleDifficultyStatus }: Props) {
+export function StudentProfileTab({ student, followups = [], onFollowupChange, onToggleDifficultyStatus }: Props) {
   const parsedPersonalNotes = parseNotes(student.personalNotes)
   const parsedTeachingNotes = parseNotes(student.teachingNotes)
 
@@ -235,6 +239,15 @@ export function StudentProfileTab({ student, onToggleDifficultyStatus }: Props) 
           <section data-testid="profile-teaching-todos">
             <SectionHeader>Teaching Todos</SectionHeader>
             <TeachingTodosCard todos={student.teachingTodos} />
+          </section>
+
+          {/* Pending Followups */}
+          <section data-testid="profile-followups">
+            <StudentFollowupsCard
+              followups={followups}
+              studentId={student.id}
+              onFollowupChange={onFollowupChange ?? (() => {})}
+            />
           </section>
 
           {/* Commercial */}

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -12,7 +12,7 @@ vi.mock('@/api/dashboard', () => ({
 }))
 
 function makeEmptyDashboard(): DashboardData {
-  return { nextSession: null, todaySessions: [], activeStudents: [] }
+  return { nextSession: null, todaySessions: [], activeStudents: [], pendingFollowups: [] }
 }
 
 function makeDashboard(overrides: Partial<DashboardData> = {}): DashboardData {
@@ -56,6 +56,7 @@ function makeDashboard(overrides: Partial<DashboardData> = {}): DashboardData {
         ],
       },
     ],
+    pendingFollowups: [],
     ...overrides,
   }
 }
@@ -143,10 +144,14 @@ describe('Dashboard', () => {
       expect(await screen.findByText(/All caught up/)).toBeInTheDocument()
     })
 
-    it('shows pending todo text when todos exist', async () => {
-      mockGetDashboard.mockResolvedValue(makeDashboard())
+    it('shows pending followup text when followups exist', async () => {
+      mockGetDashboard.mockResolvedValue(makeDashboard({
+        pendingFollowups: [
+          { id: 'f1', studentId: 'student-1', studentName: 'Ana García', text: 'Enviar ejercicio de gustar', status: 'pending', createdAt: new Date().toISOString(), dueDate: null, completedAt: null, sourceSessionLogId: null },
+        ],
+      }))
       renderDashboard()
-      expect(await screen.findByText('Review ser/estar')).toBeInTheDocument()
+      expect(await screen.findByText('Enviar ejercicio de gustar')).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -55,6 +55,7 @@ export default function Dashboard() {
   const nextSession = data?.nextSession ?? null
   const todaySessions = data?.todaySessions ?? []
   const activeStudents = data?.activeStudents ?? []
+  const pendingFollowups = data?.pendingFollowups ?? []
 
   return (
     <div className="space-y-5">
@@ -74,7 +75,7 @@ export default function Dashboard() {
           sessions={todaySessions}
           nextSessionId={nextSession?.sessionLogId ?? null}
         />
-        <PendingFollowups students={activeStudents} />
+        <PendingFollowups followups={pendingFollowups} />
       </div>
 
       {/* Zone 3: Student Roster */}

--- a/frontend/src/pages/StudentDetail.test.tsx
+++ b/frontend/src/pages/StudentDetail.test.tsx
@@ -5,6 +5,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import StudentDetail from './StudentDetail'
 import * as studentsApi from '../api/students'
 
+vi.mock('../api/followups', () => ({
+  getFollowups: vi.fn().mockResolvedValue([]),
+  createFollowup: vi.fn(),
+  updateFollowupStatus: vi.fn(),
+}))
+
 vi.mock('../api/students', () => ({
   getStudent: vi.fn(),
   updateStudent: vi.fn(),
@@ -15,6 +21,13 @@ vi.mock('../api/sessionLogs', () => ({
   createSession: vi.fn(),
   serializeTopicTags: vi.fn(() => '[]'),
   parseTopicTags: vi.fn(() => []),
+}))
+
+vi.mock('@/api/followups', () => ({
+  getFollowups: vi.fn().mockResolvedValue([]),
+  createFollowup: vi.fn(),
+  updateFollowupStatus: vi.fn(),
+  deleteFollowup: vi.fn(),
 }))
 
 vi.mock('../api/lessons', () => ({

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import { useParams, useNavigate, Link, useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft, NotebookPen, Pencil } from 'lucide-react'
 import { getStudent, updateStudent } from '../api/students'
+import { getFollowups } from '@/api/followups'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { getCefrStitchBadgeClasses } from '@/lib/cefr-colors'
@@ -36,6 +37,14 @@ export default function StudentDetail() {
     queryFn: () => getStudent(id!),
     enabled: !!id,
   })
+
+  const { data: followups = [], refetch: refetchFollowups } = useQuery({
+    queryKey: ['followups', id],
+    queryFn: () => getFollowups(id!),
+    enabled: !!id,
+  })
+
+  const onFollowupChange = useCallback(() => { refetchFollowups() }, [refetchFollowups])
 
   const { mutate: toggleDifficultyStatus } = useMutation({
     mutationFn: (vars: { difficultyId: string; status: 'Active' | 'Covered' }) => {
@@ -225,6 +234,8 @@ export default function StudentDetail() {
       {activeTab === 'profile' && (
         <StudentProfileTab
           student={student}
+          followups={followups}
+          onFollowupChange={onFollowupChange}
           onToggleDifficultyStatus={(difficultyId, status) =>
             toggleDifficultyStatus({ difficultyId, status })
           }

--- a/frontend/src/pages/StudentForm.test.tsx
+++ b/frontend/src/pages/StudentForm.test.tsx
@@ -4,6 +4,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import StudentForm from './StudentForm'
 
+vi.mock('../api/followups', () => ({
+  getFollowups: vi.fn().mockResolvedValue([]),
+  createFollowup: vi.fn(),
+  updateFollowupStatus: vi.fn(),
+}))
+
 const mockGetStudent = vi.fn()
 const mockCreateStudent = vi.fn()
 const mockUpdateStudent = vi.fn()
@@ -26,6 +32,13 @@ vi.mock('../components/student/StudentCoursesCard', () => ({
 
 vi.mock('../components/student/LessonHistoryCard', () => ({
   LessonHistoryCard: () => <div data-testid="lesson-history-card" />,
+}))
+
+vi.mock('@/api/followups', () => ({
+  getFollowups: vi.fn().mockResolvedValue([]),
+  createFollowup: vi.fn(),
+  updateFollowupStatus: vi.fn(),
+  deleteFollowup: vi.fn(),
 }))
 
 vi.mock('../lib/studentOptions', () => ({

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -21,6 +21,8 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { MultiSelect } from '@/components/ui/multi-select'
 import { StudentCoursesCard } from '@/components/student/StudentCoursesCard'
+import { StudentFollowupsCard } from '@/components/student/StudentFollowupsCard'
+import { getFollowups } from '@/api/followups'
 import { FieldTooltip } from '@/components/FieldTooltip'
 import { PageHeader } from '@/components/PageHeader'
 import { CEFR_LEVELS } from '@/lib/cefr-colors'
@@ -50,6 +52,12 @@ export default function StudentForm() {
     queryKey: ['students', id],
     queryFn: () => getStudent(id!),
     enabled: isEdit,
+  })
+
+  const { data: followups = [], refetch: refetchFollowups } = useQuery({
+    queryKey: ['followups', id],
+    queryFn: () => getFollowups(id!),
+    enabled: isEdit && !!id,
   })
 
   // Sync server student data to local form state
@@ -569,6 +577,21 @@ export default function StudentForm() {
           </CardContent>
         </Card>
       </form>
+
+      {isEdit && id && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Pending Followups</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <StudentFollowupsCard
+              followups={followups}
+              studentId={id}
+              onFollowupChange={() => refetchFollowups()}
+            />
+          </CardContent>
+        </Card>
+      )}
 
       {isEdit && id && <StudentCoursesCard studentId={id} />}
     </div>

--- a/frontend/src/pages/Students.test.tsx
+++ b/frontend/src/pages/Students.test.tsx
@@ -19,7 +19,7 @@ vi.mock('../lib/logger', () => ({
   logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
 }))
 
-const emptyDashboard = { nextSession: null, todaySessions: [], activeStudents: [] }
+const emptyDashboard = { nextSession: null, todaySessions: [], activeStudents: [], pendingFollowups: [] }
 
 function makeStudent(overrides: Partial<studentsApi.Student> = {}): studentsApi.Student {
   return {
@@ -190,6 +190,7 @@ describe('Students page', () => {
     vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
       nextSession: null,
       todaySessions: [],
+      pendingFollowups: [],
       activeStudents: [
         {
           studentId: 'abc-123',

--- a/plan/langteach-beta/task671-teacher-followup.md
+++ b/plan/langteach-beta/task671-teacher-followup.md
@@ -1,0 +1,307 @@
+# Task 671: TeacherFollowup Entity and All UI Surfaces
+
+**Issue:** #671
+**Sprint:** sprint/ui-redesign-student-polish
+**Labels:** area:backend, area:frontend, area:design, P1:must
+
+## Goal
+
+Create a dedicated `TeacherFollowup` entity (new table, CRUD endpoints, service) and wire it into 5 UI surfaces: Dashboard panel, Student Profile tab right column, StudentForm below Notes, Log Session context panel, Log Session new-followup quick-add.
+
+## Descoped (with reasons)
+
+- **Overview tab surface** -> deferred to #682 (Overview tab doesn't exist yet; #682 will add it with the Pending Followups card).
+- **Edit form right sidebar surface** -> deferred to #681 (StudentForm has no sidebar layout; #681 will restructure the form with a right sidebar and add both Teaching Todos and Pending Followups there). For now, followups appear below the Notes section in the single-column form.
+
+## Current State
+
+- `PendingFollowups.tsx` dashboard component exists but shows `TeachingTodo` items from `ActiveStudent.pendingTodos`. This is a placeholder that needs to be replaced with real `TeacherFollowup` data.
+- `TeachingTodosCard.tsx` exists for the student-level todo list (indigo convention). Followups use amber convention.
+- No `TeacherFollowup` model, migration, service, controller, or API client exists yet.
+- Dashboard endpoint (`GET /api/dashboard`) returns `ActiveStudent.PendingTodos` (TeachingTodos) but no followups.
+- `StudentProfileTab.tsx` has a right column with sections: Learning Goals, Objectives, Difficulties, Teaching Todos, Commercial. Followups card goes below Teaching Todos in this column.
+- `StudentForm.tsx` is single-column. Followups go below the Notes section.
+
+## Data Model
+
+```csharp
+public class TeacherFollowup
+{
+    public Guid Id { get; set; }
+    public Guid TeacherId { get; set; }
+    public Guid? StudentId { get; set; }
+    public string Text { get; set; } = "";       // max 500
+    public string Status { get; set; } = "pending"; // pending | done
+    public DateTime CreatedAt { get; set; }
+    public DateOnly? DueDate { get; set; }
+    public DateTime? CompletedAt { get; set; }
+    public Guid? SourceSessionLogId { get; set; }
+
+    // Navigations
+    public Teacher Teacher { get; set; } = null!;
+    public Student? Student { get; set; }
+    public SessionLog? SourceSessionLog { get; set; }
+}
+```
+
+FK constraints: TeacherId -> Teacher (cascade delete), StudentId -> Student (NoAction, nullable), SourceSessionLogId -> SessionLog (NoAction, nullable).
+
+## Backend Plan
+
+### Step 1: Model + Migration
+
+1. Create `backend/LangTeach.Api/Data/Models/TeacherFollowup.cs`
+2. Add `DbSet<TeacherFollowup> TeacherFollowups` to `AppDbContext` with Fluent API config (HasMaxLength(500) on Text, NoAction delete for Student/SessionLog FKs)
+3. `dotnet ef migrations add AddTeacherFollowups --project backend/LangTeach.Api --startup-project backend/LangTeach.Api`
+
+### Step 2: DTOs
+
+File: `backend/LangTeach.Api/DTOs/TeacherFollowupDto.cs`
+
+```csharp
+public record TeacherFollowupDto(
+    string Id,
+    string? StudentId,
+    string? StudentName,      // denormalized for dashboard display
+    string Text,
+    string Status,
+    DateTime CreatedAt,
+    DateOnly? DueDate,
+    DateTime? CompletedAt,
+    string? SourceSessionLogId);
+
+public record CreateTeacherFollowupRequest(
+    [MaxLength(500)] string Text,
+    string? StudentId,
+    DateOnly? DueDate,
+    string? SourceSessionLogId);
+
+public record UpdateTeacherFollowupRequest(
+    [Required] string Status);  // pending | done
+```
+
+### Step 3: Service
+
+Interface: `ITeacherFollowupService`
+- `GetAllAsync(Guid teacherId, CancellationToken)` -> `List<TeacherFollowupDto>`
+- `GetByStudentAsync(Guid teacherId, Guid studentId, CancellationToken)` -> `List<TeacherFollowupDto>`
+- `CreateAsync(Guid teacherId, CreateTeacherFollowupRequest, CancellationToken)` -> `TeacherFollowupDto`
+- `UpdateStatusAsync(Guid teacherId, Guid followupId, UpdateTeacherFollowupRequest, CancellationToken)` -> `TeacherFollowupDto`
+- `DeleteAsync(Guid teacherId, Guid followupId, CancellationToken)` -> `bool`
+
+Implementation: `TeacherFollowupService`
+- All queries filter by `teacherId` for multi-tenant isolation.
+- `GetAllAsync` returns all followups ordered by `CreatedAt` ascending (oldest first = most urgent).
+- `GetByStudentAsync` filters by `studentId` additionally.
+- `CreateAsync` sets `CreatedAt = DateTime.UtcNow`, `Status = "pending"`.
+- `UpdateStatusAsync` sets `CompletedAt = UtcNow` when transitioning to "done", clears it on "pending".
+
+Register in `Program.cs`.
+
+### Step 4: Controller
+
+`backend/LangTeach.Api/Controllers/TeacherFollowupsController.cs`
+
+```
+GET    /api/teacher-followups              -> GetAll (all teacher's followups)
+GET    /api/teacher-followups?studentId=X  -> filtered by student (optional query param)
+POST   /api/teacher-followups              -> Create
+PATCH  /api/teacher-followups/{id}         -> UpdateStatus
+DELETE /api/teacher-followups/{id}         -> Delete
+```
+
+All endpoints require `[Authorize]` and resolve `teacherId` from `IProfileService.UpsertTeacherAsync`.
+
+### Step 5: Dashboard DTO update
+
+Add `List<TeacherFollowupDto> PendingFollowups` to `DashboardDto`.
+
+In `DashboardService.GetAsync`: call `_teacherFollowupService.GetAllAsync(teacherId, ct)`, filter to `Status == "pending"`, pass as `PendingFollowups`. Order: oldest first.
+
+Also update `DashboardServiceTests.cs` to include `PendingFollowups = []` in the `DashboardDto` assertions.
+
+### Step 6: Backend tests
+
+File: `backend/LangTeach.Api.Tests/Services/TeacherFollowupServiceTests.cs`
+
+Tests:
+- Create followup and retrieve it via GetAll
+- GetByStudent returns only that student's followups (not unrelated student's)
+- UpdateStatus to done sets CompletedAt, status = "done"
+- UpdateStatus back to pending clears CompletedAt
+- Delete removes the followup
+- Teacher isolation: teacher A cannot see teacher B's followups
+
+## Frontend Plan
+
+### Step 7: API client
+
+File: `frontend/src/api/followups.ts`
+
+```typescript
+export interface TeacherFollowup {
+  id: string
+  studentId: string | null
+  studentName: string | null
+  text: string
+  status: 'pending' | 'done'
+  createdAt: string
+  dueDate: string | null
+  completedAt: string | null
+  sourceSessionLogId: string | null
+}
+
+export interface CreateFollowupRequest {
+  text: string
+  studentId?: string | null
+  dueDate?: string | null
+  sourceSessionLogId?: string | null
+}
+
+export async function getFollowups(studentId?: string): Promise<TeacherFollowup[]>
+export async function createFollowup(data: CreateFollowupRequest): Promise<TeacherFollowup>
+export async function updateFollowupStatus(id: string, status: 'pending' | 'done'): Promise<TeacherFollowup>
+export async function deleteFollowup(id: string): Promise<void>
+```
+
+Also add `pendingFollowups: TeacherFollowup[]` to `DashboardData` interface in `dashboard.ts`.
+
+### Step 8: Dashboard followups panel
+
+Update `PendingFollowups.tsx`:
+- Change prop from `students: ActiveStudent[]` to `followups: TeacherFollowup[]`
+- Each row: amber dot, student name (small uppercase), followup text, age badge
+- Age badge: emerald if <= 3d, amber if 4-7d, red if > 7d
+- One-click toggle: clicking the dot calls `updateFollowupStatus(id, 'done')`, removes row optimistically
+- Empty state: "All caught up"
+
+Update `Dashboard.tsx` to pass `dashboardData.pendingFollowups` to `<PendingFollowups>`.
+
+Update `PendingFollowups.test.tsx` to use new props shape (mock `TeacherFollowup[]`).
+Update `Dashboard.test.tsx` to include `pendingFollowups: []` in mock data.
+
+### Step 9: StudentFollowupsCard component
+
+New file: `frontend/src/components/student/StudentFollowupsCard.tsx`
+
+Amber convention (distinct from indigo `TeachingTodosCard`):
+- Section header: "Pending Followups"
+- Pending items: amber-500 dot, text, relative time, "Done" button
+- Done items: emerald-500 dot, strikethrough text (show last 3 done items grayed, collapsible)
+- Overdue indicator: red "Overdue (N days)" if `createdAt` > 7 days ago and status still pending
+- Inline add: text input at bottom, press Enter or click "Add" -> calls `createFollowup({ text, studentId })`
+- Props: `followups: TeacherFollowup[]`, `studentId: string`, `onFollowupChange: () => void`
+- On status toggle: calls `updateFollowupStatus`, then `onFollowupChange()` to refetch
+
+Test file: `frontend/src/components/student/StudentFollowupsCard.test.tsx`
+
+### Step 10: Wire into Student Profile tab
+
+In `StudentProfileTab.tsx` right column, add `<section data-testid="profile-followups">` below `profile-teaching-todos`:
+- `StudentProfileTab` receives `followups: TeacherFollowup[]` and `onFollowupChange: () => void` as new props
+- Render `<StudentFollowupsCard followups={followups} studentId={student.id} onFollowupChange={onFollowupChange} />`
+
+In `StudentDetail.tsx`:
+- Add `const [followups, setFollowups] = useState<TeacherFollowup[]>([])` (or useQuery pattern)
+- Fetch on mount: `getFollowups(student.id)`
+- Pass `followups` and `onFollowupChange={() => getFollowups(student.id).then(setFollowups)}` to `StudentProfileTab`
+
+Update `StudentProfileTab.test.tsx` with new props.
+Update `StudentDetail.test.tsx` to mock `GET /api/teacher-followups?studentId=X`.
+
+### Step 11: Wire into StudentForm (below Notes section)
+
+In `StudentForm.tsx`, after the Notes section (personalNotes/teachingNotes fields):
+- Add a `StudentFollowupsCard` section visible when editing an existing student (not on create)
+- Fetch followups for `studentId` when `mode === 'edit'`
+- `onFollowupChange` refetches the followup list
+
+Update `StudentForm.test.tsx` to mock the followups endpoint.
+
+### Step 12: Log Session context panel + quick-add
+
+In `SessionLogDialog.tsx`:
+
+**Left context panel** - add "Pending Followups" section:
+- Fetch `getFollowups(studentId)` on dialog open
+- Show pending followups for this student, amber dots, checkable
+- On check: `updateFollowupStatus(id, 'done')`, remove from list optimistically
+
+**Right form** - add "New Followups" quick-add section with `bg-amber-50` tint:
+- Text input + "Add" button
+- On submit: `createFollowup({ text, studentId, sourceSessionLogId: draftSessionId ?? undefined })`
+- `sourceSessionLogId` is passed only if `draftSessionId` is non-null (draft already saved); otherwise omitted
+- New items appear in the context panel's list immediately (shared local state)
+
+### Step 13: E2E test
+
+File: `e2e/tests/followups.spec.ts`
+
+Happy path:
+1. Log in as test teacher, navigate to student detail (Ewan McLeod)
+2. On Profile tab, add a new followup via `StudentFollowupsCard`
+3. Navigate to Dashboard, verify the followup appears in the Pending Followups panel with Ewan's name
+4. Mark it as done from the Dashboard panel
+5. Verify it disappears from the dashboard pending list
+
+## Amber Visual Convention
+
+Consistent across all surfaces:
+- Pending dot: `bg-amber-500` circle (6x6)
+- Done dot: `bg-emerald-500` circle (6x6)
+- Card quick-add tint: `bg-amber-50`
+- Age badge colors: emerald (fresh), amber (aging), red (overdue)
+- Overdue label: `text-red-600 font-semibold text-xs`
+- Distinct from TeachingTodos (indigo-600 convention)
+
+## Implementation Order
+
+1. Backend model + migration (Steps 1-2)
+2. Backend service + controller (Steps 3-4)
+3. Dashboard DTO update (Step 5)
+4. Backend tests (Step 6)
+5. Frontend API client (Step 7)
+6. Dashboard panel update (Step 8)
+7. StudentFollowupsCard component (Step 9)
+8. Profile tab + StudentDetail fetch (Step 10)
+9. StudentForm below Notes (Step 11)
+10. SessionLogDialog (Step 12)
+11. E2E test (Step 13)
+
+## E2E Test Student
+
+Use "Ewan McLeod" (A1.2) from the demo seeder cohort for E2E scenarios.
+
+## Files to Create
+
+- `backend/LangTeach.Api/Data/Models/TeacherFollowup.cs`
+- `backend/LangTeach.Api/DTOs/TeacherFollowupDto.cs`
+- `backend/LangTeach.Api/Services/ITeacherFollowupService.cs`
+- `backend/LangTeach.Api/Services/TeacherFollowupService.cs`
+- `backend/LangTeach.Api/Controllers/TeacherFollowupsController.cs`
+- `backend/LangTeach.Api.Tests/Services/TeacherFollowupServiceTests.cs`
+- `frontend/src/api/followups.ts`
+- `frontend/src/components/student/StudentFollowupsCard.tsx`
+- `frontend/src/components/student/StudentFollowupsCard.test.tsx`
+- `e2e/tests/followups.spec.ts`
+
+## Files to Modify
+
+- `backend/LangTeach.Api/Data/AppDbContext.cs` (DbSet + Fluent config)
+- `backend/LangTeach.Api/DTOs/DashboardDtos.cs` (add PendingFollowups to DashboardDto)
+- `backend/LangTeach.Api/Services/DashboardService.cs` (populate PendingFollowups)
+- `backend/LangTeach.Api/Program.cs` (register ITeacherFollowupService)
+- `backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs` (add PendingFollowups = [] to assertions)
+- `frontend/src/api/dashboard.ts` (add pendingFollowups to DashboardData)
+- `frontend/src/components/dashboard/PendingFollowups.tsx` (new props, real data, toggle)
+- `frontend/src/components/dashboard/PendingFollowups.test.tsx` (update to TeacherFollowup[])
+- `frontend/src/pages/Dashboard.tsx` (pass pendingFollowups)
+- `frontend/src/pages/Dashboard.test.tsx` (add pendingFollowups to mock)
+- `frontend/src/components/student/StudentProfileTab.tsx` (add followups section, new props)
+- `frontend/src/components/student/StudentProfileTab.test.tsx` (update props)
+- `frontend/src/pages/StudentDetail.tsx` (fetch followups, pass to ProfileTab)
+- `frontend/src/pages/StudentDetail.test.tsx` (mock followups endpoint)
+- `frontend/src/pages/StudentForm.tsx` (add followups below Notes for edit mode)
+- `frontend/src/pages/StudentForm.test.tsx` (mock followups endpoint)
+- `frontend/src/components/session/SessionLogDialog.tsx` (context panel + quick-add)
+- `frontend/src/components/session/SessionLogDialog.test.tsx` (mock followups)


### PR DESCRIPTION
## Summary

- New `TeacherFollowup` entity with EF Core migration, full CRUD API (`GET /api/teacher-followups`, `POST`, `PATCH /{id}`, `DELETE /{id}`)
- Dashboard "Pending Followups" panel with age badges (emerald/amber/red) and one-click mark done
- Student Profile tab: `StudentFollowupsCard` with overdue indicator, inline add (amber convention)
- Student Edit form: followups card below Notes section (edit mode only)
- `SessionLogDialog`: pending followups context panel + quick-add section with `sourceSessionLogId` linking
- All write operations use `useMutation`; multi-tenant isolation enforced throughout
- 7 backend unit tests, component tests with `QueryClientProvider`, e2e happy path

Descoped from this issue (tracked separately):
- Overview tab surface: #682
- Edit form right sidebar layout: #681

## Test plan

- [ ] Create a student, add a followup from Profile tab, verify it appears in Dashboard Pending Followups panel
- [ ] Mark followup done from Dashboard; verify it disappears
- [ ] Open SessionLogDialog, verify pending followups context shown; add new followup via quick-add
- [ ] Verify Teacher isolation: followups are not visible to other teachers
- [ ] Edit mode: open student edit form, verify followups card below Notes section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added followup management system for teachers to track student progress
  * Teachers can now create, view, and manage followups from student profiles and session logs
  * Followups display on the dashboard with pending status tracking
  * Followups can be marked complete and include optional due dates
  * Quick-add followup functionality integrated into session dialogs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->