### PR TITLE
feat: wire new student profile fields into PromptService GenerationContext (#668)

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -3321,7 +3321,7 @@ public class PromptServiceTests
         var request = _sut.BuildLessonPlanPrompt(ctx);
 
         request.SystemPrompt.Should().Contain("para vivir en Barcelona");
-        request.SystemPrompt.Should().Contain("Anchor vocabulary, topics, and examples to this motivation");
+        request.SystemPrompt.Should().Contain("Anchor vocabulary, topics, and examples to the student's stated study motivation");
     }
 
     [Fact]
@@ -3350,7 +3350,7 @@ public class PromptServiceTests
 
         request.SystemPrompt.Should().Contain("French");
         request.SystemPrompt.Should().Contain("Portuguese");
-        request.SystemPrompt.Should().Contain("cross-language awareness");
+        request.SystemPrompt.Should().Contain("cross-language awareness and cognates from the student's other languages");
     }
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -3307,5 +3307,111 @@ public class PromptServiceTests
         request.UserPrompt.Should().Contain("Subjunctive Mood");
         request.SystemPrompt.Should().Contain("CEFR-level grammar expert");
     }
+
+    // --- New student profile fields ---
+
+    [Fact]
+    public void ReasonForStudying_IncludedInSystemPrompt()
+    {
+        var ctx = BaseCtx("Ana") with
+        {
+            StudentReasonForStudying = "para vivir en Barcelona"
+        };
+
+        var request = _sut.BuildLessonPlanPrompt(ctx);
+
+        request.SystemPrompt.Should().Contain("para vivir en Barcelona");
+        request.SystemPrompt.Should().Contain("Anchor vocabulary, topics, and examples to this motivation");
+    }
+
+    [Fact]
+    public void Profession_IncludedInSystemPrompt()
+    {
+        var ctx = BaseCtx("Ana") with
+        {
+            StudentProfession = "marine biologist"
+        };
+
+        var request = _sut.BuildLessonPlanPrompt(ctx);
+
+        request.SystemPrompt.Should().Contain("marine biologist");
+        request.SystemPrompt.Should().Contain("domain-specific vocabulary");
+    }
+
+    [Fact]
+    public void SpokenLanguages_IncludedInSystemPrompt()
+    {
+        var ctx = BaseCtx("Ana") with
+        {
+            StudentSpokenLanguages = ["French", "Portuguese"]
+        };
+
+        var request = _sut.BuildLessonPlanPrompt(ctx);
+
+        request.SystemPrompt.Should().Contain("French");
+        request.SystemPrompt.Should().Contain("Portuguese");
+        request.SystemPrompt.Should().Contain("cross-language awareness");
+    }
+
+    [Fact]
+    public void OfficialCefrLevel_IncludedWithTeacherLevelWhenSet()
+    {
+        var ctx = BaseCtx("Ana") with
+        {
+            StudentOfficialCefrLevel = "A2"
+        };
+
+        var request = _sut.BuildLessonPlanPrompt(ctx);
+
+        request.SystemPrompt.Should().Contain("A2");
+        request.SystemPrompt.Should().Contain("official");
+        request.SystemPrompt.Should().Contain("teacher assessment");
+    }
+
+    [Fact]
+    public void BirthYear_AgeComputedInSystemPrompt()
+    {
+        var birthYear = 1990;
+        var ctx = BaseCtx("Ana") with
+        {
+            StudentBirthYear = birthYear
+        };
+
+        var request = _sut.BuildLessonPlanPrompt(ctx);
+
+        var expectedAge = (DateTime.UtcNow.Year - birthYear).ToString();
+        request.SystemPrompt.Should().Contain(expectedAge);
+    }
+
+    [Fact]
+    public void CountryOfOriginAndResidence_IncludedInSystemPrompt()
+    {
+        var ctx = BaseCtx("Ana") with
+        {
+            StudentCountryOfOrigin = "Brazil",
+            StudentCountryOfResidence = "Spain"
+        };
+
+        var request = _sut.BuildLessonPlanPrompt(ctx);
+
+        request.SystemPrompt.Should().Contain("Brazil");
+        request.SystemPrompt.Should().Contain("Spain");
+    }
+
+    [Fact]
+    public void NewFields_NotIncluded_WhenNull()
+    {
+        var ctx = BaseCtx("Ana");
+
+        var request = _sut.BuildLessonPlanPrompt(ctx);
+
+        request.SystemPrompt.Should().NotContain("Profession:");
+        request.SystemPrompt.Should().NotContain("Age:");
+        request.SystemPrompt.Should().NotContain("Country of origin:");
+        request.SystemPrompt.Should().NotContain("Country of residence:");
+        request.SystemPrompt.Should().NotContain("Official CEFR level:");
+        request.SystemPrompt.Should().NotContain("Also speaks:");
+        request.SystemPrompt.Should().NotContain("Reason for studying");
+    }
 }
 

