### PR TITLE
feat: redesign Students list to match Stitch design (#675)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
@@ -252,4 +252,35 @@ public class DashboardServiceTests : IDisposable
 
         result.ActiveStudents.Should().NotContain(s => s.StudentId == inactiveId);
     }
+
+    [Fact]
+    public async Task GetAsync_CancelledSessions_CountsOnlyLast30Days()
+    {
+        var within30Days = DateTime.UtcNow.AddDays(-10);
+        var within30DaysAlso = DateTime.UtcNow.AddDays(-25);
+        var olderThan30Days = DateTime.UtcNow.AddDays(-35);
+
+        _db.SessionLogs.Add(MakeSession(_studentId, within30Days, isCancelled: true));
+        _db.SessionLogs.Add(MakeSession(_studentId, within30DaysAlso, isCancelled: true));
+        _db.SessionLogs.Add(MakeSession(_studentId, olderThan30Days, isCancelled: true));
+        _db.SaveChanges();
+
+        var result = await _sut.GetAsync(_teacherId);
+
+        result.ActiveStudents.Should().HaveCount(1);
+        result.ActiveStudents[0].CancelledSessionsLast30Days.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetAsync_DeletedCancelledSessions_NotCounted()
+    {
+        var within30Days = DateTime.UtcNow.AddDays(-5);
+
+        _db.SessionLogs.Add(MakeSession(_studentId, within30Days, isCancelled: true, isDeleted: true));
+        _db.SaveChanges();
+
+        var result = await _sut.GetAsync(_teacherId);
+
+        result.ActiveStudents[0].CancelledSessionsLast30Days.Should().Be(0);
+    }
 }

--- a/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
@@ -254,15 +254,17 @@ public class DashboardServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task GetAsync_CancelledSessions_CountsOnlyLast30Days()
+    public async Task GetAsync_CancelledSessions_CountsOnlyLast30DaysPastSessions()
     {
         var within30Days = DateTime.UtcNow.AddDays(-10);
         var within30DaysAlso = DateTime.UtcNow.AddDays(-25);
         var olderThan30Days = DateTime.UtcNow.AddDays(-35);
+        var futureCancelled = DateTime.UtcNow.AddDays(5); // future — should NOT count
 
         _db.SessionLogs.Add(MakeSession(_studentId, within30Days, isCancelled: true));
         _db.SessionLogs.Add(MakeSession(_studentId, within30DaysAlso, isCancelled: true));
         _db.SessionLogs.Add(MakeSession(_studentId, olderThan30Days, isCancelled: true));
+        _db.SessionLogs.Add(MakeSession(_studentId, futureCancelled, isCancelled: true));
         _db.SaveChanges();
 
         var result = await _sut.GetAsync(_teacherId);

--- a/backend/LangTeach.Api/DTOs/DashboardDtos.cs
+++ b/backend/LangTeach.Api/DTOs/DashboardDtos.cs
@@ -33,7 +33,8 @@ public record ActiveStudentDto(
     DateTime? NextSessionDate,
     int TotalSessions,
     int TeachingTodosCount,
-    List<TeachingTodoDto> PendingTodos
+    List<TeachingTodoDto> PendingTodos,
+    int CancelledSessionsLast30Days
 );
 
 public record DashboardDto(

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -93,6 +93,8 @@ public class DashboardService : IDashboardService
 
     private async Task<List<ActiveStudentDto>> GetActiveStudentsAsync(Guid teacherId, DateTime now, CancellationToken cancellationToken)
     {
+        var cutoff30Days = now.AddDays(-30);
+
         var rows = await _db.Students
             .Where(s => s.TeacherId == teacherId && !s.IsDeleted && s.IsActive)
             .Select(s => new
@@ -109,7 +111,12 @@ public class DashboardService : IDashboardService
                 NextSessionDate = s.SessionLogs
                     .Where(sl => !sl.IsDeleted && !sl.IsCancelled && sl.SessionDate.HasValue && sl.SessionDate.Value > now)
                     .Min(sl => (DateTime?)sl.SessionDate),
-                TotalSessions = s.SessionLogs.Count(sl => !sl.IsDeleted)
+                TotalSessions = s.SessionLogs.Count(sl => !sl.IsDeleted),
+                CancelledSessionsLast30Days = s.SessionLogs
+                    .Count(sl => !sl.IsDeleted
+                              && sl.IsCancelled
+                              && sl.SessionDate.HasValue
+                              && sl.SessionDate.Value >= cutoff30Days)
             })
             .ToListAsync(cancellationToken);
 
@@ -127,7 +134,8 @@ public class DashboardService : IDashboardService
                 NextSessionDate: r.NextSessionDate,
                 TotalSessions: r.TotalSessions,
                 TeachingTodosCount: allTodos.Count,
-                PendingTodos: pendingTodos
+                PendingTodos: pendingTodos,
+                CancelledSessionsLast30Days: r.CancelledSessionsLast30Days
             );
         }).ToList();
     }

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -116,7 +116,8 @@ public class DashboardService : IDashboardService
                     .Count(sl => !sl.IsDeleted
                               && sl.IsCancelled
                               && sl.SessionDate.HasValue
-                              && sl.SessionDate.Value >= cutoff30Days)
+                              && sl.SessionDate.Value >= cutoff30Days
+                              && sl.SessionDate.Value <= now)
             })
             .ToListAsync(cancellationToken);
 

--- a/frontend/src/api/dashboard.ts
+++ b/frontend/src/api/dashboard.ts
@@ -44,6 +44,7 @@ export interface ActiveStudent {
   totalSessions: number
   teachingTodosCount: number
   pendingTodos: PendingTodo[]
+  cancelledSessionsLast30Days: number
 }
 
 export interface DashboardData {

--- a/frontend/src/components/dashboard/StudentRoster.test.tsx
+++ b/frontend/src/components/dashboard/StudentRoster.test.tsx
@@ -16,6 +16,7 @@ function makeStudent(overrides: Partial<ActiveStudent> = {}): ActiveStudent {
     totalSessions: 5,
     teachingTodosCount: 0,
     pendingTodos: [],
+    cancelledSessionsLast30Days: 0,
     ...overrides,
   }
 }

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -54,6 +54,7 @@ function makeDashboard(overrides: Partial<DashboardData> = {}): DashboardData {
         pendingTodos: [
           { id: 't1', text: 'Review ser/estar', createdAt: new Date().toISOString(), status: 'pending', sourceSessionLogId: null, coveredInSessionLogId: null },
         ],
+        cancelledSessionsLast30Days: 0,
       },
     ],
     pendingFollowups: [],

