### PR TITLE
feat: teaching todos interactive inline UI (#665)

### DIFF
--- a/e2e/tests/students.spec.ts
+++ b/e2e/tests/students.spec.ts
@@ -614,3 +614,73 @@ test('motivation fields: reason for studying and objectives round-trip', async (
 
   await context.close()
 })
+
+test('teaching todos: add, toggle covered, verify ordering on overview tab', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  const studentName = `Todo E2E Test ${Date.now()}`
+
+  // Create a student to work with
+  await page.goto('/students/new')
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: 10000 })
+  await page.getByTestId('student-name').fill(studentName)
+  await page.getByTestId('student-language').click()
+  await page.getByRole('option', { name: 'Spanish' }).click()
+  await page.getByTestId('student-cefr').click()
+  await page.getByRole('option', { name: 'B1' }).click()
+  await page.getByRole('button', { name: 'Save Student' }).click()
+  await expect(page).toHaveURL(/\/students\/[^/]+$/, { timeout: 10000 })
+
+  // Verify we're on the overview tab (default)
+  await expect(page.getByTestId('tab-overview')).toHaveAttribute('aria-selected', 'true', { timeout: 5000 })
+  await expect(page.getByTestId('teaching-todos-card')).toBeVisible({ timeout: 5000 })
+
+  // Empty state is shown
+  await expect(page.getByTestId('teaching-todos-empty')).toBeVisible()
+
+  // Add a teaching todo
+  const addInput = page.getByTestId('todo-add-input')
+  await addInput.fill('Practice ser vs estar')
+  await page.getByTestId('todo-add-btn').click()
+
+  // Todo appears in list
+  await expect(page.getByTestId('teaching-todos-list')).toBeVisible({ timeout: 5000 })
+  const firstTodo = page.getByTestId('teaching-todo-item').first()
+  await expect(firstTodo).toContainText('Practice ser vs estar')
+
+  // Add a second todo
+  await addInput.fill('Review subjunctive mood')
+  await page.getByTestId('todo-add-btn').click()
+  await expect(page.getByTestId('teaching-todo-item')).toHaveCount(2, { timeout: 5000 })
+
+  // Mark the first todo as covered
+  const items = page.getByTestId('teaching-todo-item')
+  const firstItem = items.first()
+  const todoText = await firstItem.getByTestId(/^todo-text-/).textContent()
+  const todoId = (await firstItem.getByTestId(/^todo-toggle-/).getAttribute('data-testid'))?.replace('todo-toggle-', '')
+
+  await firstItem.getByTestId(`todo-toggle-${todoId}`).click()
+
+  // Wait for covered state (strikethrough)
+  await expect(firstItem.getByTestId(`todo-text-${todoId}`)).toHaveClass(/line-through/, { timeout: 5000 })
+
+  // Verify ordering: pending todo should appear before covered
+  const reorderedItems = page.getByTestId('teaching-todo-item')
+  const firstText = await reorderedItems.first().getByTestId(/^todo-text-/).textContent()
+  const lastText = await reorderedItems.last().getByTestId(/^todo-text-/).textContent()
+  expect(firstText).not.toEqual(todoText) // the one we covered should now be last
+  expect(lastText).toEqual(todoText)
+
+  // Cleanup: delete the student
+  await page.goto('/students')
+  const row = page.locator('[data-testid^="student-row-"]').filter({
+    has: page.getByTestId('student-name').filter({ hasText: studentName })
+  })
+  await row.getByTestId('delete-student').click()
+  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: 5000 })
+  await page.getByTestId('confirm-delete').click()
+  await expect(row).not.toBeVisible({ timeout: 10000 })
+
+  await context.close()
+})