--- a/backend/LangTeach.Api/AI/IPromptService.cs
+++ b/backend/LangTeach.Api/AI/IPromptService.cs
@@ -120,5 +120,12 @@ public record GenerationContext(
     string? CurriculumObjectives = null,
     string? TeacherGrammarConstraints = null,
     string? SectionType = null,
-    SessionHistoryContext? SessionHistory = null
+    SessionHistoryContext? SessionHistory = null,
+    string? StudentReasonForStudying = null,
+    string[]? StudentSpokenLanguages = null,
+    string? StudentProfession = null,
+    int? StudentBirthYear = null,
+    string? StudentCountryOfOrigin = null,
+    string? StudentCountryOfResidence = null,
+    string? StudentOfficialCefrLevel = null
 );

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -433,6 +433,7 @@ public class PromptService : IPromptService
             if (ctx.StudentProfession is not null)
                 sb.AppendLine($"- Profession: {InputSanitizer.Sanitize(ctx.StudentProfession)}");
 
+            // Age is approximated from birth year (off by up to one year depending on birthday — acceptable for prompt personalization)
             if (ctx.StudentBirthYear is not null)
                 sb.AppendLine($"- Age: {DateTime.UtcNow.Year - ctx.StudentBirthYear.Value}");
 
@@ -459,17 +460,17 @@ public class PromptService : IPromptService
             sb.AppendLine($"Personalize content for this student. Reference their interests in examples.");
 
             if (ctx.StudentReasonForStudying is not null)
-                sb.AppendLine($"The student's reason for studying {language} is: {InputSanitizer.Sanitize(ctx.StudentReasonForStudying)}. Anchor vocabulary, topics, and examples to this motivation.");
+                sb.AppendLine($"Anchor vocabulary, topics, and examples to the student's stated study motivation.");
 
             if (ctx.StudentSpokenLanguages is { Length: > 0 })
             {
                 var spokenForPrompt = ctx.StudentSpokenLanguages.Select(InputSanitizer.Sanitize).Where(s => s.Length > 0).ToArray();
                 if (spokenForPrompt.Length > 0)
-                    sb.AppendLine($"The student also speaks {string.Join(" and ", spokenForPrompt)}. Where relevant, leverage cross-language awareness and cognates.");
+                    sb.AppendLine("Where relevant, leverage cross-language awareness and cognates from the student's other languages.");
             }
 
             if (ctx.StudentProfession is not null)
