### PR TITLE
feat: teaching todos delete + text-edit endpoints (#688)

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/StudentsControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/StudentsControllerTests.cs
@@ -381,6 +381,37 @@ public class StudentsControllerTests
         student!.Difficulties.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task DeleteTeachingTodo_Succeeds()
+    {
+        var client = _factory.CreateAuthenticatedClient("auth0|delete-todo-test", "delete-todo@example.com");
+        var student = await CreateStudentAsync(client, "Todo Delete Student");
+
+        var appendResponse = await client.PostAsJsonAsync(
+            $"/api/students/{student.Id}/teaching-todos",
+            new CreateTeachingTodoDto("Practicar subjuntivo", null));
+        appendResponse.EnsureSuccessStatusCode();
+        var withTodo = await appendResponse.Content.ReadFromJsonAsync<StudentDto>();
+        var todoId = withTodo!.TeachingTodos[0].Id;
+
+        var deleteResponse = await client.DeleteAsync($"/api/students/{student.Id}/teaching-todos/{todoId}");
+
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await deleteResponse.Content.ReadFromJsonAsync<StudentDto>();
+        result!.TeachingTodos.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeleteTeachingTodo_UnknownTodoId_ReturnsNotFound()
+    {
+        var client = _factory.CreateAuthenticatedClient("auth0|delete-todo-notfound-test", "delete-todo-notfound@example.com");
+        var student = await CreateStudentAsync(client, "Todo Delete NotFound Student");
+
+        var response = await client.DeleteAsync($"/api/students/{student.Id}/teaching-todos/nonexistent-id");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
     private static async Task<StudentDto> CreateStudentAsync(
         HttpClient client,
         string name,

--- a/backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs
@@ -278,7 +278,7 @@ public class StudentServiceTests : IDisposable
             TeachingTodos = [MakeTodo("todo-1")],
         });
 
-        var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "todo-1", new UpdateTeachingTodoDto("covered", null));
+        var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "todo-1", new UpdateTeachingTodoDto("covered", null, null));
 
         result!.TeachingTodos.Single().Status.Should().Be("covered");
     }
@@ -293,7 +293,7 @@ public class StudentServiceTests : IDisposable
             TeachingTodos = [MakeTodo("todo-1")],
         });
 
-        var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "todo-1", new UpdateTeachingTodoDto("dismissed", null));
+        var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "todo-1", new UpdateTeachingTodoDto("dismissed", null, null));
 
         result!.TeachingTodos.Single().Status.Should().Be("dismissed");
     }
@@ -334,7 +334,7 @@ public class StudentServiceTests : IDisposable
     {
         var created = await _sut.CreateAsync(_teacherId, BaseRequest());
 
-        var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "nonexistent-id", new UpdateTeachingTodoDto("covered", null));
+        var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "nonexistent-id", new UpdateTeachingTodoDto("covered", null, null));
 
         result.Should().BeNull();
     }
@@ -361,5 +361,78 @@ public class StudentServiceTests : IDisposable
         result.TeachingTodos[0].Text.Should().Be("Trabajar ser/estar");
         result.TeachingTodos[0].Status.Should().Be("pending");
         result.TeachingTodos[0].Id.Should().NotBeNullOrEmpty();
