### PR TITLE
feat: motivation fields in profile view and edit form (#664)

### DIFF
--- a/e2e/tests/students.spec.ts
+++ b/e2e/tests/students.spec.ts
@@ -412,7 +412,7 @@ test('"Create Course" button on student edit page navigates to CourseNew with st
   await context.close()
 })
 
-test('student detail shows 3 tabs and profile content', async ({ browser }) => {
+test('student detail shows 4 tabs and overview content by default', async ({ browser }) => {
   const context = await createMockAuthContext(browser)
   const page = await context.newPage()
 
@@ -434,12 +434,18 @@ test('student detail shows 3 tabs and profile content', async ({ browser }) => {
   // Should redirect directly to student detail page
   await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
 
-  // Profile tab should be active by default
-  await expect(page.getByTestId('tab-profile')).toBeVisible({ timeout: 10000 })
+  // All 4 tabs should be visible
+  await expect(page.getByTestId('tab-overview')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('tab-profile')).toBeVisible()
   await expect(page.getByTestId('tab-sessions')).toBeVisible()
   await expect(page.getByTestId('tab-progress')).toBeVisible()
 
-  // Profile tab content should be visible
+  // Overview tab content should be visible by default
+  await expect(page.getByTestId('student-overview-tab')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('primary-objective-card')).toBeVisible()
+
+  // Click Profile tab
+  await page.getByTestId('tab-profile').click()
   await expect(page.getByTestId('student-profile-tab')).toBeVisible({ timeout: 10000 })
 
   // CEFR badge and header actions should be visible
@@ -505,11 +511,12 @@ test('identity fields round-trip: save and verify in profile view and edit form'
   // Should redirect to student detail page
   await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
 
-  // Profile tab: header shows profession and compact location
+  // Header shows profession and compact location (visible on all tabs)
   await expect(page.getByTestId('student-header-profession')).toHaveText('Architect', { timeout: 5000 })
   await expect(page.getByTestId('student-header-location')).toHaveText('Lisbon / Madrid', { timeout: 5000 })
 
-  // Profile tab: About section shows identity details
+  // Navigate to Profile tab to check identity details
+  await page.getByTestId('tab-profile').click()
   await expect(page.getByTestId('profile-about')).toBeVisible({ timeout: 5000 })
   await expect(page.getByText('Lisbon, Portugal')).toBeVisible()
   await expect(page.getByText('Madrid, Spain')).toBeVisible()
@@ -528,10 +535,75 @@ test('identity fields round-trip: save and verify in profile view and edit form'
   // Cleanup
   await page.getByRole('button', { name: 'Cancel' }).click()
   await expect(page).toHaveURL('/students', { timeout: 10000 })
-  const deleteCard = page.locator('[data-testid^="student-row-"]').filter({
+  const deleteCardIdentity = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName })
   })
-  await deleteCard.getByTestId('delete-student').click()
+  await deleteCardIdentity.getByTestId('delete-student').click()
+  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: 5000 })
+  await page.getByTestId('confirm-delete').click()
+  await expect(
+    page.locator('[data-testid^="student-row-"]').filter({
+      has: page.getByTestId('student-name').filter({ hasText: studentName })
+    })
+  ).not.toBeVisible({ timeout: 10000 })
+
+  await context.close()
+})
+
+test('motivation fields: reason for studying and objectives round-trip', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  const studentName = `Motivation Test ${Date.now()}`
+  const reasonText = 'Moving to Spain for work next year'
+  const objectiveText = 'Pass DELE B2 exam'
+
+  // Create student with motivation fields
+  await page.goto('/students/new')
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: 10000 })
+  await page.getByTestId('student-name').fill(studentName)
+  await page.getByTestId('student-language').click()
+  await page.getByRole('option', { name: 'Spanish' }).click()
+  await page.getByTestId('student-cefr').click()
+  await page.getByRole('option', { name: 'B2' }).click()
+
+  // Fill reason for studying
+  await page.getByTestId('student-reason-for-studying').fill(reasonText)
+
+  // Add a short-term objective
+  await page.getByTestId('add-objective').click()
+  await page.getByTestId('objective-text-input').fill(objectiveText)
+
+  await page.getByRole('button', { name: 'Save Student' }).click()
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
+
+  // Overview tab: primary objective card shows the objective
+  await expect(page.getByTestId('primary-objective-card')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('objective-text')).toHaveText(objectiveText)
+
+  // Profile tab: hero section shows reason for studying as a quote
+  await page.getByTestId('tab-profile').click()
+  await expect(page.getByTestId('profile-hero')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('reason-quote')).toContainText(reasonText)
+
+  // Profile tab: objectives section shows objective
+  await expect(page.getByTestId('profile-objectives')).toBeVisible()
+  await expect(page.getByText(objectiveText)).toBeVisible()
+
+  // Navigate to edit form and verify round-trip
+  await page.getByTestId('edit-profile-link').click()
+  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: 10000 })
+  await expect(page.getByTestId('student-reason-for-studying')).toHaveValue(reasonText)
+  await expect(page.getByTestId('objective-row')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByTestId('objective-text-input')).toHaveValue(objectiveText)
+
+  // Cleanup
+  await page.getByRole('button', { name: 'Cancel' }).click()
+  await expect(page).toHaveURL('/students', { timeout: 10000 })
+  const deleteCardM = page.locator('[data-testid^="student-row-"]').filter({
+    has: page.getByTestId('student-name').filter({ hasText: studentName })
+  })
+  await deleteCardM.getByTestId('delete-student').click()
   await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: 5000 })
   await page.getByTestId('confirm-delete').click()
   await expect(

--- a/e2e/tests/students.spec.ts
+++ b/e2e/tests/students.spec.ts
@@ -588,7 +588,7 @@ test('motivation fields: reason for studying and objectives round-trip', async (
 
   // Profile tab: objectives section shows objective
   await expect(page.getByTestId('profile-objectives')).toBeVisible()
-  await expect(page.getByText(objectiveText)).toBeVisible()
+  await expect(page.getByTestId('profile-objectives').getByText(objectiveText)).toBeVisible()
 
   // Navigate to edit form and verify round-trip
   await page.getByTestId('edit-profile-link').click()

--- a/frontend/src/components/student/SectionHeader.tsx
+++ b/frontend/src/components/student/SectionHeader.tsx
@@ -1,0 +1,7 @@
+export function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="text-[0.6875rem] font-semibold uppercase tracking-[0.05em] text-zinc-500 mb-3">
+      {children}
+    </h3>
+  )
+}

--- a/frontend/src/components/student/StudentOverviewTab.test.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { StudentOverviewTab } from './StudentOverviewTab'
+import type { Student } from '@/api/students'
+
+vi.mock('@/api/followups', () => ({
+  createFollowup: vi.fn(),
+  updateFollowupStatus: vi.fn(),
+}))
+
+function dateOffset(days: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() + days)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+const BASE_STUDENT: Student = {
+  id: 'student-1',
+  name: 'Ana García',
+  learningLanguage: 'Spanish',
+  cefrLevel: 'B1',
+  interests: ['reading', 'travel'],
+  personalNotes: null,
+  teachingNotes: null,
+  nativeLanguages: ['English'],
+  learningGoals: ['Conversational fluency'],
+  weaknesses: [],
+  difficulties: [],
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  birthYear: null,
+  profession: 'Designer',
+  countryOfOrigin: null,
+  cityOfOrigin: null,
+  countryOfResidence: null,
+  cityOfResidence: null,
+  reasonForStudying: 'Moving to Spain next year',
+  officialCefrLevel: null,
+  shortTermObjectives: [],
+  isActive: true,
+  isCorporate: false,
+  rate: null,
+  spokenLanguages: [],
+  teachingTodos: [],
+}
+
+function renderOverview(student: Student) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <StudentOverviewTab student={student} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('StudentOverviewTab', () => {
+  it('renders overview tab', () => {
+    renderOverview(BASE_STUDENT)
+    expect(screen.getByTestId('student-overview-tab')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no objectives', () => {
+    renderOverview(BASE_STUDENT)
+    expect(screen.getByText('No objectives set')).toBeInTheDocument()
+  })
+
+  it('shows primary objective text and date', () => {
+    const student = {
+      ...BASE_STUDENT,
+      shortTermObjectives: [
+        { id: 'obj-1', text: 'Pass DELE B1 exam', targetDate: dateOffset(50) },
+      ],
+    }
+    renderOverview(student)
+    expect(screen.getByTestId('objective-text')).toHaveTextContent('Pass DELE B1 exam')
+    expect(screen.getByTestId('days-remaining')).toHaveTextContent('days left')
+  })
+
+  it('shows OVERDUE for past-due objective', () => {
+    const student = {
+      ...BASE_STUDENT,
+      shortTermObjectives: [
+        { id: 'obj-1', text: 'Complete workbook', targetDate: dateOffset(-5) },
+      ],
+    }
+    renderOverview(student)
+    expect(screen.getByTestId('days-remaining')).toHaveTextContent('OVERDUE')
+  })
+
+  it('shows critical treatment for objective within 6 weeks', () => {
+    const student = {
+      ...BASE_STUDENT,
+      shortTermObjectives: [
+        { id: 'obj-1', text: 'Prepare presentation', targetDate: dateOffset(20) },
+      ],
+    }
+    renderOverview(student)
+    const item = screen.getByTestId('objective-item')
+    expect(item.className).toContain('border-orange')
+  })
+
+  it('shows count of additional objectives', () => {
+    const student = {
+      ...BASE_STUDENT,
+      shortTermObjectives: [
+        { id: 'obj-1', text: 'First objective', targetDate: dateOffset(50) },
+        { id: 'obj-2', text: 'Second objective', targetDate: dateOffset(60) },
+        { id: 'obj-3', text: 'Third objective', targetDate: dateOffset(70) },
+      ],
+    }
+    renderOverview(student)
+    expect(screen.getByText('+2 more objectives')).toBeInTheDocument()
+  })
+
+  it('sorts overdue before critical before normal', () => {
+    const student = {
+      ...BASE_STUDENT,
+      shortTermObjectives: [
+        { id: 'obj-normal', text: 'Normal objective', targetDate: dateOffset(60) },
+        { id: 'obj-overdue', text: 'Overdue objective', targetDate: dateOffset(-10) },
+        { id: 'obj-critical', text: 'Critical objective', targetDate: dateOffset(14) },
+      ],
+    }
+    renderOverview(student)
+    expect(screen.getByTestId('objective-text')).toHaveTextContent('Overdue objective')
+  })
+})

--- a/frontend/src/components/student/StudentOverviewTab.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.tsx
@@ -18,7 +18,7 @@ function PrimaryObjectiveCard({ student }: { student: Student }) {
   if (objectives.length === 0) {
     return (
       <div
-        className="bg-white rounded-2xl p-6"
+        className="bg-white rounded-2xl px-6 py-4"
         style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
         data-testid="primary-objective-card"
       >

--- a/frontend/src/components/student/StudentOverviewTab.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.tsx
@@ -4,6 +4,7 @@ import type { TeacherFollowup } from '@/api/followups'
 import { TeachingTodosCard } from './TeachingTodosCard'
 import { StudentFollowupsCard } from './StudentFollowupsCard'
 import { getObjectiveUrgency, getDaysRemaining, formatDaysRemaining } from '@/lib/objectiveUrgency'
+import { SectionHeader } from './SectionHeader'
 
 interface Props {
   student: Student
@@ -11,13 +12,6 @@ interface Props {
   onFollowupChange?: () => void
 }
 
-function SectionHeader({ children }: { children: React.ReactNode }) {
-  return (
-    <h3 className="text-[0.6875rem] font-semibold uppercase tracking-[0.05em] text-zinc-500 mb-3">
-      {children}
-    </h3>
-  )
-}
 
 function PrimaryObjectiveCard({ student }: { student: Student }) {
   const objectives = student.shortTermObjectives

--- a/frontend/src/components/student/StudentOverviewTab.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.tsx
@@ -1,0 +1,131 @@
+import { CalendarClock } from 'lucide-react'
+import type { Student } from '@/api/students'
+import type { TeacherFollowup } from '@/api/followups'
+import { TeachingTodosCard } from './TeachingTodosCard'
+import { StudentFollowupsCard } from './StudentFollowupsCard'
+import { getObjectiveUrgency, getDaysRemaining, formatDaysRemaining } from '@/lib/objectiveUrgency'
+
+interface Props {
+  student: Student
+  followups?: TeacherFollowup[]
+  onFollowupChange?: () => void
+}
+
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="text-[0.6875rem] font-semibold uppercase tracking-[0.05em] text-zinc-500 mb-3">
+      {children}
+    </h3>
+  )
+}
+
+function PrimaryObjectiveCard({ student }: { student: Student }) {
+  const objectives = student.shortTermObjectives
+  if (objectives.length === 0) {
+    return (
+      <div
+        className="bg-white rounded-2xl p-6"
+        style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
+        data-testid="primary-objective-card"
+      >
+        <SectionHeader>Primary Objective</SectionHeader>
+        <p className="text-sm text-zinc-400 italic">No objectives set</p>
+      </div>
+    )
+  }
+
+  // Show the first (most urgent) objective -- sorted: overdue first, then critical, then normal
+  const sorted = [...objectives].sort((a, b) => {
+    const order = { overdue: 0, critical: 1, normal: 2 }
+    return order[getObjectiveUrgency(a.targetDate)] - order[getObjectiveUrgency(b.targetDate)]
+  })
+
+  const obj = sorted[0]
+  const urgency = getObjectiveUrgency(obj.targetDate)
+  const daysRemaining = getDaysRemaining(obj.targetDate)
+
+  return (
+    <div
+      className="bg-white rounded-2xl p-6"
+      style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
+      data-testid="primary-objective-card"
+    >
+      <SectionHeader>Primary Objective</SectionHeader>
+      <div
+        className={`rounded-xl p-4 ${
+          urgency === 'overdue'
+            ? 'border-2 border-red-300 bg-red-50'
+            : urgency === 'critical'
+              ? 'border-2 border-orange-300 bg-orange-50'
+              : 'border border-zinc-200 bg-zinc-50'
+        }`}
+        data-testid="objective-item"
+      >
+        <p className="text-sm font-medium text-[#1A1B22] leading-snug" data-testid="objective-text">
+          {obj.text}
+        </p>
+        {obj.targetDate && (
+          <div className="flex items-center gap-2 mt-2">
+            <CalendarClock className="h-3.5 w-3.5 text-zinc-400 shrink-0" />
+            <span className="text-xs text-zinc-500">
+              {new Date(obj.targetDate + 'T00:00:00').toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
+            </span>
+            {daysRemaining !== null && (
+              <span
+                className={`text-xs font-semibold ${
+                  urgency === 'overdue'
+                    ? 'text-red-600'
+                    : urgency === 'critical'
+                      ? 'text-orange-600'
+                      : 'text-zinc-500'
+                }`}
+                data-testid="days-remaining"
+              >
+                {formatDaysRemaining(daysRemaining)}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {objectives.length > 1 && (
+        <p className="text-xs text-zinc-400 mt-2">
+          +{objectives.length - 1} more {objectives.length - 1 === 1 ? 'objective' : 'objectives'}
+        </p>
+      )}
+    </div>
+  )
+}
+
+export function StudentOverviewTab({ student, followups = [], onFollowupChange }: Props) {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-5 gap-6" data-testid="student-overview-tab">
+      {/* Main column (3/5) */}
+      <div className="lg:col-span-3 space-y-6">
+        <PrimaryObjectiveCard student={student} />
+      </div>
+
+      {/* Side column (2/5) */}
+      <div className="lg:col-span-2 space-y-6">
+        <div
+          className="bg-white rounded-2xl p-6"
+          style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
+        >
+          <SectionHeader>Teaching Todos</SectionHeader>
+          <TeachingTodosCard todos={student.teachingTodos} />
+        </div>
+
+        <div
+          className="bg-white rounded-2xl p-6"
+          style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
+        >
+          <StudentFollowupsCard
+            followups={followups}
+            studentId={student.id}
+            onFollowupChange={onFollowupChange ?? (() => {})}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/student/StudentOverviewTab.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.tsx
@@ -31,7 +31,12 @@ function PrimaryObjectiveCard({ student }: { student: Student }) {
   // Show the first (most urgent) objective -- sorted: overdue first, then critical, then normal
   const sorted = [...objectives].sort((a, b) => {
     const order = { overdue: 0, critical: 1, normal: 2 }
-    return order[getObjectiveUrgency(a.targetDate)] - order[getObjectiveUrgency(b.targetDate)]
+    const urgencyDelta =
+      order[getObjectiveUrgency(a.targetDate)] - order[getObjectiveUrgency(b.targetDate)]
+    if (urgencyDelta !== 0) return urgencyDelta
+    const aDays = getDaysRemaining(a.targetDate)
+    const bDays = getDaysRemaining(b.targetDate)
+    return (aDays ?? Number.POSITIVE_INFINITY) - (bDays ?? Number.POSITIVE_INFINITY)
   })
 
   const obj = sorted[0]

--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -10,6 +10,15 @@ vi.mock('@/api/followups', () => ({
   createFollowup: vi.fn(),
   updateFollowupStatus: vi.fn(),
 }))
+
+function dateOffset(days: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() + days)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
 
 const FULL_STUDENT: Student = {
   id: 'student-1',
@@ -60,6 +69,7 @@ const EMPTY_STUDENT: Student = {
   reasonForStudying: null,
   personalNotes: null,
   teachingNotes: null,
+  interests: [],
   nativeLanguages: [],
   learningGoals: [],
   spokenLanguages: [],
@@ -68,12 +78,26 @@ const EMPTY_STUDENT: Student = {
   teachingTodos: [],
 }
 
-function renderProfile(student: Student, onToggle?: (id: string, status: 'Active' | 'Covered') => void) {
+function renderProfile(
+  student: Student,
+  opts?: {
+    onToggle?: (id: string, status: 'Active' | 'Covered') => void
+    onSaveReason?: (value: string) => Promise<void>
+    onSaveInterests?: (value: string[]) => Promise<void>
+    followups?: TeacherFollowup[]
+  }
+) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
   return render(
     <QueryClientProvider client={qc}>
       <MemoryRouter>
-        <StudentProfileTab student={student} onToggleDifficultyStatus={onToggle} />
+        <StudentProfileTab
+          student={student}
+          onToggleDifficultyStatus={opts?.onToggle}
+          onSaveReasonForStudying={opts?.onSaveReason}
+          onSaveInterests={opts?.onSaveInterests}
+          followups={opts?.followups}
+        />
       </MemoryRouter>
     </QueryClientProvider>
   )
@@ -85,19 +109,115 @@ describe('StudentProfileTab', () => {
     expect(screen.getByTestId('student-profile-tab')).toBeInTheDocument()
   })
 
-  describe('About section', () => {
+  describe('Hero section', () => {
+    it('renders the reason as a quote', () => {
+      renderProfile(FULL_STUDENT)
+      const quote = screen.getByTestId('reason-quote')
+      expect(quote).toHaveTextContent('Vive en Barcelona')
+    })
+
+    it('shows empty state when no reason', () => {
+      renderProfile(EMPTY_STUDENT)
+      expect(screen.getByTestId('reason-quote')).toHaveTextContent('No reason for studying added yet.')
+    })
+
+    it('shows interests beside the quote', () => {
+      renderProfile(FULL_STUDENT)
+      const heroInterests = screen.getByTestId('hero-interests')
+      expect(heroInterests).toBeInTheDocument()
+      const tags = screen.getAllByTestId('hero-interest-tag')
+      expect(tags.length).toBeGreaterThan(0)
+    })
+
+    it('does not show hero interests when no interests', () => {
+      renderProfile({ ...FULL_STUDENT, interests: [] })
+      expect(screen.queryByTestId('hero-interests')).not.toBeInTheDocument()
+    })
+
+    it('shows edit button when onSaveReasonForStudying is provided', () => {
+      renderProfile(FULL_STUDENT, { onSaveReason: vi.fn().mockResolvedValue(undefined) })
+      expect(screen.getByTestId('reason-edit-btn')).toBeInTheDocument()
+    })
+
+    it('does not show edit button when no callback', () => {
+      renderProfile(FULL_STUDENT)
+      expect(screen.queryByTestId('reason-edit-btn')).not.toBeInTheDocument()
+    })
+
+    it('switches to edit mode on pencil click', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      renderProfile(FULL_STUDENT, { onSaveReason: onSave })
+      fireEvent.click(screen.getByTestId('reason-edit-btn'))
+      expect(screen.getByTestId('reason-textarea')).toBeInTheDocument()
+    })
+
+    it('calls onSaveReasonForStudying on save', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      renderProfile(FULL_STUDENT, { onSaveReason: onSave })
+      fireEvent.click(screen.getByTestId('reason-edit-btn'))
+      const textarea = screen.getByTestId('reason-textarea')
+      fireEvent.change(textarea, { target: { value: 'New reason' } })
+      fireEvent.click(screen.getByTestId('reason-save-btn'))
+      await waitFor(() => expect(onSave).toHaveBeenCalledWith('New reason'))
+    })
+
+    it('cancels edit and restores original value', () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      renderProfile(FULL_STUDENT, { onSaveReason: onSave })
+      fireEvent.click(screen.getByTestId('reason-edit-btn'))
+      fireEvent.change(screen.getByTestId('reason-textarea'), { target: { value: 'Changed' } })
+      fireEvent.click(screen.getByTestId('reason-cancel-btn'))
+      expect(screen.getByTestId('reason-quote')).toHaveTextContent('Vive en Barcelona')
+    })
+  })
+
+  describe('Identity Details section', () => {
     it('shows identity fields when populated', () => {
       renderProfile(FULL_STUDENT)
       expect(screen.getByText('Rome, Italy')).toBeInTheDocument()
       expect(screen.getByText('Barcelona, Spain')).toBeInTheDocument()
       expect(screen.getByText(/^1998 \(\d+ years\)$/)).toBeInTheDocument()
       expect(screen.getByText('Film student')).toBeInTheDocument()
-      expect(screen.getByText('Vive en Barcelona')).toBeInTheDocument()
     })
 
     it('shows empty state when no identity data', () => {
       renderProfile(EMPTY_STUDENT)
       expect(screen.getByText('No identity details added yet')).toBeInTheDocument()
+    })
+  })
+
+  describe('Interests section (right column)', () => {
+    it('renders interest tags', () => {
+      renderProfile(FULL_STUDENT)
+      const section = screen.getByTestId('profile-interests')
+      expect(section).toBeInTheDocument()
+      const tags = screen.getAllByTestId('interest-tag')
+      expect(tags.some((t) => t.textContent === 'cinema')).toBe(true)
+    })
+
+    it('shows empty state when no interests', () => {
+      renderProfile(EMPTY_STUDENT)
+      expect(screen.getByText('No interests added yet')).toBeInTheDocument()
+    })
+
+    it('shows edit/add buttons when onSaveInterests provided', () => {
+      renderProfile(FULL_STUDENT, { onSaveInterests: vi.fn().mockResolvedValue(undefined) })
+      expect(screen.getByTestId('interests-edit-btn')).toBeInTheDocument()
+      expect(screen.getByTestId('interests-add-btn')).toBeInTheDocument()
+    })
+
+    it('enters edit mode and shows input', () => {
+      renderProfile(FULL_STUDENT, { onSaveInterests: vi.fn().mockResolvedValue(undefined) })
+      fireEvent.click(screen.getByTestId('interests-edit-btn'))
+      expect(screen.getByTestId('interests-input')).toBeInTheDocument()
+    })
+
+    it('calls onSaveInterests on save', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      renderProfile(FULL_STUDENT, { onSaveInterests: onSave })
+      fireEvent.click(screen.getByTestId('interests-edit-btn'))
+      fireEvent.click(screen.getByTestId('interests-save-btn'))
+      await waitFor(() => expect(onSave).toHaveBeenCalled())
     })
   })
 
@@ -124,12 +244,12 @@ describe('StudentProfileTab', () => {
     it('shows empty states for missing notes', () => {
       renderProfile(EMPTY_STUDENT)
       expect(screen.getByText('No personal notes')).toBeInTheDocument()
-      expect(screen.getByText('No teaching notes')).toBeInTheDocument()
+      expect(screen.getByText('No pedagogical observations')).toBeInTheDocument()
     })
   })
 
   describe('Learning Goals section', () => {
-    it('renders goals as chips', () => {
+    it('renders goals as bullet list items', () => {
       renderProfile(FULL_STUDENT)
       expect(screen.getByText('Dominar el subjuntivo')).toBeInTheDocument()
       expect(screen.getByText('Preparar DELE C1')).toBeInTheDocument()
@@ -152,6 +272,40 @@ describe('StudentProfileTab', () => {
       renderProfile(EMPTY_STUDENT)
       expect(screen.getByText('No objectives set')).toBeInTheDocument()
     })
+
+    it('shows OVERDUE label for past-due objective', () => {
+      const student = {
+        ...FULL_STUDENT,
+        shortTermObjectives: [
+          { id: 'obj-1', text: 'Overdue objective', targetDate: dateOffset(-5) },
+        ],
+      }
+      renderProfile(student)
+      expect(screen.getByTestId('objective-overdue-label')).toBeInTheDocument()
+    })
+
+    it('shows Critical label for objective within 6 weeks', () => {
+      const student = {
+        ...FULL_STUDENT,
+        shortTermObjectives: [
+          { id: 'obj-1', text: 'Critical objective', targetDate: dateOffset(20) },
+        ],
+      }
+      renderProfile(student)
+      expect(screen.getByTestId('objective-critical-label')).toBeInTheDocument()
+    })
+
+    it('does not show urgency labels for normal objectives', () => {
+      const student = {
+        ...FULL_STUDENT,
+        shortTermObjectives: [
+          { id: 'obj-1', text: 'Normal objective', targetDate: dateOffset(60) },
+        ],
+      }
+      renderProfile(student)
+      expect(screen.queryByTestId('objective-overdue-label')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('objective-critical-label')).not.toBeInTheDocument()
+    })
   })
 
   describe('Difficulties section', () => {
@@ -170,7 +324,7 @@ describe('StudentProfileTab', () => {
 
     it('calls onToggleDifficultyStatus when toggle button is clicked', () => {
       const onToggle = vi.fn()
-      renderProfile(FULL_STUDENT, onToggle)
+      renderProfile(FULL_STUDENT, { onToggle })
       const toggleBtn = screen.getByTestId('toggle-difficulty-status-d1')
       fireEvent.click(toggleBtn)
       expect(onToggle).toHaveBeenCalledWith('d1', 'Covered')

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -50,6 +50,8 @@ function ReasonHero({
     try {
       await onSave(draft)
       setEditing(false)
+    } catch {
+      // caller logs the failure; keep editor open so user can retry
     } finally {
       setSaving(false)
     }
@@ -175,6 +177,8 @@ function InterestsSection({
       setDraft(finalList)
       setEditing(false)
       setInputValue('')
+    } catch {
+      // caller logs the failure; keep editor open so user can retry
     } finally {
       setSaving(false)
     }

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -62,7 +62,7 @@ function ReasonHero({
 
   return (
     <div
-      className="group relative"
+      className="group relative bg-indigo-50/60 rounded-xl px-4 py-3"
       data-testid="reason-hero"
     >
       {editing ? (
@@ -70,7 +70,7 @@ function ReasonHero({
           <textarea
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
-            className="w-full text-lg italic text-[#1A1B22] bg-zinc-50 border border-indigo-300 rounded-xl px-4 py-3 resize-none focus:outline-none focus:ring-2 focus:ring-indigo-300"
+            className="w-full text-lg italic text-[#1A1B22] bg-white border border-indigo-300 rounded-xl px-4 py-3 resize-none focus:outline-none focus:ring-2 focus:ring-indigo-300"
             rows={3}
             maxLength={512}
             placeholder="Why is this student learning?"
@@ -306,9 +306,9 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
       style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
       data-testid="student-profile-tab"
     >
-      {/* Hero: The Why / Motivacion */}
+      {/* Hero: The Why / Motivation */}
       <section className="mb-8 pb-8 border-b border-zinc-100" data-testid="profile-hero">
-        <SectionHeader>The Why / Motivacion</SectionHeader>
+        <SectionHeader>The Why / Motivation</SectionHeader>
         <div className="flex flex-col sm:flex-row gap-4 sm:gap-8 items-start">
           <div className="flex-1 min-w-0">
             <ReasonHero key={student.id} student={student} onSave={onSaveReasonForStudying} />

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -1,3 +1,5 @@
+import { useState, useRef } from 'react'
+import { Pencil, X, Plus, Check } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import type { Student } from '@/api/students'
@@ -5,12 +7,15 @@ import type { TeacherFollowup } from '@/api/followups'
 import { parseNotes } from './studentNoteUtils'
 import { TeachingTodosCard } from './TeachingTodosCard'
 import { StudentFollowupsCard } from './StudentFollowupsCard'
+import { getObjectiveUrgency } from '@/lib/objectiveUrgency'
 
 interface Props {
   student: Student
   followups?: TeacherFollowup[]
   onFollowupChange?: () => void
   onToggleDifficultyStatus?: (id: string, status: 'Active' | 'Covered') => void
+  onSaveReasonForStudying?: (value: string) => Promise<void>
+  onSaveInterests?: (value: string[]) => Promise<void>
 }
 
 function SectionHeader({ children }: { children: React.ReactNode }) {
@@ -35,13 +40,266 @@ function EmptyState({ text }: { text: string }) {
   return <p className="text-sm text-zinc-400 italic">{text}</p>
 }
 
-export function StudentProfileTab({ student, followups = [], onFollowupChange, onToggleDifficultyStatus }: Props) {
+function ReasonHero({
+  student,
+  onSave,
+}: {
+  student: Student
+  onSave?: (value: string) => Promise<void>
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(student.reasonForStudying ?? '')
+  const [saving, setSaving] = useState(false)
+
+  async function handleSave() {
+    if (!onSave) return
+    setSaving(true)
+    try {
+      await onSave(draft)
+      setEditing(false)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function handleCancel() {
+    setDraft(student.reasonForStudying ?? '')
+    setEditing(false)
+  }
+
+  return (
+    <div
+      className="group relative"
+      data-testid="reason-hero"
+    >
+      {editing ? (
+        <div className="space-y-2">
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            className="w-full text-lg italic text-[#1A1B22] bg-zinc-50 border border-indigo-300 rounded-xl px-4 py-3 resize-none focus:outline-none focus:ring-2 focus:ring-indigo-300"
+            rows={3}
+            maxLength={512}
+            placeholder="Why is this student learning?"
+            autoFocus
+            data-testid="reason-textarea"
+          />
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleSave}
+              disabled={saving}
+              className="bg-indigo-600 hover:bg-indigo-700 text-white h-7 px-3 text-xs"
+              data-testid="reason-save-btn"
+            >
+              <Check className="h-3 w-3 mr-1" />
+              {saving ? 'Saving...' : 'Save'}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={handleCancel}
+              className="h-7 px-3 text-xs text-zinc-500"
+              data-testid="reason-cancel-btn"
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-start gap-2">
+          {student.reasonForStudying ? (
+            <p className="text-lg italic text-[#1A1B22] leading-relaxed flex-1" data-testid="reason-quote">
+              &ldquo;{student.reasonForStudying}&rdquo;
+            </p>
+          ) : (
+            <p className="text-sm text-zinc-400 italic flex-1" data-testid="reason-quote">
+              No reason for studying added yet.
+            </p>
+          )}
+          {onSave && (
+            <button
+              type="button"
+              onClick={() => setEditing(true)}
+              className="opacity-0 group-hover:opacity-100 transition-opacity p-1 text-zinc-400 hover:text-indigo-600 rounded"
+              aria-label="Edit reason for studying"
+              data-testid="reason-edit-btn"
+            >
+              <Pencil className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function InterestsSection({
+  student,
+  onSave,
+}: {
+  student: Student
+  onSave?: (value: string[]) => Promise<void>
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState<string[]>(student.interests)
+  const [inputValue, setInputValue] = useState('')
+  const [saving, setSaving] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  function handleAddInterest(value: string) {
+    const trimmed = value.trim()
+    if (trimmed && !draft.includes(trimmed)) {
+      setDraft((prev) => [...prev, trimmed])
+    }
+    setInputValue('')
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault()
+      handleAddInterest(inputValue)
+    }
+    if (e.key === 'Backspace' && inputValue === '' && draft.length > 0) {
+      setDraft((prev) => prev.slice(0, -1))
+    }
+  }
+
+  function handleRemove(item: string) {
+    setDraft((prev) => prev.filter((i) => i !== item))
+  }
+
+  async function handleSave() {
+    if (!onSave) return
+    if (inputValue.trim()) handleAddInterest(inputValue)
+    setSaving(true)
+    try {
+      await onSave(draft)
+      setEditing(false)
+      setInputValue('')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function handleCancel() {
+    setDraft(student.interests)
+    setInputValue('')
+    setEditing(false)
+  }
+
+  return (
+    <section data-testid="profile-interests">
+      <div className="flex items-center justify-between mb-3">
+        <SectionHeader>Interests</SectionHeader>
+        {onSave && !editing && (
+          <div className="flex gap-1">
+            <button
+              type="button"
+              onClick={() => { setEditing(true); setTimeout(() => inputRef.current?.focus(), 50) }}
+              className="p-1 text-zinc-400 hover:text-indigo-600 rounded transition-colors"
+              aria-label="Edit interests"
+              data-testid="interests-edit-btn"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+            <button
+              type="button"
+              onClick={() => { setEditing(true); setTimeout(() => inputRef.current?.focus(), 50) }}
+              className="p-1 text-zinc-400 hover:text-indigo-600 rounded transition-colors"
+              aria-label="Add interest"
+              data-testid="interests-add-btn"
+            >
+              <Plus className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {editing ? (
+        <div className="space-y-2">
+          <div
+            className="flex flex-wrap gap-1.5 min-h-9 w-full rounded-md border border-indigo-300 bg-white px-3 py-2 cursor-text"
+            onClick={() => inputRef.current?.focus()}
+          >
+            {draft.map((interest) => (
+              <span
+                key={interest}
+                className="inline-flex items-center gap-1 bg-indigo-50 text-indigo-700 text-xs font-medium rounded px-2 py-0.5"
+              >
+                {interest}
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); handleRemove(interest) }}
+                  className="text-indigo-400 hover:text-indigo-700"
+                  aria-label={`Remove ${interest}`}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            ))}
+            <input
+              ref={inputRef}
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              onBlur={() => { if (inputValue.trim()) handleAddInterest(inputValue) }}
+              placeholder={draft.length === 0 ? 'Type and press Enter' : ''}
+              className="flex-1 min-w-16 outline-none text-sm bg-transparent placeholder:text-zinc-400"
+              data-testid="interests-input"
+            />
+          </div>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleSave}
+              disabled={saving}
+              className="bg-indigo-600 hover:bg-indigo-700 text-white h-7 px-3 text-xs"
+              data-testid="interests-save-btn"
+            >
+              <Check className="h-3 w-3 mr-1" />
+              {saving ? 'Saving...' : 'Save'}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={handleCancel}
+              className="h-7 px-3 text-xs text-zinc-500"
+              data-testid="interests-cancel-btn"
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : student.interests.length > 0 ? (
+        <div className="flex flex-wrap gap-1.5">
+          {student.interests.map((interest) => (
+            <span
+              key={interest}
+              className="inline-block bg-indigo-50 text-indigo-700 text-xs font-medium rounded-full px-2.5 py-1"
+              data-testid="interest-tag"
+            >
+              {interest}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <EmptyState text="No interests added yet" />
+      )}
+    </section>
+  )
+}
+
+export function StudentProfileTab({ student, followups = [], onFollowupChange, onToggleDifficultyStatus, onSaveReasonForStudying, onSaveInterests }: Props) {
   const parsedPersonalNotes = parseNotes(student.personalNotes)
   const parsedTeachingNotes = parseNotes(student.teachingNotes)
 
   const hasAbout = student.birthYear || student.profession || student.countryOfOrigin ||
-    student.cityOfOrigin || student.countryOfResidence || student.cityOfResidence ||
-    student.reasonForStudying
+    student.cityOfOrigin || student.countryOfResidence || student.cityOfResidence
 
   const location = [student.cityOfResidence, student.countryOfResidence].filter(Boolean).join(', ')
   const origin = [student.cityOfOrigin, student.countryOfOrigin].filter(Boolean).join(', ')
@@ -52,59 +310,103 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
       style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
       data-testid="student-profile-tab"
     >
+      {/* Hero: The Why / Motivacion */}
+      <section className="mb-8 pb-8 border-b border-zinc-100" data-testid="profile-hero">
+        <SectionHeader>The Why / Motivacion</SectionHeader>
+        <div className="flex flex-col sm:flex-row gap-4 sm:gap-8 items-start">
+          <div className="flex-1 min-w-0">
+            <ReasonHero student={student} onSave={onSaveReasonForStudying} />
+          </div>
+          {student.interests.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 sm:max-w-[200px]" data-testid="hero-interests">
+              {student.interests.map((interest) => (
+                <span
+                  key={interest}
+                  className="inline-block bg-zinc-100 text-zinc-600 text-xs font-medium rounded-full px-2.5 py-1"
+                  data-testid="hero-interest-tag"
+                >
+                  {interest}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
       <div className="grid grid-cols-1 lg:grid-cols-5 gap-8 lg:gap-12">
         {/* Left column (3/5) */}
         <div className="lg:col-span-3 space-y-6">
-          {/* About */}
-          <section data-testid="profile-about">
-            <SectionHeader>About</SectionHeader>
-            {hasAbout ? (
-              <div>
-                {origin && <FieldValue label="Origin" value={origin} />}
-                {location && <FieldValue label="Lives in" value={location} />}
-                {student.birthYear != null && (() => {
-                  const currentYear = new Date().getFullYear()
-                  return (
-                    <FieldValue
-                      label="Birth year"
-                      value={student.birthYear <= currentYear
-                        ? `${student.birthYear} (${currentYear - student.birthYear} years)`
-                        : `${student.birthYear}`}
-                    />
-                  )
-                })()}
-                <FieldValue label="Profession" value={student.profession} />
-                <FieldValue label="Reason" value={student.reasonForStudying} />
-              </div>
-            ) : (
-              <EmptyState text="No identity details added yet" />
-            )}
-          </section>
+          {/* Pedagogical Diagnostic */}
+          <section data-testid="profile-pedagogical-diagnostic">
+            <SectionHeader>Pedagogical Diagnostic</SectionHeader>
 
-          {/* Languages */}
-          <section data-testid="profile-languages">
-            <SectionHeader>Languages</SectionHeader>
-            <div>
-              <FieldValue
-                label="Native"
-                value={student.nativeLanguages.length > 0 ? student.nativeLanguages.join(', ') : null}
-              />
-              {student.spokenLanguages.length > 0 && (
-                <FieldValue label="Spoken" value={student.spokenLanguages.join(', ')} />
+            {/* Learning Goals */}
+            <div className="mb-4" data-testid="profile-learning-goals">
+              <p className="text-xs text-zinc-400 font-medium mb-1.5">Learning Goals</p>
+              {student.learningGoals.length > 0 ? (
+                <ul className="space-y-1 list-none">
+                  {student.learningGoals.map((goal) => (
+                    <li key={goal} className="flex items-start gap-2 text-sm text-[#1A1B22]">
+                      <span className="mt-1.5 h-1.5 w-1.5 rounded-full bg-indigo-500 shrink-0" />
+                      {goal}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <EmptyState text="No learning goals set" />
               )}
-              <FieldValue
-                label="Learning"
-                value={`${student.learningLanguage} (${student.cefrLevel})`}
-              />
             </div>
-            {student.nativeLanguages.length === 0 && student.spokenLanguages.length === 0 && (
-              <EmptyState text="No language details added yet" />
-            )}
+
+            {/* Short-Term Objectives */}
+            <div data-testid="profile-objectives">
+              <p className="text-xs text-zinc-400 font-medium mb-1.5">Short-Term Objectives</p>
+              {student.shortTermObjectives.length > 0 ? (
+                <ul className="space-y-2">
+                  {student.shortTermObjectives.map((obj) => {
+                    const urgency = getObjectiveUrgency(obj.targetDate)
+                    return (
+                      <li
+                        key={obj.id}
+                        className={`rounded-lg px-3 py-2 text-sm ${
+                          urgency === 'overdue'
+                            ? 'border-2 border-red-300 bg-red-50'
+                            : urgency === 'critical'
+                              ? 'border-2 border-orange-300 bg-orange-50'
+                              : 'bg-zinc-50'
+                        }`}
+                        data-testid="objective-row"
+                      >
+                        <div className="flex items-start justify-between gap-2">
+                          <span className="text-[#1A1B22]">{obj.text}</span>
+                          {urgency === 'overdue' && (
+                            <span className="text-xs font-bold text-red-600 shrink-0 uppercase" data-testid="objective-overdue-label">
+                              OVERDUE
+                            </span>
+                          )}
+                          {urgency === 'critical' && (
+                            <span className="text-xs font-bold text-orange-600 shrink-0 uppercase" data-testid="objective-critical-label">
+                              Critical
+                            </span>
+                          )}
+                        </div>
+                        {obj.targetDate && (
+                          <span className="text-xs text-zinc-400 mt-0.5 block">
+                            Target: {new Date(obj.targetDate + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                          </span>
+                        )}
+                      </li>
+                    )
+                  })}
+                </ul>
+              ) : (
+                <EmptyState text="No objectives set" />
+              )}
+            </div>
           </section>
 
           {/* Personal notes */}
           <section data-testid="profile-personal-notes">
-            <SectionHeader>Personal Notes</SectionHeader>
+            <SectionHeader>Sensitivities / Life Context</SectionHeader>
             {parsedPersonalNotes ? (
               <div className="space-y-2">
                 {parsedPersonalNotes.sections.map((section, i) => (
@@ -125,9 +427,9 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
 
           {/* Teaching notes */}
           <section data-testid="profile-teaching-notes">
-            <SectionHeader>Teaching Notes</SectionHeader>
+            <SectionHeader>Pedagogical Observations</SectionHeader>
             {parsedTeachingNotes ? (
-              <div className="space-y-2">
+              <div className="space-y-2 border-l-2 border-indigo-200 pl-3">
                 {parsedTeachingNotes.sections.map((section, i) => (
                   <div key={`tn-${i}-${section.label}`}>
                     {section.label && (
@@ -138,52 +440,64 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
                 ))}
               </div>
             ) : student.teachingNotes ? (
-              <p className="text-sm text-[#1A1B22] whitespace-pre-wrap">{student.teachingNotes}</p>
+              <p className="text-sm text-[#1A1B22] whitespace-pre-wrap border-l-2 border-indigo-200 pl-3">{student.teachingNotes}</p>
             ) : (
-              <EmptyState text="No teaching notes" />
+              <EmptyState text="No pedagogical observations" />
             )}
           </section>
         </div>
 
         {/* Right column (2/5) */}
         <div className="lg:col-span-2 space-y-6">
-          {/* Learning goals */}
-          <section data-testid="profile-learning-goals">
-            <SectionHeader>Learning Goals</SectionHeader>
-            {student.learningGoals.length > 0 ? (
-              <div className="flex flex-wrap gap-1.5">
-                {student.learningGoals.map((goal) => (
-                  <span
-                    key={goal}
-                    className="inline-block bg-indigo-50 text-indigo-700 text-xs font-medium rounded-full px-2.5 py-1"
-                  >
-                    {goal}
-                  </span>
-                ))}
+          {/* Identity Details */}
+          <section data-testid="profile-about">
+            <SectionHeader>Identity Details</SectionHeader>
+            {hasAbout ? (
+              <div>
+                {origin && <FieldValue label="Origin" value={origin} />}
+                {location && <FieldValue label="Lives in" value={location} />}
+                {student.birthYear != null && (() => {
+                  const currentYear = new Date().getFullYear()
+                  return (
+                    <FieldValue
+                      label="Birth year"
+                      value={student.birthYear <= currentYear
+                        ? `${student.birthYear} (${currentYear - student.birthYear} years)`
+                        : `${student.birthYear}`}
+                    />
+                  )
+                })()}
+                <FieldValue label="Profession" value={student.profession} />
               </div>
             ) : (
-              <EmptyState text="No learning goals set" />
+              <EmptyState text="No identity details added yet" />
             )}
           </section>
 
-          {/* Short-term objectives */}
-          <section data-testid="profile-objectives">
-            <SectionHeader>Short-Term Objectives</SectionHeader>
-            {student.shortTermObjectives.length > 0 ? (
-              <ul className="space-y-2">
-                {student.shortTermObjectives.map((obj) => (
-                  <li key={obj.id} className="text-sm text-[#1A1B22]">
-                    {obj.text}
-                    {obj.targetDate && (
-                      <span className="ml-2 text-xs text-zinc-400">
-                        Target: {new Date(obj.targetDate + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}
-                      </span>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <EmptyState text="No objectives set" />
+          {/* Interests (dedicated editable section) */}
+          <InterestsSection student={student} onSave={onSaveInterests} />
+
+          {/* Languages */}
+          <section data-testid="profile-languages">
+            <SectionHeader>Language Ecosystem</SectionHeader>
+            <div>
+              <FieldValue
+                label="Native"
+                value={student.nativeLanguages.length > 0 ? student.nativeLanguages.join(', ') : null}
+              />
+              {student.spokenLanguages.length > 0 && (
+                <FieldValue label="Spoken" value={student.spokenLanguages.join(', ')} />
+              )}
+              <FieldValue
+                label="Learning"
+                value={`${student.learningLanguage} (${student.cefrLevel})`}
+              />
+              {student.officialCefrLevel && (
+                <FieldValue label="Official level" value={student.officialCefrLevel} />
+              )}
+            </div>
+            {student.nativeLanguages.length === 0 && student.spokenLanguages.length === 0 && (
+              <EmptyState text="No language details added yet" />
             )}
           </section>
 
@@ -245,21 +559,6 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
             )}
           </section>
 
-          {/* Teaching Todos */}
-          <section data-testid="profile-teaching-todos">
-            <SectionHeader>Teaching Todos</SectionHeader>
-            <TeachingTodosCard todos={student.teachingTodos} />
-          </section>
-
-          {/* Pending Followups */}
-          <section data-testid="profile-followups">
-            <StudentFollowupsCard
-              followups={followups}
-              studentId={student.id}
-              onFollowupChange={onFollowupChange ?? (() => {})}
-            />
-          </section>
-
           {/* Commercial */}
           <section data-testid="profile-commercial">
             <SectionHeader>Commercial</SectionHeader>
@@ -285,6 +584,21 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
                 <span className="text-sm text-[#1A1B22]">{student.rate}</span>
               )}
             </div>
+          </section>
+
+          {/* Teaching Todos */}
+          <section data-testid="profile-teaching-todos">
+            <SectionHeader>Teaching Todos</SectionHeader>
+            <TeachingTodosCard todos={student.teachingTodos} />
+          </section>
+
+          {/* Pending Followups */}
+          <section data-testid="profile-followups">
+            <StudentFollowupsCard
+              followups={followups}
+              studentId={student.id}
+              onFollowupChange={onFollowupChange ?? (() => {})}
+            />
           </section>
         </div>
       </div>

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -8,6 +8,7 @@ import { parseNotes } from './studentNoteUtils'
 import { TeachingTodosCard } from './TeachingTodosCard'
 import { StudentFollowupsCard } from './StudentFollowupsCard'
 import { getObjectiveUrgency } from '@/lib/objectiveUrgency'
+import { SectionHeader } from './SectionHeader'
 
 interface Props {
   student: Student
@@ -16,14 +17,6 @@ interface Props {
   onToggleDifficultyStatus?: (id: string, status: 'Active' | 'Covered') => void
   onSaveReasonForStudying?: (value: string) => Promise<void>
   onSaveInterests?: (value: string[]) => Promise<void>
-}
-
-function SectionHeader({ children }: { children: React.ReactNode }) {
-  return (
-    <h3 className="text-[0.6875rem] font-semibold uppercase tracking-[0.05em] text-zinc-500 mb-3">
-      {children}
-    </h3>
-  )
 }
 
 function FieldValue({ label, value }: { label: string; value: string | number | null | undefined }) {

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -173,10 +173,13 @@ function InterestsSection({
 
   async function handleSave() {
     if (!onSave) return
-    if (inputValue.trim()) handleAddInterest(inputValue)
+    const trimmed = inputValue.trim()
+    const finalList =
+      trimmed && !draft.includes(trimmed) ? [...draft, trimmed] : draft
     setSaving(true)
     try {
-      await onSave(draft)
+      await onSave(finalList)
+      setDraft(finalList)
       setEditing(false)
       setInputValue('')
     } finally {
@@ -315,7 +318,7 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
         <SectionHeader>The Why / Motivacion</SectionHeader>
         <div className="flex flex-col sm:flex-row gap-4 sm:gap-8 items-start">
           <div className="flex-1 min-w-0">
-            <ReasonHero student={student} onSave={onSaveReasonForStudying} />
+            <ReasonHero key={student.id} student={student} onSave={onSaveReasonForStudying} />
           </div>
           {student.interests.length > 0 && (
             <div className="flex flex-wrap gap-1.5 sm:max-w-[200px]" data-testid="hero-interests">
@@ -475,7 +478,7 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
           </section>
 
           {/* Interests (dedicated editable section) */}
-          <InterestsSection student={student} onSave={onSaveInterests} />
+          <InterestsSection key={student.id} student={student} onSave={onSaveInterests} />
 
           {/* Languages */}
           <section data-testid="profile-languages">

--- a/frontend/src/lib/objectiveUrgency.test.ts
+++ b/frontend/src/lib/objectiveUrgency.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { getObjectiveUrgency, getDaysRemaining, formatDaysRemaining } from './objectiveUrgency'
+
+function dateString(offsetDays: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() + offsetDays)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+describe('getObjectiveUrgency', () => {
+  it('returns normal for null', () => {
+    expect(getObjectiveUrgency(null)).toBe('normal')
+  })
+
+  it('returns overdue for past date', () => {
+    expect(getObjectiveUrgency(dateString(-1))).toBe('overdue')
+  })
+
+  it('returns overdue for yesterday', () => {
+    expect(getObjectiveUrgency(dateString(-30))).toBe('overdue')
+  })
+
+  it('returns critical for today', () => {
+    expect(getObjectiveUrgency(dateString(0))).toBe('critical')
+  })
+
+  it('returns critical for date within 42 days', () => {
+    expect(getObjectiveUrgency(dateString(42))).toBe('critical')
+  })
+
+  it('returns normal for date beyond 42 days', () => {
+    expect(getObjectiveUrgency(dateString(43))).toBe('normal')
+  })
+})
+
+describe('getDaysRemaining', () => {
+  it('returns null for null date', () => {
+    expect(getDaysRemaining(null)).toBeNull()
+  })
+
+  it('returns negative for past date', () => {
+    expect(getDaysRemaining(dateString(-5))).toBe(-5)
+  })
+
+  it('returns 0 for today', () => {
+    expect(getDaysRemaining(dateString(0))).toBe(0)
+  })
+
+  it('returns positive for future date', () => {
+    expect(getDaysRemaining(dateString(10))).toBe(10)
+  })
+})
+
+describe('formatDaysRemaining', () => {
+  it('returns OVERDUE for negative', () => {
+    expect(formatDaysRemaining(-1)).toBe('OVERDUE')
+  })
+
+  it('returns Due today for 0', () => {
+    expect(formatDaysRemaining(0)).toBe('Due today')
+  })
+
+  it('returns 1 day left for 1', () => {
+    expect(formatDaysRemaining(1)).toBe('1 day left')
+  })
+
+  it('returns N days left for N > 1', () => {
+    expect(formatDaysRemaining(30)).toBe('30 days left')
+  })
+})

--- a/frontend/src/lib/objectiveUrgency.ts
+++ b/frontend/src/lib/objectiveUrgency.ts
@@ -1,0 +1,36 @@
+export type UrgencyStatus = 'overdue' | 'critical' | 'normal'
+
+/**
+ * Returns the urgency status for a short-term objective based on its target date.
+ * - 'overdue': past due
+ * - 'critical': due within 6 weeks (42 days)
+ * - 'normal': more than 6 weeks away or no date
+ */
+export function getObjectiveUrgency(targetDate: string | null): UrgencyStatus {
+  if (!targetDate) return 'normal'
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const due = new Date(targetDate + 'T00:00:00')
+  const diffDays = Math.floor((due.getTime() - today.getTime()) / 86400000)
+  if (diffDays < 0) return 'overdue'
+  if (diffDays <= 42) return 'critical'
+  return 'normal'
+}
+
+/**
+ * Returns days remaining until target date (negative if overdue).
+ */
+export function getDaysRemaining(targetDate: string | null): number | null {
+  if (!targetDate) return null
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const due = new Date(targetDate + 'T00:00:00')
+  return Math.floor((due.getTime() - today.getTime()) / 86400000)
+}
+
+export function formatDaysRemaining(days: number): string {
+  if (days < 0) return 'OVERDUE'
+  if (days === 0) return 'Due today'
+  if (days === 1) return '1 day left'
+  return `${days} days left`
+}

--- a/frontend/src/pages/StudentDetail.test.tsx
+++ b/frontend/src/pages/StudentDetail.test.tsx
@@ -124,20 +124,30 @@ describe('StudentDetail', () => {
     expect(await screen.findByText('Student not found.')).toBeInTheDocument()
   })
 
-  it('renders Profile, Sessions, and Progress tabs', async () => {
+  it('renders Overview, Profile, Sessions, and Progress tabs', async () => {
     wrapper()
     await screen.findByTestId('student-detail-name')
+    expect(screen.getByTestId('tab-overview')).toBeInTheDocument()
     expect(screen.getByTestId('tab-profile')).toBeInTheDocument()
     expect(screen.getByTestId('tab-sessions')).toBeInTheDocument()
     expect(screen.getByTestId('tab-progress')).toBeInTheDocument()
   })
 
-  it('shows Profile tab content by default', async () => {
+  it('shows Overview tab content by default', async () => {
     wrapper()
     await screen.findByTestId('student-detail-name')
-    expect(screen.getByTestId('student-profile-tab')).toBeInTheDocument()
+    expect(screen.getByTestId('student-overview-tab')).toBeInTheDocument()
+    expect(screen.queryByTestId('student-profile-tab')).not.toBeInTheDocument()
     expect(screen.queryByTestId('session-history-tab')).not.toBeInTheDocument()
     expect(screen.queryByTestId('progress-dashboard')).not.toBeInTheDocument()
+  })
+
+  it('switches to Profile tab on click', async () => {
+    wrapper()
+    await screen.findByTestId('student-detail-name')
+    fireEvent.click(screen.getByTestId('tab-profile'))
+    expect(screen.getByTestId('student-profile-tab')).toBeInTheDocument()
+    expect(screen.queryByTestId('student-overview-tab')).not.toBeInTheDocument()
   })
 
   it('switches to Sessions tab on click', async () => {
@@ -223,23 +233,65 @@ describe('StudentDetail', () => {
   })
 })
 
+describe('StudentDetail - Overview tab', () => {
+  beforeEach(() => {
+    vi.mocked(studentsApi.getStudent).mockResolvedValue(MOCK_STUDENT)
+  })
+
+  it('renders primary objective card', async () => {
+    wrapper()
+    await screen.findByTestId('primary-objective-card')
+    expect(screen.getByTestId('objective-text')).toHaveTextContent('Complete DELE B1 exam prep')
+  })
+
+  it('shows days remaining for objective with future date', async () => {
+    vi.mocked(studentsApi.getStudent).mockResolvedValue({
+      ...MOCK_STUDENT,
+      shortTermObjectives: [
+        { id: 'obj-1', text: 'Future objective', targetDate: '2030-01-01' },
+      ],
+    })
+    wrapper()
+    await screen.findByTestId('primary-objective-card')
+    expect(screen.getByTestId('days-remaining')).toHaveTextContent('days left')
+  })
+
+  it('shows empty state when no objectives', async () => {
+    vi.mocked(studentsApi.getStudent).mockResolvedValue({ ...MOCK_STUDENT, shortTermObjectives: [] })
+    wrapper()
+    await screen.findByTestId('primary-objective-card')
+    expect(screen.getByText('No objectives set')).toBeInTheDocument()
+  })
+})
+
 describe('StudentDetail - Profile tab sections', () => {
   beforeEach(() => {
     vi.mocked(studentsApi.getStudent).mockResolvedValue(MOCK_STUDENT)
   })
 
-  it('renders About section with identity fields', async () => {
+  async function openProfileTab() {
     wrapper()
+    await screen.findByTestId('student-detail-name')
+    fireEvent.click(screen.getByTestId('tab-profile'))
+  }
+
+  it('renders hero section with reason for studying', async () => {
+    await openProfileTab()
+    await screen.findByTestId('profile-hero')
+    expect(screen.getByTestId('reason-quote')).toHaveTextContent('Moved to Barcelona for work')
+  })
+
+  it('renders Identity Details section with identity fields', async () => {
+    await openProfileTab()
     await screen.findByTestId('profile-about')
     expect(screen.getByText('London, United Kingdom')).toBeInTheDocument()
     expect(screen.getByText('Barcelona, Spain')).toBeInTheDocument()
     expect(screen.getByText(/^1995 \(\d+ years\)$/)).toBeInTheDocument()
     expect(screen.getAllByText('Designer').length).toBeGreaterThanOrEqual(1)
-    expect(screen.getByText('Moved to Barcelona for work')).toBeInTheDocument()
   })
 
   it('renders Languages section', async () => {
-    wrapper()
+    await openProfileTab()
     const section = await screen.findByTestId('profile-languages')
     expect(section).toHaveTextContent('English')
     expect(section).toHaveTextContent('French')
@@ -247,26 +299,26 @@ describe('StudentDetail - Profile tab sections', () => {
   })
 
   it('renders Learning Goals section', async () => {
-    wrapper()
+    await openProfileTab()
     await screen.findByTestId('profile-learning-goals')
     expect(screen.getByText('Travel')).toBeInTheDocument()
     expect(screen.getByText('DELE B1')).toBeInTheDocument()
   })
 
   it('renders Short-Term Objectives section', async () => {
-    wrapper()
+    await openProfileTab()
     await screen.findByTestId('profile-objectives')
     expect(screen.getByText('Complete DELE B1 exam prep')).toBeInTheDocument()
   })
 
   it('renders Teaching Todos section', async () => {
-    wrapper()
+    await openProfileTab()
     await screen.findByTestId('profile-teaching-todos')
     expect(screen.getByText('Send homework exercises')).toBeInTheDocument()
   })
 
   it('renders Commercial section with active status', async () => {
-    wrapper()
+    await openProfileTab()
     await screen.findByTestId('profile-commercial')
     expect(screen.getByTestId('active-status-badge')).toHaveTextContent('Active')
     expect(screen.getByText('30 EUR/h')).toBeInTheDocument()
@@ -286,7 +338,7 @@ describe('StudentDetail - Profile tab sections', () => {
       shortTermObjectives: [],
       teachingTodos: [],
     })
-    wrapper()
+    await openProfileTab()
     await screen.findByTestId('profile-about')
     expect(screen.getByText('No identity details added yet')).toBeInTheDocument()
     expect(screen.getByText('No learning goals set')).toBeInTheDocument()

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, Link, useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft, NotebookPen, Pencil } from 'lucide-react'
 import { getStudent, updateStudent } from '../api/students'
+import { logger } from '../lib/logger'
 import { getFollowups } from '@/api/followups'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -88,7 +89,7 @@ export default function StudentDetail() {
       queryClient.invalidateQueries({ queryKey: ['student', id] })
     },
     onError: (err) => {
-      console.error('Failed to update difficulty status', err)
+      logger.error('StudentDetail', 'Failed to update difficulty status', err)
     },
   })
 
@@ -99,7 +100,7 @@ export default function StudentDetail() {
       queryClient.invalidateQueries({ queryKey: ['student', id] })
     },
     onError: (err) => {
-      console.error('Failed to update reason for studying', err)
+      logger.error('StudentDetail', 'Failed to update reason for studying', err)
     },
   })
 
@@ -110,7 +111,7 @@ export default function StudentDetail() {
       queryClient.invalidateQueries({ queryKey: ['student', id] })
     },
     onError: (err) => {
-      console.error('Failed to update interests', err)
+      logger.error('StudentDetail', 'Failed to update interests', err)
     },
   })
 

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { CefrBadge } from '@/components/dashboard/CefrBadge'
 import { StudentProfileTab } from '@/components/student/StudentProfileTab'
+import { StudentOverviewTab } from '@/components/student/StudentOverviewTab'
 import { SessionHistoryTab } from '@/components/session/SessionHistoryTab'
 import { ProgressDashboard } from '@/components/student/ProgressDashboard'
 import { TeachingTodosCard } from '@/components/student/TeachingTodosCard'
@@ -28,7 +29,7 @@ export default function StudentDetail() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [searchParams] = useSearchParams()
-  const defaultTab = searchParams.get('tab') ?? 'profile'
+  const defaultTab = searchParams.get('tab') ?? 'overview'
   const [activeTab, setActiveTab] = useState(defaultTab)
   const [logSessionOpen, setLogSessionOpen] = useState(false)
 
@@ -46,44 +47,70 @@ export default function StudentDetail() {
 
   const onFollowupChange = useCallback(() => { refetchFollowups() }, [refetchFollowups])
 
+  function buildStudentPayload() {
+    if (!student) throw new Error('Student not loaded')
+    return {
+      name: student.name,
+      learningLanguage: student.learningLanguage,
+      cefrLevel: student.cefrLevel,
+      interests: student.interests,
+      nativeLanguages: student.nativeLanguages,
+      learningGoals: student.learningGoals,
+      weaknesses: student.weaknesses,
+      difficulties: student.difficulties,
+      personalNotes: student.personalNotes,
+      teachingNotes: student.teachingNotes,
+      birthYear: student.birthYear,
+      profession: student.profession,
+      countryOfOrigin: student.countryOfOrigin,
+      cityOfOrigin: student.cityOfOrigin,
+      countryOfResidence: student.countryOfResidence,
+      cityOfResidence: student.cityOfResidence,
+      reasonForStudying: student.reasonForStudying,
+      officialCefrLevel: student.officialCefrLevel,
+      shortTermObjectives: student.shortTermObjectives,
+      isActive: student.isActive,
+      isCorporate: student.isCorporate,
+      rate: student.rate,
+      spokenLanguages: student.spokenLanguages,
+      teachingTodos: student.teachingTodos,
+    }
+  }
+
   const { mutate: toggleDifficultyStatus } = useMutation({
     mutationFn: (vars: { difficultyId: string; status: 'Active' | 'Covered' }) => {
-      if (!student) throw new Error('Student not loaded')
-      const updated = student.difficulties.map((d) =>
+      const updated = student!.difficulties.map((d) =>
         d.id === vars.difficultyId ? { ...d, status: vars.status } : d
       )
-      return updateStudent(id!, {
-        name: student.name,
-        learningLanguage: student.learningLanguage,
-        cefrLevel: student.cefrLevel,
-        interests: student.interests,
-        nativeLanguages: student.nativeLanguages,
-        learningGoals: student.learningGoals,
-        weaknesses: student.weaknesses,
-        difficulties: updated,
-        personalNotes: student.personalNotes,
-        teachingNotes: student.teachingNotes,
-        birthYear: student.birthYear,
-        profession: student.profession,
-        countryOfOrigin: student.countryOfOrigin,
-        cityOfOrigin: student.cityOfOrigin,
-        countryOfResidence: student.countryOfResidence,
-        cityOfResidence: student.cityOfResidence,
-        reasonForStudying: student.reasonForStudying,
-        officialCefrLevel: student.officialCefrLevel,
-        shortTermObjectives: student.shortTermObjectives,
-        isActive: student.isActive,
-        isCorporate: student.isCorporate,
-        rate: student.rate,
-        spokenLanguages: student.spokenLanguages,
-        teachingTodos: student.teachingTodos,
-      })
+      return updateStudent(id!, { ...buildStudentPayload(), difficulties: updated })
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['student', id] })
     },
     onError: (err) => {
       console.error('Failed to update difficulty status', err)
+    },
+  })
+
+  const { mutateAsync: saveReasonForStudying } = useMutation({
+    mutationFn: (value: string) =>
+      updateStudent(id!, { ...buildStudentPayload(), reasonForStudying: value || null }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['student', id] })
+    },
+    onError: (err) => {
+      console.error('Failed to update reason for studying', err)
+    },
+  })
+
+  const { mutateAsync: saveInterests } = useMutation({
+    mutationFn: (value: string[]) =>
+      updateStudent(id!, { ...buildStudentPayload(), interests: value }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['student', id] })
+    },
+    onError: (err) => {
+      console.error('Failed to update interests', err)
     },
   })
 
@@ -113,6 +140,7 @@ export default function StudentDetail() {
   }
 
   const tabs = [
+    { key: 'overview', label: 'Overview' },
     { key: 'profile', label: 'Profile' },
     { key: 'sessions', label: 'Sessions' },
     { key: 'progress', label: 'Progress' },
@@ -244,6 +272,14 @@ export default function StudentDetail() {
       </div>
 
       {/* Tab content */}
+      {activeTab === 'overview' && (
+        <StudentOverviewTab
+          student={student}
+          followups={followups}
+          onFollowupChange={onFollowupChange}
+        />
+      )}
+
       {activeTab === 'profile' && (
         <StudentProfileTab
           student={student}
@@ -252,6 +288,8 @@ export default function StudentDetail() {
           onToggleDifficultyStatus={(difficultyId, status) =>
             toggleDifficultyStatus({ difficultyId, status })
           }
+          onSaveReasonForStudying={(v) => saveReasonForStudying(v).then(() => {})}
+          onSaveInterests={(v) => saveInterests(v).then(() => {})}
         />
       )}
 

--- a/frontend/src/pages/StudentForm.test.tsx
+++ b/frontend/src/pages/StudentForm.test.tsx
@@ -602,4 +602,111 @@ describe('StudentForm', () => {
     })
   })
 
+  it('renders Reason for Studying textarea', () => {
+    renderNew()
+    expect(screen.getByTestId('student-reason-for-studying')).toBeInTheDocument()
+  })
+
+  it('renders Teaching Goals card with Add Objective button', () => {
+    renderNew()
+    expect(screen.getByTestId('add-objective')).toBeInTheDocument()
+    expect(screen.getByTestId('objectives-empty')).toBeInTheDocument()
+  })
+
+  it('adds a short-term objective row on click', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+    renderNew()
+
+    expect(screen.queryAllByTestId('objective-row')).toHaveLength(0)
+    await user.click(screen.getByTestId('add-objective'))
+    expect(screen.getAllByTestId('objective-row')).toHaveLength(1)
+    expect(screen.queryByTestId('objectives-empty')).not.toBeInTheDocument()
+  })
+
+  it('removes a short-term objective row', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+    renderNew()
+
+    await user.click(screen.getByTestId('add-objective'))
+    expect(screen.getAllByTestId('objective-row')).toHaveLength(1)
+    await user.click(screen.getByTestId('remove-objective'))
+    expect(screen.queryAllByTestId('objective-row')).toHaveLength(0)
+  })
+
+  it('includes reasonForStudying in submission', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+    mockCreateStudent.mockResolvedValue({ id: 'new-id' })
+    renderNew()
+
+    await user.type(screen.getByTestId('student-name'), 'Test Student')
+    await user.click(screen.getByTestId('student-language'))
+    await user.click(await screen.findByRole('option', { name: 'Spanish' }))
+    await user.click(screen.getByTestId('student-cefr'))
+    await user.click(await screen.findByRole('option', { name: 'B1' }))
+    await user.type(screen.getByTestId('student-reason-for-studying'), 'Moving to Spain')
+
+    await user.click(screen.getByRole('button', { name: 'Save Student' }))
+
+    await vi.waitFor(() => {
+      expect(mockCreateStudent).toHaveBeenCalledWith(
+        expect.objectContaining({ reasonForStudying: 'Moving to Spain' }),
+      )
+    })
+  })
+
+  it('pre-populates reasonForStudying and objectives in edit mode', async () => {
+    mockGetStudent.mockResolvedValue({
+      id: 'stu-1',
+      name: 'Ana',
+      learningLanguage: 'Spanish',
+      cefrLevel: 'B1',
+      interests: [],
+      nativeLanguages: [],
+      learningGoals: [],
+      weaknesses: [],
+      difficulties: [],
+      personalNotes: null,
+      teachingNotes: null,
+      reasonForStudying: 'Loves Spanish culture',
+      shortTermObjectives: [
+        { id: 'obj-1', text: 'Pass DELE B1', targetDate: '2026-06-01' },
+      ],
+    })
+    renderEdit()
+    await screen.findByRole('heading', { name: 'Edit Student' })
+    expect(screen.getByTestId('student-reason-for-studying')).toHaveValue('Loves Spanish culture')
+    const rows = await screen.findAllByTestId('objective-row')
+    expect(rows).toHaveLength(1)
+    expect(screen.getByTestId('objective-text-input')).toHaveValue('Pass DELE B1')
+  })
+
+  it('includes shortTermObjectives in submission (filtering empty text)', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+    mockCreateStudent.mockResolvedValue({ id: 'new-id' })
+    renderNew()
+
+    await user.type(screen.getByTestId('student-name'), 'Test Student')
+    await user.click(screen.getByTestId('student-language'))
+    await user.click(await screen.findByRole('option', { name: 'Spanish' }))
+    await user.click(screen.getByTestId('student-cefr'))
+    await user.click(await screen.findByRole('option', { name: 'B1' }))
+
+    await user.click(screen.getByTestId('add-objective'))
+    await user.type(screen.getByTestId('objective-text-input'), 'Pass DELE B1')
+
+    await user.click(screen.getByRole('button', { name: 'Save Student' }))
+
+    await vi.waitFor(() => {
+      expect(mockCreateStudent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          shortTermObjectives: [expect.objectContaining({ text: 'Pass DELE B1' })],
+        }),
+      )
+    })
+  })
+
 })

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState, useRef } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { X, Plus, Trash2 } from 'lucide-react'
-import { getStudent, createStudent, updateStudent, type StudentFormData, type Difficulty, type StudentWeaknessItem } from '../api/students'
+import { getStudent, createStudent, updateStudent, type StudentFormData, type Difficulty, type StudentWeaknessItem, type ShortTermObjective } from '../api/students'
+import { getObjectiveUrgency } from '@/lib/objectiveUrgency'
 import { LEARNING_GOALS, COMPETENCY_OPTIONS } from '../lib/studentOptions'
 import { logger } from '../lib/logger'
 import { Button } from '@/components/ui/button'
@@ -51,6 +52,8 @@ export default function StudentForm() {
   const [cityOfOrigin, setCityOfOrigin] = useState('')
   const [countryOfResidence, setCountryOfResidence] = useState('')
   const [cityOfResidence, setCityOfResidence] = useState('')
+  const [reasonForStudying, setReasonForStudying] = useState('')
+  const [shortTermObjectives, setShortTermObjectives] = useState<ShortTermObjective[]>([])
   const [errors, setErrors] = useState<Record<string, string>>({})
   const interestInputRef = useRef<HTMLInputElement>(null)
 
@@ -86,6 +89,8 @@ export default function StudentForm() {
       setCityOfOrigin(existing.cityOfOrigin ?? '')
       setCountryOfResidence(existing.countryOfResidence ?? '')
       setCityOfResidence(existing.cityOfResidence ?? '')
+      setReasonForStudying(existing.reasonForStudying ?? '')
+      setShortTermObjectives(existing.shortTermObjectives ?? [])
     }
   }, [existing])
   /* eslint-enable react-hooks/set-state-in-effect */
@@ -157,6 +162,23 @@ export default function StudentForm() {
     setDifficulties((prev) => prev.filter((d) => d.id !== id))
   }
 
+  function addObjective() {
+    const newId = typeof crypto !== 'undefined' && crypto.randomUUID
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
+    setShortTermObjectives((prev) => [...prev, { id: newId, text: '', targetDate: null }])
+  }
+
+  function updateObjective(id: string, field: 'text' | 'targetDate', value: string | null) {
+    setShortTermObjectives((prev) =>
+      prev.map((o) => (o.id === id ? { ...o, [field]: value } : o))
+    )
+  }
+
+  function removeObjective(id: string) {
+    setShortTermObjectives((prev) => prev.filter((o) => o.id !== id))
+  }
+
   function validate(): boolean {
     const errs: Record<string, string> = {}
     if (!name.trim()) errs.name = 'Name is required'
@@ -193,6 +215,8 @@ export default function StudentForm() {
       cityOfOrigin: cityOfOrigin.trim() || null,
       countryOfResidence: countryOfResidence.trim() || null,
       cityOfResidence: cityOfResidence.trim() || null,
+      reasonForStudying: reasonForStudying.trim() || null,
+      shortTermObjectives: shortTermObjectives.filter((o) => o.text.trim()),
     })
   }
 
@@ -409,6 +433,27 @@ export default function StudentForm() {
                   data-testid="student-city-residence"
                 />
               </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Reason for Studying</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-1.5">
+              <Label htmlFor="reason-for-studying">Why is this student learning this language?</Label>
+              <Textarea
+                id="reason-for-studying"
+                value={reasonForStudying}
+                onChange={(e) => setReasonForStudying(e.target.value)}
+                placeholder="e.g. Moving to Spain next year, loves the culture..."
+                maxLength={512}
+                rows={3}
+                className="max-w-sm resize-none"
+                data-testid="student-reason-for-studying"
+              />
             </div>
           </CardContent>
         </Card>
@@ -641,6 +686,85 @@ export default function StudentForm() {
               {difficulties.length === 0 && (
                 <p className="text-xs text-zinc-400 italic">
                   No specific difficulties tracked yet.
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Teaching Goals</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {/* Short-Term Objectives */}
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label>Short-Term Objectives</Label>
+                  <p className="text-xs text-zinc-400 mt-0.5">Specific goals with optional target dates (max 10).</p>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={addObjective}
+                  disabled={shortTermObjectives.length >= 10}
+                  data-testid="add-objective"
+                >
+                  <Plus className="h-3.5 w-3.5 mr-1" />
+                  Add Objective
+                </Button>
+              </div>
+
+              {shortTermObjectives.map((obj) => {
+                const urgency = getObjectiveUrgency(obj.targetDate)
+                return (
+                  <div
+                    key={obj.id}
+                    className="flex flex-col sm:flex-row gap-2 sm:items-start"
+                    data-testid="objective-row"
+                  >
+                    <Input
+                      value={obj.text}
+                      onChange={(e) => updateObjective(obj.id, 'text', e.target.value)}
+                      placeholder="e.g. Pass DELE B1 exam"
+                      maxLength={500}
+                      className="flex-1"
+                      data-testid="objective-text-input"
+                    />
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="date"
+                        value={obj.targetDate ?? ''}
+                        onChange={(e) => updateObjective(obj.id, 'targetDate', e.target.value || null)}
+                        className="h-9 rounded-md border border-zinc-200 bg-white px-3 py-1 text-sm text-[#1A1B22] focus:outline-none focus:ring-2 focus:ring-indigo-300"
+                        data-testid="objective-date-input"
+                      />
+                      {urgency === 'critical' && obj.targetDate && (
+                        <span className="text-xs font-semibold text-orange-600 shrink-0" data-testid="objective-near-date-warning">
+                          NEAR DATE
+                        </span>
+                      )}
+                    </div>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => removeObjective(obj.id)}
+                      className="text-zinc-400 hover:text-red-600 h-9 w-9 shrink-0"
+                      data-testid="remove-objective"
+                      aria-label="Remove objective"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                )
+              })}
+
+              {shortTermObjectives.length === 0 && (
+                <p className="text-xs text-zinc-400 italic" data-testid="objectives-empty">
+                  No short-term objectives added yet.
                 </p>
               )}
             </div>

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -443,7 +443,7 @@ export default function StudentForm() {
           </CardHeader>
           <CardContent>
             <div className="space-y-1.5">
-              <Label htmlFor="reason-for-studying">Why is this student learning this language?</Label>
+              <Label htmlFor="reason-for-studying">Reason for studying</Label>
               <Textarea
                 id="reason-for-studying"
                 value={reasonForStudying}

--- a/plan/langteach-beta/task664-motivation-fields.md
+++ b/plan/langteach-beta/task664-motivation-fields.md
@@ -1,0 +1,148 @@
+# Task #664: Motivation Fields (ReasonForStudying, ShortTermObjectives, LearningGoals, Interests)
+
+## Issue
+https://github.com/Robert-Freire/langTeachSaaS/issues/664
+
+## Context
+
+All backend fields exist. This is purely frontend work. The task adds:
+- ReasonForStudying: hero quote on Profile tab + inline edit + edit form field
+- ShortTermObjectives: urgency treatment on Profile tab + edit form list + Overview tab Primary Objective card
+- LearningGoals: bullet list in Pedagogical Diagnostic on Profile tab (was chips -- gap from #667)
+- Interests: tags in hero section + dedicated editable section on Profile tab right column (was missing -- gap from #667)
+
+Design reference: `plan/langteach-beta/student-screen-field-mapping.md` (approved 2026-04-11).
+
+## Acceptance Criteria (from issue)
+
+- [ ] ReasonForStudying editable in create/edit forms AND inline on Profile tab (ghost pencil)
+- [ ] ReasonForStudying renders as hero italic quote on Profile tab with interests beside it
+- [ ] Interests render as tags beside the quote when data exists
+- [ ] Interests have a dedicated editable section on Profile tab right column
+- [ ] LearningGoals render as bullet list in Pedagogical Diagnostic when data exists
+- [ ] ShortTermObjectives editable with add/remove/edit in the edit form
+- [ ] Each objective supports optional TargetDate via date picker
+- [ ] Profile tab shows objectives with "OVERDUE" label (red) when past due
+- [ ] Profile tab shows "Critical" treatment (red border) for objectives within 6 weeks
+- [ ] Past-due and upcoming objectives are visually distinct
+- [ ] Overview tab Primary Objective card shows first objective with days remaining
+- [ ] No "65% Ready" or completion percentage
+- [ ] Follows Stitch design
+
+## Architecture
+
+### Component changes
+
+**`StudentProfileTab.tsx`** -- largest change:
+- Add "The Why / Motivacion" hero section above the grid (ReasonForStudying + Interests tags)
+- Inline edit for ReasonForStudying: local `editingReason` state, pencil-on-hover, textarea + save/cancel
+- Interests editable section on right column: local `editingInterests` state, tag add/remove
+- Change LearningGoals rendering from chips to bullet list (add to left column "Pedagogical Diagnostic")
+- ShortTermObjectives urgency logic:
+  - `targetDate < today` => "OVERDUE" red label
+  - `targetDate within 42 days` => "Critical" red border
+  - No chevron arrows
+- Props add: `onSaveReasonForStudying?: (value: string) => Promise<void>` and `onSaveInterests?: (value: string[]) => Promise<void>`
+
+**`StudentDetail.tsx`**:
+- Add "overview" tab to `tabs` array (before "profile")
+- New `activeTab === 'overview'` block renders `StudentOverviewTab`
+- Add `mutate: updateReasonForStudying` and `updateInterests` mutations (same pattern as `toggleDifficultyStatus`)
+- Pass callbacks to `StudentProfileTab`
+
+**New `StudentOverviewTab.tsx`** (new file):
+- Primary Objective card: shows first (most urgent) `shortTermObjectives` item
+  - Text + target date + days remaining (positive = "N days left", 0 = "today", negative = "OVERDUE")
+  - No progress %, no chevrons
+- TeachingTodosCard (already implemented, also stays in Profile tab -- per field mapping, both tabs show it)
+- StudentFollowupsCard (already implemented, also stays in Profile tab -- per field mapping, both tabs show it)
+- Empty state if no objectives
+- Note: TeachingTodosCard and StudentFollowupsCard are NOT removed from StudentProfileTab; they appear on both tabs per field mapping design.
+
+**`StudentForm.tsx`**:
+- Add `reasonForStudying` state (string)
+- Add `shortTermObjectives` state (array of `{ id: string; text: string; targetDate: string | null }`)
+- Sync both from `existing` in `useEffect`
+- Include both in `mutate()` call
+- Add "ReasonForStudying" textarea to Personal Background card (right column or below existing fields)
+- Add "Teaching Goals" card with:
+  - LearningGoals multi-select (move from Teaching Context card OR add section header inside it)
+  - ShortTermObjectives list: text input + `<input type="date">` + remove button + "Add Objective" button
+  - "NEAR DATE" warning: show orange badge on row when targetDate is within 6 weeks
+
+### Objective urgency logic (shared utility `objectiveUrgency.ts`)
+
+```ts
+type UrgencyStatus = 'overdue' | 'critical' | 'normal'
+
+function getObjectiveUrgency(targetDate: string | null): UrgencyStatus {
+  if (!targetDate) return 'normal'
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const due = new Date(targetDate + 'T00:00:00')
+  const diffDays = Math.floor((due.getTime() - today.getTime()) / 86400000)
+  if (diffDays < 0) return 'overdue'
+  if (diffDays <= 42) return 'critical'
+  return 'normal'
+}
+```
+
+### Inline edit pattern (ReasonForStudying)
+
+```tsx
+// In StudentProfileTab
+const [editingReason, setEditingReason] = useState(false)
+const [reasonDraft, setReasonDraft] = useState(student.reasonForStudying ?? '')
+// On save: call onSaveReasonForStudying(reasonDraft)
+// On cancel: reset draft to student.reasonForStudying, close edit
+```
+
+The save callback is wired in `StudentDetail.tsx` as a `useMutation` that calls `updateStudent` with the full student + new value (same pattern as difficulty toggle).
+
+### Inline edit pattern (Interests)
+
+```tsx
+// In StudentProfileTab
+const [editingInterests, setEditingInterests] = useState(false)
+const [interestsDraft, setInterestsDraft] = useState(student.interests)
+// Simple tag add/remove UI; on save: call onSaveInterests(interestsDraft)
+```
+
+## File list
+
+| File | Change |
+|------|--------|
+| `frontend/src/components/student/StudentProfileTab.tsx` | Major: add hero section, inline edits, urgency on objectives, bullet list goals, interests section |
+| `frontend/src/components/student/StudentProfileTab.test.tsx` | Update: add tests for hero, urgency, inline edit, interests section |
+| `frontend/src/components/student/StudentOverviewTab.tsx` | New: Primary Objective card + TeachingTodos + Followups |
+| `frontend/src/components/student/StudentOverviewTab.test.tsx` | New |
+| `frontend/src/lib/objectiveUrgency.ts` | New: urgency logic utility |
+| `frontend/src/lib/objectiveUrgency.test.ts` | New |
+| `frontend/src/pages/StudentDetail.tsx` | Add overview tab, add mutation callbacks |
+| `frontend/src/pages/StudentDetail.test.tsx` | Update: add overview tab test |
+| `frontend/src/pages/StudentForm.tsx` | Add reasonForStudying + shortTermObjectives states + form fields |
+| `frontend/src/pages/StudentForm.test.tsx` | Update: add tests for new fields |
+| `e2e/tests/students.spec.ts` | Add e2e happy path for new fields round-trip |
+
+## E2E happy path
+
+Test scenario: create a student with ReasonForStudying and a short-term objective, navigate to student detail, verify overview tab shows objective with days remaining, verify profile tab shows hero quote and interests.
+
+## Decisions
+
+- **Overview tab scope**: Add minimal Overview tab with Primary Objective card + Teaching Todos + Pending Followups. Session history preview and Pedagogical Profile card are future tasks.
+- **Inline edit save**: Full `updateStudent` call with all fields (same pattern as difficulty status toggle). No partial update endpoint.
+- **Date picker**: Native `<input type="date">`. No date picker component needed.
+- **Teaching Goals card in form**: Keep LearningGoals in "Teaching Context" card, add new "Teaching Goals" card for ShortTermObjectives only. The issue maps LearningGoals to the "Teaching Goals > Learning Goals" section, but since it already exists in Teaching Context with a working UI, we only add the missing ShortTermObjectives section to avoid breaking existing functionality.
+- **Interests editable section**: Pencil button opens edit mode; shows add input + tags with X remove. Save calls `onSaveInterests`. No separate modal.
+
+## Implementation order
+
+1. `objectiveUrgency.ts` + test (10 min)
+2. `StudentOverviewTab.tsx` + test (20 min)
+3. `StudentDetail.tsx` -- add overview tab + callbacks (15 min)
+4. `StudentProfileTab.tsx` -- hero section, interests section, goals bullet list, objectives urgency (45 min)
+5. `StudentProfileTab.test.tsx` -- update tests (20 min)
+6. `StudentForm.tsx` -- add fields + states (25 min)
+7. `StudentForm.test.tsx` -- update tests (15 min)
+8. `e2e/tests/students.spec.ts` -- add happy path (15 min)


### PR DESCRIPTION
## Summary
- Adds a new **Overview tab** (default) to student detail with a Primary Objective card showing urgency coloring (overdue/critical/normal)
- Redesigns the **Profile tab** hero section with an inline-editable motivation quote and interests tags
- Adds **ReasonForStudying** and **ShortTermObjectives** fields to the student edit form
- Extracts shared `SectionHeader` component; uses `logger` utility for error handling

## Test plan
- [ ] Overview tab is the default tab on student detail
- [ ] Primary Objective card shows urgency (red for overdue, orange for critical)
- [ ] Profile tab hero shows motivation quote with inline edit (pencil on hover)
- [ ] Edit form: Reason for Studying textarea saves and round-trips
- [ ] Edit form: Short-Term Objectives list - add, remove, date picker works
- [ ] All 76 unit tests pass
- [ ] E2E motivation round-trip test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Overview tab as the new default view on student detail pages, displaying primary objectives with urgency indicators (overdue, critical, normal).
  * Introduced motivation/reason for studying field in student creation and edit forms.
  * Added short-term objectives management with target dates and remaining days display.
  * Added interests/tags management for student profiles.
  * Reorganized student profile layout with new pedagogical diagnostic sections.

* **Tests**
  * Expanded end-to-end and unit test coverage for new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->