--- a/e2e/tests/students.spec.ts
+++ b/e2e/tests/students.spec.ts
@@ -630,7 +630,7 @@ test('teaching todos: add, toggle covered, verify ordering on overview tab', asy
   await page.getByTestId('student-cefr').click()
   await page.getByRole('option', { name: 'B1' }).click()
   await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL(/\/students\/[^/]+$/, { timeout: 10000 })
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
 
   // Verify we're on the overview tab (default)
   await expect(page.getByTestId('tab-overview')).toHaveAttribute('aria-selected', 'true', { timeout: 5000 })
@@ -654,16 +654,16 @@ test('teaching todos: add, toggle covered, verify ordering on overview tab', asy
   await page.getByTestId('todo-add-btn').click()
   await expect(page.getByTestId('teaching-todo-item')).toHaveCount(2, { timeout: 5000 })
 
-  // Mark the first todo as covered
-  const items = page.getByTestId('teaching-todo-item')
-  const firstItem = items.first()
-  const todoText = await firstItem.getByTestId(/^todo-text-/).textContent()
-  const todoId = (await firstItem.getByTestId(/^todo-toggle-/).getAttribute('data-testid'))?.replace('todo-toggle-', '')
+  // Mark the first todo as covered — capture id before any reorder so locators stay stable
+  const toggleTestId = await page.getByTestId('teaching-todo-item').first().getByTestId(/^todo-toggle-/).getAttribute('data-testid')
+  expect(toggleTestId).toBeTruthy()
+  const todoId = toggleTestId!.replace('todo-toggle-', '')
+  const todoText = await page.getByTestId(`todo-text-${todoId}`).textContent()
 
-  await firstItem.getByTestId(`todo-toggle-${todoId}`).click()
+  await page.getByTestId(`todo-toggle-${todoId}`).click()
 
   // Wait for covered state (strikethrough)
-  await expect(firstItem.getByTestId(`todo-text-${todoId}`)).toHaveClass(/line-through/, { timeout: 5000 })
+  await expect(page.getByTestId(`todo-text-${todoId}`)).toHaveClass(/line-through/, { timeout: 5000 })
 
   // Verify ordering: pending todo should appear before covered
   const reorderedItems = page.getByTestId('teaching-todo-item')

--- a/frontend/src/api/students.ts
+++ b/frontend/src/api/students.ts
@@ -147,3 +147,22 @@ export async function getLessonHistory(studentId: string): Promise<LessonHistory
   const res = await apiClient.get<LessonHistoryEntry[]>(`/api/students/${studentId}/lesson-history`)
   return res.data
 }
+
+export async function appendTeachingTodo(studentId: string, text: string): Promise<Student> {
+  const res = await apiClient.post<Student>(`/api/students/${studentId}/teaching-todos`, { text })
+  return res.data
+}
+
+export async function updateTeachingTodo(
+  studentId: string,
+  todoId: string,
+  update: { status: string; text?: string }
+): Promise<Student> {
+  const res = await apiClient.patch<Student>(`/api/students/${studentId}/teaching-todos/${todoId}`, update)
+  return res.data
+}
+
+export async function deleteTeachingTodo(studentId: string, todoId: string): Promise<Student> {
+  const res = await apiClient.delete<Student>(`/api/students/${studentId}/teaching-todos/${todoId}`)
+  return res.data
+}

--- a/frontend/src/components/student/StudentOverviewTab.test.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.test.tsx
@@ -64,7 +64,7 @@ function renderOverview(student: Student) {
   return render(
     <QueryClientProvider client={qc}>
       <MemoryRouter>
-        <StudentOverviewTab student={student} />
+        <StudentOverviewTab student={student} onStudentChange={() => {}} />
       </MemoryRouter>
     </QueryClientProvider>
   )

--- a/frontend/src/components/student/StudentOverviewTab.test.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.test.tsx
@@ -10,6 +10,16 @@ vi.mock('@/api/followups', () => ({
   updateFollowupStatus: vi.fn(),
 }))
 
+vi.mock('@/api/students', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/students')>()
+  return {
+    ...actual,
+    appendTeachingTodo: vi.fn(),
+    updateTeachingTodo: vi.fn(),
+    deleteTeachingTodo: vi.fn(),
+  }
+})
+
 function dateOffset(days: number): string {
   const d = new Date()
   d.setDate(d.getDate() + days)

--- a/frontend/src/components/student/StudentOverviewTab.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.tsx
@@ -10,7 +10,7 @@ interface Props {
   student: Student
   followups?: TeacherFollowup[]
   onFollowupChange?: () => void
-  onStudentChange?: () => void
+  onStudentChange: () => void
 }
 
 
@@ -115,7 +115,7 @@ export function StudentOverviewTab({ student, followups = [], onFollowupChange, 
           <TeachingTodosCard
             todos={student.teachingTodos}
             studentId={student.id}
-            onStudentChange={onStudentChange ?? (() => {})}
+            onStudentChange={onStudentChange}
           />
         </div>
 

--- a/frontend/src/components/student/StudentOverviewTab.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.tsx
@@ -10,6 +10,7 @@ interface Props {
   student: Student
   followups?: TeacherFollowup[]
   onFollowupChange?: () => void
+  onStudentChange?: () => void
 }
 
 
@@ -96,7 +97,7 @@ function PrimaryObjectiveCard({ student }: { student: Student }) {
   )
 }
 
-export function StudentOverviewTab({ student, followups = [], onFollowupChange }: Props) {
+export function StudentOverviewTab({ student, followups = [], onFollowupChange, onStudentChange }: Props) {
   return (
     <div className="grid grid-cols-1 lg:grid-cols-5 gap-6" data-testid="student-overview-tab">
       {/* Main column (3/5) */}
@@ -111,7 +112,11 @@ export function StudentOverviewTab({ student, followups = [], onFollowupChange }
           style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
         >
           <SectionHeader>Teaching Todos</SectionHeader>
-          <TeachingTodosCard todos={student.teachingTodos} />
+          <TeachingTodosCard
+            todos={student.teachingTodos}
+            studentId={student.id}
+            onStudentChange={onStudentChange ?? (() => {})}
+          />
         </div>
 
         <div

--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -103,6 +103,7 @@ function renderProfile(
       <MemoryRouter>
         <StudentProfileTab
           student={student}
+          onStudentChange={() => {}}
           onToggleDifficultyStatus={opts?.onToggle}
           onSaveReasonForStudying={opts?.onSaveReason}
           onSaveInterests={opts?.onSaveInterests}
@@ -377,7 +378,7 @@ describe('StudentProfileTab', () => {
       render(
         <QueryClientProvider client={qc}>
           <MemoryRouter>
-            <StudentProfileTab student={FULL_STUDENT} followups={[FOLLOWUP]} onFollowupChange={vi.fn()} />
+            <StudentProfileTab student={FULL_STUDENT} followups={[FOLLOWUP]} onFollowupChange={vi.fn()} onStudentChange={() => {}} />
           </MemoryRouter>
         </QueryClientProvider>
       )

--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -11,6 +11,16 @@ vi.mock('@/api/followups', () => ({
   updateFollowupStatus: vi.fn(),
 }))
 
+vi.mock('@/api/students', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/students')>()
+  return {
+    ...actual,
+    appendTeachingTodo: vi.fn(),
+    updateTeachingTodo: vi.fn(),
+    deleteTeachingTodo: vi.fn(),
+  }
+})
+
 function dateOffset(days: number): string {
   const d = new Date()
   d.setDate(d.getDate() + days)

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -14,6 +14,7 @@ interface Props {
   student: Student
   followups?: TeacherFollowup[]
   onFollowupChange?: () => void
+  onStudentChange?: () => void
   onToggleDifficultyStatus?: (id: string, status: 'Active' | 'Covered') => void
   onSaveReasonForStudying?: (value: string) => Promise<void>
   onSaveInterests?: (value: string[]) => Promise<void>
@@ -294,7 +295,7 @@ function InterestsSection({
   )
 }
 
-export function StudentProfileTab({ student, followups = [], onFollowupChange, onToggleDifficultyStatus, onSaveReasonForStudying, onSaveInterests }: Props) {
+export function StudentProfileTab({ student, followups = [], onFollowupChange, onStudentChange, onToggleDifficultyStatus, onSaveReasonForStudying, onSaveInterests }: Props) {
   const parsedPersonalNotes = parseNotes(student.personalNotes)
   const parsedTeachingNotes = parseNotes(student.teachingNotes)
 
@@ -589,7 +590,11 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
           {/* Teaching Todos */}
           <section data-testid="profile-teaching-todos">
             <SectionHeader>Teaching Todos</SectionHeader>
-            <TeachingTodosCard todos={student.teachingTodos} />
+            <TeachingTodosCard
+              todos={student.teachingTodos}
+              studentId={student.id}
+              onStudentChange={onStudentChange ?? (() => {})}
+            />
           </section>
 
           {/* Pending Followups */}

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -14,7 +14,7 @@ interface Props {
   student: Student
   followups?: TeacherFollowup[]
   onFollowupChange?: () => void
-  onStudentChange?: () => void
+  onStudentChange: () => void
   onToggleDifficultyStatus?: (id: string, status: 'Active' | 'Covered') => void
   onSaveReasonForStudying?: (value: string) => Promise<void>
   onSaveInterests?: (value: string[]) => Promise<void>
@@ -593,7 +593,7 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
             <TeachingTodosCard
               todos={student.teachingTodos}
               studentId={student.id}
-              onStudentChange={onStudentChange ?? (() => {})}
+              onStudentChange={onStudentChange}
             />
           </section>
 

--- a/frontend/src/components/student/TeachingTodosCard.test.tsx
+++ b/frontend/src/components/student/TeachingTodosCard.test.tsx
@@ -1,44 +1,148 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { TeachingTodosCard } from './TeachingTodosCard'
 import type { TeachingTodo } from '@/api/students'
+import * as studentsApi from '@/api/students'
 
-const TODOS: TeachingTodo[] = [
-  { id: '1', text: 'Send exercises', createdAt: '2026-01-01T00:00:00Z', sourceSessionLogId: null, status: 'Pending', coveredInSessionLogId: null },
-  { id: '2', text: 'Explain subjunctive', createdAt: '2026-01-01T00:00:00Z', sourceSessionLogId: null, status: 'Covered', coveredInSessionLogId: 'session-1' },
-  { id: '3', text: 'Old task', createdAt: '2026-01-01T00:00:00Z', sourceSessionLogId: null, status: 'Dismissed', coveredInSessionLogId: null },
-]
+vi.mock('@/api/students', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/students')>()
+  return {
+    ...actual,
+    appendTeachingTodo: vi.fn(),
+    updateTeachingTodo: vi.fn(),
+    deleteTeachingTodo: vi.fn(),
+  }
+})
+
+const PENDING_TODO: TeachingTodo = {
+  id: '1',
+  text: 'Explain subjunctive',
+  createdAt: new Date(Date.now() - 86400000).toISOString(), // 1 day ago
+  sourceSessionLogId: null,
+  status: 'Pending',
+  coveredInSessionLogId: null,
+}
+const COVERED_TODO: TeachingTodo = {
+  id: '2',
+  text: 'Past tense review',
+  createdAt: new Date(Date.now() - 172800000).toISOString(), // 2 days ago
+  sourceSessionLogId: null,
+  status: 'Covered',
+  coveredInSessionLogId: 'session-1',
+}
+
+function makeStudent(todos: TeachingTodo[]) {
+  return { teachingTodos: todos } as unknown as import('@/api/students').Student
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+}
+
+const defaultProps = {
+  todos: [PENDING_TODO, COVERED_TODO],
+  studentId: 'student-1',
+  onStudentChange: vi.fn(),
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
 
 describe('TeachingTodosCard', () => {
-  it('renders empty state when no todos', () => {
-    render(<TeachingTodosCard todos={[]} />)
+  it('renders empty state with add prompt when no todos', () => {
+    render(<TeachingTodosCard todos={[]} studentId="s1" onStudentChange={vi.fn()} />, { wrapper })
     expect(screen.getByTestId('teaching-todos-empty')).toBeInTheDocument()
-    expect(screen.getByText('No teaching todos yet')).toBeInTheDocument()
+    expect(screen.getByText(/No ideas yet/)).toBeInTheDocument()
+    expect(screen.getByTestId('todo-add-input')).toBeInTheDocument()
   })
 
   it('renders list of todos', () => {
-    render(<TeachingTodosCard todos={TODOS} />)
+    render(<TeachingTodosCard {...defaultProps} />, { wrapper })
     expect(screen.getByTestId('teaching-todos-list')).toBeInTheDocument()
-    expect(screen.getAllByTestId('teaching-todo-item')).toHaveLength(3)
+    expect(screen.getAllByTestId('teaching-todo-item')).toHaveLength(2)
   })
 
-  it('shows correct text for each todo', () => {
-    render(<TeachingTodosCard todos={TODOS} />)
-    expect(screen.getByText('Send exercises')).toBeInTheDocument()
-    expect(screen.getByText('Explain subjunctive')).toBeInTheDocument()
-    expect(screen.getByText('Old task')).toBeInTheDocument()
-  })
-
-  it('renders status dots with correct colors', () => {
-    render(<TeachingTodosCard todos={TODOS} />)
-    expect(screen.getByTestId('todo-status-pending')).toBeInTheDocument()
-    expect(screen.getByTestId('todo-status-covered')).toBeInTheDocument()
-    expect(screen.getByTestId('todo-status-dismissed')).toBeInTheDocument()
+  it('sorts pending todos before covered ones', () => {
+    // Pass covered first to verify sorting
+    render(
+      <TeachingTodosCard
+        todos={[COVERED_TODO, PENDING_TODO]}
+        studentId="s1"
+        onStudentChange={vi.fn()}
+      />,
+      { wrapper }
+    )
+    const items = screen.getAllByTestId('teaching-todo-item')
+    expect(items[0]).toHaveTextContent('Explain subjunctive') // pending first
+    expect(items[1]).toHaveTextContent('Past tense review')   // covered second
   })
 
   it('applies strikethrough to covered todos', () => {
-    render(<TeachingTodosCard todos={TODOS} />)
-    const coveredItem = screen.getByText('Explain subjunctive')
-    expect(coveredItem.className).toContain('line-through')
+    render(<TeachingTodosCard {...defaultProps} />, { wrapper })
+    const coveredText = screen.getByTestId(`todo-text-${COVERED_TODO.id}`)
+    expect(coveredText.className).toContain('line-through')
+  })
+
+  it('shows relative time for each todo', () => {
+    render(<TeachingTodosCard {...defaultProps} />, { wrapper })
+    expect(screen.getAllByText(/ago/)).toHaveLength(2)
+  })
+
+  it('calls appendTeachingTodo on add and updates list optimistically', async () => {
+    const newStudent = makeStudent([
+      PENDING_TODO,
+      COVERED_TODO,
+      { ...PENDING_TODO, id: '3', text: 'New idea' },
+    ])
+    vi.mocked(studentsApi.appendTeachingTodo).mockResolvedValue(newStudent)
+    const onStudentChange = vi.fn()
+    render(<TeachingTodosCard todos={[PENDING_TODO, COVERED_TODO]} studentId="s1" onStudentChange={onStudentChange} />, { wrapper })
+
+    fireEvent.change(screen.getByTestId('todo-add-input'), { target: { value: 'New idea' } })
+    fireEvent.click(screen.getByTestId('todo-add-btn'))
+
+    await waitFor(() => expect(studentsApi.appendTeachingTodo).toHaveBeenCalledWith('s1', 'New idea'))
+    await waitFor(() => expect(onStudentChange).toHaveBeenCalled())
+  })
+
+  it('calls updateTeachingTodo on toggle', async () => {
+    vi.mocked(studentsApi.updateTeachingTodo).mockResolvedValue(makeStudent([
+      { ...PENDING_TODO, status: 'Covered' },
+      COVERED_TODO,
+    ]))
+    render(<TeachingTodosCard {...defaultProps} onStudentChange={vi.fn()} />, { wrapper })
+
+    fireEvent.click(screen.getByTestId(`todo-toggle-${PENDING_TODO.id}`))
+    await waitFor(() =>
+      expect(studentsApi.updateTeachingTodo).toHaveBeenCalledWith('student-1', PENDING_TODO.id, { status: 'Covered' })
+    )
+  })
+
+  it('does not show delete button without allowEdit', () => {
+    render(<TeachingTodosCard {...defaultProps} />, { wrapper })
+    expect(screen.queryByTestId(`todo-delete-${PENDING_TODO.id}`)).not.toBeInTheDocument()
+  })
+
+  it('calls deleteTeachingTodo when delete button clicked (allowEdit)', async () => {
+    vi.mocked(studentsApi.deleteTeachingTodo).mockResolvedValue(makeStudent([COVERED_TODO]))
+    render(<TeachingTodosCard {...defaultProps} allowEdit onStudentChange={vi.fn()} />, { wrapper })
+
+    // Hover is handled by CSS; click directly
+    fireEvent.click(screen.getByTestId(`todo-delete-${PENDING_TODO.id}`))
+    await waitFor(() =>
+      expect(studentsApi.deleteTeachingTodo).toHaveBeenCalledWith('student-1', PENDING_TODO.id)
+    )
+  })
+
+  it('adds on Enter key press in input', async () => {
+    vi.mocked(studentsApi.appendTeachingTodo).mockResolvedValue(makeStudent([PENDING_TODO]))
+    render(<TeachingTodosCard todos={[PENDING_TODO]} studentId="s1" onStudentChange={vi.fn()} />, { wrapper })
+
+    fireEvent.change(screen.getByTestId('todo-add-input'), { target: { value: 'Via enter' } })
+    fireEvent.keyDown(screen.getByTestId('todo-add-input'), { key: 'Enter' })
+    await waitFor(() => expect(studentsApi.appendTeachingTodo).toHaveBeenCalledWith('s1', 'Via enter'))
   })
 })

--- a/frontend/src/components/student/TeachingTodosCard.tsx
+++ b/frontend/src/components/student/TeachingTodosCard.tsx
@@ -1,49 +1,270 @@
-import { ClipboardList } from 'lucide-react'
+import { useState, useMemo } from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { Plus, Trash2, Check } from 'lucide-react'
 import type { TeachingTodo } from '@/api/students'
+import { appendTeachingTodo, updateTeachingTodo, deleteTeachingTodo } from '@/api/students'
 
-interface Props {
+interface TeachingTodosCardProps {
   todos: TeachingTodo[]
+  studentId: string
+  onStudentChange: () => void
+  allowEdit?: boolean
 }
 
-function statusDot(status: string) {
-  if (status === 'Pending') return 'bg-indigo-500'
-  if (status === 'Covered') return 'bg-green-500'
-  return 'bg-zinc-400'
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  const months = Math.floor(days / 30)
+  return `${months}mo ago`
 }
 
-export function TeachingTodosCard({ todos }: Props) {
-  if (todos.length === 0) {
-    return (
-      <div className="py-6 text-center" data-testid="teaching-todos-empty">
-        <ClipboardList className="h-6 w-6 text-zinc-300 mx-auto mb-2" />
-        <p className="text-sm text-zinc-400">No teaching todos yet</p>
-      </div>
-    )
+function sortTodos(todos: TeachingTodo[]): TeachingTodo[] {
+  return [...todos].sort((a, b) => {
+    const priority = (s: string) => (s === 'Pending' ? 0 : 1)
+    const p = priority(a.status) - priority(b.status)
+    if (p !== 0) return p
+    return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+  })
+}
+
+interface OptimisticAdd extends TeachingTodo { _temp: true }
+interface PendingUpdate { status?: string; text?: string }
+
+export function TeachingTodosCard({ todos, studentId, onStudentChange, allowEdit = false }: TeachingTodosCardProps) {
+  // Optimistic state: overlays on top of the server-provided `todos` prop
+  const [optimisticAdds, setOptimisticAdds] = useState<OptimisticAdd[]>([])
+  const [pendingUpdates, setPendingUpdates] = useState<Map<string, PendingUpdate>>(() => new Map())
+  const [deletedIds, setDeletedIds] = useState<Set<string>>(() => new Set())
+
+  const [newText, setNewText] = useState('')
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editText, setEditText] = useState('')
+
+  // Derive displayed list from server state + optimistic overlays
+  const displayedTodos = useMemo(() => {
+    const serverMerged = todos
+      .filter(t => !deletedIds.has(t.id))
+      .map(t => {
+        const pending = pendingUpdates.get(t.id)
+        return pending ? { ...t, ...pending } : t
+      })
+    return sortTodos([...serverMerged, ...optimisticAdds])
+  }, [todos, deletedIds, pendingUpdates, optimisticAdds])
+
+  const addMutation = useMutation({
+    mutationFn: (text: string) => appendTeachingTodo(studentId, text),
+    onMutate: (text) => {
+      const tempId = `temp-${Date.now()}`
+      const temp: OptimisticAdd = {
+        _temp: true,
+        id: tempId,
+        text,
+        status: 'Pending',
+        createdAt: new Date().toISOString(),
+        sourceSessionLogId: null,
+        coveredInSessionLogId: null,
+      }
+      setOptimisticAdds(prev => [...prev, temp])
+      return { tempId }
+    },
+    onSuccess: (_, __, context) => {
+      setOptimisticAdds(prev => prev.filter(t => t.id !== context?.tempId))
+      onStudentChange()
+    },
+    onError: (_, __, context) => {
+      setOptimisticAdds(prev => prev.filter(t => t.id !== context?.tempId))
+    },
+  })
+
+  const toggleMutation = useMutation({
+    mutationFn: ({ todoId, status }: { todoId: string; status: string }) =>
+      updateTeachingTodo(studentId, todoId, { status }),
+    onMutate: ({ todoId, status }) => {
+      setPendingUpdates(prev => new Map(prev).set(todoId, { ...prev.get(todoId), status }))
+    },
+    onSuccess: (_, { todoId }) => {
+      setPendingUpdates(prev => { const m = new Map(prev); m.delete(todoId); return m })
+      onStudentChange()
+    },
+    onError: (_, { todoId }) => {
+      setPendingUpdates(prev => { const m = new Map(prev); m.delete(todoId); return m })
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (todoId: string) => deleteTeachingTodo(studentId, todoId),
+    onMutate: (todoId) => {
+      setDeletedIds(prev => new Set([...prev, todoId]))
+    },
+    onSuccess: (_, todoId) => {
+      setDeletedIds(prev => { const s = new Set(prev); s.delete(todoId); return s })
+      onStudentChange()
+    },
+    onError: (_, todoId) => {
+      setDeletedIds(prev => { const s = new Set(prev); s.delete(todoId); return s })
+    },
+  })
+
+  const editMutation = useMutation({
+    mutationFn: ({ todoId, text, status }: { todoId: string; text: string; status: string }) =>
+      updateTeachingTodo(studentId, todoId, { status, text }),
+    onMutate: ({ todoId, text }) => {
+      setPendingUpdates(prev => new Map(prev).set(todoId, { ...prev.get(todoId), text }))
+    },
+    onSuccess: (_, { todoId }) => {
+      setPendingUpdates(prev => { const m = new Map(prev); m.delete(todoId); return m })
+      onStudentChange()
+    },
+    onError: (_, { todoId }) => {
+      setPendingUpdates(prev => { const m = new Map(prev); m.delete(todoId); return m })
+    },
+  })
+
+  function handleAdd() {
+    const text = newText.trim()
+    if (!text || addMutation.isPending) return
+    setNewText('')
+    addMutation.mutate(text)
+  }
+
+  function handleToggle(todo: TeachingTodo) {
+    if (toggleMutation.isPending) return
+    const next = todo.status === 'Pending' ? 'Covered' : 'Pending'
+    toggleMutation.mutate({ todoId: todo.id, status: next })
+  }
+
+  function startEdit(todo: TeachingTodo) {
+    setEditingId(todo.id)
+    setEditText(todo.text)
+  }
+
+  function commitEdit(todoId: string, currentStatus: string) {
+    const text = editText.trim()
+    setEditingId(null)
+    const originalTodo = todos.find(t => t.id === todoId) ?? displayedTodos.find(t => t.id === todoId)
+    if (text && text !== originalTodo?.text) {
+      editMutation.mutate({ todoId, text, status: currentStatus })
+    }
   }
 
   return (
-    <ul className="space-y-2" data-testid="teaching-todos-list">
-      {todos.map((todo) => {
-        const isCovered = todo.status === 'Covered'
-        const isDismissed = todo.status === 'Dismissed'
-        return (
-          <li key={todo.id} className="flex items-start gap-2.5" data-testid="teaching-todo-item">
-            <span
-              className={`mt-1.5 h-2 w-2 rounded-full shrink-0 ${statusDot(todo.status)}`}
-              data-testid={`todo-status-${todo.status.toLowerCase()}`}
-            />
-            <span
-              className={`text-sm ${
-                isCovered ? 'line-through text-zinc-400' :
-                isDismissed ? 'text-zinc-400' :
-                'text-[#1A1B22]'
-              }`}
-            >
-              {todo.text}
-            </span>
-          </li>
-        )
-      })}
-    </ul>
+    <div data-testid="teaching-todos-card">
+      {displayedTodos.length === 0 ? (
+        <p className="text-sm text-zinc-400 italic mb-3" data-testid="teaching-todos-empty">
+          No ideas yet. Add one below.
+        </p>
+      ) : (
+        <ul className="space-y-2 mb-3" data-testid="teaching-todos-list">
+          {displayedTodos.map((todo) => {
+            const isCovered = todo.status === 'Covered'
+            const isDismissed = todo.status === 'Dismissed'
+            const isInactive = isCovered || isDismissed
+            const isEditing = editingId === todo.id
+
+            return (
+              <li
+                key={todo.id}
+                className="flex items-start gap-2 group"
+                data-testid="teaching-todo-item"
+              >
+                {/* Checkbox / status toggle */}
+                <button
+                  type="button"
+                  onClick={() => handleToggle(todo)}
+                  aria-label={isCovered ? 'Mark pending' : 'Mark covered'}
+                  data-testid={`todo-toggle-${todo.id}`}
+                  className={`mt-0.5 shrink-0 w-4 h-4 rounded border-2 flex items-center justify-center transition-colors ${
+                    isCovered
+                      ? 'bg-green-500 border-green-500'
+                      : isDismissed
+                        ? 'border-zinc-300 bg-zinc-100'
+                        : 'border-indigo-400 hover:border-indigo-600'
+                  }`}
+                >
+                  {isCovered && <Check className="h-2.5 w-2.5 text-white" strokeWidth={3} />}
+                </button>
+
+                {/* Text / edit */}
+                <div className="flex-1 min-w-0">
+                  {isEditing ? (
+                    <input
+                      autoFocus
+                      type="text"
+                      value={editText}
+                      onChange={e => setEditText(e.target.value)}
+                      onBlur={() => commitEdit(todo.id, todo.status)}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter') commitEdit(todo.id, todo.status)
+                        if (e.key === 'Escape') setEditingId(null)
+                      }}
+                      maxLength={500}
+                      className="w-full text-sm border-b border-indigo-300 bg-transparent outline-none text-[#1A1B22] py-0.5"
+                      data-testid={`todo-edit-input-${todo.id}`}
+                    />
+                  ) : (
+                    <span
+                      className={`text-sm leading-snug ${
+                        isInactive ? 'line-through text-zinc-400' : 'text-[#1A1B22]'
+                      } ${allowEdit ? 'cursor-text hover:text-indigo-700' : ''}`}
+                      onClick={() => allowEdit && startEdit(todo)}
+                      data-testid={`todo-text-${todo.id}`}
+                    >
+                      {todo.text}
+                    </span>
+                  )}
+                  <span className="block text-[0.6875rem] text-zinc-400 mt-0.5" data-testid={`todo-time-${todo.id}`}>
+                    {relativeTime(todo.createdAt)}
+                  </span>
+                </div>
+
+                {/* Delete button (allowEdit only) */}
+                {allowEdit && !isEditing && (
+                  <button
+                    type="button"
+                    onClick={() => deleteMutation.mutate(todo.id)}
+                    aria-label="Delete todo"
+                    data-testid={`todo-delete-${todo.id}`}
+                    className="shrink-0 text-zinc-300 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100 mt-0.5"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      )}
+
+      {/* Add input */}
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={newText}
+          onChange={e => setNewText(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && handleAdd()}
+          placeholder="Add a teaching idea..."
+          maxLength={500}
+          className="flex-1 rounded-lg border border-zinc-200 bg-indigo-50 px-3 py-1.5 text-sm text-[#1A1B22] placeholder:text-zinc-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+          data-testid="todo-add-input"
+          disabled={addMutation.isPending}
+        />
+        <button
+          type="button"
+          onClick={handleAdd}
+          disabled={addMutation.isPending || !newText.trim()}
+          data-testid="todo-add-btn"
+          aria-label="Add todo"
+          className="shrink-0 rounded-lg bg-indigo-600 p-1.5 text-white hover:bg-indigo-700 disabled:opacity-40 transition-colors"
+        >
+          <Plus className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
   )
 }

--- a/frontend/src/components/student/TeachingTodosCard.tsx
+++ b/frontend/src/components/student/TeachingTodosCard.tsx
@@ -166,6 +166,7 @@ export function TeachingTodosCard({ todos, studentId, onStudentChange, allowEdit
             const isDismissed = todo.status === 'Dismissed'
             const isInactive = isCovered || isDismissed
             const isEditing = editingId === todo.id
+            const isOptimistic = '_temp' in todo
 
             return (
               <li
@@ -176,7 +177,7 @@ export function TeachingTodosCard({ todos, studentId, onStudentChange, allowEdit
                 {/* Checkbox / status toggle */}
                 <button
                   type="button"
-                  onClick={() => handleToggle(todo)}
+                  onClick={() => !isOptimistic && handleToggle(todo)}
                   aria-label={isCovered ? 'Mark pending' : 'Mark covered'}
                   data-testid={`todo-toggle-${todo.id}`}
                   className={`mt-0.5 shrink-0 w-4 h-4 rounded border-2 flex items-center justify-center transition-colors ${
@@ -211,8 +212,8 @@ export function TeachingTodosCard({ todos, studentId, onStudentChange, allowEdit
                     <span
                       className={`text-sm leading-snug ${
                         isInactive ? 'line-through text-zinc-400' : 'text-[#1A1B22]'
-                      } ${allowEdit ? 'cursor-text hover:text-indigo-700' : ''}`}
-                      onClick={() => allowEdit && startEdit(todo)}
+                      } ${allowEdit && !isOptimistic ? 'cursor-text hover:text-indigo-700' : ''}`}
+                      onClick={() => allowEdit && !isOptimistic && startEdit(todo)}
                       data-testid={`todo-text-${todo.id}`}
                     >
                       {todo.text}
@@ -223,8 +224,8 @@ export function TeachingTodosCard({ todos, studentId, onStudentChange, allowEdit
                   </span>
                 </div>
 
-                {/* Delete button (allowEdit only) */}
-                {allowEdit && !isEditing && (
+                {/* Delete button (allowEdit only, not for provisional optimistic items) */}
+                {allowEdit && !isEditing && !isOptimistic && (
                   <button
                     type="button"
                     onClick={() => deleteMutation.mutate(todo.id)}

--- a/frontend/src/pages/StudentDetail.test.tsx
+++ b/frontend/src/pages/StudentDetail.test.tsx
@@ -14,6 +14,9 @@ vi.mock('../api/followups', () => ({
 vi.mock('../api/students', () => ({
   getStudent: vi.fn(),
   updateStudent: vi.fn(),
+  appendTeachingTodo: vi.fn(),
+  updateTeachingTodo: vi.fn(),
+  deleteTeachingTodo: vi.fn(),
 }))
 
 vi.mock('../api/sessionLogs', () => ({
@@ -343,6 +346,6 @@ describe('StudentDetail - Profile tab sections', () => {
     expect(screen.getByText('No identity details added yet')).toBeInTheDocument()
     expect(screen.getByText('No learning goals set')).toBeInTheDocument()
     expect(screen.getByText('No objectives set')).toBeInTheDocument()
-    expect(screen.getByText('No teaching todos yet')).toBeInTheDocument()
+    expect(screen.getByTestId('teaching-todos-empty')).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -12,7 +12,6 @@ import { StudentProfileTab } from '@/components/student/StudentProfileTab'
 import { StudentOverviewTab } from '@/components/student/StudentOverviewTab'
 import { SessionHistoryTab } from '@/components/session/SessionHistoryTab'
 import { ProgressDashboard } from '@/components/student/ProgressDashboard'
-import { TeachingTodosCard } from '@/components/student/TeachingTodosCard'
 import { SessionLogDialog } from '@/components/session/SessionLogDialog'
 
 function getInitials(name: string): string {
@@ -47,6 +46,9 @@ export default function StudentDetail() {
   })
 
   const onFollowupChange = useCallback(() => { refetchFollowups() }, [refetchFollowups])
+  const onStudentChange = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['student', id] })
+  }, [queryClient, id])
 
   function buildStudentPayload() {
     if (!student) throw new Error('Student not loaded')
@@ -278,6 +280,7 @@ export default function StudentDetail() {
           student={student}
           followups={followups}
           onFollowupChange={onFollowupChange}
+          onStudentChange={onStudentChange}
         />
       )}
 
@@ -286,6 +289,7 @@ export default function StudentDetail() {
           student={student}
           followups={followups}
           onFollowupChange={onFollowupChange}
+          onStudentChange={onStudentChange}
           onToggleDifficultyStatus={(difficultyId, status) =>
             toggleDifficultyStatus({ difficultyId, status })
           }
@@ -295,18 +299,7 @@ export default function StudentDetail() {
       )}
 
       {activeTab === 'sessions' && (
-        <div className="space-y-6">
-          <SessionHistoryTab studentId={student.id} />
-          <div
-            className="bg-white rounded-2xl p-6"
-            style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
-          >
-            <h3 className="text-[0.6875rem] font-semibold uppercase tracking-[0.05em] text-zinc-500 mb-3">
-              Teaching Todos
-            </h3>
-            <TeachingTodosCard todos={student.teachingTodos} />
-          </div>
-        </div>
+        <SessionHistoryTab studentId={student.id} />
       )}
 
       {activeTab === 'progress' && (

--- a/frontend/src/pages/StudentForm.test.tsx
+++ b/frontend/src/pages/StudentForm.test.tsx
@@ -20,6 +20,9 @@ vi.mock('../api/students', () => ({
   createStudent: (...args: unknown[]) => mockCreateStudent(...args),
   updateStudent: (...args: unknown[]) => mockUpdateStudent(...args),
   getStudents: (...args: unknown[]) => mockGetStudents(...args),
+  appendTeachingTodo: vi.fn(),
+  updateTeachingTodo: vi.fn(),
+  deleteTeachingTodo: vi.fn(),
 }))
 
 vi.mock('../lib/logger', () => ({
@@ -709,4 +712,29 @@ describe('StudentForm', () => {
     })
   })
 
+  it('shows teaching todos sidebar in edit mode', async () => {
+    mockGetStudent.mockResolvedValue({
+      id: 'stu-1', name: 'Ana', learningLanguage: 'Spanish', cefrLevel: 'B1',
+      interests: [], nativeLanguages: [], learningGoals: [], weaknesses: [], difficulties: [],
+      personalNotes: null, teachingNotes: null,
+      teachingTodos: [
+        { id: 't1', text: 'Review subjunctive', status: 'Pending', createdAt: '2026-01-01T00:00:00Z', sourceSessionLogId: null, coveredInSessionLogId: null },
+      ],
+      shortTermObjectives: [], spokenLanguages: [],
+      birthYear: null, profession: null, countryOfOrigin: null, cityOfOrigin: null,
+      countryOfResidence: null, cityOfResidence: null, reasonForStudying: null,
+      officialCefrLevel: null, isActive: true, isCorporate: false, rate: null,
+      createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z',
+    })
+    renderEdit()
+    expect(await screen.findByTestId('sidebar-teaching-todos')).toBeInTheDocument()
+    expect(await screen.findByText('Review subjunctive')).toBeInTheDocument()
+    // Delete button visible (allowEdit=true on sidebar)
+    expect(screen.getByTestId('todo-delete-t1')).toBeInTheDocument()
+  })
+
+  it('does not show teaching todos sidebar in create mode', () => {
+    renderNew()
+    expect(screen.queryByTestId('form-sidebar')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState, useRef } from 'react'
+import { useCallback, useEffect, useState, useRef } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { X, Plus, Trash2 } from 'lucide-react'
 import { getStudent, createStudent, updateStudent, type StudentFormData, type Difficulty, type StudentWeaknessItem, type ShortTermObjective } from '../api/students'
+import { TeachingTodosCard } from '@/components/student/TeachingTodosCard'
 import { getObjectiveUrgency } from '@/lib/objectiveUrgency'
 import { LEARNING_GOALS, COMPETENCY_OPTIONS } from '../lib/studentOptions'
 import { logger } from '../lib/logger'
@@ -23,6 +24,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import { MultiSelect } from '@/components/ui/multi-select'
 import { StudentCoursesCard } from '@/components/student/StudentCoursesCard'
 import { StudentFollowupsCard } from '@/components/student/StudentFollowupsCard'
+import { SectionHeader } from '@/components/student/SectionHeader'
 import { getFollowups } from '@/api/followups'
 import { FieldTooltip } from '@/components/FieldTooltip'
 import { PageHeader } from '@/components/PageHeader'
@@ -68,6 +70,19 @@ export default function StudentForm() {
     queryFn: () => getFollowups(id!),
     enabled: isEdit && !!id,
   })
+
+  // Separate query for sidebar todos — intentionally uses the singular key ['student', id]
+  // (not ['students', id] used by the form) so that invalidating it on todo mutations
+  // does NOT trigger a refetch of the form data and reset unsaved field edits.
+  const { data: sidebarStudent } = useQuery({
+    queryKey: ['student', id],
+    queryFn: () => getStudent(id!),
+    enabled: isEdit && !!id,
+  })
+  const sidebarTodos = sidebarStudent?.teachingTodos ?? []
+  const onSidebarTodoChange = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['student', id] })
+  }, [queryClient, id])
 
   // Sync server student data to local form state
   /* eslint-disable react-hooks/set-state-in-effect */
@@ -254,7 +269,8 @@ export default function StudentForm() {
   }
 
   return (
-    <div className="max-w-2xl space-y-6">
+    <div className={isEdit ? 'grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_280px] gap-6 items-start' : 'max-w-2xl space-y-6'}>
+    <div className="space-y-6">
       <PageHeader
         backTo="/students"
         backLabel="Students"
@@ -806,22 +822,36 @@ export default function StudentForm() {
         </Card>
       </form>
 
-      {isEdit && id && (
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-base">Pending Followups</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <StudentFollowupsCard
-              followups={followups}
-              studentId={id}
-              onFollowupChange={() => refetchFollowups()}
-            />
-          </CardContent>
-        </Card>
-      )}
-
       {isEdit && id && <StudentCoursesCard studentId={id} />}
+    </div>
+
+    {isEdit && id && (
+      <div className="space-y-4 lg:sticky lg:top-6" data-testid="form-sidebar">
+        <div
+          className="bg-white rounded-2xl p-4"
+          style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
+          data-testid="sidebar-teaching-todos"
+        >
+          <SectionHeader>Teaching Todos</SectionHeader>
+          <TeachingTodosCard
+            todos={sidebarTodos}
+            studentId={id}
+            onStudentChange={onSidebarTodoChange}
+            allowEdit
+          />
+        </div>
+        <div
+          className="bg-white rounded-2xl p-4"
+          style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
+        >
+          <StudentFollowupsCard
+            followups={followups}
+            studentId={id}
+            onFollowupChange={() => refetchFollowups()}
+          />
+        </div>
+      </div>
+    )}
     </div>
   )
 }

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -79,7 +79,7 @@ export default function StudentForm() {
     queryFn: () => getStudent(id!),
     enabled: isEdit && !!id,
   })
-  const sidebarTodos = sidebarStudent?.teachingTodos ?? []
+  const sidebarTodos = sidebarStudent?.teachingTodos ?? existing?.teachingTodos ?? []
   const onSidebarTodoChange = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: ['student', id] })
   }, [queryClient, id])

--- a/plan/langteach-beta/task665-teaching-todos-inline-ui.md
+++ b/plan/langteach-beta/task665-teaching-todos-inline-ui.md
@@ -1,0 +1,118 @@
+# Task 665: Teaching Todos Inline UI
+
+## Issue
+https://github.com/Robert-Freire/langTeachSaaS/issues/665
+
+## Context
+Backend is complete (#627 + #688):
+- `POST /api/students/{id}/teaching-todos` — create
+- `PATCH /api/students/{id}/teaching-todos/{todoId}` — update status and/or text
+- `DELETE /api/students/{id}/teaching-todos/{todoId}` — delete
+
+The `StudentOverviewTab` (added by #688) exists with a read-only `TeachingTodosCard`.
+`StudentProfileTab` also has a read-only card. Sessions tab has a stray read-only card
+(to be removed — todos live in Overview per field mapping). `StudentForm` has no todos.
+
+## Design decisions
+- `studentId` derived from `student.id` inside Overview/Profile tab components (not an extra prop).
+- Only `onStudentChange` added to those Props interfaces.
+- Sessions tab `TeachingTodosCard` removed (it was a placeholder; Overview is the correct location).
+- `allowEdit` prop enables delete + inline text edit (edit form sidebar only).
+- Reorder deferred — no backend endpoint. Todos displayed pending-first, then covered/dismissed.
+- `StudentForm` sidebar uses separate query key `['student', id]` to avoid resetting form fields.
+- `StudentFollowupsCard` moves from below the form to the sidebar (same data, same query).
+
+## Files to change
+
+### 1. `frontend/src/api/students.ts`
+Add:
+```ts
+appendTeachingTodo(studentId: string, text: string): Promise<Student>
+updateTeachingTodo(studentId: string, todoId: string, update: { status: string; text?: string }): Promise<Student>
+deleteTeachingTodo(studentId: string, todoId: string): Promise<Student>
+```
+
+### 2. `frontend/src/components/student/TeachingTodosCard.tsx`
+Full rewrite. Props:
+```ts
+interface TeachingTodosCardProps {
+  todos: TeachingTodo[]
+  studentId: string
+  onStudentChange: () => void
+  allowEdit?: boolean   // enables delete + inline text edit; default false
+}
+```
+- Local `localTodos` state for optimistic updates.
+- On add: POST, optimistically append temp todo, on success onStudentChange + sync.
+- On toggle: PATCH status, optimistically flip status.
+- On delete (allowEdit): DELETE, optimistically remove.
+- On text edit (allowEdit): PATCH text, optimistically update text.
+- Sort: pending first, covered/dismissed after (stable within group by createdAt).
+- Relative time: "2d ago", "just now", etc.
+- Indigo convention: indigo ring checkbox for pending, green filled for covered.
+- Empty state: "No ideas yet. Add one below." with input visible.
+
+### 3. `frontend/src/components/student/TeachingTodosCard.test.tsx`
+Full rewrite (all render calls need new required props). Cover:
+- Empty state renders add prompt
+- Renders list of todos with correct status styling
+- Add mutation called on Enter / button click
+- Toggle mutation called on checkbox click
+- Delete mutation called (allowEdit=true)
+- Pending todos sorted before covered ones
+
+### 4. `frontend/src/components/student/StudentOverviewTab.tsx`
+- Add `onStudentChange?: () => void` to Props.
+- Pass `studentId={student.id}` and `onStudentChange={onStudentChange ?? (() => {})}` to TeachingTodosCard.
+
+### 5. `frontend/src/components/student/StudentOverviewTab.test.tsx`
+- Add `onStudentChange` where TeachingTodosCard renders (mock-mutation friendly).
+
+### 6. `frontend/src/components/student/StudentProfileTab.tsx`
+- Add `onStudentChange?: () => void` to Props.
+- Pass `studentId={student.id}` and `onStudentChange` to TeachingTodosCard.
+
+### 7. `frontend/src/components/student/StudentProfileTab.test.tsx`
+- Update TeachingTodosCard test helpers to include new props.
+
+### 8. `frontend/src/pages/StudentDetail.tsx`
+- Add `onStudentChange = useCallback(() => { queryClient.invalidateQueries({ queryKey: ['student', id] }) }, [queryClient, id])`.
+- Pass `onStudentChange` to `StudentOverviewTab` and `StudentProfileTab`.
+- **Remove** `TeachingTodosCard` from sessions tab (the sessions tab renders session history; todos live in overview).
+
+### 9. `frontend/src/pages/StudentForm.tsx`
+Layout change for edit mode:
+- Outer container: `isEdit ? 'grid grid-cols-1 lg:grid-cols-[1fr_280px] gap-6 items-start' : 'max-w-2xl space-y-6'`
+- Left column: PageHeader + `<form>` + StudentCoursesCard (existing content).
+- Right column (edit only, sticky): TeachingTodosCard (allowEdit=true) + StudentFollowupsCard.
+  - Remove the existing StudentFollowupsCard below the form.
+  - Add separate query: `queryKey: ['student', id]` → `studentSidebar`.
+  - `onStudentChange` for todos: `() => queryClient.invalidateQueries({ queryKey: ['student', id] })`.
+  - Followups remain on existing `['followups', id]` query.
+
+### 10. `frontend/src/pages/StudentForm.test.tsx`
+Add tests for teaching todos sidebar appearance in edit mode.
+
+### 11. `e2e/tests/students.spec.ts`
+E2E happy path:
+1. Navigate to /students, click into a student with existing todos (from DemoSeeder).
+2. Confirm overview tab is default; todos card is visible.
+3. Add a new todo via the input.
+4. Verify it appears in the list as pending.
+5. Click its checkbox to mark as covered.
+6. Verify strikethrough applied.
+7. Verify the order: pending todos come before covered ones (use a student with mixed statuses from seeder).
+
+## Acceptance criteria traceability
+| AC | Covered by |
+|----|-----------|
+| Add inline (Overview + Profile) | Step 2 mutations + Steps 4, 6, 8 |
+| Toggle status one click | Step 2 toggle + optimistic |
+| Pending before covered | Step 2 sort |
+| Covered = strikethrough + green | Step 2 styling |
+| Relative time | Step 2 createdAt format |
+| Edit form manageable (add/toggle/text/delete) | Step 9, allowEdit=true |
+| Empty state with add prompt | Step 2 empty state |
+| Optimistic UI | Step 2 local state |
+| Indigo convention | Step 2 styling |
+| Stitch design | Steps 2, 4, 6, 9 |


### PR DESCRIPTION
## Summary

- Adds interactive Teaching Todos card (add, toggle Pending/Covered, delete, inline text edit) to StudentDetail Overview tab and Profile tab
- Shows the same card with `allowEdit` in the StudentForm edit sidebar, alongside the existing Followups card (both moved into a sticky right-side panel)
- Optimistic UI via useMemo overlay (no useEffect, avoids React lint violations); separate query key `['student', id]` for sidebar prevents form reset on todo mutations

## Test plan

- [ ] Unit: `TeachingTodosCard.test.tsx` (10 tests — empty state, render, sort, strikethrough, relative time, add, toggle, delete, Enter key)
- [ ] Unit: `StudentForm.test.tsx` — sidebar visible in edit mode, hidden in create mode
- [ ] Unit: `StudentDetail.test.tsx` and `StudentProfileTab.test.tsx` — mocks updated, all pass
- [ ] E2E: `students.spec.ts` — add todo, toggle covered, verify ordering on Overview tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full teaching todos management: create, edit, mark as complete, and delete teaching todos for students.
  * Implemented automatic sorting (pending todos first) and strikethrough styling for completed items.
  * Added relative timestamps (e.g., "2 hours ago") to teaching todos.
  * Added a teaching todos sidebar in student editing view for quick access and management.

* **Tests**
  * Added comprehensive E2E and unit tests for teaching todos functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->