+    }
+
+    // DeleteTeachingTodoAsync tests
+
+    [Fact]
+    public async Task DeleteTeachingTodoAsync_RemovesTodo_ReturnsUpdatedStudent()
+    {
+        var created = await _sut.CreateAsync(_teacherId, BaseRequest());
+        await _sut.UpdateAsync(_teacherId, created.Id, new UpdateStudentRequest
+        {
+            Name = created.Name, LearningLanguage = created.LearningLanguage, CefrLevel = created.CefrLevel,
+            TeachingTodos = [MakeTodo("todo-1"), MakeTodo("todo-2")],
+        });
+
+        var result = await _sut.DeleteTeachingTodoAsync(_teacherId, created.Id, "todo-1");
+
+        result!.TeachingTodos.Should().HaveCount(1);
+        result.TeachingTodos[0].Id.Should().Be("todo-2");
+    }
+
+    [Fact]
+    public async Task DeleteTeachingTodoAsync_UnknownTodoId_ReturnsNull()
+    {
+        var created = await _sut.CreateAsync(_teacherId, BaseRequest());
+
+        var result = await _sut.DeleteTeachingTodoAsync(_teacherId, created.Id, "nonexistent-id");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteTeachingTodoAsync_WrongTeacher_ReturnsNull()
+    {
+        var otherTeacherId = Guid.NewGuid();
+        var created = await _sut.CreateAsync(_teacherId, BaseRequest());
+
+        var result = await _sut.DeleteTeachingTodoAsync(otherTeacherId, created.Id, "todo-1");
+
+        result.Should().BeNull();
+    }
+
+    // UpdateTeachingTodoAsync text-edit tests
+
+    [Fact]
+    public async Task UpdateTeachingTodoAsync_WithText_UpdatesText()
+    {
+        var created = await _sut.CreateAsync(_teacherId, BaseRequest());
+        await _sut.UpdateAsync(_teacherId, created.Id, new UpdateStudentRequest
+        {
+            Name = created.Name, LearningLanguage = created.LearningLanguage, CefrLevel = created.CefrLevel,
+            TeachingTodos = [MakeTodo("todo-1", "Original text")],
+        });
+
+        var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "todo-1",
+            new UpdateTeachingTodoDto("pending", null, "Updated text"));
+
+        result!.TeachingTodos.Single().Text.Should().Be("Updated text");
+    }
+
+    [Fact]
+    public async Task UpdateTeachingTodoAsync_TextTooLong_ThrowsValidation()
+    {
+        var created = await _sut.CreateAsync(_teacherId, BaseRequest());
+        await _sut.UpdateAsync(_teacherId, created.Id, new UpdateStudentRequest
+        {
+            Name = created.Name, LearningLanguage = created.LearningLanguage, CefrLevel = created.CefrLevel,
+            TeachingTodos = [MakeTodo("todo-1")],
+        });
+
+        var act = () => _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "todo-1",
+            new UpdateTeachingTodoDto("pending", null, new string('x', 501)));
+
+        await act.Should().ThrowAsync<ValidationException>();
     }
 }

--- a/backend/LangTeach.Api/Controllers/StudentsController.cs
+++ b/backend/LangTeach.Api/Controllers/StudentsController.cs
@@ -169,6 +169,20 @@ public class StudentsController : ControllerBase
         }
     }
 
+    [HttpDelete("{id:guid}/teaching-todos/{todoId}")]
+    public async Task<IActionResult> DeleteTeachingTodo(Guid id, string todoId, CancellationToken cancellationToken)
+    {
+        if (Auth0Id is null) return Unauthorized();
+        var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
+        var student = await _studentService.DeleteTeachingTodoAsync(teacherId, id, todoId, cancellationToken);
+        if (student is null)
+        {
+            _logger.LogWarning("DELETE /api/students/{StudentId}/teaching-todos/{TodoId} not found or forbidden. TeacherId={TeacherId}", id, todoId, teacherId);
+            return NotFound();
+        }
+        return Ok(student);
+    }
+
     [HttpDelete("{id:guid}")]
     public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {

--- a/backend/LangTeach.Api/DTOs/TeachingTodoDto.cs
+++ b/backend/LangTeach.Api/DTOs/TeachingTodoDto.cs
@@ -16,4 +16,5 @@ public record CreateTeachingTodoDto(
 
 public record UpdateTeachingTodoDto(
     [Required] string Status,
-    string? CoveredInSessionLogId);
+    string? CoveredInSessionLogId,
+    [MaxLength(500)] string? Text);

--- a/backend/LangTeach.Api/Services/IStudentService.cs
+++ b/backend/LangTeach.Api/Services/IStudentService.cs
@@ -11,4 +11,5 @@ public interface IStudentService
     Task<bool> DeleteAsync(Guid teacherId, Guid studentId, CancellationToken cancellationToken = default);
     Task<StudentDto?> AppendTeachingTodoAsync(Guid teacherId, Guid studentId, CreateTeachingTodoDto request, CancellationToken cancellationToken = default);
     Task<StudentDto?> UpdateTeachingTodoAsync(Guid teacherId, Guid studentId, string todoId, UpdateTeachingTodoDto request, CancellationToken cancellationToken = default);
+    Task<StudentDto?> DeleteTeachingTodoAsync(Guid teacherId, Guid studentId, string todoId, CancellationToken cancellationToken = default);
 }

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -356,13 +356,45 @@ public class StudentService : IStudentService
         if (index < 0)
             return null;
 