-                sb.AppendLine($"The student's profession is {InputSanitizer.Sanitize(ctx.StudentProfession)}. Use domain-specific vocabulary and scenarios from this field where appropriate.");
+                sb.AppendLine("Use domain-specific vocabulary and scenarios from the student's professional field where appropriate.");
 
             if (ctx.StudentNativeLanguage is not null)
             {

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -430,8 +430,46 @@ public class PromptService : IPromptService
             if (weaknesses.Length > 0)
                 sb.AppendLine($"- Areas to improve: {string.Join(", ", weaknesses)}");
 
+            if (ctx.StudentProfession is not null)
+                sb.AppendLine($"- Profession: {InputSanitizer.Sanitize(ctx.StudentProfession)}");
+
+            if (ctx.StudentBirthYear is not null)
+                sb.AppendLine($"- Age: {DateTime.UtcNow.Year - ctx.StudentBirthYear.Value}");
+
+            if (ctx.StudentCountryOfOrigin is not null)
+                sb.AppendLine($"- Country of origin: {InputSanitizer.Sanitize(ctx.StudentCountryOfOrigin)}");
+
+            if (ctx.StudentCountryOfResidence is not null)
+                sb.AppendLine($"- Country of residence: {InputSanitizer.Sanitize(ctx.StudentCountryOfResidence)}");
+
+            if (ctx.StudentOfficialCefrLevel is not null)
+                sb.AppendLine($"- Official CEFR level: {InputSanitizer.Sanitize(ctx.StudentOfficialCefrLevel)} (official) / {cefrLevel} (teacher assessment)");
+
+            if (ctx.StudentSpokenLanguages is { Length: > 0 })
+            {
+                var spokenLangs = ctx.StudentSpokenLanguages.Select(InputSanitizer.Sanitize).Where(s => s.Length > 0).ToArray();
+                if (spokenLangs.Length > 0)
+                    sb.AppendLine($"- Also speaks: {string.Join(", ", spokenLangs)}");
+            }
+
+            if (ctx.StudentReasonForStudying is not null)
+                sb.AppendLine($"- Reason for studying {language}: {InputSanitizer.Sanitize(ctx.StudentReasonForStudying)}");
+
             sb.AppendLine();
             sb.AppendLine($"Personalize content for this student. Reference their interests in examples.");
+
+            if (ctx.StudentReasonForStudying is not null)
+                sb.AppendLine($"The student's reason for studying {language} is: {InputSanitizer.Sanitize(ctx.StudentReasonForStudying)}. Anchor vocabulary, topics, and examples to this motivation.");
+
+            if (ctx.StudentSpokenLanguages is { Length: > 0 })
+            {
+                var spokenForPrompt = ctx.StudentSpokenLanguages.Select(InputSanitizer.Sanitize).Where(s => s.Length > 0).ToArray();
+                if (spokenForPrompt.Length > 0)
+                    sb.AppendLine($"The student also speaks {string.Join(" and ", spokenForPrompt)}. Where relevant, leverage cross-language awareness and cognates.");
+            }
+
+            if (ctx.StudentProfession is not null)
+                sb.AppendLine($"The student's profession is {InputSanitizer.Sanitize(ctx.StudentProfession)}. Use domain-specific vocabulary and scenarios from this field where appropriate.");
 
             if (ctx.StudentNativeLanguage is not null)
             {

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -430,21 +430,32 @@ public class PromptService : IPromptService
             if (weaknesses.Length > 0)
                 sb.AppendLine($"- Areas to improve: {string.Join(", ", weaknesses)}");
 
-            if (ctx.StudentProfession is not null)
-                sb.AppendLine($"- Profession: {InputSanitizer.Sanitize(ctx.StudentProfession)}");
+            var profession       = InputSanitizer.Sanitize(ctx.StudentProfession);
+            var reasonForStudying = InputSanitizer.Sanitize(ctx.StudentReasonForStudying);
+            var countryOfOrigin  = InputSanitizer.Sanitize(ctx.StudentCountryOfOrigin);
+            var countryOfResidence = InputSanitizer.Sanitize(ctx.StudentCountryOfResidence);
+            var officialCefr     = InputSanitizer.Sanitize(ctx.StudentOfficialCefrLevel);
 
             // Age is approximated from birth year (off by up to one year depending on birthday — acceptable for prompt personalization)
-            if (ctx.StudentBirthYear is not null)
-                sb.AppendLine($"- Age: {DateTime.UtcNow.Year - ctx.StudentBirthYear.Value}");
+            var currentYear = DateTime.UtcNow.Year;
+            var age = ctx.StudentBirthYear is int birthYear && birthYear >= currentYear - 120 && birthYear <= currentYear
+                ? currentYear - birthYear
+                : (int?)null;
 
-            if (ctx.StudentCountryOfOrigin is not null)
-                sb.AppendLine($"- Country of origin: {InputSanitizer.Sanitize(ctx.StudentCountryOfOrigin)}");
+            if (profession.Length > 0)
+                sb.AppendLine($"- Profession: {profession}");
 
-            if (ctx.StudentCountryOfResidence is not null)
-                sb.AppendLine($"- Country of residence: {InputSanitizer.Sanitize(ctx.StudentCountryOfResidence)}");
+            if (age is not null)
+                sb.AppendLine($"- Age: {age}");
 
-            if (ctx.StudentOfficialCefrLevel is not null)
-                sb.AppendLine($"- Official CEFR level: {InputSanitizer.Sanitize(ctx.StudentOfficialCefrLevel)} (official) / {cefrLevel} (teacher assessment)");
+            if (countryOfOrigin.Length > 0)
+                sb.AppendLine($"- Country of origin: {countryOfOrigin}");
+
+            if (countryOfResidence.Length > 0)
+                sb.AppendLine($"- Country of residence: {countryOfResidence}");
+
+            if (officialCefr.Length > 0)
+                sb.AppendLine($"- Official CEFR level: {officialCefr} (official) / {cefrLevel} (teacher assessment)");
 
             if (ctx.StudentSpokenLanguages is { Length: > 0 })
             {
@@ -453,13 +464,13 @@ public class PromptService : IPromptService
                     sb.AppendLine($"- Also speaks: {string.Join(", ", spokenLangs)}");
             }
 
-            if (ctx.StudentReasonForStudying is not null)
-                sb.AppendLine($"- Reason for studying {language}: {InputSanitizer.Sanitize(ctx.StudentReasonForStudying)}");
+            if (reasonForStudying.Length > 0)
+                sb.AppendLine($"- Reason for studying {language}: {reasonForStudying}");
 
             sb.AppendLine();
             sb.AppendLine($"Personalize content for this student. Reference their interests in examples.");
 
-            if (ctx.StudentReasonForStudying is not null)
+            if (reasonForStudying.Length > 0)
                 sb.AppendLine($"Anchor vocabulary, topics, and examples to the student's stated study motivation.");
 
             if (ctx.StudentSpokenLanguages is { Length: > 0 })
@@ -469,7 +480,7 @@ public class PromptService : IPromptService
                     sb.AppendLine("Where relevant, leverage cross-language awareness and cognates from the student's other languages.");
             }
 
-            if (ctx.StudentProfession is not null)
+            if (profession.Length > 0)
                 sb.AppendLine("Use domain-specific vocabulary and scenarios from the student's professional field where appropriate.");
 
             if (ctx.StudentNativeLanguage is not null)

--- a/backend/LangTeach.Api/Controllers/GenerateController.cs
+++ b/backend/LangTeach.Api/Controllers/GenerateController.cs
@@ -196,7 +196,14 @@ public class GenerateController : ControllerBase
             CurriculumObjectives: lesson.Objectives,
             TeacherGrammarConstraints: request.GrammarConstraints,
             SectionType: request.SectionType,
-            SessionHistory: sessionHistory
+            SessionHistory: sessionHistory,
+            StudentReasonForStudying: student?.ReasonForStudying,
+            StudentSpokenLanguages: student?.SpokenLanguages.ToArray(),
+            StudentProfession: student?.Profession,
+            StudentBirthYear: student?.BirthYear,
+            StudentCountryOfOrigin: student?.CountryOfOrigin,
+            StudentCountryOfResidence: student?.CountryOfResidence,
+            StudentOfficialCefrLevel: student?.OfficialCefrLevel
         );
 
         var claudeRequest = buildPrompt(_promptService, ctx);
