### PR TITLE
fix: replace invalid 'Reading' competency with 'Discourse' in DemoSeeder (#683)

### DIFF
--- a/backend/LangTeach.Api/Data/DemoSeeder.cs
+++ b/backend/LangTeach.Api/Data/DemoSeeder.cs
@@ -302,7 +302,7 @@ public static class DemoSeeder
             NativeLanguages     = """["Spanish"]""",
             LearningGoals       = """["Achieve C1 certification","Improve academic writing"]""",
             Interests           = """["history","cinema","chess"]""",
-            Difficulties        = """[{"id":"d1","description":"Third conditional structures","competency":"Grammar","subcategory":"Conditionals","severity":"medium","status":"Active","trend":"stable"},{"id":"d2","description":"Academic vocabulary range","competency":"Vocabulary","subcategory":"Academic","severity":"high","status":"Active","trend":"worsening"},{"id":"d3","description":"Reading speed","competency":"Reading","subcategory":"Comprehension","severity":"low","status":"Covered","trend":"improving"}]""",
+            Difficulties        = """[{"id":"d1","description":"Third conditional structures","competency":"Grammar","subcategory":"Conditionals","severity":"medium","status":"Active","trend":"stable"},{"id":"d2","description":"Academic vocabulary range","competency":"Vocabulary","subcategory":"Academic","severity":"high","status":"Active","trend":"worsening"},{"id":"d3","description":"Reading speed","competency":"Discourse","subcategory":"Comprehension","severity":"low","status":"Covered","trend":"improving"}]""",
             Weaknesses          = "[]",
             PersonalNotes       = "[scenario-seed]",
             BirthYear           = 1988,

--- a/plan/langteach-beta/task683-fix-demo-seeder-competency.md
+++ b/plan/langteach-beta/task683-fix-demo-seeder-competency.md
@@ -1,0 +1,12 @@
+# Task 683 — Fix DemoSeeder "Reading" competency
+
+## Problem
+`DemoSeeder.cs:305` seeded Clara Seed's difficulty record with `competency:"Reading"`, which is not in the difficulty taxonomy (`Grammar, Vocabulary, Pronunciation, Interaction, Discourse, Mediation`).
+
+## Fix
+Replaced `"competency":"Reading"` with `"competency":"Discourse"` (best fit for "Reading speed / Comprehension").
+
+## Acceptance Criteria
+- [x] `DemoSeeder.cs:305` no longer seeds a difficulty record with `competency: "Reading"`
+- [x] The replacement competency is `Discourse`
+- [ ] All existing e2e / visual specs that use Clara Seed data continue to pass


### PR DESCRIPTION
## Summary
- Replaces `"competency":"Reading"` with `"competency":"Discourse"` in Clara Seed's difficulty record at `DemoSeeder.cs:305`
- `Reading` was not in the difficulty taxonomy (`Grammar, Vocabulary, Pronunciation, Interaction, Discourse, Mediation`); `Discourse` is the correct fit for "Reading speed / Comprehension"

## Test plan
- [x] `dotnet test` passes
- [x] No e2e test asserts on the old "Reading" competency value for Clara Seed

Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data**
  * Updated demonstration data to refine difficulty category assignments for sample student profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->