### PR TITLE
feat: student identity fields in edit form and profile view (#662)

### DIFF
--- a/e2e/tests/students.spec.ts
+++ b/e2e/tests/students.spec.ts
@@ -476,3 +476,69 @@ test('student detail shows 3 tabs and profile content', async ({ browser }) => {
 
   await context.close()
 })
+
+test('identity fields round-trip: save and verify in profile view and edit form', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  const studentName = `Identity Test ${Date.now()}`
+
+  await page.goto('/students/new')
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: 10000 })
+
+  await page.getByTestId('student-name').fill(studentName)
+  await page.getByTestId('student-language').click()
+  await page.getByRole('option', { name: 'Spanish' }).click()
+  await page.getByTestId('student-cefr').click()
+  await page.getByRole('option', { name: 'B2' }).click()
+
+  // Fill identity fields
+  await page.getByTestId('student-birth-year').fill('1990')
+  await page.getByTestId('student-profession').fill('Architect')
+  await page.getByTestId('student-country-origin').fill('Portugal')
+  await page.getByTestId('student-city-origin').fill('Lisbon')
+  await page.getByTestId('student-country-residence').fill('Spain')
+  await page.getByTestId('student-city-residence').fill('Madrid')
+
+  await page.getByRole('button', { name: 'Save Student' }).click()
+
+  // Should redirect to student detail page
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
+
+  // Profile tab: header shows profession and compact location
+  await expect(page.getByTestId('student-header-profession')).toHaveText('Architect', { timeout: 5000 })
+  await expect(page.getByTestId('student-header-location')).toHaveText('Lisbon / Madrid', { timeout: 5000 })
+
+  // Profile tab: About section shows identity details
+  await expect(page.getByTestId('profile-about')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByText('Lisbon, Portugal')).toBeVisible()
+  await expect(page.getByText('Madrid, Spain')).toBeVisible()
+  await expect(page.getByText(/1990 \(\d+ years\)/)).toBeVisible()
+
+  // Navigate to edit and verify round-trip
+  await page.getByTestId('edit-profile-link').click()
+  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: 10000 })
+  await expect(page.getByTestId('student-birth-year')).toHaveValue('1990')
+  await expect(page.getByTestId('student-profession')).toHaveValue('Architect')
+  await expect(page.getByTestId('student-country-origin')).toHaveValue('Portugal')
+  await expect(page.getByTestId('student-city-origin')).toHaveValue('Lisbon')
+  await expect(page.getByTestId('student-country-residence')).toHaveValue('Spain')
+  await expect(page.getByTestId('student-city-residence')).toHaveValue('Madrid')
+
+  // Cleanup
+  await page.getByRole('button', { name: 'Cancel' }).click()
+  await expect(page).toHaveURL('/students', { timeout: 10000 })
+  const deleteCard = page.locator('[data-testid^="student-row-"]').filter({
+    has: page.getByTestId('student-name').filter({ hasText: studentName })
+  })
+  await deleteCard.getByTestId('delete-student').click()
+  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: 5000 })
+  await page.getByTestId('confirm-delete').click()
+  await expect(
+    page.locator('[data-testid^="student-row-"]').filter({
+      has: page.getByTestId('student-name').filter({ hasText: studentName })
+    })
+  ).not.toBeVisible({ timeout: 10000 })
+
+  await context.close()
+})

--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -80,7 +80,7 @@ describe('StudentProfileTab', () => {
       renderProfile(FULL_STUDENT)
       expect(screen.getByText('Rome, Italy')).toBeInTheDocument()
       expect(screen.getByText('Barcelona, Spain')).toBeInTheDocument()
-      expect(screen.getByText('1998')).toBeInTheDocument()
+      expect(screen.getByText(/^1998 \(\d+ years\)$/)).toBeInTheDocument()
       expect(screen.getByText('Film student')).toBeInTheDocument()
       expect(screen.getByText('Vive en Barcelona')).toBeInTheDocument()
     })

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -58,7 +58,12 @@ export function StudentProfileTab({ student, onToggleDifficultyStatus }: Props) 
               <div>
                 {origin && <FieldValue label="Origin" value={origin} />}
                 {location && <FieldValue label="Lives in" value={location} />}