@@ -355,7 +362,14 @@ public class GenerateController : ControllerBase
             TemplateName: templateName,
             CurriculumObjectives: lesson.Objectives,
             TeacherGrammarConstraints: request.GrammarConstraints,
-            SessionHistory: sessionHistory
+            SessionHistory: sessionHistory,
+            StudentReasonForStudying: student?.ReasonForStudying,
+            StudentSpokenLanguages: student?.SpokenLanguages.ToArray(),
+            StudentProfession: student?.Profession,
+            StudentBirthYear: student?.BirthYear,
+            StudentCountryOfOrigin: student?.CountryOfOrigin,
+            StudentCountryOfResidence: student?.CountryOfResidence,
+            StudentOfficialCefrLevel: student?.OfficialCefrLevel
         );
 
         var claudeRequest = buildPrompt(ctx);

--- a/backend/LangTeach.Api/Controllers/GenerateController.cs
+++ b/backend/LangTeach.Api/Controllers/GenerateController.cs
@@ -362,6 +362,7 @@ public class GenerateController : ControllerBase
             TemplateName: templateName,
             CurriculumObjectives: lesson.Objectives,
             TeacherGrammarConstraints: request.GrammarConstraints,
+            SectionType: request.SectionType,
             SessionHistory: sessionHistory,
             StudentReasonForStudying: student?.ReasonForStudying,
             StudentSpokenLanguages: student?.SpokenLanguages.ToArray(),