--- a/frontend/src/pages/Students.test.tsx
+++ b/frontend/src/pages/Students.test.tsx
@@ -21,6 +21,9 @@ vi.mock('../lib/logger', () => ({
 
 const emptyDashboard = { nextSession: null, todaySessions: [], activeStudents: [], pendingFollowups: [] }
 
+// Default createdAt is 30 days ago to avoid triggering the NEW signal badge
+const DEFAULT_CREATED_AT = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
+
 function makeStudent(overrides: Partial<studentsApi.Student> = {}): studentsApi.Student {
   return {
     id: 'abc-123',
@@ -34,12 +37,29 @@ function makeStudent(overrides: Partial<studentsApi.Student> = {}): studentsApi.
     learningGoals: [],
     weaknesses: [],
     difficulties: [],
-    createdAt: '',
+    createdAt: DEFAULT_CREATED_AT,
     updatedAt: '',
     birthYear: null, profession: null, countryOfOrigin: null, cityOfOrigin: null,
     countryOfResidence: null, cityOfResidence: null, reasonForStudying: null,
     officialCefrLevel: null, shortTermObjectives: [], isActive: true, isCorporate: false,
     rate: null, spokenLanguages: [], teachingTodos: [], skillLevelOverrides: {},
+    ...overrides,
+  }
+}
+
+function makeActiveStudent(overrides: Partial<dashboardApi.ActiveStudent> = {}): dashboardApi.ActiveStudent {
+  return {
+    studentId: 'abc-123',
+    name: 'Ana García',
+    cefrLevel: 'B2',
+    nativeLanguages: [],
+    isActive: true,
+    lastSessionDate: null,
+    nextSessionDate: null,
+    totalSessions: 5,
+    teachingTodosCount: 0,
+    pendingTodos: [],
+    cancelledSessionsLast30Days: 0,
     ...overrides,
   }
 }
@@ -183,7 +203,7 @@ describe('Students page', () => {
     expect(screen.getByText('No students match your search.')).toBeInTheDocument()
   })
 
-  it('renders dashboard-sourced signals when dashboard data available', async () => {
+  it('renders Review pending signal when student has pending todos', async () => {
     vi.mocked(studentsApi.getStudents).mockResolvedValue(
       makeListResponse([makeStudent({ id: 'abc-123' })])
     )
@@ -192,23 +212,189 @@ describe('Students page', () => {
       todaySessions: [],
       pendingFollowups: [],
       activeStudents: [
-        {
+        makeActiveStudent({
           studentId: 'abc-123',
-          name: 'Ana García',
-          cefrLevel: 'B2',
-          nativeLanguages: [],
-          isActive: true,
-          lastSessionDate: null,
-          nextSessionDate: null,
-          totalSessions: 0,
           teachingTodosCount: 3,
-          pendingTodos: [],
-        },
+          pendingTodos: [{ id: 't1', text: 'Review grammar', createdAt: '', sourceSessionLogId: null, status: 'pending', coveredInSessionLogId: null }],
+        }),
       ],
     })
 
     wrapper(<Students />)
     await screen.findByTestId('student-name')
-    expect(screen.getByText('3 followups')).toBeInTheDocument()
+    expect(screen.getByText('Review pending')).toBeInTheDocument()
+  })
+
+  it('renders initials avatar for each student', async () => {
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([makeStudent({ name: 'Ana García' })])
+    )
+    wrapper(<Students />)
+    const avatar = await screen.findByTestId('student-avatar')
+    expect(avatar).toHaveTextContent('AG')
+  })
+
+  it('sort by Name orders students alphabetically', async () => {
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([
+        makeStudent({ id: 'z', name: 'Zara Smith' }),
+        makeStudent({ id: 'a', name: 'Ana García' }),
+      ])
+    )
+    wrapper(<Students />)
+    await screen.findByText('Zara Smith')
+
+    const select = screen.getByRole('combobox', { name: /sort/i })
+    fireEvent.change(select, { target: { value: 'name' } })
+
+    const names = screen.getAllByTestId('student-name').map(el => el.textContent)
+    expect(names[0]).toBe('Ana García')
+    expect(names[1]).toBe('Zara Smith')
+  })
+
+  it('sort by CEFR Level orders students from A1 to C2', async () => {
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([
+        makeStudent({ id: 'b', name: 'Bruno', cefrLevel: 'B2' }),
+        makeStudent({ id: 'a', name: 'Ana', cefrLevel: 'A1' }),
+      ])
+    )
+    wrapper(<Students />)
+    await screen.findByText('Bruno')
+
+    const select = screen.getByRole('combobox', { name: /sort/i })
+    fireEvent.change(select, { target: { value: 'cefrLevel' } })
+
+    const names = screen.getAllByTestId('student-name').map(el => el.textContent)
+    expect(names[0]).toBe('Ana')
+    expect(names[1]).toBe('Bruno')
+  })
+
+  it('shows Inactive Xd badge in red for student with 20-day gap', async () => {
+    const lastSession = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000).toISOString()
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([makeStudent({ id: 'abc-123' })])
+    )
+    vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
+      nextSession: null, todaySessions: [], pendingFollowups: [],
+      activeStudents: [makeActiveStudent({ studentId: 'abc-123', lastSessionDate: lastSession, nextSessionDate: null })],
+    })
+    wrapper(<Students />)
+    await screen.findByTestId('student-name')
+    expect(screen.getByText('Inactive 20d')).toBeInTheDocument()
+  })
+
+  it('shows Cancelled 2x badge when student had 2+ cancellations in last 30 days', async () => {
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([makeStudent({ id: 'abc-123' })])
+    )
+    vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
+      nextSession: null, todaySessions: [], pendingFollowups: [],
+      activeStudents: [makeActiveStudent({ studentId: 'abc-123', cancelledSessionsLast30Days: 2 })],
+    })
+    wrapper(<Students />)
+    await screen.findByTestId('student-name')
+    expect(screen.getByText('Cancelled 2x')).toBeInTheDocument()
+  })
+
+  it('shows NEW badge for student created 5 days ago with fewer than 3 sessions', async () => {
+    const recentDate = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString()
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([makeStudent({ id: 'abc-123', createdAt: recentDate })])
+    )
+    vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
+      nextSession: null, todaySessions: [], pendingFollowups: [],
+      activeStudents: [makeActiveStudent({ studentId: 'abc-123', totalSessions: 1 })],
+    })
+    wrapper(<Students />)
+    await screen.findByTestId('student-name')
+    expect(screen.getByText('NEW')).toBeInTheDocument()
+  })
+
+  it('does not show NEW badge for student created 20 days ago', async () => {
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([makeStudent({ id: 'abc-123' })])
+    )
+    vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
+      nextSession: null, todaySessions: [], pendingFollowups: [],
+      activeStudents: [makeActiveStudent({ studentId: 'abc-123', totalSessions: 1 })],
+    })
+    wrapper(<Students />)
+    await screen.findByTestId('student-name')
+    expect(screen.queryByText('NEW')).not.toBeInTheDocument()
+  })
+
+  it('shows Exam prep badge for student with objective due in 3 weeks', async () => {
+    const targetDate = new Date(Date.now() + 21 * 24 * 60 * 60 * 1000).toISOString()
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([makeStudent({
+        id: 'abc-123',
+        shortTermObjectives: [{ id: 'obj1', text: 'DELE B2 exam', targetDate }],
+      })])
+    )
+    vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
+      nextSession: null, todaySessions: [], pendingFollowups: [],
+      activeStudents: [makeActiveStudent({ studentId: 'abc-123' })],
+    })
+    wrapper(<Students />)
+    await screen.findByTestId('student-name')
+    expect(screen.getByText('Exam prep')).toBeInTheDocument()
+  })
+
+  it('shows RETURNING badge for student inactive 35 days who now has upcoming session', async () => {
+    const lastSession = new Date(Date.now() - 35 * 24 * 60 * 60 * 1000).toISOString()
+    const nextSession = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString()
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([makeStudent({ id: 'abc-123' })])
+    )
+    vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
+      nextSession: null, todaySessions: [], pendingFollowups: [],
+      activeStudents: [makeActiveStudent({ studentId: 'abc-123', lastSessionDate: lastSession, nextSessionDate: nextSession })],
+    })
+    wrapper(<Students />)
+    await screen.findByTestId('student-name')
+    expect(screen.getByText('RETURNING')).toBeInTheDocument()
+    expect(screen.queryByText(/Inactive/)).not.toBeInTheDocument()
+  })
+
+  it('shows load more button when students exceed page size and loads more on click', async () => {
+    const students = Array.from({ length: 13 }, (_, i) =>
+      makeStudent({ id: `s${i}`, name: `Student ${String(i).padStart(2, '0')}` })
+    )
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(makeListResponse(students))
+    wrapper(<Students />)
+    await screen.findAllByTestId('student-name')
+
+    expect(screen.getAllByTestId('student-name')).toHaveLength(12)
+    expect(screen.getByTestId('load-more')).toBeInTheDocument()
+    expect(screen.getByText('Showing 12 of 13 students')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('load-more'))
+    expect(screen.getAllByTestId('student-name')).toHaveLength(13)
+    expect(screen.queryByTestId('load-more')).not.toBeInTheDocument()
+  })
+
+  it('shows Next Session with time when session is today', async () => {
+    const todayAt2PM = new Date()
+    todayAt2PM.setHours(14, 30, 0, 0)
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([makeStudent({ id: 'abc-123' })])
+    )
+    vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
+      nextSession: null, todaySessions: [], pendingFollowups: [],
+      activeStudents: [makeActiveStudent({ studentId: 'abc-123', nextSessionDate: todayAt2PM.toISOString() })],
+    })
+    wrapper(<Students />)
+    await screen.findByTestId('student-name')
+    expect(screen.getByText(/Today 14:30/)).toBeInTheDocument()
+  })
+
+  it('shows pagination count text', async () => {
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([makeStudent()])
+    )
+    wrapper(<Students />)
+    await screen.findByTestId('student-name')
+    expect(screen.getByText('Showing 1 of 1 student')).toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/Students.test.tsx
+++ b/frontend/src/pages/Students.test.tsx
@@ -234,6 +234,58 @@ describe('Students page', () => {
     expect(avatar).toHaveTextContent('AG')
   })
 
+  it('sort by Next Session orders students by upcoming session date ascending', async () => {
+    const soon = new Date(Date.now() + 1 * 86400000).toISOString()
+    const later = new Date(Date.now() + 5 * 86400000).toISOString()
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([
+        makeStudent({ id: 'b', name: 'Bruno' }),
+        makeStudent({ id: 'a', name: 'Ana' }),
+      ])
+    )
+    vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
+      nextSession: null, todaySessions: [], pendingFollowups: [],
+      activeStudents: [
+        makeActiveStudent({ studentId: 'b', name: 'Bruno', nextSessionDate: later }),
+        makeActiveStudent({ studentId: 'a', name: 'Ana', nextSessionDate: soon }),
+      ],
+    })
+    wrapper(<Students />)
+    await screen.findByText('Ana')
+
+    // "Next Session" is the default sort — Ana (sooner) should appear first
+    const names = screen.getAllByTestId('student-name').map(el => el.textContent)
+    expect(names[0]).toBe('Ana')
+    expect(names[1]).toBe('Bruno')
+  })
+
+  it('sort by Last Session orders students by most recent session first', async () => {
+    const recent = new Date(Date.now() - 2 * 86400000).toISOString()
+    const older = new Date(Date.now() - 10 * 86400000).toISOString()
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([
+        makeStudent({ id: 'b', name: 'Bruno' }),
+        makeStudent({ id: 'a', name: 'Ana' }),
+      ])
+    )
+    vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
+      nextSession: null, todaySessions: [], pendingFollowups: [],
+      activeStudents: [
+        makeActiveStudent({ studentId: 'b', name: 'Bruno', lastSessionDate: older }),
+        makeActiveStudent({ studentId: 'a', name: 'Ana', lastSessionDate: recent }),
+      ],
+    })
+    wrapper(<Students />)
+    await screen.findByText('Ana')
+
+    const select = screen.getByRole('combobox', { name: /sort/i })
+    fireEvent.change(select, { target: { value: 'lastSession' } })
+
+    const names = screen.getAllByTestId('student-name').map(el => el.textContent)
+    expect(names[0]).toBe('Ana')
+    expect(names[1]).toBe('Bruno')
+  })
+
   it('sort by Name orders students alphabetically', async () => {
     vi.mocked(studentsApi.getStudents).mockResolvedValue(
       makeListResponse([

--- a/frontend/src/pages/Students.test.tsx
+++ b/frontend/src/pages/Students.test.tsx
@@ -225,6 +225,16 @@ describe('Students page', () => {
     expect(screen.getByText('Review pending')).toBeInTheDocument()
   })
 
+  it('shows Former badge for inactive student even without dashboard data', async () => {
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([makeStudent({ id: 'abc-123', isActive: false })])
+    )
+    // dashboard has no entry for this student (inactive students excluded from dashboard)
+    wrapper(<Students />)
+    await screen.findByTestId('student-name')
+    expect(screen.getByText('Former')).toBeInTheDocument()
+  })
+
   it('renders initials avatar for each student', async () => {
     vi.mocked(studentsApi.getStudents).mockResolvedValue(
       makeListResponse([makeStudent({ name: 'Ana García' })])

--- a/frontend/src/pages/Students.tsx
+++ b/frontend/src/pages/Students.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Pencil, Search, Trash2, UserPlus, Users } from 'lucide-react'
@@ -261,12 +261,6 @@ export default function Students() {
   })
 
   const sortedStudents = sortStudents(filteredStudents, dashboardMap, sortBy)
-
-  // Reset visible count when filter/sort/search changes
-  useEffect(() => {
-    setVisibleCount(PAGE_SIZE)
-  }, [searchQuery, cefrFilter, sortBy])
-
   const visibleStudents = sortedStudents.slice(0, visibleCount)
 
   if (isStudentsLoading) {
@@ -281,7 +275,7 @@ export default function Students() {
         </div>
         <div className="bg-white rounded-xl overflow-hidden">
           <div className={cn('grid gap-4 px-4 py-2 border-b border-zinc-100', COL_CLASSES)}>
-            {TABLE_HEADERS.map((h, i) => (
+            {TABLE_HEADERS.map((_h, i) => (
               <Skeleton key={i} className="h-3 w-full" />
             ))}
           </div>
@@ -341,7 +335,7 @@ export default function Students() {
             {CEFR_FILTER_OPTIONS.map(level => (
               <button
                 key={level}
-                onClick={() => setCefrFilter(level)}
+                onClick={() => { setCefrFilter(level); setVisibleCount(PAGE_SIZE) }}
                 className={cn(
                   'px-2.5 py-1 text-xs font-medium rounded-md transition-colors',
                   cefrFilter === level
@@ -360,7 +354,7 @@ export default function Students() {
             <Input
               placeholder="Search students..."
               value={searchQuery}
-              onChange={e => setSearchQuery(e.target.value)}
+              onChange={e => { setSearchQuery(e.target.value); setVisibleCount(PAGE_SIZE) }}
               className="pl-8 h-8 text-sm bg-white border-zinc-200 focus-visible:ring-indigo-500"
             />
           </div>
@@ -369,7 +363,7 @@ export default function Students() {
           <div className="ml-auto">
             <select
               value={sortBy}
-              onChange={e => setSortBy(e.target.value as SortOption)}
+              onChange={e => { setSortBy(e.target.value as SortOption); setVisibleCount(PAGE_SIZE) }}
               aria-label="Sort students"
               className="text-xs font-medium text-zinc-500 bg-white border border-zinc-200 rounded-md px-2.5 py-1.5 h-8 focus:outline-none focus:ring-1 focus:ring-indigo-500 cursor-pointer"
             >

--- a/frontend/src/pages/Students.tsx
+++ b/frontend/src/pages/Students.tsx
@@ -423,7 +423,7 @@ export default function Students() {
                     data-testid={`student-row-${student.id}`}
                     onClick={() => navigate(`/students/${student.id}`)}
                     className={cn(
-                      'grid gap-x-4 items-center px-2 py-2 rounded-lg cursor-pointer transition-colors group',
+                      'grid gap-x-4 items-center px-2 py-1.5 rounded-lg cursor-pointer transition-colors group',
                       'hover:bg-[#E3E1EC]',
                       COL_CLASSES
                     )}

--- a/frontend/src/pages/Students.tsx
+++ b/frontend/src/pages/Students.tsx
@@ -93,11 +93,11 @@ interface Signal {
 }
 
 function buildSignals(student: Student, dash: ActiveStudent | undefined): Signal[] {
-  if (!dash) return []
-
-  if (!dash.isActive) {
+  if (!student.isActive) {
     return [{ label: 'Former', variant: 'zinc' }]
   }
+
+  if (!dash) return []
 
   const signals: Signal[] = []
   const now = Date.now()
@@ -252,7 +252,7 @@ export default function Students() {
   )
 
   const allStudents = studentsData?.items ?? []
-  const activeCount = dashboardData?.activeStudents.length ?? allStudents.length
+  const activeCount = dashboardData?.activeStudents.length ?? allStudents.filter(s => s.isActive).length
 
   const filteredStudents = allStudents.filter(s => {
     const matchesSearch = s.name.toLowerCase().includes(searchQuery.toLowerCase())

--- a/frontend/src/pages/Students.tsx
+++ b/frontend/src/pages/Students.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Pencil, Search, Trash2, UserPlus, Users } from 'lucide-react'
@@ -24,7 +24,33 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 
-function formatRelativeDate(dateStr: string | null | undefined): string {
+// ── Avatar helpers ──────────────────────────────────────────────────────────
+
+function getInitials(name: string): string {
+  const words = name.trim().split(/\s+/)
+  return words.slice(0, 2).map(w => w[0]?.toUpperCase() ?? '').join('')
+}
+
+const AVATAR_PALETTES = [
+  'bg-indigo-100 text-indigo-700',
+  'bg-violet-100 text-violet-700',
+  'bg-sky-100 text-sky-700',
+  'bg-teal-100 text-teal-700',
+  'bg-emerald-100 text-emerald-700',
+  'bg-amber-100 text-amber-700',
+  'bg-rose-100 text-rose-700',
+  'bg-orange-100 text-orange-700',
+]
+
+function getAvatarColor(id: string): string {
+  let hash = 0
+  for (let i = 0; i < id.length; i++) hash = (hash * 31 + id.charCodeAt(i)) >>> 0
+  return AVATAR_PALETTES[hash % AVATAR_PALETTES.length]
+}
+
+// ── Date formatting ─────────────────────────────────────────────────────────
+
+function formatRelativeDate(dateStr: string | null | undefined, showTime = false): string {
   if (!dateStr) return '—'
   const date = new Date(dateStr)
   if (isNaN(date.getTime())) return '—'
@@ -32,15 +58,154 @@ function formatRelativeDate(dateStr: string | null | undefined): string {
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
   const targetDay = new Date(date.getFullYear(), date.getMonth(), date.getDate())
   const diffDays = Math.round((today.getTime() - targetDay.getTime()) / (1000 * 60 * 60 * 24))
-  if (diffDays === 0) return 'Today'
+
+  if (diffDays === 0) {
+    if (showTime) {
+      const timeStr = date.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })
+      return `Today ${timeStr}`
+    }
+    return 'Today'
+  }
   if (diffDays === 1) return 'Yesterday'
   if (diffDays > 0) return `${diffDays}d ago`
+
+  // Future dates
   const futureDays = Math.abs(diffDays)
+  if (showTime) {
+    const timeStr = date.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })
+    if (futureDays === 1) return `Tomorrow ${timeStr}`
+    if (futureDays <= 6) {
+      const dayAbbr = date.toLocaleDateString('en-GB', { weekday: 'short' })
+      return `${dayAbbr} ${timeStr}`
+    }
+  }
   if (futureDays === 1) return 'Tomorrow'
   return `in ${futureDays}d`
 }
 
+// ── Signal badges ───────────────────────────────────────────────────────────
+
+type SignalVariant = 'amber' | 'zinc' | 'indigo' | 'red'
+
+interface Signal {
+  label: string
+  variant: SignalVariant
+}
+
+function buildSignals(student: Student, dash: ActiveStudent | undefined): Signal[] {
+  if (!dash) return []
+
+  if (!dash.isActive) {
+    return [{ label: 'Former', variant: 'zinc' }]
+  }
+
+  const signals: Signal[] = []
+  const now = Date.now()
+
+  const lastSessionMs = dash.lastSessionDate ? new Date(dash.lastSessionDate).getTime() : null
+  const lastSessionGapDays = lastSessionMs != null
+    ? Math.floor((now - lastSessionMs) / (1000 * 60 * 60 * 24))
+    : null
+
+  const hasNextSession = !!dash.nextSessionDate
+
+  // RETURNING: was inactive 30+ days and now has a scheduled next session
+  const isReturning = lastSessionGapDays != null && lastSessionGapDays >= 30 && hasNextSession
+  if (isReturning) {
+    signals.push({ label: 'RETURNING', variant: 'zinc' })
+  } else if (lastSessionGapDays != null && lastSessionGapDays >= 14) {
+    // Inactive Xd: last session 14+ days ago and no upcoming session (or < 30d gap)
+    signals.push({ label: `Inactive ${lastSessionGapDays}d`, variant: 'red' })
+  }
+
+  // Cancelled 2x
+  if (dash.cancelledSessionsLast30Days >= 2) {
+    signals.push({ label: 'Cancelled 2x', variant: 'amber' })
+  }
+
+  // NEW: created in last 14 days with fewer than 3 sessions
+  if (student.createdAt) {
+    const createdMs = new Date(student.createdAt).getTime()
+    const daysSinceCreation = Math.floor((now - createdMs) / (1000 * 60 * 60 * 24))
+    if (daysSinceCreation <= 14 && dash.totalSessions < 3) {
+      signals.push({ label: 'NEW', variant: 'indigo' })
+    }
+  }
+
+  // Exam prep: short-term objective with targetDate within 6 weeks
+  const sixWeeksMs = 6 * 7 * 24 * 60 * 60 * 1000
+  const hasExamPrep = student.shortTermObjectives.some(o => {
+    if (!o.targetDate) return false
+    const targetMs = new Date(o.targetDate).getTime()
+    const msUntil = targetMs - now
+    return msUntil >= 0 && msUntil <= sixWeeksMs
+  })
+  if (hasExamPrep) {
+    signals.push({ label: 'Exam prep', variant: 'indigo' })
+  }
+
+  // Review pending: has pending teaching todos
+  if (dash.pendingTodos.length > 0) {
+    signals.push({ label: 'Review pending', variant: 'indigo' })
+  }
+
+  return signals
+}
+
+const SIGNAL_VARIANT_CLASSES: Record<SignalVariant, string> = {
+  amber: 'bg-amber-50 text-amber-700',
+  zinc: 'bg-zinc-100 text-zinc-600',
+  indigo: 'bg-indigo-50 text-indigo-700',
+  red: 'bg-red-50 text-red-700',
+}
+
+// ── Sort ────────────────────────────────────────────────────────────────────
+
+type SortOption = 'nextSession' | 'lastSession' | 'name' | 'cefrLevel'
+
+function sortStudents(
+  students: Student[],
+  dashMap: Map<string, ActiveStudent>,
+  sortBy: SortOption
+): Student[] {
+  const sorted = [...students]
+  const cefrOrder = Object.fromEntries(CEFR_LEVELS.map((l, i) => [l, i]))
+
+  switch (sortBy) {
+    case 'nextSession':
+      return sorted.sort((a, b) => {
+        const aDate = dashMap.get(a.id)?.nextSessionDate
+        const bDate = dashMap.get(b.id)?.nextSessionDate
+        if (!aDate && !bDate) return 0
+        if (!aDate) return 1
+        if (!bDate) return -1
+        return new Date(aDate).getTime() - new Date(bDate).getTime()
+      })
+    case 'lastSession':
+      return sorted.sort((a, b) => {
+        const aDate = dashMap.get(a.id)?.lastSessionDate
+        const bDate = dashMap.get(b.id)?.lastSessionDate
+        if (!aDate && !bDate) return 0
+        if (!aDate) return 1
+        if (!bDate) return -1
+        return new Date(bDate).getTime() - new Date(aDate).getTime()
+      })
+    case 'name':
+      return sorted.sort((a, b) => a.name.localeCompare(b.name))
+    case 'cefrLevel':
+      return sorted.sort((a, b) => (cefrOrder[a.cefrLevel] ?? 99) - (cefrOrder[b.cefrLevel] ?? 99))
+  }
+}
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
 const CEFR_FILTER_OPTIONS = ['All', ...CEFR_LEVELS] as const
+const PAGE_SIZE = 12
+
+const COL_CLASSES = 'grid-cols-[32px_minmax(160px,2fr)_80px_120px_110px_140px_1fr_56px]'
+const TABLE_HEADERS = ['', 'Name', 'Level', 'Native Language', 'Last Session', 'Next Session', 'Signals', ''] as const
+
+// ── Component ───────────────────────────────────────────────────────────────
 
 export default function Students() {
   const queryClient = useQueryClient()
@@ -49,6 +214,8 @@ export default function Students() {
   const [deleteError, setDeleteError] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [cefrFilter, setCefrFilter] = useState<string>('All')
+  const [sortBy, setSortBy] = useState<SortOption>('nextSession')
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
 
   const {
     data: studentsData,
@@ -85,6 +252,7 @@ export default function Students() {
   )
 
   const allStudents = studentsData?.items ?? []
+  const activeCount = dashboardData?.activeStudents.length ?? allStudents.length
 
   const filteredStudents = allStudents.filter(s => {
     const matchesSearch = s.name.toLowerCase().includes(searchQuery.toLowerCase())
@@ -92,30 +260,41 @@ export default function Students() {
     return matchesSearch && matchesCefr
   })
 
+  const sortedStudents = sortStudents(filteredStudents, dashboardMap, sortBy)
+
+  // Reset visible count when filter/sort/search changes
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE)
+  }, [searchQuery, cefrFilter, sortBy])
+
+  const visibleStudents = sortedStudents.slice(0, visibleCount)
+
   if (isStudentsLoading) {
     return (
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <div>
-            <Skeleton className="h-7 w-32" />
-            <Skeleton className="h-4 w-48 mt-2" />
+            <Skeleton className="h-7 w-40" />
+            <Skeleton className="h-4 w-64 mt-2" />
           </div>
-          <Skeleton className="h-8 w-28" />
+          <Skeleton className="h-8 w-32" />
         </div>
         <div className="bg-white rounded-xl overflow-hidden">
-          <div className="grid grid-cols-6 gap-4 px-4 py-2 border-b border-zinc-100">
-            {['Name', 'Level', 'Native Language', 'Last Session', 'Next Session', 'Signals'].map(h => (
-              <Skeleton key={h} className="h-3 w-full" />
+          <div className={cn('grid gap-4 px-4 py-2 border-b border-zinc-100', COL_CLASSES)}>
+            {TABLE_HEADERS.map((h, i) => (
+              <Skeleton key={i} className="h-3 w-full" />
             ))}
           </div>
           {[1, 2, 3].map(i => (
-            <div key={i} className="grid grid-cols-6 gap-4 px-4 py-3">
+            <div key={i} className={cn('grid gap-4 px-4 py-3', COL_CLASSES)}>
+              <Skeleton className="h-8 w-8 rounded-full" />
               <Skeleton className="h-4 w-28" />
               <Skeleton className="h-5 w-10 rounded-md" />
               <Skeleton className="h-4 w-20" />
               <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-4 w-20" />
               <Skeleton className="h-4 w-12" />
+              <div />
             </div>
           ))}
         </div>
@@ -134,12 +313,15 @@ export default function Students() {
   return (
     <div className="space-y-5">
       <PageHeader
-        title="Students"
-        subtitle="Manage your student profiles."
+        title="Student Roster"
+        subtitle={`Managing ${activeCount} active language learner${activeCount === 1 ? '' : 's'} in your atelier.`}
         actions={
           <Link
             to="/students/new"
-            className={cn(buttonVariants(), 'bg-indigo-600 hover:bg-indigo-700 text-white')}
+            className={cn(
+              buttonVariants(),
+              'bg-gradient-to-br from-[#3525CD] to-[#4F46E5] hover:opacity-90 text-white border-0'
+            )}
           >
             <UserPlus className="h-4 w-4 mr-1.5" />
             Add Student
@@ -151,18 +333,10 @@ export default function Students() {
         <span className="text-sm text-red-600 font-medium" data-testid="delete-error">{deleteError}</span>
       )}
 
-      {/* Search and filter bar */}
+      {/* Search, filter and sort bar */}
       {allStudents.length > 0 && (
         <div className="flex items-center gap-3 flex-wrap">
-          <div className="relative flex-1 min-w-48 max-w-xs">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-zinc-400 pointer-events-none" />
-            <Input
-              placeholder="Search students..."
-              value={searchQuery}
-              onChange={e => setSearchQuery(e.target.value)}
-              className="pl-8 h-8 text-sm bg-white border-zinc-200 focus-visible:ring-indigo-500"
-            />
-          </div>
+          {/* CEFR pills */}
           <div className="flex items-center gap-1">
             {CEFR_FILTER_OPTIONS.map(level => (
               <button
@@ -178,6 +352,32 @@ export default function Students() {
                 {level}
               </button>
             ))}
+          </div>
+
+          {/* Search */}
+          <div className="relative flex-1 min-w-48 max-w-xs">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-zinc-400 pointer-events-none" />
+            <Input
+              placeholder="Search students..."
+              value={searchQuery}
+              onChange={e => setSearchQuery(e.target.value)}
+              className="pl-8 h-8 text-sm bg-white border-zinc-200 focus-visible:ring-indigo-500"
+            />
+          </div>
+
+          {/* Sort dropdown */}
+          <div className="ml-auto">
+            <select
+              value={sortBy}
+              onChange={e => setSortBy(e.target.value as SortOption)}
+              aria-label="Sort students"
+              className="text-xs font-medium text-zinc-500 bg-white border border-zinc-200 rounded-md px-2.5 py-1.5 h-8 focus:outline-none focus:ring-1 focus:ring-indigo-500 cursor-pointer"
+            >
+              <option value="nextSession">Sort: Next Session</option>
+              <option value="lastSession">Sort: Last Session</option>
+              <option value="name">Sort: Name</option>
+              <option value="cefrLevel">Sort: CEFR Level</option>
+            </select>
           </div>
         </div>
       )}
@@ -201,10 +401,10 @@ export default function Students() {
       {allStudents.length > 0 && (
         <div className="bg-white rounded-xl overflow-hidden">
           {/* Table header */}
-          <div className="grid grid-cols-[minmax(160px,2fr)_80px_120px_110px_110px_1fr_56px] gap-x-4 px-4 py-2.5">
-            {(['Name', 'Level', 'Native Language', 'Last Session', 'Next Session', 'Signals', ''] as const).map(h => (
+          <div className={cn('grid gap-x-4 px-4 py-2.5', COL_CLASSES)}>
+            {TABLE_HEADERS.map((h, i) => (
               <span
-                key={h}
+                key={i}
                 className="text-[0.6875rem] font-medium uppercase tracking-[0.05em] text-zinc-400"
               >
                 {h}
@@ -219,18 +419,33 @@ export default function Students() {
             </div>
           ) : (
             <div className="px-2 pb-2 space-y-0.5">
-              {filteredStudents.map(student => {
+              {visibleStudents.map(student => {
                 const dash = dashboardMap.get(student.id)
                 const signals = buildSignals(student, dash)
-                const isFormer = dash ? !dash.isActive : false
 
                 return (
                   <div
                     key={student.id}
                     data-testid={`student-row-${student.id}`}
                     onClick={() => navigate(`/students/${student.id}`)}
-                    className="grid grid-cols-[minmax(160px,2fr)_80px_120px_110px_110px_1fr_56px] gap-x-4 items-center px-2 py-2.5 rounded-lg cursor-pointer hover:bg-[#ECE8F6] transition-colors group"
+                    className={cn(
+                      'grid gap-x-4 items-center px-2 py-2 rounded-lg cursor-pointer transition-colors group',
+                      'hover:bg-[#E3E1EC]',
+                      COL_CLASSES
+                    )}
                   >
+                    {/* Avatar */}
+                    <div
+                      className={cn(
+                        'flex-none w-8 h-8 rounded-full flex items-center justify-center text-xs font-semibold',
+                        getAvatarColor(student.id)
+                      )}
+                      aria-hidden="true"
+                      data-testid="student-avatar"
+                    >
+                      {getInitials(student.name)}
+                    </div>
+
                     {/* Name */}
                     <span
                       data-testid="student-name"
@@ -259,12 +474,12 @@ export default function Students() {
 
                     {/* Next session */}
                     <span className="text-sm text-zinc-500">
-                      {formatRelativeDate(dash?.nextSessionDate)}
+                      {formatRelativeDate(dash?.nextSessionDate, true)}
                     </span>
 
                     {/* Signals */}
                     <div className="flex items-center gap-1 flex-wrap">
-                      {signals.length === 0 && !isFormer ? (
+                      {signals.length === 0 ? (
                         <span className="text-zinc-300 text-sm">—</span>
                       ) : (
                         signals.map((sig) => (
@@ -272,9 +487,7 @@ export default function Students() {
                             key={sig.label}
                             className={cn(
                               'inline-flex items-center px-1.5 py-0.5 rounded-md text-[0.6875rem] font-medium',
-                              sig.variant === 'amber'
-                                ? 'bg-amber-50 text-amber-700'
-                                : 'bg-zinc-100 text-zinc-600'
+                              SIGNAL_VARIANT_CLASSES[sig.variant]
                             )}
                           >
                             {sig.label}
@@ -329,6 +542,25 @@ export default function Students() {
               })}
             </div>
           )}
+
+          {/* Pagination footer */}
+          {sortedStudents.length > 0 && (
+            <div className="px-4 py-3 flex items-center justify-between border-t border-zinc-50">
+              <span className="text-xs text-zinc-400">
+                Showing {Math.min(visibleCount, sortedStudents.length)} of {sortedStudents.length} student{sortedStudents.length === 1 ? '' : 's'}
+              </span>
+              {visibleCount < sortedStudents.length && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setVisibleCount(v => v + PAGE_SIZE)}
+                  data-testid="load-more"
+                >
+                  Load more
+                </Button>
+              )}
+            </div>
+          )}
         </div>
       )}
 
@@ -356,35 +588,4 @@ export default function Students() {
       </AlertDialog>
     </div>
   )
-}
-
-interface Signal {
-  label: string
-  variant: 'amber' | 'zinc'
-}
-
-function buildSignals(_student: Student, dash: ActiveStudent | undefined): Signal[] {
-  const signals: Signal[] = []
-
-  if (dash && !dash.isActive) {
-    signals.push({ label: 'Former', variant: 'zinc' })
-    return signals
-  }
-
-  if (dash?.isActive && dash.lastSessionDate) {
-    const diffMs = Date.now() - new Date(dash.lastSessionDate).getTime()
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
-    if (diffDays >= 14) {
-      signals.push({ label: `${diffDays}d gap`, variant: 'amber' })
-    }
-  }
-
-  if (dash && dash.teachingTodosCount > 0) {
-    signals.push({
-      label: `${dash.teachingTodosCount} followup${dash.teachingTodosCount > 1 ? 's' : ''}`,
-      variant: 'zinc',
-    })
-  }
-
-  return signals
 }

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -70,3 +70,10 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 **Severity:** Low  
 
 `d.description` (e.g. "Separable vs inseparable phrasal verbs") is not shown anywhere in the Focus Areas table. The Subcategory column now shows `d.subcategory || d.description`, so description is only visible when subcategory is empty. Consider adding a tooltip or secondary line in the Subcategory cell for the full description.
+
+## #675 — 2026-04-12
+
+| Reviewer | Severity | Note |
+|---|---|---|
+| architecture-reviewer | minor | `getInitials` is defined privately in Students.tsx, StudentDetail.tsx, and LogSession.tsx — three copies of the same two-word-initials helper. Should be extracted to `src/utils/initials.ts` in a cleanup pass. |
+| architecture-reviewer | minor | `formatRelativeDate` in Students.tsx reimplements day-relative logic already in `src/utils/formatDate.ts:relativeTime`. The time-of-day extension is new, but base logic should build on the shared util in a future refactor. |

--- a/plan/langteach-beta/task675-students-list-redesign.md
+++ b/plan/langteach-beta/task675-students-list-redesign.md
@@ -1,0 +1,287 @@
+# Task 675 — Redesign Students List to match Stitch design
+
+## Issue
+[#675](https://github.com/Robert-Freire/langTeachSaaS/issues/675)
+
+## Scope decision
+`Cancelled 2x` badge requires `CancelledSessionsLast30Days` not currently in `ActiveStudentDto`. Approved to add it in this task (option c).
+
+**Delete button deferral:** The issue asks to remove the inline trash icon and move delete to the student detail/edit page. However, 10+ e2e tests use `data-testid="delete-student"` as their only cleanup mechanism, and the student edit page has no delete functionality yet. Implementing the removal without updating e2e tests would break AC#8. Resolution: keep the trash button in the row for this task. File a follow-up issue to move delete to the edit page (and update e2e tests then). This satisfies AC#8 and avoids scope creep.
+
+## Acceptance criteria
+1. Students list matches the Stitch design reference (layout, typography, colors, density)
+2. 10-12 students visible without scrolling on 1440x900
+3. Initials avatars render with deterministic colors
+4. Sort dropdown works (Next Session, Last Session, Name, CEFR Level)
+5. Signal badges show all 7 states listed
+6. Pagination footer shows count and "Load more" works
+7. Next Session shows time for today/this-week sessions
+8. All existing e2e tests for `/students` still pass
+9. No visual regressions on other pages
+
+---
+
+## Part 1: Backend — Add `CancelledSessionsLast30Days` to `ActiveStudentDto`
+
+### 1a. `DashboardDtos.cs`
+Add field to `ActiveStudentDto` record:
+```csharp
+public record ActiveStudentDto(
+    Guid StudentId,
+    string Name,
+    string CefrLevel,
+    List<string> NativeLanguages,
+    bool IsActive,
+    DateTime? LastSessionDate,
+    DateTime? NextSessionDate,
+    int TotalSessions,
+    int TeachingTodosCount,
+    List<TeachingTodoDto> PendingTodos,
+    int CancelledSessionsLast30Days   // NEW
+);
+```
+
+### 1b. `DashboardService.cs` — `GetActiveStudentsAsync`
+In the EF projection (the anonymous `Select`), add:
+```csharp
+CancelledSessionsLast30Days = s.SessionLogs
+    .Count(sl => !sl.IsDeleted
+              && sl.IsCancelled
+              && sl.SessionDate.HasValue
+              && sl.SessionDate.Value >= cutoff30Days)
+```
+Where `cutoff30Days = now.AddDays(-30)`. Define it as a local variable at the top of `GetActiveStudentsAsync` alongside `now`.
+
+In the `rows.Select(r => ...)` mapping block (lines 116-132), add `CancelledSessionsLast30Days: r.CancelledSessionsLast30Days` to the `new ActiveStudentDto(...)` constructor call.
+
+### 1c. `dashboard.ts` (frontend)
+Add `cancelledSessionsLast30Days: number` to the `ActiveStudent` interface.
+
+### 1d. Backend unit test
+In `DashboardServiceTests`, add test: one student with 2 cancelled sessions in the last 30 days plus 1 cancelled session older than 30 days. Assert `CancelledSessionsLast30Days == 2`.
+
+---
+
+## Part 2: Frontend redesign — `Students.tsx`
+
+### 2a. Header
+- Title: `"Student Roster"` (was `"Students"`)
+- Subtitle: `"Managing N active language learners in your atelier."` where N = count of active students from dashboard data (students where `dash?.isActive !== false`)
+- "Add Student" button: indigo gradient (`bg-gradient-to-br from-[#3525CD] to-[#4F46E5]`), white text, `UserPlus` icon — same as current but with the gradient class
+
+### 2b. Toolbar layout
+Order: CEFR pills (left) | search (center) | sort dropdown (right)
+
+Sort dropdown — native `<select>` or a small shadcn `Select` component:
+- "Sort by: Next Session" (default)
+- "Last Session"
+- "Name"
+- "CEFR Level"
+
+State: `const [sortBy, setSortBy] = useState<'nextSession' | 'lastSession' | 'name' | 'cefrLevel'>('nextSession')`
+
+### 2c. Sort logic
+After filtering, sort `filteredStudents` before pagination slice. Reference `CEFR_LEVELS` array for ordering.
+
+- **Next Session**: Students with `nextSessionDate` ascending (soonest first); null nextSessionDate last
+- **Last Session**: Students with `lastSessionDate` descending (most recent first); null last
+- **Name**: `student.name` alphabetical A-Z
+- **CEFR Level**: index in `CEFR_LEVELS` array ascending (A1 first, C2 last)
+
+Sort reads dashboard data for nextSessionDate/lastSessionDate (from `dashboardMap`).
+
+Reset `visibleCount` to 12 whenever `searchQuery`, `cefrFilter`, or `sortBy` changes (use `useEffect`).
+
+### 2d. Initials avatar
+```ts
+function getInitials(name: string): string {
+  const words = name.trim().split(/\s+/)
+  return words.slice(0, 2).map(w => w[0]?.toUpperCase() ?? '').join('')
+}
+
+const AVATAR_PALETTES = [
+  'bg-indigo-100 text-indigo-700',
+  'bg-violet-100 text-violet-700',
+  'bg-sky-100 text-sky-700',
+  'bg-teal-100 text-teal-700',
+  'bg-emerald-100 text-emerald-700',
+  'bg-amber-100 text-amber-700',
+  'bg-rose-100 text-rose-700',
+  'bg-orange-100 text-orange-700',
+]
+
+function getAvatarColor(id: string): string {
+  let hash = 0
+  for (let i = 0; i < id.length; i++) hash = (hash * 31 + id.charCodeAt(i)) >>> 0
+  return AVATAR_PALETTES[hash % AVATAR_PALETTES.length]
+}
+```
+
+Render before name cell:
+```tsx
+<div className={cn('flex-none w-8 h-8 rounded-full flex items-center justify-center text-xs font-semibold', getAvatarColor(student.id))}>
+  {getInitials(student.name)}
+</div>
+```
+
+### 2e. Row layout changes
+Grid columns:
+```
+grid-cols-[32px_minmax(160px,2fr)_80px_120px_140px_1fr_56px]
+```
+(avatar | name | level | native lang | next session | signals | actions)
+
+Last session column is removed from the visible grid (it was column 4). Sort by last session still works via `dashboardMap`. The column header row must match.
+
+Hover: `hover:bg-[#E3E1EC]` (surface-container-highest per design spec; was `#ECE8F6`)
+Name hover color: `group-hover:text-indigo-700` (unchanged)
+Vertical padding: `py-2` (was `py-2.5`) — tighter for density
+
+**Delete button**: Keep `data-testid="delete-student"` and the `Trash2` icon. This satisfies AC#8 (e2e compat). See scope deferral note above.
+
+### 2f. Next Session column formatting
+Add optional `showTime` parameter to `formatRelativeDate`:
+
+```ts
+function formatRelativeDate(dateStr: string | null | undefined, showTime = false): string {
+  if (!dateStr) return '—'
+  const date = new Date(dateStr)
+  if (isNaN(date.getTime())) return '—'
+  const now = new Date()
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const targetDay = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+  const diffDays = Math.round((today.getTime() - targetDay.getTime()) / (1000 * 60 * 60 * 24))
+  
+  if (showTime && diffDays < 0) {
+    const futureDays = Math.abs(diffDays)
+    const timeStr = date.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })
+    if (diffDays === -1) return `Tomorrow ${timeStr}`         // "Tomorrow 09:30"
+    if (futureDays <= 6) {
+      const dayAbbr = date.toLocaleDateString('en-GB', { weekday: 'short' })  // "Mon", "Thu"
+      return `${dayAbbr} ${timeStr}`                          // "Thu 15:00"
+    }
+  }
+  if (diffDays === 0) {
+    if (showTime) {
+      const timeStr = date.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })
+      return `Today ${timeStr}`                               // "Today 14:30"
+    }
+    return 'Today'
+  }
+  if (diffDays === 1) return 'Yesterday'
+  if (diffDays > 0) return `${diffDays}d ago`
+  const futureDays = Math.abs(diffDays)
+  if (futureDays === 1) return 'Tomorrow'
+  return `in ${futureDays}d`
+}
+```
+
+Pass `showTime: true` for Next Session column only. Last session column (now removed from view) is unaffected.
+
+### 2g. Signal badges — full 7 states
+Variant CSS classes:
+- `indigo`: `bg-indigo-50 text-indigo-700`
+- `amber`: `bg-amber-50 text-amber-700`
+- `zinc`: `bg-zinc-100 text-zinc-600`
+- `red`: `bg-red-50 text-red-700`
+
+Updated `buildSignals` signature: `buildSignals(student: Student, dash: ActiveStudent | undefined): Signal[]`
+
+Logic (in priority order):
+1. If `dash && !dash.isActive` → `[{ label: 'Former', variant: 'zinc' }]` (return immediately, exclusive)
+2. Otherwise build array:
+   - **`RETURNING`**: `dash.isActive && lastSessionGapDays >= 30 && dash.nextSessionDate != null` → `{ label: 'RETURNING', variant: 'zinc' }` (exclusive with `Inactive Xd`)
+   - **`Inactive Xd`**: `dash.isActive && lastSessionDate && lastSessionGapDays >= 14 && !(RETURNING condition)` → `{ label: 'Inactive ${lastSessionGapDays}d', variant: 'red' }` — replaces old `Xd gap` amber
+   - **`Cancelled 2x`**: `dash.cancelledSessionsLast30Days >= 2` → `{ label: 'Cancelled 2x', variant: 'amber' }`
+   - **`NEW`**: `student.createdAt && daysSince(student.createdAt) <= 14 && dash.totalSessions < 3` → `{ label: 'NEW', variant: 'indigo' }`
+   - **`Exam prep`**: `student.shortTermObjectives.some(o => o.targetDate && weeksUntil(o.targetDate) <= 6 && weeksUntil(o.targetDate) >= 0)` → `{ label: 'Exam prep', variant: 'indigo' }`
+   - **`Review pending`**: `dash.teachingTodosCount > 0` → `{ label: 'Review pending', variant: 'indigo' }` — replaces old `N followup(s)` zinc
+
+**Threshold clarification:**
+- `Inactive Xd` threshold: 14 days (matches existing behavior — just changes color from amber to red)
+- `RETURNING` threshold: 30 days (as per issue spec) — if lastSessionGapDays >= 30 but student now has nextSessionDate, show RETURNING instead of Inactive
+- These are not mutually exclusive at 14-29 days: at 14d gap with next session → show both? No — per issue spec, RETURNING overrides Inactive when next session exists. Rule: if `nextSessionDate != null && lastSessionGapDays >= 30` → RETURNING (no Inactive). If `lastSessionGapDays >= 14` without RETURNING condition → Inactive.
+
+**TeachingTodosCount clarification:** The backend currently sets `TeachingTodosCount = allTodos.Count` (line 129 of DashboardService), counting ALL todos including covered ones. The badge condition `dash.teachingTodosCount > 0` should actually use `dash.pendingTodos.length > 0` (the filtered pending list). No backend change needed — use `dash.pendingTodos.length` in the frontend badge logic.
+
+### 2h. Pagination — client-side "Load more"
+State: `const [visibleCount, setVisibleCount] = useState(12)`
+
+```ts
+const visibleStudents = sortedStudents.slice(0, visibleCount)
+```
+
+Render `visibleStudents` in the row loop. Footer inside the white card, below rows:
+```tsx
+<div className="px-4 py-3 flex items-center justify-between">
+  <span className="text-xs text-zinc-400">
+    Showing {Math.min(visibleCount, sortedStudents.length)} of {sortedStudents.length} students
+  </span>
+  {visibleCount < sortedStudents.length && (
+    <Button variant="ghost" size="sm" onClick={() => setVisibleCount(v => v + 12)}>
+      Load more
+    </Button>
+  )}
+</div>
+```
+
+Reset on filter/sort/search change (via `useEffect` watching those three state values).
+
+---
+
+## Part 3: Unit tests — `Students.test.tsx`
+
+### Factory updates
+`makeStudent`: set `createdAt` default to `new Date().toISOString()` (was `''`). Tests that don't want the NEW badge should pass `createdAt: new Date(Date.now() - 20 * 86400000).toISOString()` (20 days ago).
+
+Add `makeActiveStudent` factory:
+```ts
+function makeActiveStudent(overrides: Partial<ActiveStudent> = {}): ActiveStudent {
+  return {
+    studentId: 'abc-123',
+    name: 'Ana García',
+    cefrLevel: 'B2',
+    nativeLanguages: [],
+    isActive: true,
+    lastSessionDate: null,
+    nextSessionDate: null,
+    totalSessions: 5,
+    teachingTodosCount: 0,
+    pendingTodos: [],
+    cancelledSessionsLast30Days: 0,
+    ...overrides,
+  }
+}
+```
+
+### New test cases (add to existing describe block)
+1. **Avatar initials**: student named "Ana García" shows `AG` in avatar circle
+2. **Sort by Name**: two students "Zara" and "Ana" — sort by Name → "Ana" appears first in DOM
+3. **Sort by CEFR Level**: students B2 and A1 — sort by CEFR → A1 row precedes B2
+4. **Signal `Inactive Xd`** (red): `lastSessionDate = 20d ago, nextSessionDate = null` → shows red `Inactive 20d` badge
+5. **Signal `Cancelled 2x`** (amber): `cancelledSessionsLast30Days = 2` → shows amber `Cancelled 2x` badge
+6. **Signal `NEW`** (indigo): `createdAt = 5d ago, totalSessions = 1` → shows indigo `NEW` badge
+7. **Signal `Exam prep`** (indigo): student with `shortTermObjectives = [{ id: '1', text: 'Exam', targetDate: <3 weeks from now> }]` → shows `Exam prep` badge
+8. **Signal `RETURNING`** (zinc): `lastSessionDate = 35d ago, nextSessionDate = <future>` → shows `RETURNING` (no Inactive)
+9. **Signal `Review pending`** (indigo): `pendingTodos = [{ ... }]`, `teachingTodosCount = 1` → shows `Review pending` (not `1 followups`)
+10. **No NEW badge** for old student: `createdAt = 20d ago` → no NEW badge
+11. **Load more**: 13 students → 12 rows visible + "Load more" button; click → all 13 visible
+12. **Next session today with time**: `nextSessionDate = today at 14:30 UTC` → shows "Today 14:30"
+13. **Pagination count text**: "Showing 12 of 13 students" visible when 13 students loaded
+
+---
+
+## Part 4: Follow-up issue to file at task completion
+Create GitHub issue: "Move student delete action to edit page" — currently deferred from #675 due to e2e dependency. Should add a Delete button to `StudentForm.tsx` (edit mode) and then update the 10 e2e cleanup sequences.
+
+---
+
+## Files changed
+| File | Change |
+|------|--------|
+| `backend/LangTeach.Api/DTOs/DashboardDtos.cs` | Add `CancelledSessionsLast30Days` field to record |
+| `backend/LangTeach.Api/Services/DashboardService.cs` | Add `cutoff30Days` local + projection field + constructor call |
+| `backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs` | Add cancelled count test |
+| `frontend/src/api/dashboard.ts` | Add `cancelledSessionsLast30Days` to `ActiveStudent` |
+| `frontend/src/pages/Students.tsx` | Full redesign (header, toolbar, sort, avatars, signals, pagination, Next Session time) |
+| `frontend/src/pages/Students.test.tsx` | Factory updates + 13 new unit tests |


### PR DESCRIPTION
## Summary

- Adds `CancelledSessionsLast30Days` to `ActiveStudentDto` and computes it in `DashboardService`
- Redesigns `/students` page to match Stitch Academic Atelier design: initials avatars, 7-state signal badges, sort dropdown, client-side pagination, smarter Next Session time display
- Header updated to "Student Roster" with dynamic active student count

## Signal badges (all 7 states)
| Badge | Condition | Color |
|-------|-----------|-------|
| `Former` | isActive = false | zinc |
| `RETURNING` | inactive 30d+ now has upcoming session | zinc |
| `Inactive Xd` | last session 14d+ ago (replaces old amber gap) | red |
| `Cancelled 2x` | 2+ cancellations in last 30 days | amber |
| `NEW` | created <14 days ago, <3 sessions | indigo |
| `Exam prep` | short-term objective due in 6 weeks | indigo |
| `Review pending` | pending teaching todos (replaces "N followups") | indigo |

## Test plan
- [ ] `npm test` (77 files, 1087 tests) passes
- [ ] `dotnet test` (1064 passing) passes
- [ ] Backend: DashboardServiceTests passes including 2 new cancelled-sessions tests
- [ ] Frontend: Students.test.tsx — 26 unit tests including all 7 signal badges, sort, pagination, time display
- [ ] Visual: row density fits 12 rows at 1440x900 (verified by review-ui agent, ~46px/row)
- [ ] Follow-up issue #699 filed to move delete action to edit page (deferred from this task to preserve e2e compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Student avatars now display with initials
  * Multiple sorting options added to student roster: next session, last session, name, and CEFR level
  * Pagination functionality with "Load more" button
  * Enhanced student status badges including pending reviews, exam prep, returning, inactive, and cancelled indicators
  * New metric tracking cancelled sessions from the past 30 days

<!-- end of auto-generated comment: release notes by coderabbit.ai -->