-                <FieldValue label="Birth year" value={student.birthYear} />
+                {student.birthYear != null && (
+                  <FieldValue
+                    label="Birth year"
+                    value={`${student.birthYear} (${new Date().getFullYear() - student.birthYear} years)`}
+                  />
+                )}
                 <FieldValue label="Profession" value={student.profession} />
                 <FieldValue label="Reason" value={student.reasonForStudying} />
               </div>

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -58,12 +58,17 @@ export function StudentProfileTab({ student, onToggleDifficultyStatus }: Props) 
               <div>
                 {origin && <FieldValue label="Origin" value={origin} />}
                 {location && <FieldValue label="Lives in" value={location} />}
-                {student.birthYear != null && (
-                  <FieldValue
-                    label="Birth year"
-                    value={`${student.birthYear} (${new Date().getFullYear() - student.birthYear} years)`}
-                  />
-                )}
+                {student.birthYear != null && (() => {
+                  const currentYear = new Date().getFullYear()
+                  return (
+                    <FieldValue
+                      label="Birth year"
+                      value={student.birthYear <= currentYear
+                        ? `${student.birthYear} (${currentYear - student.birthYear} years)`
+                        : `${student.birthYear}`}
+                    />
+                  )
+                })()}
                 <FieldValue label="Profession" value={student.profession} />
                 <FieldValue label="Reason" value={student.reasonForStudying} />
               </div>

--- a/frontend/src/pages/StudentDetail.test.tsx
+++ b/frontend/src/pages/StudentDetail.test.tsx
@@ -175,6 +175,39 @@ describe('StudentDetail', () => {
     await screen.findByTestId('student-detail-name')
     expect(screen.getByTestId('official-cefr-badge')).toHaveTextContent('Official: B1')
   })