--- a/plan/langteach-beta/task668-prompt-service-new-fields.md
+++ b/plan/langteach-beta/task668-prompt-service-new-fields.md
@@ -1,0 +1,94 @@
+# Task 668: Wire new student profile fields into PromptService GenerationContext
+
+## Context
+
+The `Student` model already has all the new fields (`ReasonForStudying`, `SpokenLanguages`, `Profession`, `BirthYear`, `CountryOfOrigin`, `CountryOfResidence`, `OfficialCefrLevel`) from previous tasks. They are stored in the DB but NOT passed to AI generation. This task wires them through.
+
+## Files to change
+
+| File | Change |
+|------|--------|
+| `backend/LangTeach.Api/AI/IPromptService.cs` | Add 7 new optional fields to `GenerationContext` |
+| `backend/LangTeach.Api/AI/PromptService.cs` | Include new fields in `BuildSystemPrompt` student profile block |
+| `backend/LangTeach.Api/Controllers/GenerateController.cs` | Populate new fields in both `GenerationContext` constructors (lines ~179 and ~339) |
+| `backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs` | Tests verifying new fields appear in generated prompts |
+
+## Step-by-step
+
+### 1. Extend `GenerationContext` (IPromptService.cs:102)
+
+Add 7 optional parameters at the end of the record (all nullable, default `null` so they're backward-compatible):
+
+```csharp
+string? StudentReasonForStudying = null,
+string[]? StudentSpokenLanguages = null,
+string? StudentProfession = null,
+int? StudentBirthYear = null,
+string? StudentCountryOfOrigin = null,
+string? StudentCountryOfResidence = null,
+string? StudentOfficialCefrLevel = null
+```
+
+### 2. Update `BuildSystemPrompt` (PromptService.cs:~411)
+
+Inside the `if (ctx.StudentName is not null)` block, after the existing student profile lines, add:
+
+```
+- Reason for studying: {ReasonForStudying}          (if set)
+- Profession: {Profession}                           (if set)
+- Age: {computed from BirthYear}                    (if set)
+- Country of origin: {CountryOfOrigin}              (if set)
+- Country of residence: {CountryOfResidence}        (if set)
+- Official CEFR level: {OfficialCefrLevel}          (if set, format: "X1 (official) / {CefrLevel} (teacher assessment)")
+- Also speaks: {SpokenLanguages joined by ", "}     (if non-empty)
+```
+
+Personalization instructions to add after the profile block:
+- If `ReasonForStudying` is set: "The student's reason for studying {language} is: {reason}. Anchor vocabulary, topics, and examples to this motivation."
+- If `SpokenLanguages` is non-empty: "The student also speaks {langs}. Where relevant, leverage cross-language awareness and cognates."
+- If `Profession` is set: "The student's profession is {profession}. Use domain-specific vocabulary and scenarios from this field where appropriate."
+- If `OfficialCefrLevel` is set and differs from `CefrLevel`: note the gap in the prompt.
+
+### 3. Populate in GenerateController (two sites: ~line 179 and ~line 339)
+
+`student` is `StudentDto?` in `GenerateController`. `StudentDto.SpokenLanguages` is already `List<string>` (pre-deserialized by the mapper). Both `GenerationContext` constructor calls are identical in structure; apply the same mapping to both.
+
+```csharp
+StudentReasonForStudying: student?.ReasonForStudying,
+StudentSpokenLanguages: student?.SpokenLanguages.ToArray(),
+StudentProfession: student?.Profession,
+StudentBirthYear: student?.BirthYear,
+StudentCountryOfOrigin: student?.CountryOfOrigin,
+StudentCountryOfResidence: student?.CountryOfResidence,
+StudentOfficialCefrLevel: student?.OfficialCefrLevel,
+```
+
+### 4. Tests (PromptServiceTests.cs)
+
+Add a test class `StudentProfileNewFieldsTests` (or add to existing) with:
+
+- `ReasonForStudying_IncludedInSystemPrompt`: set `StudentReasonForStudying`, assert system prompt contains the value and the motivation instruction
+- `Profession_IncludedInSystemPrompt`: set `StudentProfession`, assert prompt contains the profession
+- `SpokenLanguages_IncludedInSystemPrompt`: set `StudentSpokenLanguages = ["French", "Portuguese"]`, assert prompt contains cross-language instruction
+- `OfficialCefrLevel_IncludedWhenDiffersFromTeacherLevel`: set `StudentOfficialCefrLevel = "A2"` with `CefrLevel = "B1"`, assert both appear in prompt
+- `NewFields_NotIncluded_WhenNull`: verify no extra lines appear when all new fields are null (regression guard)
+- `Age_ComputedFromBirthYear`: set `StudentBirthYear = 1990`, assert prompt contains the string for `(DateTime.UtcNow.Year - 1990)` so the test stays valid year over year
+- `CountryOfOrigin_AndResidence_IncludedInSystemPrompt`: set both, assert both appear
+
+Use `BuildLessonPlanPrompt` (simplest entry point) for all tests. Pattern follows existing tests in the file.
+
+## Acceptance criteria
+
+- [x] `GenerationContext` has all 7 new fields
+- [x] `BuildSystemPrompt` includes them in the student profile block (when non-null/non-empty)
+- [x] Both `GenerationContext` constructors in `GenerateController` populate the new fields from `student`
+- [x] `SpokenLanguages` is deserialized from JSON before being passed to `GenerationContext`
+- [x] Tests cover each new field appearing in the prompt output
+- [x] Existing tests still pass (no regressions)
+- [x] No frontend changes needed (pure backend)
+
+## Out of scope
+
+- `SkillLevelOverrides` wiring (already handled in `SessionHistoryContext`)
+- `ShortTermObjectives` or `TeachingTodos` in prompts (separate concerns)
+- Any frontend changes


### PR DESCRIPTION
## Summary

- Extends `GenerationContext` with 7 new optional fields: `StudentReasonForStudying`, `StudentSpokenLanguages`, `StudentProfession`, `StudentBirthYear`, `StudentCountryOfOrigin`, `StudentCountryOfResidence`, `StudentOfficialCefrLevel`
- Updates `PromptService.BuildSystemPrompt` to include these fields in the student profile block (conditionally, when set)
- Populates both `GenerationContext` constructors in `GenerateController` from `StudentDto`
- Adds 7 unit tests covering each new field and a null-guard regression test

## Test plan

- [ ] `dotnet test --filter FullyQualifiedName~PromptService` passes (285 passed, 0 failed)
- [ ] Spot-check: generate a lesson section for a student with `ReasonForStudying` set and confirm the prompt includes the motivation anchor instruction
- [ ] Spot-check: generate a lesson section for a student with `SpokenLanguages` set and confirm the cross-language instruction appears

Closes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AI-generated lesson plans now incorporate additional student profile information including profession, spoken languages, country of origin/residence, official CEFR level, and reason for studying.
  * Enhanced personalization with domain-specific vocabulary and cross-language awareness based on student background.

* **Tests**
  * Added comprehensive test coverage for expanded student profile integration in lesson plan generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->