-        todos[index] = todos[index] with { Status = request.Status, CoveredInSessionLogId = request.CoveredInSessionLogId };
+        var updated = todos[index] with { Status = request.Status, CoveredInSessionLogId = request.CoveredInSessionLogId };
+        if (request.Text is not null)
+        {
+            if (string.IsNullOrWhiteSpace(request.Text) || request.Text.Length > 500)
+                throw new ValidationException("Todo text must be between 1 and 500 characters.");
+            updated = updated with { Text = request.Text };
+        }
+        todos[index] = updated;
         student.TeachingTodos = Serialize(todos);
         student.UpdatedAt = DateTime.UtcNow;
 
         await _db.SaveChangesAsync(cancellationToken);
         _logger.LogInformation("Teaching todo updated. TeacherId={TeacherId} StudentId={StudentId} TodoId={TodoId} Status={Status}",
             teacherId, student.Id, todoId, request.Status);
+
+        return MapToDto(student);
+    }
+
+    public async Task<StudentDto?> DeleteTeachingTodoAsync(Guid teacherId, Guid studentId, string todoId, CancellationToken cancellationToken = default)
+    {
+        var student = await _db.Students
+            .FirstOrDefaultAsync(s => s.Id == studentId && s.TeacherId == teacherId && !s.IsDeleted, cancellationToken);
+
+        if (student is null)
+            return null;
+
+        var todos = JsonStorageHelper.DeserializeList<TeachingTodoDto>(student.TeachingTodos);
+        var index = todos.FindIndex(t => t.Id == todoId);
+
+        if (index < 0)
+            return null;
+
+        todos.RemoveAt(index);
+        student.TeachingTodos = Serialize(todos);
+        student.UpdatedAt = DateTime.UtcNow;
+
+        await _db.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("Teaching todo deleted. TeacherId={TeacherId} StudentId={StudentId} TodoId={TodoId}",
+            teacherId, student.Id, todoId);
 
         return MapToDto(student);
     }

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -49,3 +49,10 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 | architecture-reviewer | minor | Same case-sensitivity note as above. |
 | Sophy | minor | Dual mutation path (PUT full-replace + POST/PATCH sub-resource) -- intentional per issue spec. Sophy asked to document intent. Both paths are valid: PUT for import/sync, POST/PATCH for incremental UI. |
 | Sophy | info | `UpdateTeachingTodoAsync` returns null for both student-not-found and todo-not-found; controller maps both to 404. Minor ambiguity for callers; consistent with existing not-found handling. |
+
+## #688 — 2026-04-12
+
+| Reviewer | Severity | Note |
+|---|---|---|
+| architecture-reviewer | minor | `UpdateTeachingTodoAsync` text validation fires after `index < 0` guard; passing invalid text with nonexistent todo ID returns null instead of ValidationException. Not blocking: 404 on unknown ID is correct behavior regardless. Could align with AppendTeachingTodoAsync (validate first) in a future cleanup. |
+| Sophy | minor | `[MaxLength(500)]` on `UpdateTeachingTodoDto.Text` + manual length check in service is redundant. Same pattern exists in `AppendTeachingTodoAsync`. Fix both together in a cleanup pass. |