+
+  it('shows profession below name in header when set', async () => {
+    wrapper()
+    await screen.findByTestId('student-detail-name')
+    expect(screen.getByTestId('student-header-profession')).toHaveTextContent('Designer')
+  })
+
+  it('does not render profession element when profession is null', async () => {
+    vi.mocked(studentsApi.getStudent).mockResolvedValue({
+      ...MOCK_STUDENT,
+      profession: null,
+    })
+    wrapper()
+    await screen.findByTestId('student-detail-name')
+    expect(screen.queryByTestId('student-header-profession')).not.toBeInTheDocument()
+  })
+
+  it('shows origin/residence compact in metadata when cities are set', async () => {
+    wrapper()
+    await screen.findByTestId('student-detail-name')
+    expect(screen.getByTestId('student-header-location')).toHaveTextContent('London / Barcelona')
+  })
+
+  it('does not render location element when no city data', async () => {
+    vi.mocked(studentsApi.getStudent).mockResolvedValue({
+      ...MOCK_STUDENT,
+      cityOfOrigin: null,
+      cityOfResidence: null,
+    })
+    wrapper()
+    await screen.findByTestId('student-detail-name')
+    expect(screen.queryByTestId('student-header-location')).not.toBeInTheDocument()
+  })
 })
 
 describe('StudentDetail - Profile tab sections', () => {
@@ -187,8 +220,8 @@ describe('StudentDetail - Profile tab sections', () => {
     await screen.findByTestId('profile-about')
     expect(screen.getByText('London, United Kingdom')).toBeInTheDocument()
     expect(screen.getByText('Barcelona, Spain')).toBeInTheDocument()
-    expect(screen.getByText('1995')).toBeInTheDocument()
-    expect(screen.getByText('Designer')).toBeInTheDocument()
+    expect(screen.getByText(/^1995 \(\d+ years\)$/)).toBeInTheDocument()
+    expect(screen.getAllByText('Designer').length).toBeGreaterThanOrEqual(1)
     expect(screen.getByText('Moved to Barcelona for work')).toBeInTheDocument()
   })
 

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -141,6 +141,16 @@ export default function StudentDetail() {
                 {student.name}
               </h1>
 
+              {/* Profession */}
+              {student.profession && (
+                <p
+                  className="text-sm text-zinc-500 mt-0.5 truncate"
+                  data-testid="student-header-profession"
+                >
+                  {student.profession}
+                </p>
+              )}
+
               {/* Metadata row */}
               <div className="flex items-center gap-2 mt-1 flex-wrap">
                 {/* Teacher CEFR level */}
@@ -163,6 +173,16 @@ export default function StudentDetail() {
                 {student.nativeLanguages.length > 0 && (
                   <span className="text-[0.6875rem] uppercase tracking-[0.05em] text-zinc-400 font-medium">
                     Native: {student.nativeLanguages.join(', ')}
+                  </span>
+                )}
+
+                {/* Origin / Residence compact */}
+                {(student.cityOfOrigin || student.cityOfResidence) && (
+                  <span
+                    className="text-[0.6875rem] text-zinc-400 font-medium"
+                    data-testid="student-header-location"
+                  >
+                    {[student.cityOfOrigin, student.cityOfResidence].filter(Boolean).join(' / ')}
                   </span>
                 )}
               </div>

--- a/frontend/src/pages/StudentForm.test.tsx
+++ b/frontend/src/pages/StudentForm.test.tsx
@@ -566,8 +566,11 @@ describe('StudentForm', () => {
     await user.click(await screen.findByRole('option', { name: 'Spanish' }))
     await user.click(screen.getByTestId('student-cefr'))
     await user.click(await screen.findByRole('option', { name: 'B1' }))
+    await user.type(screen.getByTestId('student-birth-year'), '1990')
     await user.type(screen.getByTestId('student-profession'), 'Engineer')
+    await user.type(screen.getByTestId('student-country-origin'), 'Portugal')
     await user.type(screen.getByTestId('student-city-origin'), 'Porto')
+    await user.type(screen.getByTestId('student-country-residence'), 'Spain')
     await user.type(screen.getByTestId('student-city-residence'), 'Madrid')
 
     await user.click(screen.getByRole('button', { name: 'Save Student' }))
@@ -575,8 +578,11 @@ describe('StudentForm', () => {
     await vi.waitFor(() => {
       expect(mockCreateStudent).toHaveBeenCalledWith(
         expect.objectContaining({
+          birthYear: 1990,
           profession: 'Engineer',
+          countryOfOrigin: 'Portugal',
           cityOfOrigin: 'Porto',
+          countryOfResidence: 'Spain',
           cityOfResidence: 'Madrid',
         }),
       )

--- a/frontend/src/pages/StudentForm.test.tsx
+++ b/frontend/src/pages/StudentForm.test.tsx
@@ -514,4 +514,73 @@ describe('StudentForm', () => {
     expect(btn).toBeDisabled()
   })
 
+  it('renders Personal Background section with all 6 identity fields', () => {
+    renderNew()
+    expect(screen.getByText('Personal Background')).toBeInTheDocument()
+    expect(screen.getByTestId('student-birth-year')).toBeInTheDocument()
+    expect(screen.getByTestId('student-profession')).toBeInTheDocument()
+    expect(screen.getByTestId('student-country-origin')).toBeInTheDocument()
+    expect(screen.getByTestId('student-city-origin')).toBeInTheDocument()
+    expect(screen.getByTestId('student-country-residence')).toBeInTheDocument()
+    expect(screen.getByTestId('student-city-residence')).toBeInTheDocument()
+  })
+
+  it('pre-populates identity fields in edit mode', async () => {
+    mockGetStudent.mockResolvedValue({
+      id: 'stu-1',
+      name: 'Ana',
+      learningLanguage: 'Spanish',
+      cefrLevel: 'B1',
+      interests: [],
+      nativeLanguages: [],
+      learningGoals: [],
+      weaknesses: [],
+      difficulties: [],
+      personalNotes: null,
+      teachingNotes: null,
+      birthYear: 1990,
+      profession: 'Architect',
+      countryOfOrigin: 'Portugal',
+      cityOfOrigin: 'Lisbon',
+      countryOfResidence: 'Spain',
+      cityOfResidence: 'Madrid',
+    })
+    renderEdit()
+    await screen.findByRole('heading', { name: 'Edit Student' })
+    expect(screen.getByTestId('student-birth-year')).toHaveValue(1990)
+    expect(screen.getByTestId('student-profession')).toHaveValue('Architect')
+    expect(screen.getByTestId('student-country-origin')).toHaveValue('Portugal')
+    expect(screen.getByTestId('student-city-origin')).toHaveValue('Lisbon')
+    expect(screen.getByTestId('student-country-residence')).toHaveValue('Spain')
+    expect(screen.getByTestId('student-city-residence')).toHaveValue('Madrid')
+  })
+
+  it('includes identity fields in form submission', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+    mockCreateStudent.mockResolvedValue({ id: 'new-id' })
+    renderNew()
+
+    await user.type(screen.getByTestId('student-name'), 'Test Student')
+    await user.click(screen.getByTestId('student-language'))
+    await user.click(await screen.findByRole('option', { name: 'Spanish' }))
+    await user.click(screen.getByTestId('student-cefr'))
+    await user.click(await screen.findByRole('option', { name: 'B1' }))
+    await user.type(screen.getByTestId('student-profession'), 'Engineer')
+    await user.type(screen.getByTestId('student-city-origin'), 'Porto')
+    await user.type(screen.getByTestId('student-city-residence'), 'Madrid')
+
+    await user.click(screen.getByRole('button', { name: 'Save Student' }))
+
+    await vi.waitFor(() => {
+      expect(mockCreateStudent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          profession: 'Engineer',
+          cityOfOrigin: 'Porto',
+          cityOfResidence: 'Madrid',
+        }),
+      )
+    })
+  })
+
 })

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -331,7 +331,10 @@ export default function StudentForm() {
                   id="birth-year"
                   type="number"
                   value={birthYear ?? ''}
-                  onChange={(e) => setBirthYear(e.target.value ? parseInt(e.target.value, 10) : null)}
+                  onChange={(e) => {
+                    const parsed = parseInt(e.target.value, 10)
+                    setBirthYear(e.target.value && !isNaN(parsed) ? parsed : null)
+                  }}
                   placeholder="e.g. 1990"
                   min={1900}
                   max={new Date().getFullYear()}

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -332,8 +332,9 @@ export default function StudentForm() {
                   type="number"
                   value={birthYear ?? ''}
                   onChange={(e) => {
-                    const parsed = parseInt(e.target.value, 10)
-                    setBirthYear(e.target.value && !isNaN(parsed) ? parsed : null)
+                    const raw = e.target.value
+                    const num = Number(raw)
+                    setBirthYear(raw && !isNaN(num) && Number.isInteger(num) ? num : null)
                   }}
                   placeholder="e.g. 1990"
                   min={1900}

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -43,6 +43,12 @@ export default function StudentForm() {
   const [difficulties, setDifficulties] = useState<Difficulty[]>([])
   const [personalNotes, setPersonalNotes] = useState('')
   const [teachingNotes, setTeachingNotes] = useState('')
+  const [birthYear, setBirthYear] = useState<number | null>(null)
+  const [profession, setProfession] = useState('')
+  const [countryOfOrigin, setCountryOfOrigin] = useState('')
+  const [cityOfOrigin, setCityOfOrigin] = useState('')
+  const [countryOfResidence, setCountryOfResidence] = useState('')
+  const [cityOfResidence, setCityOfResidence] = useState('')
   const [errors, setErrors] = useState<Record<string, string>>({})
   const interestInputRef = useRef<HTMLInputElement>(null)
 
@@ -66,6 +72,12 @@ export default function StudentForm() {
       setDifficulties(existing.difficulties ?? [])
       setPersonalNotes(existing.personalNotes ?? '')
       setTeachingNotes(existing.teachingNotes ?? '')
+      setBirthYear(existing.birthYear ?? null)
+      setProfession(existing.profession ?? '')
+      setCountryOfOrigin(existing.countryOfOrigin ?? '')
+      setCityOfOrigin(existing.cityOfOrigin ?? '')
+      setCountryOfResidence(existing.countryOfResidence ?? '')
+      setCityOfResidence(existing.cityOfResidence ?? '')
     }
   }, [existing])
   /* eslint-enable react-hooks/set-state-in-effect */
@@ -167,6 +179,12 @@ export default function StudentForm() {
       difficulties: validDifficulties,
       personalNotes: personalNotes.trim() || null,
       teachingNotes: teachingNotes.trim() || null,
+      birthYear: birthYear ?? null,
+      profession: profession.trim() || null,
+      countryOfOrigin: countryOfOrigin.trim() || null,
+      cityOfOrigin: cityOfOrigin.trim() || null,
+      countryOfResidence: countryOfResidence.trim() || null,
+      cityOfResidence: cityOfResidence.trim() || null,
     })
   }
 
@@ -296,6 +314,88 @@ export default function StudentForm() {
                   </SelectContent>
                 </Select>
                 {errors.cefrLevel && <p className="text-xs text-red-600">{errors.cefrLevel}</p>}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Personal Background</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-sm">
+              <div className="space-y-1.5">
+                <Label htmlFor="birth-year">Birth Year</Label>
+                <Input
+                  id="birth-year"
+                  type="number"
+                  value={birthYear ?? ''}
+                  onChange={(e) => setBirthYear(e.target.value ? parseInt(e.target.value, 10) : null)}
+                  placeholder="e.g. 1990"
+                  min={1900}
+                  max={new Date().getFullYear()}
+                  data-testid="student-birth-year"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="profession">Profession</Label>
+                <Input
+                  id="profession"
+                  value={profession}
+                  onChange={(e) => setProfession(e.target.value)}
+                  placeholder="e.g. Software engineer"
+                  maxLength={128}
+                  data-testid="student-profession"
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-sm">
+              <div className="space-y-1.5">
+                <Label htmlFor="country-origin">Country of Origin</Label>
+                <Input
+                  id="country-origin"
+                  value={countryOfOrigin}
+                  onChange={(e) => setCountryOfOrigin(e.target.value)}
+                  placeholder="e.g. Portugal"
+                  maxLength={64}
+                  data-testid="student-country-origin"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="city-origin">City of Origin</Label>
+                <Input
+                  id="city-origin"
+                  value={cityOfOrigin}
+                  onChange={(e) => setCityOfOrigin(e.target.value)}
+                  placeholder="e.g. Lisbon"
+                  maxLength={64}
+                  data-testid="student-city-origin"
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-sm">
+              <div className="space-y-1.5">
+                <Label htmlFor="country-residence">Country of Residence</Label>
+                <Input
+                  id="country-residence"
+                  value={countryOfResidence}
+                  onChange={(e) => setCountryOfResidence(e.target.value)}
+                  placeholder="e.g. Spain"
+                  maxLength={64}
+                  data-testid="student-country-residence"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="city-residence">City of Residence</Label>
+                <Input
+                  id="city-residence"
+                  value={cityOfResidence}
+                  onChange={(e) => setCityOfResidence(e.target.value)}
+                  placeholder="e.g. Madrid"
+                  maxLength={64}
+                  data-testid="student-city-residence"
+                />
               </div>
             </div>
           </CardContent>

--- a/plan/langteach-beta/task662-student-identity-fields.md
+++ b/plan/langteach-beta/task662-student-identity-fields.md
@@ -1,0 +1,52 @@
+# Task 662: Student Identity Fields in Edit Form and Profile View
+
+## Goal
+Surface the 6 identity fields (birthYear, profession, countryOfOrigin, cityOfOrigin, countryOfResidence, cityOfResidence) that already exist in the backend but have no UI.
+
+## Current state
+- `Student` type and `StudentFormData` in `api/students.ts` already include all 6 fields.
+- `StudentProfileTab.tsx` already renders an "About" section showing origin, location, birthYear (raw), profession, and reasonForStudying.
+- `StudentForm.tsx` has NO inputs for these fields.
+- `StudentDetail.tsx` header does NOT show profession or origin/residence.
+
+## Changes
+
+### 1. `StudentProfileTab.tsx` - fix birthYear display
+Change `<FieldValue label="Birth year" value={student.birthYear} />` to render "YYYY (age years)" using `new Date().getFullYear() - birthYear`.
+
+### 2. `StudentDetail.tsx` - add header fields
+Below the `<h1>` name heading:
+- Profession line (if set): small muted text below name
+- In metadata row: compact "CityOfOrigin / CityOfResidence" if either is set
+
+### 3. `StudentForm.tsx` - add "Personal Background" card
+New card between "Basic Info" and "Interests" with:
+- BirthYear: number input (data-testid="student-birth-year")
+- Profession: text input max 128 (data-testid="student-profession")
+- CountryOfOrigin: text input max 64 (data-testid="student-country-origin")
+- CityOfOrigin: text input max 64 (data-testid="student-city-origin")
+- CountryOfResidence: text input max 64 (data-testid="student-country-residence")
+- CityOfResidence: text input max 64 (data-testid="student-city-residence")
+
+Also: add state, sync in useEffect, include in mutate call.
+
+### 4. Unit tests
+- `StudentProfileTab.test.tsx`: update birthYear assertion from `'1998'` to `/1998 \(\d+ years\)/`
+- `StudentForm.test.tsx`: add test for Personal Background section rendered
+- `StudentDetail.test.tsx` (if present): add header fields test
+
+### 5. E2E test
+- `students.spec.ts`: round-trip test - create student with identity fields, verify they appear in profile
+
+## Acceptance criteria (from issue)
+- [ ] All 6 fields editable in student create and edit forms (Personal Background section)
+- [ ] Identity Details card on Profile tab renders all fields when populated
+- [ ] Student header shows Profession below name and Origin/Residence in compact format
+- [ ] BirthYear displayed as "YYYY (age years)" not raw number
+- [ ] Empty fields do not render (no "N/A" clutter)
+- [ ] Round-trip works: save in form, see in profile view, re-edit preserves values
+- [ ] Follows Stitch design system
+
+## Notes
+- No backend changes needed (all fields exist in Student.cs, StudentDto, etc.)
+- Screenshots referenced in issue are not in the worktree; following explicit AC requirements


### PR DESCRIPTION
## Summary

- Adds **Personal Background** card to student create/edit form with 6 fields: Birth Year, Profession, Country of Origin, City of Origin, Country of Residence, City of Residence
- Student detail header shows profession below name and compact `CityOfOrigin / CityOfResidence` in metadata row
- Profile tab About section formats birth year as "YYYY (age years)" instead of raw number

Closes #662

## Test plan

- [ ] Unit tests: `StudentForm.test.tsx`, `StudentDetail.test.tsx`, `StudentProfileTab.test.tsx` (all pass, 940/940)
- [ ] E2E: `students.spec.ts` includes full round-trip test for identity fields
- [ ] UI review: PASS (Personal Background card consistent with design system, header fields render correctly, empty state works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New "Personal Background" section in student form for collecting identity information: birth year, profession, country and city of origin, and country and city of residence
  * Student detail page header now displays profession and location (origin/residence) information
  * Birth year display automatically includes calculated age based on current date
  * Identity field values persist accurately between form and profile view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->