--- a/plan/langteach-beta/task688-teaching-todos-delete-edit.md
+++ b/plan/langteach-beta/task688-teaching-todos-delete-edit.md
@@ -1,0 +1,45 @@
+# Task 688: Teaching Todos Delete + Text-Edit Backend Endpoints
+
+## Goal
+Add DELETE and text-edit support for teaching todos, unblocking #665.
+
+## Acceptance Criteria
+- [ ] `DELETE /api/students/{id}/teaching-todos/{todoId}` removes the todo and returns updated student
+- [ ] `PATCH /api/students/{id}/teaching-todos/{todoId}` accepts optional `Text` field (max 500 chars)
+- [ ] Unit tests for both operations in `StudentServiceTests`
+- [ ] Controller tests updated
+
+## Current State
+- `TeachingTodos` stored as JSON on the `Student` entity
+- `UpdateTeachingTodoDto` only has `Status` + `CoveredInSessionLogId`
+- No DELETE endpoint exists
+
+## Changes
+
+### 1. DTOs (`backend/LangTeach.Api/DTOs/TeachingTodoDto.cs`)
+- Add `Text? string` to `UpdateTeachingTodoDto` (optional, max 500 chars)
+
+### 2. Service interface (`backend/LangTeach.Api/Services/IStudentService.cs`)
+- Add `Task<StudentDto?> DeleteTeachingTodoAsync(Guid teacherId, Guid studentId, string todoId, CancellationToken ct)`
+
+### 3. Service (`backend/LangTeach.Api/Services/StudentService.cs`)
+- `UpdateTeachingTodoAsync`: `Status` remains `[Required]`; if `request.Text` is provided, validate (1-500 chars) and update the text field. Callers must always pass the current/desired status (keeps existing validation logic unchanged).
+- `DeleteTeachingTodoAsync`: find student, deserialize todos, remove by id, return null if todo not found, save + return updated student
+
+### 4. Controller (`backend/LangTeach.Api/Controllers/StudentsController.cs`)
+- Add `DELETE {id:guid}/teaching-todos/{todoId}` action calling `DeleteTeachingTodoAsync`
+- Returns 200 with updated student on success (consistent with PATCH), 404 if not found
+
+### 5. Tests (`backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs`)
+- `DeleteTeachingTodoAsync_RemovesTodo_ReturnsUpdatedStudent`
+- `DeleteTeachingTodoAsync_UnknownTodoId_ReturnsNull`
+- `DeleteTeachingTodoAsync_WrongTeacher_ReturnsNull`
+- `UpdateTeachingTodoAsync_WithText_UpdatesText`
+- `UpdateTeachingTodoAsync_TextTooLong_ThrowsValidation`
+
+### 6. Controller tests (`backend/LangTeach.Api.Tests/Controllers/StudentsControllerTests.cs`)
+- Add DELETE endpoint tests (success 204, not found 404)
+
+## Notes
+- No migration needed (TeachingTodos is a JSON column, no schema change)
+- Reorder is out of scope per issue recommendation


### PR DESCRIPTION
## Summary
- Adds `DELETE /api/students/{id}/teaching-todos/{todoId}` — removes the todo, returns updated student (200)
- Extends `PATCH /api/students/{id}/teaching-todos/{todoId}` with optional `Text` field for in-place text editing (max 500 chars)
- Unit tests: delete (success, wrong teacher, unknown id) + text-edit (success, too-long validation)
- Controller tests: DELETE success (200) and not-found (404)

Prerequisite for #665 (teaching todos inline UI).

## Test plan
- [ ] `dotnet test --filter TeachingTodo` — 16 tests pass
- [ ] DELETE with valid todoId returns 200 with updated student (todo removed)
- [ ] DELETE with unknown todoId returns 404
- [ ] PATCH with Text field updates the todo text
- [ ] PATCH with Text > 500 chars returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to delete teaching todos from student records, returning updated student data
  * Added ability to edit teaching todo text content with validation constraints (maximum 500 characters, non-whitespace required)

* **Tests**
  * Added comprehensive test coverage for delete functionality including successful deletion and error scenarios
  * Added test coverage for text editing functionality with validation enforcement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->