### PR TITLE
feat: edit form redesign - commercial fields, section nav, delete action (#666 #681 #699)

### DIFF
--- a/e2e/tests/students.spec.ts
+++ b/e2e/tests/students.spec.ts
@@ -84,9 +84,10 @@ test('creates student with lexical weakness and verifies round-trip', async ({ b
   await page.getByRole('option', { name: 'Lexical' }).click()
 
   await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
 
-  // Find the student card and navigate to edit
+  // Go to roster to find the student card and navigate to edit
+  await page.goto('/students')
   const studentCard = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName })
   })
@@ -225,7 +226,7 @@ test('full student CRUD flow', async ({ browser }) => {
   await page.getByTestId('student-cefr').click()
   await page.getByRole('option', { name: 'C1' }).click()
 
-  await page.getByRole('button', { name: 'Update Student' }).click()
+  await page.getByRole('button', { name: 'Save Profile' }).first().click()
 
   // Should redirect to student profile page
   await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
@@ -247,7 +248,7 @@ test('full student CRUD flow', async ({ browser }) => {
   await verifyDiffRow.getByTestId('remove-difficulty').click()
   await expect(page.getByTestId('difficulty-row')).not.toBeVisible()
 
-  await page.getByRole('button', { name: 'Update Student' }).click()
+  await page.getByRole('button', { name: 'Save Profile' }).first().click()
 
   // Should redirect to student profile page
   await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })

--- a/e2e/tests/students.spec.ts
+++ b/e2e/tests/students.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { createMockAuthContext } from '../helpers/auth-helper'
 import { setupMockTeacher } from '../helpers/mock-teacher-helper'
+import { NAV_TIMEOUT, UI_TIMEOUT, FEEDBACK_TIMEOUT } from '../helpers/timeouts'
 
 test.beforeAll(async ({ browser }) => {
   const ctx = await createMockAuthContext(browser)
@@ -15,11 +16,11 @@ test('students list loads and renders the table with student rows', async ({ bro
   const page = await context.newPage()
 
   await page.goto('/students')
-  await expect(page.locator('h1')).toHaveText('Students', { timeout: 15000 })
+  await expect(page.locator('h1')).toHaveText('Students', { timeout: NAV_TIMEOUT })
 
   // Table renders with at least one student row (seeded by setupMockTeacher)
   const firstRow = page.locator('[data-testid^="student-row-"]').first()
-  await expect(firstRow).toBeVisible({ timeout: 10000 })
+  await expect(firstRow).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Name, level badge, and native language cell are present
   await expect(firstRow.getByTestId('student-name')).toBeVisible()
@@ -34,15 +35,15 @@ test('student list row click navigates to student detail', async ({ browser }) =
   const page = await context.newPage()
 
   await page.goto('/students')
-  await expect(page.locator('h1')).toHaveText('Students', { timeout: 15000 })
+  await expect(page.locator('h1')).toHaveText('Students', { timeout: NAV_TIMEOUT })
 
   // Click the first student row (not the edit/delete buttons)
   const firstRow = page.locator('[data-testid^="student-row-"]').first()
-  await expect(firstRow).toBeVisible({ timeout: 10000 })
+  await expect(firstRow).toBeVisible({ timeout: UI_TIMEOUT })
   await firstRow.click()
 
   // Should navigate to the student detail page
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
 
   await context.close()
 })
@@ -52,11 +53,11 @@ test('shows not-found message for invalid student edit URL', async ({ browser })
   const page = await context.newPage()
 
   await page.goto('/students/nonexistent-id/edit')
-  await expect(page.getByText('Student not found.')).toBeVisible({ timeout: 15000 })
+  await expect(page.getByText('Student not found.')).toBeVisible({ timeout: NAV_TIMEOUT })
   const goBack = page.getByRole('button', { name: 'Go back' })
   await expect(goBack).toBeVisible()
   await goBack.click()
-  await expect(page).toHaveURL('/students', { timeout: 15000 })
+  await expect(page).toHaveURL('/students', { timeout: NAV_TIMEOUT })
 
   await context.close()
 })
@@ -68,7 +69,7 @@ test('creates student with lexical weakness and verifies round-trip', async ({ b
   const studentName = `Lexical Weakness Test ${Date.now()}`
 
   await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
 
   await page.getByTestId('student-name').fill(studentName)
   await page.getByTestId('student-language').click()
@@ -83,36 +84,39 @@ test('creates student with lexical weakness and verifies round-trip', async ({ b
   await page.getByRole('option', { name: 'Lexical' }).click()
 
   await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL('/students', { timeout: 10000 })
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
 
   // Find the student card and navigate to edit
   const studentCard = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName })
   })
-  await expect(studentCard).toBeVisible({ timeout: 10000 })
+  await expect(studentCard).toBeVisible({ timeout: UI_TIMEOUT })
   await studentCard.getByTestId('edit-student').click()
-  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: UI_TIMEOUT })
 
   // Verify weakness round-tripped correctly
   const descInput = page.getByTestId('weakness-description')
-  await expect(descInput).toHaveValue('Vocabulary gaps for travel', { timeout: 5000 })
+  await expect(descInput).toHaveValue('Vocabulary gaps for travel', { timeout: FEEDBACK_TIMEOUT })
   const typeSelect = page.getByTestId('weakness-type')
-  await expect(typeSelect).toContainText('Lexical', { timeout: 5000 })
+  await expect(typeSelect).toContainText('Lexical', { timeout: FEEDBACK_TIMEOUT })
 
   // Cleanup
   await page.getByRole('button', { name: 'Cancel' }).click()
-  await expect(page).toHaveURL('/students', { timeout: 10000 })
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
   const deleteCard = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName })
   })
-  await deleteCard.getByTestId('delete-student').click()
-  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: 5000 })
+  await deleteCard.getByTestId('edit-student').click()
+  await expect(page).toHaveURL(/\/edit$/, { timeout: UI_TIMEOUT })
+  await page.getByTestId('delete-student-btn').click()
+  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await page.getByTestId('confirm-delete').click()
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
   await expect(
     page.locator('[data-testid^="student-row-"]').filter({
       has: page.getByTestId('student-name').filter({ hasText: studentName })
     })
-  ).not.toBeVisible({ timeout: 10000 })
+  ).not.toBeVisible({ timeout: UI_TIMEOUT })
 
   await context.close()
 })
@@ -123,12 +127,12 @@ test('full student CRUD flow', async ({ browser }) => {
 
   // Navigate to students list
   await page.goto('/students')
-  await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {})
-  await expect(page.locator('h1')).toHaveText('Students', { timeout: 15000 })
+  await page.waitForLoadState('networkidle', { timeout: NAV_TIMEOUT }).catch(() => {})
+  await expect(page.locator('h1')).toHaveText('Students', { timeout: NAV_TIMEOUT })
 
   // Navigate directly to create form
   await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
 
   // Use a unique name to avoid conflicts with previous test runs
   const studentName = `Ana García ${Date.now()}`
@@ -169,7 +173,7 @@ test('full student CRUD flow', async ({ browser }) => {
   await addDiffBtn.scrollIntoViewIfNeeded()
   await addDiffBtn.click()
   const diffRow = page.getByTestId('difficulty-row').first()
-  await expect(diffRow).toBeVisible({ timeout: 10000 })
+  await expect(diffRow).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Fill difficulty description
   await diffRow.getByTestId('difficulty-description').fill('Confuses ser/estar in past tense')
@@ -185,24 +189,24 @@ test('full student CRUD flow', async ({ browser }) => {
   await page.getByRole('button', { name: 'Save Student' }).click()
 
   // Should redirect to student profile page
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
 
   // Navigate to list to verify the new student appears
   await page.goto('/students')
-  await expect(page.locator('h1')).toHaveText('Students', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Students', { timeout: UI_TIMEOUT })
 
   // Find the student card using the per-row testid (scoped by student ID)
   const studentCard = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName })
   })
-  await expect(studentCard).toBeVisible({ timeout: 10000 })
+  await expect(studentCard).toBeVisible({ timeout: UI_TIMEOUT })
   await expect(studentCard.getByTestId('student-level')).toContainText('B2')
   await expect(studentCard.getByTestId('interest-chip').filter({ hasText: 'travel' })).toBeAttached()
   await expect(studentCard.getByTestId('native-language-chip')).toContainText('Portuguese')
 
   // Edit: click the edit button within this student's card
   await studentCard.getByTestId('edit-student').click()
-  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: UI_TIMEOUT })
   await expect(page.getByTestId('student-name')).toHaveValue(studentName)
 
   // Confirm enrichment fields round-trip correctly
@@ -211,7 +215,7 @@ test('full student CRUD flow', async ({ browser }) => {
 
   // Verify difficulty persisted
   const editDiffRow = page.getByTestId('difficulty-row')
-  await expect(editDiffRow).toBeVisible({ timeout: 5000 })
+  await expect(editDiffRow).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await expect(editDiffRow.getByTestId('difficulty-description')).toHaveValue('Confuses ser/estar in past tense')
 
   // Modify the difficulty description
@@ -224,18 +228,18 @@ test('full student CRUD flow', async ({ browser }) => {
   await page.getByRole('button', { name: 'Update Student' }).click()
 
   // Should redirect to student profile page
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
 
   // Navigate to list to verify updated level
   await page.goto('/students')
   const updatedCard = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName })
   })
-  await expect(updatedCard.getByTestId('student-level')).toContainText('C1', { timeout: 10000 })
+  await expect(updatedCard.getByTestId('student-level')).toContainText('C1', { timeout: UI_TIMEOUT })
 
   // Re-enter edit to verify difficulty was updated and remove it
   await updatedCard.getByTestId('edit-student').click()
-  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: UI_TIMEOUT })
   const verifyDiffRow = page.getByTestId('difficulty-row')
   await expect(verifyDiffRow.getByTestId('difficulty-description')).toHaveValue('ser/estar in all tenses')
 
@@ -246,7 +250,7 @@ test('full student CRUD flow', async ({ browser }) => {
   await page.getByRole('button', { name: 'Update Student' }).click()
 
   // Should redirect to student profile page
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
 
   // Navigate to list to re-enter edit for verification
   await page.goto('/students')
@@ -254,28 +258,31 @@ test('full student CRUD flow', async ({ browser }) => {
     has: page.getByTestId('student-name').filter({ hasText: studentName })
   })
   await finalCard.getByTestId('edit-student').click()
-  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: UI_TIMEOUT })
   await expect(page.getByTestId('difficulty-row')).not.toBeVisible()
   await expect(page.getByText('No specific difficulties tracked yet.')).toBeVisible()
 
   // Go back to list for delete step
   await page.getByRole('button', { name: 'Cancel' }).click()
-  await expect(page).toHaveURL('/students', { timeout: 10000 })
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
 
   // Delete
   const deleteCard = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName })
   })
-  await deleteCard.getByTestId('delete-student').click()
-  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: 5000 })
+  await deleteCard.getByTestId('edit-student').click()
+  await expect(page).toHaveURL(/\/edit$/, { timeout: UI_TIMEOUT })
+  await page.getByTestId('delete-student-btn').click()
+  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await page.getByTestId('confirm-delete').click()
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
 
   // Student should no longer be in the list
   await expect(
     page.locator('[data-testid^="student-row-"]').filter({
       has: page.getByTestId('student-name').filter({ hasText: studentName })
     })
-  ).not.toBeVisible({ timeout: 10000 })
+  ).not.toBeVisible({ timeout: UI_TIMEOUT })
 
   await context.close()
 })
@@ -288,7 +295,7 @@ test('custom free-text learning goal persists after save', async ({ browser }) =
 
   // Create a student with a custom learning goal
   await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
 
   await page.getByTestId('student-name').fill(studentName)
 
@@ -312,7 +319,7 @@ test('custom free-text learning goal persists after save', async ({ browser }) =
     await cmdInput.fill(text)
     // Wait for React to render the "Add" option
     const addBtn = page.getByTestId('add-custom-entry')
-    await expect(addBtn).toBeVisible({ timeout: 5000 })
+    await expect(addBtn).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
     await addBtn.click()
     await page.keyboard.press('Escape')
   }
@@ -330,16 +337,16 @@ test('custom free-text learning goal persists after save', async ({ browser }) =
 
   // Save
   await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
 
   // Navigate to list to verify persistence
   await page.goto('/students')
   const studentCard = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName })
   })
-  await expect(studentCard).toBeVisible({ timeout: 10000 })
+  await expect(studentCard).toBeVisible({ timeout: UI_TIMEOUT })
   await studentCard.getByTestId('edit-student').click()
-  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: UI_TIMEOUT })
 
   // Verify predefined and custom goals persisted
   await expect(page.getByTestId('learning-goal-chip').filter({ hasText: 'Travel' })).toBeVisible()
@@ -348,18 +355,21 @@ test('custom free-text learning goal persists after save', async ({ browser }) =
 
   // Clean up: go back and delete the student
   await page.getByRole('button', { name: 'Cancel' }).click()
-  await expect(page).toHaveURL('/students', { timeout: 10000 })
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
   const deleteCard = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName })
   })
-  await deleteCard.getByTestId('delete-student').click()
-  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: 5000 })
+  await deleteCard.getByTestId('edit-student').click()
+  await expect(page).toHaveURL(/\/edit$/, { timeout: UI_TIMEOUT })
+  await page.getByTestId('delete-student-btn').click()
+  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await page.getByTestId('confirm-delete').click()
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
   await expect(
     page.locator('[data-testid^="student-row-"]').filter({
       has: page.getByTestId('student-name').filter({ hasText: studentName }),
     }),
-  ).not.toBeVisible({ timeout: 10000 })
+  ).not.toBeVisible({ timeout: UI_TIMEOUT })
 
   await context.close()
 })
@@ -371,23 +381,23 @@ test('"Create Course" button on student edit page navigates to CourseNew with st
   // Create a student with full profile
   const studentName = `Create Course Test ${Date.now()}`
   await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
   await page.getByTestId('student-name').fill(studentName)
   await page.getByTestId('student-language').click()
   await page.getByRole('option', { name: 'Spanish' }).click()
   await page.getByTestId('student-cefr').click()
   await page.getByRole('option', { name: 'B2' }).click()
   await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
 
   // Navigate to list then to edit page
   await page.goto('/students')
   const studentCard = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName })
   })
-  await expect(studentCard).toBeVisible({ timeout: 10000 })
+  await expect(studentCard).toBeVisible({ timeout: UI_TIMEOUT })
   await studentCard.getByTestId('edit-student').click()
-  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: UI_TIMEOUT })
 
   // Capture the student ID from the edit URL
   const editUrl = page.url()
@@ -396,16 +406,16 @@ test('"Create Course" button on student edit page navigates to CourseNew with st
 
   // "Create Course" button should be visible and enabled (profile is complete)
   const createCourseBtn = page.getByTestId('create-course-btn')
-  await expect(createCourseBtn).toBeVisible({ timeout: 5000 })
+  await expect(createCourseBtn).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await expect(createCourseBtn).not.toBeDisabled()
 
   // Click it and verify navigation
   await createCourseBtn.click()
-  await expect(page).toHaveURL(`/courses/new?studentId=${studentId}`, { timeout: 10000 })
+  await expect(page).toHaveURL(`/courses/new?studentId=${studentId}`, { timeout: UI_TIMEOUT })
 
   // Student should appear as locked (not a dropdown)
   const lockedStudent = page.getByTestId('student-locked')
-  await expect(lockedStudent).toBeVisible({ timeout: 10000 })
+  await expect(lockedStudent).toBeVisible({ timeout: UI_TIMEOUT })
   await expect(lockedStudent).toContainText(studentName)
   await expect(page.getByTestId('student-select')).not.toBeVisible()
 
@@ -420,7 +430,7 @@ test('student detail shows 4 tabs and overview content by default', async ({ bro
 
   // Create a student with native language set
   await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
   await page.getByTestId('student-name').fill(studentName)
   await page.getByTestId('student-language').click()
   await page.getByRole('option', { name: 'Spanish' }).click()
@@ -432,21 +442,21 @@ test('student detail shows 4 tabs and overview content by default', async ({ bro
   await page.getByRole('button', { name: 'Save Student' }).click()
 
   // Should redirect directly to student detail page
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
 
   // All 4 tabs should be visible
-  await expect(page.getByTestId('tab-overview')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('tab-overview')).toBeVisible({ timeout: UI_TIMEOUT })
   await expect(page.getByTestId('tab-profile')).toBeVisible()
   await expect(page.getByTestId('tab-sessions')).toBeVisible()
   await expect(page.getByTestId('tab-progress')).toBeVisible()
 
   // Overview tab content should be visible by default
-  await expect(page.getByTestId('student-overview-tab')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('student-overview-tab')).toBeVisible({ timeout: UI_TIMEOUT })
   await expect(page.getByTestId('primary-objective-card')).toBeVisible()
 
   // Click Profile tab
   await page.getByTestId('tab-profile').click()
-  await expect(page.getByTestId('student-profile-tab')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('student-profile-tab')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // CEFR badge and header actions should be visible
   await expect(page.getByTestId('cefr-badge')).toBeVisible()
@@ -455,30 +465,33 @@ test('student detail shows 4 tabs and overview content by default', async ({ bro
 
   // Switch to Sessions tab (new student has no sessions)
   await page.getByTestId('tab-sessions').click()
-  await expect(page.getByTestId('session-history-empty')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('session-history-empty')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Switch to Progress tab (new student has no course)
   await page.getByTestId('tab-progress').click()
-  await expect(page.getByTestId('progress-no-course')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('progress-no-course')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Switch back to Profile tab
   await page.getByTestId('tab-profile').click()
-  await expect(page.getByTestId('student-profile-tab')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('student-profile-tab')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Cleanup: go back and delete student
   await page.goto('/students')
-  await expect(page).toHaveURL('/students', { timeout: 10000 })
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
   const deleteCard = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName })
   })
-  await deleteCard.getByTestId('delete-student').click()
-  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: 5000 })
+  await deleteCard.getByTestId('edit-student').click()
+  await expect(page).toHaveURL(/\/edit$/, { timeout: UI_TIMEOUT })
+  await page.getByTestId('delete-student-btn').click()
+  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await page.getByTestId('confirm-delete').click()
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
   await expect(
     page.locator('[data-testid^="student-row-"]').filter({
       has: page.getByTestId('student-name').filter({ hasText: studentName }),
     }),
-  ).not.toBeVisible({ timeout: 10000 })
+  ).not.toBeVisible({ timeout: UI_TIMEOUT })
 
   await context.close()
 })
@@ -490,7 +503,7 @@ test('saves and displays SpokenLanguages, OfficialCefrLevel, and SkillLevelOverr
   const studentName = `Language Fields Test ${Date.now()}`
 
   await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
 
   await page.getByTestId('student-name').fill(studentName)
   await page.getByTestId('student-language').click()
@@ -505,30 +518,30 @@ test('saves and displays SpokenLanguages, OfficialCefrLevel, and SkillLevelOverr
   // Add a spoken language
   await page.getByTestId('spoken-language-input').fill('English')
   await page.getByTestId('spoken-language-input').press('Enter')
-  await expect(page.getByTestId('spoken-lang-chip').first()).toBeVisible({ timeout: 5000 })
+  await expect(page.getByTestId('spoken-lang-chip').first()).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
 
   // Set skill override for Reading
   await page.getByTestId('skill-override-reading').click()
   await page.getByRole('option', { name: 'B2' }).click()
 
   await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL(/\/students\/[^/]+$/, { timeout: 10000 })
+  await expect(page).toHaveURL(/\/students\/[^/]+$/, { timeout: UI_TIMEOUT })
 
   // Verify Overview tab shows skill bar
-  await expect(page.getByTestId('tab-overview')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByTestId('tab-overview')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   const overviewSkillBadge = page.getByTestId('overview-skill-badge-reading')
-  await expect(overviewSkillBadge).toBeVisible({ timeout: 5000 })
+  await expect(overviewSkillBadge).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await expect(overviewSkillBadge).toHaveText('B2')
 
   // Switch to Profile tab and verify Language Ecosystem and Skill Assessment
   await page.getByTestId('tab-profile').click()
   const langSection = page.getByTestId('profile-language-ecosystem')
-  await expect(langSection).toBeVisible({ timeout: 5000 })
+  await expect(langSection).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await expect(langSection).toContainText('English')
   await expect(langSection).toContainText('A2')
 
   const skillSection = page.getByTestId('profile-skill-assessment')
-  await expect(skillSection).toBeVisible({ timeout: 5000 })
+  await expect(skillSection).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await expect(skillSection).toContainText('Reading')
   await expect(skillSection).toContainText('B2')
 
@@ -537,14 +550,17 @@ test('saves and displays SpokenLanguages, OfficialCefrLevel, and SkillLevelOverr
   const deleteCard = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName }),
   })
-  await deleteCard.getByTestId('delete-student').click()
-  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: 5000 })
+  await deleteCard.getByTestId('edit-student').click()
+  await expect(page).toHaveURL(/\/edit$/, { timeout: UI_TIMEOUT })
+  await page.getByTestId('delete-student-btn').click()
+  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await page.getByTestId('confirm-delete').click()
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
   await expect(
     page.locator('[data-testid^="student-row-"]').filter({
       has: page.getByTestId('student-name').filter({ hasText: studentName }),
     }),
-  ).not.toBeVisible({ timeout: 10000 })
+  ).not.toBeVisible({ timeout: UI_TIMEOUT })
 
   await context.close()
 })
@@ -556,7 +572,7 @@ test('identity fields round-trip: save and verify in profile view and edit form'
   const studentName = `Identity Test ${Date.now()}`
 
   await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
 
   await page.getByTestId('student-name').fill(studentName)
   await page.getByTestId('student-language').click()
@@ -575,22 +591,22 @@ test('identity fields round-trip: save and verify in profile view and edit form'
   await page.getByRole('button', { name: 'Save Student' }).click()
 
   // Should redirect to student detail page
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
 
   // Header shows profession and compact location (visible on all tabs)
-  await expect(page.getByTestId('student-header-profession')).toHaveText('Architect', { timeout: 5000 })
-  await expect(page.getByTestId('student-header-location')).toHaveText('Lisbon / Madrid', { timeout: 5000 })
+  await expect(page.getByTestId('student-header-profession')).toHaveText('Architect', { timeout: FEEDBACK_TIMEOUT })
+  await expect(page.getByTestId('student-header-location')).toHaveText('Lisbon / Madrid', { timeout: FEEDBACK_TIMEOUT })
 
   // Navigate to Profile tab to check identity details
   await page.getByTestId('tab-profile').click()
-  await expect(page.getByTestId('profile-about')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByTestId('profile-about')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await expect(page.getByText('Lisbon, Portugal')).toBeVisible()
   await expect(page.getByText('Madrid, Spain')).toBeVisible()
   await expect(page.getByText(/1990 \(\d+ years\)/)).toBeVisible()
 
   // Navigate to edit and verify round-trip
   await page.getByTestId('edit-profile-link').click()
-  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: UI_TIMEOUT })
   await expect(page.getByTestId('student-birth-year')).toHaveValue('1990')
   await expect(page.getByTestId('student-profession')).toHaveValue('Architect')
   await expect(page.getByTestId('student-country-origin')).toHaveValue('Portugal')
@@ -600,18 +616,21 @@ test('identity fields round-trip: save and verify in profile view and edit form'
 
   // Cleanup
   await page.getByRole('button', { name: 'Cancel' }).click()
-  await expect(page).toHaveURL('/students', { timeout: 10000 })
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
   const deleteCardIdentity = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName }),
   })
-  await deleteCardIdentity.getByTestId('delete-student').click()
-  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: 5000 })
+  await deleteCardIdentity.getByTestId('edit-student').click()
+  await expect(page).toHaveURL(/\/edit$/, { timeout: UI_TIMEOUT })
+  await page.getByTestId('delete-student-btn').click()
+  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await page.getByTestId('confirm-delete').click()
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
   await expect(
     page.locator('[data-testid^="student-row-"]').filter({
       has: page.getByTestId('student-name').filter({ hasText: studentName }),
     }),
-  ).not.toBeVisible({ timeout: 10000 })
+  ).not.toBeVisible({ timeout: UI_TIMEOUT })
 
   await context.close()
 })
@@ -626,7 +645,7 @@ test('motivation fields: reason for studying and objectives round-trip', async (
 
   // Create student with motivation fields
   await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
   await page.getByTestId('student-name').fill(studentName)
   await page.getByTestId('student-language').click()
   await page.getByRole('option', { name: 'Spanish' }).click()
@@ -641,15 +660,15 @@ test('motivation fields: reason for studying and objectives round-trip', async (
   await page.getByTestId('objective-text-input').fill(objectiveText)
 
   await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
 
   // Overview tab: primary objective card shows the objective
-  await expect(page.getByTestId('primary-objective-card')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('primary-objective-card')).toBeVisible({ timeout: UI_TIMEOUT })
   await expect(page.getByTestId('objective-text')).toHaveText(objectiveText)
 
   // Profile tab: hero section shows reason for studying as a quote
   await page.getByTestId('tab-profile').click()
-  await expect(page.getByTestId('profile-hero')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('profile-hero')).toBeVisible({ timeout: UI_TIMEOUT })
   await expect(page.getByTestId('reason-quote')).toContainText(reasonText)
 
   // Profile tab: objectives section shows objective
@@ -658,25 +677,28 @@ test('motivation fields: reason for studying and objectives round-trip', async (
 
   // Navigate to edit form and verify round-trip
   await page.getByTestId('edit-profile-link').click()
-  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: UI_TIMEOUT })
   await expect(page.getByTestId('student-reason-for-studying')).toHaveValue(reasonText)
-  await expect(page.getByTestId('objective-row')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByTestId('objective-row')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await expect(page.getByTestId('objective-text-input')).toHaveValue(objectiveText)
 
   // Cleanup
   await page.getByRole('button', { name: 'Cancel' }).click()
-  await expect(page).toHaveURL('/students', { timeout: 10000 })
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
   const deleteCardM = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName }),
   })
-  await deleteCardM.getByTestId('delete-student').click()
-  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: 5000 })
+  await deleteCardM.getByTestId('edit-student').click()
+  await expect(page).toHaveURL(/\/edit$/, { timeout: UI_TIMEOUT })
+  await page.getByTestId('delete-student-btn').click()
+  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await page.getByTestId('confirm-delete').click()
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
   await expect(
     page.locator('[data-testid^="student-row-"]').filter({
       has: page.getByTestId('student-name').filter({ hasText: studentName }),
     }),
-  ).not.toBeVisible({ timeout: 10000 })
+  ).not.toBeVisible({ timeout: UI_TIMEOUT })
 
   await context.close()
 })
@@ -700,7 +722,7 @@ test('Ana Visual profile tab shows Focus Areas section with difficulties and wea
 
   // Navigate to Profile tab
   await page.getByTestId('tab-profile').click()
-  await expect(page.getByTestId('student-profile-tab')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('student-profile-tab')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Focus Areas & Difficulties section renders
   const focusSection = page.getByTestId('profile-focus-areas')
@@ -731,18 +753,18 @@ test('teaching todos: add, toggle covered, verify ordering on overview tab', asy
 
   // Create a student to work with
   await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
   await page.getByTestId('student-name').fill(studentName)
   await page.getByTestId('student-language').click()
   await page.getByRole('option', { name: 'Spanish' }).click()
   await page.getByTestId('student-cefr').click()
   await page.getByRole('option', { name: 'B1' }).click()
   await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
 
   // Verify we're on the overview tab (default)
-  await expect(page.getByTestId('tab-overview')).toHaveAttribute('aria-selected', 'true', { timeout: 5000 })
-  await expect(page.getByTestId('teaching-todos-card')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByTestId('tab-overview')).toHaveAttribute('aria-selected', 'true', { timeout: FEEDBACK_TIMEOUT })
+  await expect(page.getByTestId('teaching-todos-card')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
 
   // Empty state is shown
   await expect(page.getByTestId('teaching-todos-empty')).toBeVisible()
@@ -753,14 +775,14 @@ test('teaching todos: add, toggle covered, verify ordering on overview tab', asy
   await page.getByTestId('todo-add-btn').click()
 
   // Todo appears in list
-  await expect(page.getByTestId('teaching-todos-list')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByTestId('teaching-todos-list')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   const firstTodo = page.getByTestId('teaching-todo-item').first()
   await expect(firstTodo).toContainText('Practice ser vs estar')
 
   // Add a second todo
   await addInput.fill('Review subjunctive mood')
   await page.getByTestId('todo-add-btn').click()
-  await expect(page.getByTestId('teaching-todo-item')).toHaveCount(2, { timeout: 5000 })
+  await expect(page.getByTestId('teaching-todo-item')).toHaveCount(2, { timeout: FEEDBACK_TIMEOUT })
 
   // Mark the first todo as covered — capture id before any reorder so locators stay stable
   const toggleTestId = await page.getByTestId('teaching-todo-item').first().getByTestId(/^todo-toggle-/).getAttribute('data-testid')
@@ -771,7 +793,7 @@ test('teaching todos: add, toggle covered, verify ordering on overview tab', asy
   await page.getByTestId(`todo-toggle-${todoId}`).click()
 
   // Wait for covered state (strikethrough)
-  await expect(page.getByTestId(`todo-text-${todoId}`)).toHaveClass(/line-through/, { timeout: 5000 })
+  await expect(page.getByTestId(`todo-text-${todoId}`)).toHaveClass(/line-through/, { timeout: FEEDBACK_TIMEOUT })
 
   // Verify ordering: pending todo should appear before covered
   const reorderedItems = page.getByTestId('teaching-todo-item')
@@ -785,10 +807,13 @@ test('teaching todos: add, toggle covered, verify ordering on overview tab', asy
   const row = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName })
   })
-  await row.getByTestId('delete-student').click()
-  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: 5000 })
+  await row.getByTestId('edit-student').click()
+  await expect(page).toHaveURL(/\/edit$/, { timeout: UI_TIMEOUT })
+  await page.getByTestId('delete-student-btn').click()
+  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await page.getByTestId('confirm-delete').click()
-  await expect(row).not.toBeVisible({ timeout: 10000 })
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
+  await expect(row).not.toBeVisible({ timeout: UI_TIMEOUT })
 
   await context.close()
 })
@@ -800,24 +825,24 @@ test('log session page: create session from full-page form and redirect back', a
 
   // Create a student
   await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
   await page.getByTestId('student-name').fill(studentName)
   await page.getByTestId('student-language').click()
   await page.getByRole('option', { name: 'Spanish' }).click()
   await page.getByTestId('student-cefr').click()
   await page.getByRole('option', { name: 'B1' }).click()
   await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
 
   // Click "Log Session" button - should navigate to full page
-  await expect(page.getByTestId('log-session-button')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-button')).toBeVisible({ timeout: UI_TIMEOUT })
   await page.getByTestId('log-session-button').click()
 
   // Assert full-page route
-  await expect(page).toHaveURL(/\/students\/[^/]+\/log-session$/, { timeout: 10000 })
+  await expect(page).toHaveURL(/\/students\/[^/]+\/log-session$/, { timeout: UI_TIMEOUT })
 
   // Left panel shows student name and session number
-  await expect(page.getByTestId('student-name')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('student-name')).toBeVisible({ timeout: UI_TIMEOUT })
   await expect(page.getByTestId('student-name')).toHaveText(studentName)
   await expect(page.getByTestId('session-number')).toHaveText('Session #1')
 
@@ -833,22 +858,25 @@ test('log session page: create session from full-page form and redirect back', a
   await page.getByTestId('submit-button').click()
 
   // Should redirect back to student detail
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 15000 })
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
 
   // Sessions tab should show the new session
   await page.getByTestId('tab-sessions').click()
   const sessionEntries = page.locator('[data-testid="session-entry"]')
-  await expect(sessionEntries.first()).toBeVisible({ timeout: 10000 })
+  await expect(sessionEntries.first()).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Cleanup: delete student
   await page.goto('/students')
   const row = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName })
   })
-  await row.getByTestId('delete-student').click()
-  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: 5000 })
+  await row.getByTestId('edit-student').click()
+  await expect(page).toHaveURL(/\/edit$/, { timeout: UI_TIMEOUT })
+  await page.getByTestId('delete-student-btn').click()
+  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await page.getByTestId('confirm-delete').click()
-  await expect(row).not.toBeVisible({ timeout: 10000 })
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
+  await expect(row).not.toBeVisible({ timeout: UI_TIMEOUT })
 
   await context.close()
 })
@@ -859,28 +887,28 @@ test('overview tab: header badges, pedagogical profile, teaching notes panel vis
   const studentName = `OverviewSectionsTest_${Date.now()}`
 
   await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: 10000 })
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
   await page.getByTestId('student-name').fill(studentName)
   await page.getByTestId('student-language').click()
   await page.getByRole('option', { name: 'Spanish' }).click()
   await page.getByTestId('student-cefr').click()
   await page.getByRole('option', { name: 'B1' }).click()
   await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: 10000 })
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
 
   // Header status badge should show Active + Private
-  await expect(page.getByTestId('student-status-badge')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('student-status-badge')).toBeVisible({ timeout: UI_TIMEOUT })
   await expect(page.getByTestId('student-status-badge')).toContainText('Active')
   await expect(page.getByTestId('student-status-badge')).toContainText('Private')
 
   // Pedagogical Profile card present
-  await expect(page.getByTestId('pedagogical-profile-card')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('pedagogical-profile-card')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Recent sessions empty state (no sessions yet)
-  await expect(page.getByTestId('recent-sessions-empty')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('recent-sessions-empty')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Teaching notes panel visible with Add Memory button
-  await expect(page.getByTestId('teaching-notes-panel')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('teaching-notes-panel')).toBeVisible({ timeout: UI_TIMEOUT })
   await expect(page.getByTestId('add-memory-btn')).toBeVisible()
 
   // Cleanup
@@ -888,10 +916,72 @@ test('overview tab: header badges, pedagogical profile, teaching notes panel vis
   const overviewRow = page.locator('[data-testid^="student-row-"]').filter({
     has: page.getByTestId('student-name').filter({ hasText: studentName }),
   })
-  await overviewRow.getByTestId('delete-student').click()
-  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: 5000 })
+  await overviewRow.getByTestId('edit-student').click()
+  await expect(page).toHaveURL(/\/edit$/, { timeout: UI_TIMEOUT })
+  await page.getByTestId('delete-student-btn').click()
+  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await page.getByTestId('confirm-delete').click()
-  await expect(overviewRow).not.toBeVisible({ timeout: 10000 })
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
+  await expect(overviewRow).not.toBeVisible({ timeout: UI_TIMEOUT })
+
+  await context.close()
+})
+
+test('commercial fields round-trip: isActive, isCorporate, rate', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  const studentName = `CommercialTest_${Date.now()}`
+
+  // Create a student
+  await page.goto('/students/new')
+  await page.getByTestId('student-name').fill(studentName)
+  await page.getByTestId('student-language').click()
+  await page.getByRole('option', { name: 'Spanish' }).click()
+  await page.getByTestId('student-cefr').click()
+  await page.getByRole('option', { name: 'B1' }).click()
+  await page.getByRole('button', { name: 'Save Student' }).click()
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
+
+  // Navigate to edit
+  await page.getByTestId('edit-profile-link').click()
+  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: UI_TIMEOUT })
+
+  // Section nav is present
+  await expect(page.getByTestId('section-nav')).toBeVisible()
+
+  // Navigate to commercial section via nav link
+  await page.getByTestId('section-nav-section-commercial').click()
+  await expect(page.getByTestId('toggle-is-active')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
+  await expect(page.getByTestId('toggle-is-corporate')).toBeVisible()
+  await expect(page.getByTestId('student-rate')).toBeVisible()
+
+  // Fill commercial fields
+  await page.getByTestId('student-rate').fill('55/hr')
+  await page.getByTestId('toggle-is-corporate').click()
+  await page.getByTestId('toggle-is-active').click()
+  await expect(page.getByTestId('inactive-badge')).toBeVisible()
+
+  // Save
+  await page.getByRole('button', { name: 'Save Profile' }).first().click()
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
+
+  // Profile tab: commercial section shows updated values
+  await page.getByTestId('tab-profile').click()
+  await expect(page.getByTestId('profile-commercial')).toBeVisible({ timeout: UI_TIMEOUT })
+  await expect(page.getByTestId('profile-commercial')).toContainText('Inactive')
+  await expect(page.getByTestId('profile-commercial')).toContainText('Corporate')
+  await expect(page.getByTestId('profile-commercial')).toContainText('55/hr')
+
+  // Re-open edit and verify inactive badge persists
+  await page.getByTestId('edit-profile-link').click()
+  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: UI_TIMEOUT })
+  await expect(page.getByTestId('inactive-badge')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
+
+  // Cleanup via delete button on edit page
+  await page.getByTestId('delete-student-btn').click()
+  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
+  await page.getByTestId('confirm-delete').click()
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
 
   await context.close()
 })

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@fontsource-variable/geist": "^5.2.8",
-        "@fontsource-variable/inter": "^5.2.8",
+        "@fontsource-variable/inter": "5.2.8",
         "@fontsource-variable/manrope": "^5.2.8",
         "@tailwindcss/vite": "^4.2.1",
         "@tanstack/react-query": "^5.90.21",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/geist": "^5.2.8",
-    "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource-variable/inter": "5.2.8",
     "@fontsource-variable/manrope": "^5.2.8",
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/react-query": "^5.90.21",

--- a/frontend/src/pages/StudentForm.test.tsx
+++ b/frontend/src/pages/StudentForm.test.tsx
@@ -15,10 +15,13 @@ const mockCreateStudent = vi.fn()
 const mockUpdateStudent = vi.fn()
 const mockGetStudents = vi.fn()
 
+const mockDeleteStudent = vi.fn()
+
 vi.mock('../api/students', () => ({
   getStudent: (...args: unknown[]) => mockGetStudent(...args),
   createStudent: (...args: unknown[]) => mockCreateStudent(...args),
   updateStudent: (...args: unknown[]) => mockUpdateStudent(...args),
+  deleteStudent: (...args: unknown[]) => mockDeleteStudent(...args),
   getStudents: (...args: unknown[]) => mockGetStudents(...args),
   appendTeachingTodo: vi.fn(),
   updateTeachingTodo: vi.fn(),
@@ -92,20 +95,20 @@ describe('StudentForm', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetStudent.mockResolvedValue({
-      id: 'stu-1',
-      name: 'Ana',
-      learningLanguage: 'Spanish',
-      cefrLevel: 'B1',
-      interests: [],
-      nativeLanguages: [],
-      learningGoals: [],
+      id: 'stu-1', name: 'Ana', learningLanguage: 'Spanish', cefrLevel: 'B1',
+      interests: [], nativeLanguages: [], learningGoals: [],
       weaknesses: [] as { description: string; weaknessType: string }[],
-      difficulties: [],
-      personalNotes: null, teachingNotes: null,
+      difficulties: [], personalNotes: null, teachingNotes: null,
+      shortTermObjectives: [], spokenLanguages: [], teachingTodos: [],
+      birthYear: null, profession: null, countryOfOrigin: null, cityOfOrigin: null,
+      countryOfResidence: null, cityOfResidence: null, reasonForStudying: null,
+      officialCefrLevel: null, isActive: true, isCorporate: false, rate: null,
+      skillLevelOverrides: {}, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z',
     })
     mockGetStudents.mockResolvedValue({ items: [], totalCount: 0 })
     mockCreateStudent.mockResolvedValue({ id: 'new-id' })
     mockUpdateStudent.mockResolvedValue({ id: 'stu-1' })
+    mockDeleteStudent.mockResolvedValue(undefined)
   })
 
   it('renders Back link to students list', () => {
@@ -115,9 +118,11 @@ describe('StudentForm', () => {
     expect(back).toHaveTextContent('Students')
   })
 
-  it('shows "Teaching Context" section heading instead of "AI Personalization"', () => {
+  it('shows Teaching Goals and Difficulties sections instead of a combined Teaching Context', () => {
     renderNew()
-    expect(screen.getByText('Teaching Context')).toBeInTheDocument()
+    expect(screen.getByText('Teaching Goals')).toBeInTheDocument()
+    expect(screen.getByText('Difficulties')).toBeInTheDocument()
+    expect(screen.queryByText('Teaching Context')).not.toBeInTheDocument()
     expect(screen.queryByText('AI Personalization')).not.toBeInTheDocument()
   })
 
@@ -176,7 +181,7 @@ describe('StudentForm', () => {
     renderEdit()
 
     await screen.findByRole('heading', { name: 'Edit Student' })
-    await user.click(screen.getByRole('button', { name: 'Update Student' }))
+    await user.click(screen.getAllByRole('button', { name: 'Save Profile' })[0])
 
     await vi.waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/students/stu-1')
@@ -500,7 +505,7 @@ describe('StudentForm', () => {
     expect(chips[1]).toHaveTextContent('English')
     expect(chips[2]).toHaveTextContent('Catalan')
 
-    await user.click(screen.getByRole('button', { name: 'Update Student' }))
+    await user.click(screen.getAllByRole('button', { name: 'Save Profile' })[0])
 
     await vi.waitFor(() => {
       expect(mockUpdateStudent).toHaveBeenCalledWith(
@@ -736,5 +741,91 @@ describe('StudentForm', () => {
   it('does not show teaching todos sidebar in create mode', () => {
     renderNew()
     expect(screen.queryByTestId('form-sidebar')).not.toBeInTheDocument()
+  })
+
+  it('renders commercial fields in edit mode', async () => {
+    renderEdit()
+    await screen.findByRole('heading', { name: 'Edit Student' })
+    expect(screen.getByTestId('toggle-is-active')).toBeInTheDocument()
+    expect(screen.getByTestId('toggle-is-corporate')).toBeInTheDocument()
+    expect(screen.getByTestId('student-rate')).toBeInTheDocument()
+  })
+
+  it('does not render commercial section in create mode', () => {
+    renderNew()
+    expect(screen.queryByTestId('toggle-is-active')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('toggle-is-corporate')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('student-rate')).not.toBeInTheDocument()
+  })
+
+  it('submits commercial fields in edit mode', async () => {
+    mockGetStudent.mockResolvedValue({
+      id: 'stu-1', name: 'Ana', learningLanguage: 'Spanish', cefrLevel: 'B1',
+      interests: [], nativeLanguages: [], learningGoals: [], weaknesses: [], difficulties: [],
+      personalNotes: null, teachingNotes: null, shortTermObjectives: [], spokenLanguages: [],
+      teachingTodos: [], birthYear: null, profession: null, countryOfOrigin: null,
+      cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null,
+      reasonForStudying: null, officialCefrLevel: null,
+      isActive: true, isCorporate: false, rate: '45/hr',
+      skillLevelOverrides: {}, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z',
+    })
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+    renderEdit()
+    await screen.findByRole('heading', { name: 'Edit Student' })
+
+    // Toggle isActive off
+    await user.click(screen.getByTestId('toggle-is-active'))
+    // inactive badge should appear
+    expect(await screen.findByTestId('inactive-badge')).toBeInTheDocument()
+
+    await user.click(screen.getAllByRole('button', { name: 'Save Profile' })[0])
+
+    await vi.waitFor(() => {
+      expect(mockUpdateStudent).toHaveBeenCalledWith(
+        'stu-1',
+        expect.objectContaining({ isActive: false, isCorporate: false, rate: '45/hr' }),
+      )
+    })
+  })
+
+  it('shows delete button in edit mode', async () => {
+    renderEdit()
+    await screen.findByRole('heading', { name: 'Edit Student' })
+    expect(screen.getByTestId('delete-student-btn')).toBeInTheDocument()
+  })
+
+  it('does not show delete button in create mode', () => {
+    renderNew()
+    expect(screen.queryByTestId('delete-student-btn')).not.toBeInTheDocument()
+  })
+
+  it('opens delete dialog and confirms deletion', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+    renderEdit()
+    await screen.findByRole('heading', { name: 'Edit Student' })
+
+    await user.click(screen.getByTestId('delete-student-btn'))
+    expect(await screen.findByRole('alertdialog')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('confirm-delete'))
+
+    await vi.waitFor(() => {
+      expect(mockDeleteStudent).toHaveBeenCalledWith('stu-1')
+    })
+  })
+
+  it('shows section nav in edit mode', async () => {
+    renderEdit()
+    await screen.findByRole('heading', { name: 'Edit Student' })
+    expect(screen.getByTestId('section-nav')).toBeInTheDocument()
+    expect(screen.getByTestId('section-nav-section-basic')).toBeInTheDocument()
+    expect(screen.getByTestId('section-nav-section-commercial')).toBeInTheDocument()
+  })
+
+  it('does not show section nav in create mode', () => {
+    renderNew()
+    expect(screen.queryByTestId('section-nav')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -215,6 +215,8 @@ export default function StudentForm() {
     },
   })
 
+  const isBusy = isPending || isDeleting
+
   function addInterest(value: string) {
     const trimmed = value.trim()
     if (trimmed && !interests.includes(trimmed)) {
@@ -438,6 +440,7 @@ export default function StudentForm() {
                 type="button"
                 variant="outline"
                 onClick={() => setShowDeleteDialog(true)}
+                disabled={isBusy}
                 className="text-red-600 border-red-200 hover:bg-red-50"
                 data-testid="delete-student-btn"
               >
@@ -502,7 +505,7 @@ export default function StudentForm() {
               type="submit"
               form="student-form"
               size="sm"
-              disabled={isPending}
+              disabled={isBusy}
               className="bg-indigo-600 hover:bg-indigo-700 text-white"
             >
               {isPending ? 'Saving...' : 'Save Profile'}
@@ -1272,7 +1275,7 @@ export default function StudentForm() {
               <AlertDialogCancel>Cancel</AlertDialogCancel>
               <AlertDialogAction
                 onClick={() => doDelete(id)}
-                disabled={isDeleting}
+                disabled={isBusy}
                 className="bg-red-600 hover:bg-red-700 text-white"
                 data-testid="confirm-delete"
               >

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState, useRef } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { X, Plus, Trash2 } from 'lucide-react'
-import { getStudent, createStudent, updateStudent, type StudentFormData, type Difficulty, type StudentWeaknessItem, type ShortTermObjective } from '../api/students'
+import { getStudent, createStudent, updateStudent, deleteStudent, type StudentFormData, type Difficulty, type StudentWeaknessItem, type ShortTermObjective } from '../api/students'
 import { TeachingTodosCard } from '@/components/student/TeachingTodosCard'
 import { getObjectiveUrgency } from '@/lib/objectiveUrgency'
 import { LEARNING_GOALS, COMPETENCY_OPTIONS } from '../lib/studentOptions'
@@ -30,6 +30,37 @@ import { FieldTooltip } from '@/components/FieldTooltip'
 import { PageHeader } from '@/components/PageHeader'
 import { CEFR_LEVELS } from '@/lib/cefr-colors'
 import { LANGUAGES, NATIVE_LANGUAGE_OPTIONS } from '@/lib/languages'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+
+const FORM_SECTIONS = [
+  { id: 'section-basic', label: 'Basic Info' },
+  { id: 'section-background', label: 'Background' },
+  { id: 'section-proficiency', label: 'Proficiency' },
+  { id: 'section-teaching-goals', label: 'Teaching Goals' },
+  { id: 'section-difficulties', label: 'Difficulties' },
+  { id: 'section-notes', label: 'Notes' },
+  { id: 'section-commercial', label: 'Commercial' },
+]
+
+// Scrollspy tracks these in order; section-proficiency omitted because it shares
+// the same Y position as section-basic (2-column layout) and basic wins.
+const SCROLLSPY_IDS = [
+  'section-basic',
+  'section-background',
+  'section-teaching-goals',
+  'section-difficulties',
+  'section-notes',
+  'section-commercial',
+]
 
 export default function StudentForm() {
   const navigate = useNavigate()
@@ -60,7 +91,13 @@ export default function StudentForm() {
   const [cityOfResidence, setCityOfResidence] = useState('')
   const [reasonForStudying, setReasonForStudying] = useState('')
   const [shortTermObjectives, setShortTermObjectives] = useState<ShortTermObjective[]>([])
+  const [isActive, setIsActive] = useState(true)
+  const [isCorporate, setIsCorporate] = useState(false)
+  const [rate, setRate] = useState('')
   const [errors, setErrors] = useState<Record<string, string>>({})
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+  const [activeSection, setActiveSection] = useState(SCROLLSPY_IDS[0])
   const interestInputRef = useRef<HTMLInputElement>(null)
   const spokenInputRef = useRef<HTMLInputElement>(null)
 
@@ -114,9 +151,41 @@ export default function StudentForm() {
       setCityOfResidence(existing.cityOfResidence ?? '')
       setReasonForStudying(existing.reasonForStudying ?? '')
       setShortTermObjectives(existing.shortTermObjectives ?? [])
+      setIsActive(existing.isActive ?? true)
+      setIsCorporate(existing.isCorporate ?? false)
+      setRate(existing.rate ?? '')
     }
   }, [existing])
   /* eslint-enable react-hooks/set-state-in-effect */
+
+  // Scrollspy: listen on the main scroll container
+  useEffect(() => {
+    if (!isEdit) return
+    const container = document.querySelector('main')
+    if (!container) return
+    function onScroll() {
+      const offset = 80
+      let current = SCROLLSPY_IDS[0]
+      for (const sid of SCROLLSPY_IDS) {
+        const el = document.getElementById(sid)
+        if (el && el.getBoundingClientRect().top <= offset) current = sid
+      }
+      setActiveSection(current)
+    }
+    container.addEventListener('scroll', onScroll, { passive: true })
+    return () => container.removeEventListener('scroll', onScroll)
+  }, [isEdit])
+
+  function scrollToSection(sid: string) {
+    const container = document.querySelector('main')
+    const el = document.getElementById(sid)
+    if (!el || !container) return
+    const elTop =
+      el.getBoundingClientRect().top -
+      container.getBoundingClientRect().top +
+      container.scrollTop
+    container.scrollTo({ top: elTop - 60, behavior: 'smooth' })
+  }
 
   const { mutate, isPending } = useMutation({
     mutationFn: (data: StudentFormData) =>
@@ -127,6 +196,23 @@ export default function StudentForm() {
       navigate(`/students/${student.id}`)
     },
     onError: (err) => logger.error('StudentForm', 'save failed', err),
+  })
+
+  const { mutate: doDelete, isPending: isDeleting } = useMutation({
+    mutationFn: (studentId: string) => deleteStudent(studentId),
+    onSuccess: () => {
+      logger.info('StudentForm', 'student deleted')
+      queryClient.invalidateQueries({ queryKey: ['students'] })
+      queryClient.invalidateQueries({ queryKey: ['dashboard'] })
+      setShowDeleteDialog(false)
+      setDeleteError(null)
+      navigate('/students')
+    },
+    onError: (err) => {
+      logger.error('StudentForm', 'delete failed', err)
+      setDeleteError('Failed to delete student. Please try again.')
+      setShowDeleteDialog(false)
+    },
   })
 
   function addInterest(value: string) {
@@ -199,23 +285,23 @@ export default function StudentForm() {
   }
 
   function addDifficulty() {
-    const id = typeof crypto !== 'undefined' && crypto.randomUUID
+    const newId = typeof crypto !== 'undefined' && crypto.randomUUID
       ? crypto.randomUUID()
       : `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
     setDifficulties((prev) => [
       ...prev,
-      { id, description: '', competency: '', subcategory: '', severity: 'medium', trend: 'stable', status: 'Active' },
+      { id: newId, description: '', competency: '', subcategory: '', severity: 'medium', trend: 'stable', status: 'Active' },
     ])
   }
 
-  function updateDifficulty(id: string, field: keyof Difficulty, value: string) {
+  function updateDifficulty(diffId: string, field: keyof Difficulty, value: string) {
     setDifficulties((prev) =>
-      prev.map((d) => (d.id === id ? { ...d, [field]: value } : d))
+      prev.map((d) => (d.id === diffId ? { ...d, [field]: value } : d))
     )
   }
 
-  function removeDifficulty(id: string) {
-    setDifficulties((prev) => prev.filter((d) => d.id !== id))
+  function removeDifficulty(diffId: string) {
+    setDifficulties((prev) => prev.filter((d) => d.id !== diffId))
   }
 
   function addObjective() {
@@ -225,14 +311,14 @@ export default function StudentForm() {
     setShortTermObjectives((prev) => [...prev, { id: newId, text: '', targetDate: null }])
   }
 
-  function updateObjective(id: string, field: 'text' | 'targetDate', value: string | null) {
+  function updateObjective(objId: string, field: 'text' | 'targetDate', value: string | null) {
     setShortTermObjectives((prev) =>
-      prev.map((o) => (o.id === id ? { ...o, [field]: value } : o))
+      prev.map((o) => (o.id === objId ? { ...o, [field]: value } : o))
     )
   }
 
-  function removeObjective(id: string) {
-    setShortTermObjectives((prev) => prev.filter((o) => o.id !== id))
+  function removeObjective(objId: string) {
+    setShortTermObjectives((prev) => prev.filter((o) => o.id !== objId))
   }
 
   function validate(): boolean {
@@ -279,6 +365,9 @@ export default function StudentForm() {
       cityOfResidence: cityOfResidence.trim() || null,
       reasonForStudying: reasonForStudying.trim() || null,
       shortTermObjectives: shortTermObjectives.filter((o) => o.text.trim()),
+      isActive,
+      isCorporate,
+      rate: rate.trim() || null,
     })
   }
 
@@ -316,8 +405,8 @@ export default function StudentForm() {
   }
 
   return (
-    <div className={isEdit ? 'grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_280px] gap-6 items-start' : 'max-w-2xl space-y-6'}>
-    <div className="space-y-6">
+    <>
+      {/* Page header — always at top, full width */}
       <PageHeader
         backTo="/students"
         backLabel="Students"
@@ -333,7 +422,6 @@ export default function StudentForm() {
                 </Button>
               ) : (
                 <Tooltip>
-                  {/* render as span so pointer events fire even when the inner button is disabled */}
                   <TooltipTrigger render={<span tabIndex={0} className="inline-flex" />}>
                     <Button type="button" variant="outline" disabled data-testid="create-course-btn">
                       Create Course
@@ -345,655 +433,855 @@ export default function StudentForm() {
                 </Tooltip>
               )
             })()}
-            <Button type="button" variant="outline" onClick={() => navigate('/students')}>
-              Cancel
-            </Button>
-            <Button type="submit" form="student-form" disabled={isPending} className="bg-indigo-600 hover:bg-indigo-700 text-white">
-              {isPending ? 'Saving...' : isEdit ? 'Update Student' : 'Save Student'}
-            </Button>
+            {isEdit && id && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setShowDeleteDialog(true)}
+                className="text-red-600 border-red-200 hover:bg-red-50"
+                data-testid="delete-student-btn"
+              >
+                Delete
+              </Button>
+            )}
+            {!isEdit && (
+              <>
+                <Button type="button" variant="outline" onClick={() => navigate('/students')}>
+                  Cancel
+                </Button>
+                <Button type="submit" form="student-form" disabled={isPending} className="bg-indigo-600 hover:bg-indigo-700 text-white">
+                  {isPending ? 'Saving...' : 'Save Student'}
+                </Button>
+              </>
+            )}
           </div>
         }
       />
 
-      <form id="student-form" onSubmit={handleSubmit} className="space-y-6">
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Basic Info</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {/* Name */}
-            <div className="space-y-1.5">
-              <Label htmlFor="name" className="inline-flex items-center gap-1">Name <span className="text-red-500">*</span> <FieldTooltip fieldKey="name" /></Label>
-              <Input
-                id="name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="e.g. Ana García"
-                maxLength={200}
-                className="max-w-sm"
-                data-testid="student-name"
-              />
-              {errors.name && <p className="text-xs text-red-600">{errors.name}</p>}
-            </div>
+      {/* Inactive badge — only shown when student is deactivated */}
+      {isEdit && !isActive && (
+        <div className="mt-2">
+          <span
+            className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-zinc-100 text-zinc-500 border border-zinc-200"
+            data-testid="inactive-badge"
+          >
+            Inactive
+          </span>
+        </div>
+      )}
 
-            {/* Learning Language + Teacher's Assessment side-by-side */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-sm">
-              <div className="space-y-1.5">
-                <Label className="inline-flex items-center gap-1">Learning Language <span className="text-red-500">*</span> <FieldTooltip fieldKey="learningLanguage" /></Label>
-                <Select value={language} onValueChange={(v) => {
-                  if (!v) return
-                  setLanguage(v)
-                }}>
-                  <SelectTrigger data-testid="student-language">
-                    <SelectValue placeholder="Select a language" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {LANGUAGES.map((lang) => (
-                      <SelectItem key={lang} value={lang}>{lang}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {errors.language && <p className="text-xs text-red-600">{errors.language}</p>}
-              </div>
+      {deleteError && (
+        <span className="text-sm text-red-600 font-medium mt-2" data-testid="delete-error">{deleteError}</span>
+      )}
 
-              <div className="space-y-1.5">
-                <Label className="inline-flex items-center gap-1">Teacher's Assessment <span className="text-red-500">*</span> <FieldTooltip fieldKey="cefrLevel" /></Label>
-                <Select value={cefrLevel} onValueChange={(v) => v && setCefrLevel(v)}>
-                  <SelectTrigger data-testid="student-cefr">
-                    <SelectValue placeholder="Select a level" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {CEFR_LEVELS.map((level) => (
-                      <SelectItem key={level} value={level}>{level}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {errors.cefrLevel && <p className="text-xs text-red-600">{errors.cefrLevel}</p>}
-              </div>
-            </div>
-
-            {/* Official CEFR Level */}
-            <div className="space-y-1.5 max-w-[calc(50%-0.5rem)]">
-              <Label className="inline-flex items-center gap-1">Official Level <FieldTooltip fieldKey="officialCefrLevel" /></Label>
-              <Select value={officialCefrLevel} onValueChange={(v) => setOfficialCefrLevel(!v || v === '__none__' ? '' : v)}>
-                <SelectTrigger data-testid="student-official-cefr">
-                  <SelectValue placeholder="None" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">None</SelectItem>
-                  {CEFR_LEVELS.map((level) => (
-                    <SelectItem key={level} value={level}>{level}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <p className="text-xs text-zinc-400">Official exam result or external assessment.</p>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Languages card */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Languages</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {/* Native Languages */}
-            <div className="space-y-1.5">
-              <Label className="inline-flex items-center gap-1">Native Languages <FieldTooltip fieldKey="nativeLanguages" /></Label>
-              <MultiSelect
-                options={NATIVE_LANGUAGE_OPTIONS}
-                selected={nativeLanguages}
-                onChange={setNativeLanguages}
-                placeholder="Select native languages (optional)"
-                triggerId="student-native-language"
-                chipTestId="native-lang-chip"
-                maxItems={5}
-                allowCustom={false}
-              />
-            </div>
-
-            {/* Spoken Languages */}
-            <div className="space-y-1.5">
-              <Label className="inline-flex items-center gap-1">Spoken Languages <FieldTooltip fieldKey="spokenLanguages" /></Label>
-              <div
-                className="flex flex-wrap gap-1.5 min-h-10 w-full max-w-sm rounded-md border border-input bg-white px-3 py-2 cursor-text"
-                onClick={() => spokenInputRef.current?.focus()}
-                data-testid="spoken-languages-container"
+      {/* Sticky section nav — edit mode only, renders below header so it sticks as header scrolls away */}
+      {isEdit && (
+        <div className="sticky top-14 lg:top-0 z-30 bg-white/95 backdrop-blur-sm border-b border-zinc-100 flex items-center gap-3 py-2 -mx-4 lg:-mx-6 px-4 lg:px-6 mt-4 mb-6" data-testid="section-nav">
+          <nav className="flex items-center gap-1 overflow-x-auto shrink min-w-0" style={{ scrollbarWidth: 'none' }} aria-label="Form sections">
+            {FORM_SECTIONS.map((s) => (
+              <button
+                key={s.id}
+                type="button"
+                onClick={() => scrollToSection(s.id)}
+                className={`px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors ${
+                  activeSection === s.id
+                    ? 'bg-indigo-50 text-indigo-700'
+                    : 'text-zinc-500 hover:text-zinc-800'
+                }`}
+                data-testid={`section-nav-${s.id}`}
               >
-                {spokenLanguages.map((lang) => (
-                  <span
-                    key={lang}
-                    className="inline-flex items-center gap-1 bg-indigo-50 text-indigo-700 text-xs font-medium rounded px-2 py-0.5"
-                    data-testid="spoken-lang-chip"
-                  >
-                    {lang}
-                    <button
-                      type="button"
-                      onClick={(e) => { e.stopPropagation(); removeSpokenLanguage(lang) }}
-                      className="text-indigo-400 hover:text-indigo-700 p-0.5 -mr-0.5"
-                      aria-label={`Remove ${lang}`}
-                    >
-                      <X className="h-4 w-4" />
-                    </button>
-                  </span>
-                ))}
-                <input
-                  ref={spokenInputRef}
-                  value={spokenInput}
-                  onChange={(e) => setSpokenInput(e.target.value)}
-                  onKeyDown={handleSpokenKeyDown}
-                  onBlur={() => { if (spokenInput.trim()) addSpokenLanguage(spokenInput) }}
-                  placeholder={spokenLanguages.length === 0 ? 'Type and press Enter' : ''}
-                  className="flex-1 min-w-20 outline-none text-sm bg-transparent placeholder:text-zinc-400"
-                  data-testid="spoken-language-input"
-                />
-              </div>
-              <p className="text-xs text-zinc-400">Other languages spoken. Flat list, no proficiency level.</p>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Skill Overrides card */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base inline-flex items-center gap-1">Skill Overrides <FieldTooltip fieldKey="skillLevelOverrides" /></CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-xs text-zinc-400 mb-4">Override the general CEFR level per skill for AI generation. Leave empty to inherit the general level.</p>
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 max-w-lg">
-              {(['Reading', 'Writing', 'Speaking', 'Listening'] as const).map((skill) => (
-                <div key={skill} className="space-y-1.5">
-                  <Label className="text-xs">{skill}</Label>
-                  <Select
-                    value={skillLevelOverrides[skill] ?? ''}
-                    onValueChange={(v) => setSkillOverride(skill, !v || v === '__none__' ? '' : v)}
-                  >
-                    <SelectTrigger data-testid={`skill-override-${skill.toLowerCase()}`} className="h-8 text-xs">
-                      <SelectValue placeholder="--" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none__">--</SelectItem>
-                      {CEFR_LEVELS.map((level) => (
-                        <SelectItem key={level} value={level}>{level}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Personal Background</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-sm">
-              <div className="space-y-1.5">
-                <Label htmlFor="birth-year">Birth Year</Label>
-                <Input
-                  id="birth-year"
-                  type="number"
-                  value={birthYear ?? ''}
-                  onChange={(e) => {
-                    const raw = e.target.value
-                    const num = Number(raw)
-                    setBirthYear(raw && !isNaN(num) && Number.isInteger(num) ? num : null)
-                  }}
-                  placeholder="e.g. 1990"
-                  min={1900}
-                  max={new Date().getFullYear()}
-                  data-testid="student-birth-year"
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="profession">Profession</Label>
-                <Input
-                  id="profession"
-                  value={profession}
-                  onChange={(e) => setProfession(e.target.value)}
-                  placeholder="e.g. Software engineer"
-                  maxLength={128}
-                  data-testid="student-profession"
-                />
-              </div>
-            </div>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-sm">
-              <div className="space-y-1.5">
-                <Label htmlFor="country-origin">Country of Origin</Label>
-                <Input
-                  id="country-origin"
-                  value={countryOfOrigin}
-                  onChange={(e) => setCountryOfOrigin(e.target.value)}
-                  placeholder="e.g. Portugal"
-                  maxLength={64}
-                  data-testid="student-country-origin"
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="city-origin">City of Origin</Label>
-                <Input
-                  id="city-origin"
-                  value={cityOfOrigin}
-                  onChange={(e) => setCityOfOrigin(e.target.value)}
-                  placeholder="e.g. Lisbon"
-                  maxLength={64}
-                  data-testid="student-city-origin"
-                />
-              </div>
-            </div>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-sm">
-              <div className="space-y-1.5">
-                <Label htmlFor="country-residence">Country of Residence</Label>
-                <Input
-                  id="country-residence"
-                  value={countryOfResidence}
-                  onChange={(e) => setCountryOfResidence(e.target.value)}
-                  placeholder="e.g. Spain"
-                  maxLength={64}
-                  data-testid="student-country-residence"
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="city-residence">City of Residence</Label>
-                <Input
-                  id="city-residence"
-                  value={cityOfResidence}
-                  onChange={(e) => setCityOfResidence(e.target.value)}
-                  placeholder="e.g. Madrid"
-                  maxLength={64}
-                  data-testid="student-city-residence"
-                />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Reason for Studying</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-1.5">
-              <Label htmlFor="reason-for-studying">Reason for studying</Label>
-              <Textarea
-                id="reason-for-studying"
-                value={reasonForStudying}
-                onChange={(e) => setReasonForStudying(e.target.value)}
-                placeholder="e.g. Moving to Spain next year, loves the culture..."
-                maxLength={512}
-                rows={3}
-                className="max-w-sm resize-none"
-                data-testid="student-reason-for-studying"
-              />
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base inline-flex items-center gap-1">Interests <FieldTooltip fieldKey="interests" /></CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <div
-              className="flex flex-wrap gap-1.5 min-h-10 w-full max-w-sm rounded-md border border-zinc-200 bg-white px-3 py-2 cursor-text"
-              onClick={() => interestInputRef.current?.focus()}
+                {s.label}
+              </button>
+            ))}
+          </nav>
+          <div className="flex items-center gap-2 shrink-0 ml-auto">
+            <Button type="button" variant="outline" size="sm" onClick={() => navigate('/students')}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              form="student-form"
+              size="sm"
+              disabled={isPending}
+              className="bg-indigo-600 hover:bg-indigo-700 text-white"
             >
-              {interests.map((interest) => (
-                <span
-                  key={interest}
-                  className="inline-flex items-center gap-1 bg-indigo-50 text-indigo-700 text-xs font-medium rounded px-2 py-0.5"
-                  data-testid="interest-chip"
-                >
-                  {interest}
-                  <button
-                    type="button"
-                    onClick={(e) => { e.stopPropagation(); removeInterest(interest) }}
-                    className="text-indigo-400 hover:text-indigo-700 p-0.5 -mr-0.5"
-                    aria-label={`Remove ${interest}`}
-                  >
-                    <X className="h-4 w-4" />
-                  </button>
-                </span>
-              ))}
-              <input
-                ref={interestInputRef}
-                value={interestInput}
-                onChange={(e) => setInterestInput(e.target.value)}
-                onKeyDown={handleInterestKeyDown}
-                onBlur={() => { if (interestInput.trim()) addInterest(interestInput) }}
-                placeholder={interests.length === 0 ? 'Type and press Enter' : ''}
-                className="flex-1 min-w-20 outline-none text-sm bg-transparent placeholder:text-zinc-400"
-                data-testid="interest-input"
-              />
-            </div>
-            <p className="text-xs text-zinc-400">Press Enter or comma to add. Backspace to remove last.</p>
-          </CardContent>
-        </Card>
+              {isPending ? 'Saving...' : 'Save Profile'}
+            </Button>
+          </div>
+        </div>
+      )}
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Teaching Context</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
+      <div className={isEdit ? 'grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_280px] gap-6 items-start' : 'max-w-2xl space-y-6'}>
+        <div className="space-y-6">
 
-            {/* Learning Goals */}
-            <div className="space-y-1.5">
-              <Label className="inline-flex items-center gap-1">Learning Goals <FieldTooltip fieldKey="learningGoals" /></Label>
-              <MultiSelect
-                options={LEARNING_GOALS}
-                selected={learningGoals}
-                onChange={setLearningGoals}
-                placeholder="Select or type goals..."
-                triggerId="learning-goals-trigger"
-                chipTestId="learning-goal-chip"
-                maxLength={100}
-              />
-            </div>
+          <form id="student-form" onSubmit={handleSubmit} className="space-y-6">
 
-            {/* Weaknesses */}
-            <div className="space-y-3 pt-2 border-t border-zinc-100">
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label className="inline-flex items-center gap-1">Areas to Improve <FieldTooltip fieldKey="weaknesses" /></Label>
-                  <p className="text-xs text-zinc-400 mt-0.5">
-                    Free-text description with category (grammatical, lexical, orthographic).
-                  </p>
-                </div>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={addWeakness}
-                  data-testid="add-weakness"
-                >
-                  <Plus className="h-3.5 w-3.5 mr-1" />
-                  Add
-                </Button>
-              </div>
-
-              {weaknesses.map((w, i) => (
-                <div
-                  key={i}
-                  className="flex flex-col sm:flex-row gap-2 sm:items-start"
-                  data-testid="weakness-row"
-                >
-                  <Input
-                    value={w.description}
-                    onChange={(e) => updateWeakness(i, 'description', e.target.value)}
-                    placeholder="e.g. Confuses ser/estar"
-                    maxLength={200}
-                    className="flex-1"
-                    data-testid="weakness-description"
-                  />
-                  <Select
-                    value={w.weaknessType}
-                    onValueChange={(v) => v && updateWeakness(i, 'weaknessType', v)}
-                  >
-                    <SelectTrigger data-testid="weakness-type" className="w-[160px]">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="grammatical">Grammatical</SelectItem>
-                      <SelectItem value="lexical">Lexical</SelectItem>
-                      <SelectItem value="orthographic">Orthographic</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => removeWeakness(i)}
-                    className="text-zinc-400 hover:text-red-600 h-9 w-9"
-                    data-testid="remove-weakness"
-                    aria-label="Remove weakness"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </div>
-              ))}
-
-              {weaknesses.length === 0 && (
-                <p className="text-xs text-zinc-400 italic" data-testid="weaknesses-empty">
-                  No areas to improve tracked yet.
-                </p>
-              )}
-            </div>
-
-            {/* Structured Difficulties */}
-            <div className="space-y-3 pt-2 border-t border-zinc-100">
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label className="inline-flex items-center gap-1">Specific Difficulties <FieldTooltip fieldKey="difficulties" /></Label>
-                  <p className="text-xs text-zinc-400 mt-0.5">
-                    Track granular issues for targeted exercise generation.
-                  </p>
-                </div>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={addDifficulty}
-                  data-testid="add-difficulty"
-                >
-                  <Plus className="h-3.5 w-3.5 mr-1" />
-                  Add
-                </Button>
-              </div>
-
-              {difficulties.map((d) => (
-                <div
-                  key={d.id}
-                  className="space-y-2 sm:space-y-0 sm:grid sm:grid-cols-[1fr_auto_1fr_auto_auto] sm:gap-2 sm:items-start"
-                  data-testid="difficulty-row"
-                >
-                  <Input
-                    value={d.description}
-                    onChange={(e) => updateDifficulty(d.id, 'description', e.target.value)}
-                    placeholder="e.g. Confuses ser/estar in past tense"
-                    maxLength={500}
-                    className="sm:col-span-1"
-                    data-testid="difficulty-description"
-                  />
-
-                  <Select value={d.competency || undefined} onValueChange={(v) => v && updateDifficulty(d.id, 'competency', v)}>
-                    <SelectTrigger data-testid="difficulty-competency" className="w-[140px]">
-                      <SelectValue placeholder="Competency" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {COMPETENCY_OPTIONS.map((opt) => (
-                        <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-
-                  <Input
-                    value={d.subcategory}
-                    onChange={(e) => updateDifficulty(d.id, 'subcategory', e.target.value)}
-                    placeholder="Subcategory (e.g. ser/estar)"
-                    maxLength={200}
-                    data-testid="difficulty-subcategory"
-                  />
-
-                  <Button
-                    type="button"
-                    variant={d.status === 'Covered' ? 'secondary' : 'outline'}
-                    size="sm"
-                    onClick={() => updateDifficulty(d.id, 'status', d.status === 'Covered' ? 'Active' : 'Covered')}
-                    data-testid="difficulty-status"
-                    className="whitespace-nowrap"
-                  >
-                    {d.status === 'Covered' ? 'Covered' : 'Active'}
-                  </Button>
-
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => removeDifficulty(d.id)}
-                    className="text-zinc-400 hover:text-red-600 h-9 w-9"
-                    data-testid="remove-difficulty"
-                    aria-label="Remove difficulty"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </div>
-              ))}
-
-              {difficulties.length === 0 && (
-                <p className="text-xs text-zinc-400 italic">
-                  No specific difficulties tracked yet.
-                </p>
-              )}
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Teaching Goals</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {/* Short-Term Objectives */}
-            <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <div>
-                  <Label>Short-Term Objectives</Label>
-                  <p className="text-xs text-zinc-400 mt-0.5">Specific goals with optional target dates (max 10).</p>
-                </div>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={addObjective}
-                  disabled={shortTermObjectives.length >= 10}
-                  data-testid="add-objective"
-                >
-                  <Plus className="h-3.5 w-3.5 mr-1" />
-                  Add Objective
-                </Button>
-              </div>
-
-              {shortTermObjectives.map((obj) => {
-                const urgency = getObjectiveUrgency(obj.targetDate)
-                return (
-                  <div
-                    key={obj.id}
-                    className="flex flex-col sm:flex-row gap-2 sm:items-start"
-                    data-testid="objective-row"
-                  >
-                    <Input
-                      value={obj.text}
-                      onChange={(e) => updateObjective(obj.id, 'text', e.target.value)}
-                      placeholder="e.g. Pass DELE B1 exam"
-                      maxLength={500}
-                      className="flex-1"
-                      data-testid="objective-text-input"
-                    />
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="date"
-                        value={obj.targetDate ?? ''}
-                        onChange={(e) => updateObjective(obj.id, 'targetDate', e.target.value || null)}
-                        className="h-9 rounded-md border border-zinc-200 bg-white px-3 py-1 text-sm text-[#1A1B22] focus:outline-none focus:ring-2 focus:ring-indigo-300"
-                        data-testid="objective-date-input"
+            {/* ── SECTION: Basic Info + Proficiency (2-column on desktop) ── */}
+            <div id="section-basic" className="grid grid-cols-1 lg:grid-cols-[7fr_5fr] gap-6 items-start">
+              <div className="space-y-6">
+                {/* Basic Info card */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">Basic Info</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    {/* Name */}
+                    <div className="space-y-1.5">
+                      <Label htmlFor="name" className="inline-flex items-center gap-1">Name <span className="text-red-500">*</span> <FieldTooltip fieldKey="name" /></Label>
+                      <Input
+                        id="name"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        placeholder="e.g. Ana García"
+                        maxLength={200}
+                        className="max-w-sm"
+                        data-testid="student-name"
                       />
-                      {urgency === 'critical' && obj.targetDate && (
-                        <span className="text-xs font-semibold text-orange-600 shrink-0" data-testid="objective-near-date-warning">
-                          NEAR DATE
-                        </span>
-                      )}
+                      {errors.name && <p className="text-xs text-red-600">{errors.name}</p>}
                     </div>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => removeObjective(obj.id)}
-                      className="text-zinc-400 hover:text-red-600 h-9 w-9 shrink-0"
-                      data-testid="remove-objective"
-                      aria-label="Remove objective"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
+
+                    {/* Learning Language + Teacher's Assessment side-by-side */}
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-sm">
+                      <div className="space-y-1.5">
+                        <Label className="inline-flex items-center gap-1">Learning Language <span className="text-red-500">*</span> <FieldTooltip fieldKey="learningLanguage" /></Label>
+                        <Select value={language} onValueChange={(v) => {
+                          if (!v) return
+                          setLanguage(v)
+                        }}>
+                          <SelectTrigger data-testid="student-language">
+                            <SelectValue placeholder="Select a language" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {LANGUAGES.map((lang) => (
+                              <SelectItem key={lang} value={lang}>{lang}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        {errors.language && <p className="text-xs text-red-600">{errors.language}</p>}
+                      </div>
+
+                      <div className="space-y-1.5">
+                        <Label className="inline-flex items-center gap-1">Teacher's Assessment <span className="text-red-500">*</span> <FieldTooltip fieldKey="cefrLevel" /></Label>
+                        <Select value={cefrLevel} onValueChange={(v) => v && setCefrLevel(v)}>
+                          <SelectTrigger data-testid="student-cefr">
+                            <SelectValue placeholder="Select a level" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {CEFR_LEVELS.map((level) => (
+                              <SelectItem key={level} value={level}>{level}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        {errors.cefrLevel && <p className="text-xs text-red-600">{errors.cefrLevel}</p>}
+                      </div>
+                    </div>
+
+                    {/* Official CEFR Level */}
+                    <div className="space-y-1.5 max-w-[calc(50%-0.5rem)]">
+                      <Label className="inline-flex items-center gap-1">Official Level <FieldTooltip fieldKey="officialCefrLevel" /></Label>
+                      <Select value={officialCefrLevel} onValueChange={(v) => setOfficialCefrLevel(!v || v === '__none__' ? '' : v)}>
+                        <SelectTrigger data-testid="student-official-cefr">
+                          <SelectValue placeholder="None" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="__none__">None</SelectItem>
+                          {CEFR_LEVELS.map((level) => (
+                            <SelectItem key={level} value={level}>{level}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <p className="text-xs text-zinc-400">Official exam result or external assessment.</p>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                {/* Languages card */}
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">Languages</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    {/* Native Languages */}
+                    <div className="space-y-1.5">
+                      <Label className="inline-flex items-center gap-1">Native Languages <FieldTooltip fieldKey="nativeLanguages" /></Label>
+                      <MultiSelect
+                        options={NATIVE_LANGUAGE_OPTIONS}
+                        selected={nativeLanguages}
+                        onChange={setNativeLanguages}
+                        placeholder="Select native languages (optional)"
+                        triggerId="student-native-language"
+                        chipTestId="native-lang-chip"
+                        maxItems={5}
+                        allowCustom={false}
+                      />
+                    </div>
+
+                    {/* Spoken Languages */}
+                    <div className="space-y-1.5">
+                      <Label className="inline-flex items-center gap-1">Spoken Languages <FieldTooltip fieldKey="spokenLanguages" /></Label>
+                      <div
+                        className="flex flex-wrap gap-1.5 min-h-10 w-full max-w-sm rounded-md border border-input bg-white px-3 py-2 cursor-text"
+                        onClick={() => spokenInputRef.current?.focus()}
+                        data-testid="spoken-languages-container"
+                      >
+                        {spokenLanguages.map((lang) => (
+                          <span
+                            key={lang}
+                            className="inline-flex items-center gap-1 bg-indigo-50 text-indigo-700 text-xs font-medium rounded px-2 py-0.5"
+                            data-testid="spoken-lang-chip"
+                          >
+                            {lang}
+                            <button
+                              type="button"
+                              onClick={(e) => { e.stopPropagation(); removeSpokenLanguage(lang) }}
+                              className="text-indigo-400 hover:text-indigo-700 p-0.5 -mr-0.5"
+                              aria-label={`Remove ${lang}`}
+                            >
+                              <X className="h-4 w-4" />
+                            </button>
+                          </span>
+                        ))}
+                        <input
+                          ref={spokenInputRef}
+                          value={spokenInput}
+                          onChange={(e) => setSpokenInput(e.target.value)}
+                          onKeyDown={handleSpokenKeyDown}
+                          onBlur={() => { if (spokenInput.trim()) addSpokenLanguage(spokenInput) }}
+                          placeholder={spokenLanguages.length === 0 ? 'Type and press Enter' : ''}
+                          className="flex-1 min-w-20 outline-none text-sm bg-transparent placeholder:text-zinc-400"
+                          data-testid="spoken-language-input"
+                        />
+                      </div>
+                      <p className="text-xs text-zinc-400">Other languages spoken. Flat list, no proficiency level.</p>
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+
+              {/* Skill Overrides card — right column, anchored as section-proficiency */}
+              <div id="section-proficiency">
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base inline-flex items-center gap-1">Skill Overrides <FieldTooltip fieldKey="skillLevelOverrides" /></CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-xs text-zinc-400 mb-4">Override the general CEFR level per skill for AI generation. Leave empty to inherit the general level.</p>
+                    <div className="grid grid-cols-2 gap-3">
+                      {(['Reading', 'Writing', 'Speaking', 'Listening'] as const).map((skill) => (
+                        <div key={skill} className="space-y-1.5">
+                          <Label className="text-xs">{skill}</Label>
+                          <Select
+                            value={skillLevelOverrides[skill] ?? ''}
+                            onValueChange={(v) => setSkillOverride(skill, !v || v === '__none__' ? '' : v)}
+                          >
+                            <SelectTrigger data-testid={`skill-override-${skill.toLowerCase()}`} className="h-8 text-xs">
+                              <SelectValue placeholder="--" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="__none__">--</SelectItem>
+                              {CEFR_LEVELS.map((level) => (
+                                <SelectItem key={level} value={level}>{level}</SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+
+            {/* ── SECTION: Personal Background ── */}
+            <div id="section-background" className="space-y-6">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Personal Background</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-sm">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="birth-year">Birth Year</Label>
+                      <Input
+                        id="birth-year"
+                        type="number"
+                        value={birthYear ?? ''}
+                        onChange={(e) => {
+                          const raw = e.target.value
+                          const num = Number(raw)
+                          setBirthYear(raw && !isNaN(num) && Number.isInteger(num) ? num : null)
+                        }}
+                        placeholder="e.g. 1990"
+                        min={1900}
+                        max={new Date().getFullYear()}
+                        data-testid="student-birth-year"
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="profession">Profession</Label>
+                      <Input
+                        id="profession"
+                        value={profession}
+                        onChange={(e) => setProfession(e.target.value)}
+                        placeholder="e.g. Software engineer"
+                        maxLength={128}
+                        data-testid="student-profession"
+                      />
+                    </div>
                   </div>
-                )
-              })}
 
-              {shortTermObjectives.length === 0 && (
-                <p className="text-xs text-zinc-400 italic" data-testid="objectives-empty">
-                  No short-term objectives added yet.
-                </p>
-              )}
+                  {/* Origin */}
+                  <div>
+                    <p className="text-xs font-medium text-zinc-500 mb-2">Origin</p>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-sm">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="country-origin">Country</Label>
+                        <Input
+                          id="country-origin"
+                          value={countryOfOrigin}
+                          onChange={(e) => setCountryOfOrigin(e.target.value)}
+                          placeholder="e.g. Portugal"
+                          maxLength={64}
+                          data-testid="student-country-origin"
+                        />
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="city-origin">City</Label>
+                        <Input
+                          id="city-origin"
+                          value={cityOfOrigin}
+                          onChange={(e) => setCityOfOrigin(e.target.value)}
+                          placeholder="e.g. Lisbon"
+                          maxLength={64}
+                          data-testid="student-city-origin"
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Residence */}
+                  <div>
+                    <p className="text-xs font-medium text-zinc-500 mb-2">Residence</p>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-sm">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="country-residence">Country</Label>
+                        <Input
+                          id="country-residence"
+                          value={countryOfResidence}
+                          onChange={(e) => setCountryOfResidence(e.target.value)}
+                          placeholder="e.g. Spain"
+                          maxLength={64}
+                          data-testid="student-country-residence"
+                        />
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="city-residence">City</Label>
+                        <Input
+                          id="city-residence"
+                          value={cityOfResidence}
+                          onChange={(e) => setCityOfResidence(e.target.value)}
+                          placeholder="e.g. Madrid"
+                          maxLength={64}
+                          data-testid="student-city-residence"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Reason for Studying</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="reason-for-studying">Reason for studying</Label>
+                    <Textarea
+                      id="reason-for-studying"
+                      value={reasonForStudying}
+                      onChange={(e) => setReasonForStudying(e.target.value)}
+                      placeholder="e.g. Moving to Spain next year, loves the culture..."
+                      maxLength={512}
+                      rows={3}
+                      className="max-w-sm resize-none"
+                      data-testid="student-reason-for-studying"
+                    />
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base inline-flex items-center gap-1">Interests <FieldTooltip fieldKey="interests" /></CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <div
+                    className="flex flex-wrap gap-1.5 min-h-10 w-full max-w-sm rounded-md border border-zinc-200 bg-white px-3 py-2 cursor-text"
+                    onClick={() => interestInputRef.current?.focus()}
+                  >
+                    {interests.map((interest) => (
+                      <span
+                        key={interest}
+                        className="inline-flex items-center gap-1 bg-indigo-50 text-indigo-700 text-xs font-medium rounded px-2 py-0.5"
+                        data-testid="interest-chip"
+                      >
+                        {interest}
+                        <button
+                          type="button"
+                          onClick={(e) => { e.stopPropagation(); removeInterest(interest) }}
+                          className="text-indigo-400 hover:text-indigo-700 p-0.5 -mr-0.5"
+                          aria-label={`Remove ${interest}`}
+                        >
+                          <X className="h-4 w-4" />
+                        </button>
+                      </span>
+                    ))}
+                    <input
+                      ref={interestInputRef}
+                      value={interestInput}
+                      onChange={(e) => setInterestInput(e.target.value)}
+                      onKeyDown={handleInterestKeyDown}
+                      onBlur={() => { if (interestInput.trim()) addInterest(interestInput) }}
+                      placeholder={interests.length === 0 ? 'Type and press Enter' : ''}
+                      className="flex-1 min-w-20 outline-none text-sm bg-transparent placeholder:text-zinc-400"
+                      data-testid="interest-input"
+                    />
+                  </div>
+                  <p className="text-xs text-zinc-400">Press Enter or comma to add. Backspace to remove last.</p>
+                </CardContent>
+              </Card>
             </div>
-          </CardContent>
-        </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Notes</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-1.5">
-              <Label className="inline-flex items-center gap-1">Personal notes <FieldTooltip fieldKey="personalNotes" /></Label>
-              <p className="text-xs text-zinc-400">About the student as a person (sensitivities, context, life situation).</p>
-              <Textarea
-                value={personalNotes}
-                onChange={(e) => setPersonalNotes(e.target.value)}
-                placeholder="Optional personal notes..."
-                maxLength={2000}
-                rows={3}
-                className="max-w-sm resize-none"
-                data-testid="student-personal-notes"
+            {/* ── SECTION: Teaching Goals (Learning Goals + Short-Term Objectives) ── */}
+            <div id="section-teaching-goals">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Teaching Goals</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  {/* Learning Goals */}
+                  <div className="space-y-1.5">
+                    <Label className="inline-flex items-center gap-1">Learning Goals <FieldTooltip fieldKey="learningGoals" /></Label>
+                    <MultiSelect
+                      options={LEARNING_GOALS}
+                      selected={learningGoals}
+                      onChange={setLearningGoals}
+                      placeholder="Select or type goals..."
+                      triggerId="learning-goals-trigger"
+                      chipTestId="learning-goal-chip"
+                      maxLength={100}
+                    />
+                  </div>
+
+                  {/* Short-Term Objectives */}
+                  <div className="space-y-3 pt-2 border-t border-zinc-100">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <Label>Short-Term Objectives</Label>
+                        <p className="text-xs text-zinc-400 mt-0.5">Specific goals with optional target dates (max 10).</p>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={addObjective}
+                        disabled={shortTermObjectives.length >= 10}
+                        data-testid="add-objective"
+                      >
+                        <Plus className="h-3.5 w-3.5 mr-1" />
+                        Add Objective
+                      </Button>
+                    </div>
+
+                    {shortTermObjectives.map((obj) => {
+                      const urgency = getObjectiveUrgency(obj.targetDate)
+                      return (
+                        <div
+                          key={obj.id}
+                          className="flex flex-col sm:flex-row gap-2 sm:items-start"
+                          data-testid="objective-row"
+                        >
+                          <Input
+                            value={obj.text}
+                            onChange={(e) => updateObjective(obj.id, 'text', e.target.value)}
+                            placeholder="e.g. Pass DELE B1 exam"
+                            maxLength={500}
+                            className="flex-1"
+                            data-testid="objective-text-input"
+                          />
+                          <div className="flex items-center gap-2">
+                            <input
+                              type="date"
+                              value={obj.targetDate ?? ''}
+                              onChange={(e) => updateObjective(obj.id, 'targetDate', e.target.value || null)}
+                              className="h-9 rounded-md border border-zinc-200 bg-white px-3 py-1 text-sm text-[#1A1B22] focus:outline-none focus:ring-2 focus:ring-indigo-300"
+                              data-testid="objective-date-input"
+                            />
+                            {urgency === 'critical' && obj.targetDate && (
+                              <span className="text-xs font-semibold text-orange-600 shrink-0" data-testid="objective-near-date-warning">
+                                NEAR DATE
+                              </span>
+                            )}
+                          </div>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => removeObjective(obj.id)}
+                            className="text-zinc-400 hover:text-red-600 h-9 w-9 shrink-0"
+                            data-testid="remove-objective"
+                            aria-label="Remove objective"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      )
+                    })}
+
+                    {shortTermObjectives.length === 0 && (
+                      <p className="text-xs text-zinc-400 italic" data-testid="objectives-empty">
+                        No short-term objectives added yet.
+                      </p>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* ── SECTION: Difficulties (Weaknesses + Structured Difficulties) ── */}
+            <div id="section-difficulties">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Difficulties</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                  {/* Weaknesses */}
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <Label className="inline-flex items-center gap-1">Areas to Improve <FieldTooltip fieldKey="weaknesses" /></Label>
+                        <p className="text-xs text-zinc-400 mt-0.5">
+                          Free-text description with category (grammatical, lexical, orthographic).
+                        </p>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={addWeakness}
+                        data-testid="add-weakness"
+                      >
+                        <Plus className="h-3.5 w-3.5 mr-1" />
+                        Add
+                      </Button>
+                    </div>
+
+                    {weaknesses.map((w, i) => (
+                      <div
+                        key={i}
+                        className="flex flex-col sm:flex-row gap-2 sm:items-start"
+                        data-testid="weakness-row"
+                      >
+                        <Input
+                          value={w.description}
+                          onChange={(e) => updateWeakness(i, 'description', e.target.value)}
+                          placeholder="e.g. Confuses ser/estar"
+                          maxLength={200}
+                          className="flex-1"
+                          data-testid="weakness-description"
+                        />
+                        <Select
+                          value={w.weaknessType}
+                          onValueChange={(v) => v && updateWeakness(i, 'weaknessType', v)}
+                        >
+                          <SelectTrigger data-testid="weakness-type" className="w-[160px]">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="grammatical">Grammatical</SelectItem>
+                            <SelectItem value="lexical">Lexical</SelectItem>
+                            <SelectItem value="orthographic">Orthographic</SelectItem>
+                          </SelectContent>
+                        </Select>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => removeWeakness(i)}
+                          className="text-zinc-400 hover:text-red-600 h-9 w-9"
+                          data-testid="remove-weakness"
+                          aria-label="Remove weakness"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    ))}
+
+                    {weaknesses.length === 0 && (
+                      <p className="text-xs text-zinc-400 italic" data-testid="weaknesses-empty">
+                        No areas to improve tracked yet.
+                      </p>
+                    )}
+                  </div>
+
+                  {/* Structured Difficulties */}
+                  <div className="space-y-3 pt-2 border-t border-zinc-100">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <Label className="inline-flex items-center gap-1">Specific Difficulties <FieldTooltip fieldKey="difficulties" /></Label>
+                        <p className="text-xs text-zinc-400 mt-0.5">
+                          Track granular issues for targeted exercise generation.
+                        </p>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={addDifficulty}
+                        data-testid="add-difficulty"
+                      >
+                        <Plus className="h-3.5 w-3.5 mr-1" />
+                        Add
+                      </Button>
+                    </div>
+
+                    {difficulties.map((d) => (
+                      <div
+                        key={d.id}
+                        className="space-y-2 sm:space-y-0 sm:grid sm:grid-cols-[1fr_auto_1fr_auto_auto] sm:gap-2 sm:items-start"
+                        data-testid="difficulty-row"
+                      >
+                        <Input
+                          value={d.description}
+                          onChange={(e) => updateDifficulty(d.id, 'description', e.target.value)}
+                          placeholder="e.g. Confuses ser/estar in past tense"
+                          maxLength={500}
+                          className="sm:col-span-1"
+                          data-testid="difficulty-description"
+                        />
+
+                        <Select value={d.competency || undefined} onValueChange={(v) => v && updateDifficulty(d.id, 'competency', v)}>
+                          <SelectTrigger data-testid="difficulty-competency" className="w-[140px]">
+                            <SelectValue placeholder="Competency" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {COMPETENCY_OPTIONS.map((opt) => (
+                              <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+
+                        <Input
+                          value={d.subcategory}
+                          onChange={(e) => updateDifficulty(d.id, 'subcategory', e.target.value)}
+                          placeholder="Subcategory (e.g. ser/estar)"
+                          maxLength={200}
+                          data-testid="difficulty-subcategory"
+                        />
+
+                        <Button
+                          type="button"
+                          variant={d.status === 'Covered' ? 'secondary' : 'outline'}
+                          size="sm"
+                          onClick={() => updateDifficulty(d.id, 'status', d.status === 'Covered' ? 'Active' : 'Covered')}
+                          data-testid="difficulty-status"
+                          className="whitespace-nowrap"
+                        >
+                          {d.status === 'Covered' ? 'Covered' : 'Active'}
+                        </Button>
+
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => removeDifficulty(d.id)}
+                          className="text-zinc-400 hover:text-red-600 h-9 w-9"
+                          data-testid="remove-difficulty"
+                          aria-label="Remove difficulty"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    ))}
+
+                    {difficulties.length === 0 && (
+                      <p className="text-xs text-zinc-400 italic">
+                        No specific difficulties tracked yet.
+                      </p>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* ── SECTION: Notes (2-column) ── */}
+            <div id="section-notes">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Notes</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div className="space-y-1.5">
+                      <Label className="inline-flex items-center gap-1">Personal notes <FieldTooltip fieldKey="personalNotes" /></Label>
+                      <p className="text-xs text-zinc-400">Sensitivities / life context.</p>
+                      <Textarea
+                        value={personalNotes}
+                        onChange={(e) => setPersonalNotes(e.target.value)}
+                        placeholder="Optional personal notes..."
+                        maxLength={2000}
+                        rows={5}
+                        className="resize-none w-full"
+                        data-testid="student-personal-notes"
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label className="inline-flex items-center gap-1">Teaching notes <FieldTooltip fieldKey="teachingNotes" /></Label>
+                      <p className="text-xs text-zinc-400">Learning style, teaching observations.</p>
+                      <Textarea
+                        value={teachingNotes}
+                        onChange={(e) => setTeachingNotes(e.target.value)}
+                        placeholder="Optional teaching notes..."
+                        maxLength={2000}
+                        rows={5}
+                        className="resize-none w-full"
+                        data-testid="student-teaching-notes"
+                      />
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* ── SECTION: Commercial Info (edit only) ── */}
+            {isEdit && (
+              <div id="section-commercial">
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">Commercial Info</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    {/* IsActive toggle */}
+                    <div className="flex items-center justify-between p-3 bg-zinc-50 rounded-lg">
+                      <div>
+                        <Label className="text-sm font-medium cursor-pointer" htmlFor="toggle-is-active">Account Status</Label>
+                        <p className="text-xs text-zinc-400 mt-0.5">{isActive ? 'Active' : 'Inactive'}</p>
+                      </div>
+                      <button
+                        id="toggle-is-active"
+                        type="button"
+                        role="switch"
+                        aria-checked={isActive}
+                        onClick={() => setIsActive(!isActive)}
+                        data-testid="toggle-is-active"
+                        className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 ${isActive ? 'bg-indigo-600' : 'bg-zinc-300'}`}
+                        aria-label="Toggle active status"
+                      >
+                        <span
+                          className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${isActive ? 'translate-x-6' : 'translate-x-1'}`}
+                        />
+                      </button>
+                    </div>
+
+                    {/* IsCorporate toggle */}
+                    <div className="flex items-center justify-between p-3 bg-zinc-50 rounded-lg">
+                      <div>
+                        <Label className="text-sm font-medium cursor-pointer" htmlFor="toggle-is-corporate">Student Type</Label>
+                        <p className="text-xs text-zinc-400 mt-0.5">{isCorporate ? 'Corporate' : 'Private'}</p>
+                      </div>
+                      <button
+                        id="toggle-is-corporate"
+                        type="button"
+                        role="switch"
+                        aria-checked={isCorporate}
+                        onClick={() => setIsCorporate(!isCorporate)}
+                        data-testid="toggle-is-corporate"
+                        className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-600 ${isCorporate ? 'bg-indigo-600' : 'bg-zinc-300'}`}
+                        aria-label="Toggle corporate status"
+                      >
+                        <span
+                          className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${isCorporate ? 'translate-x-6' : 'translate-x-1'}`}
+                        />
+                      </button>
+                    </div>
+
+                    {/* Rate */}
+                    <div className="space-y-1.5">
+                      <Label htmlFor="rate">Hourly Rate</Label>
+                      <Input
+                        id="rate"
+                        value={rate}
+                        onChange={(e) => setRate(e.target.value)}
+                        placeholder="e.g. 45/hr"
+                        maxLength={50}
+                        className="max-w-[200px]"
+                        data-testid="student-rate"
+                      />
+                      <p className="text-xs text-zinc-400">Free text. No billing frequency tracked.</p>
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            )}
+          </form>
+
+          {isEdit && id && <StudentCoursesCard studentId={id} />}
+        </div>
+
+        {isEdit && id && (
+          <div className="space-y-4 lg:sticky lg:top-6" data-testid="form-sidebar">
+            <div
+              className="bg-white rounded-2xl p-4"
+              style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
+              data-testid="sidebar-teaching-todos"
+            >
+              <SectionHeader>Teaching Todos</SectionHeader>
+              <TeachingTodosCard
+                todos={sidebarTodos}
+                studentId={id}
+                onStudentChange={onSidebarTodoChange}
+                allowEdit
               />
             </div>
-            <div className="space-y-1.5">
-              <Label className="inline-flex items-center gap-1">Teaching notes <FieldTooltip fieldKey="teachingNotes" /></Label>
-              <p className="text-xs text-zinc-400">How this student learns, what works in class, teaching observations.</p>
-              <Textarea
-                value={teachingNotes}
-                onChange={(e) => setTeachingNotes(e.target.value)}
-                placeholder="Optional teaching notes..."
-                maxLength={2000}
-                rows={3}
-                className="max-w-sm resize-none"
-                data-testid="student-teaching-notes"
+            <div
+              className="bg-white rounded-2xl p-4"
+              style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
+            >
+              <StudentFollowupsCard
+                followups={followups}
+                studentId={id}
+                onFollowupChange={() => refetchFollowups()}
               />
             </div>
-          </CardContent>
-        </Card>
-      </form>
-
-      {isEdit && id && <StudentCoursesCard studentId={id} />}
-    </div>
-
-    {isEdit && id && (
-      <div className="space-y-4 lg:sticky lg:top-6" data-testid="form-sidebar">
-        <div
-          className="bg-white rounded-2xl p-4"
-          style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
-          data-testid="sidebar-teaching-todos"
-        >
-          <SectionHeader>Teaching Todos</SectionHeader>
-          <TeachingTodosCard
-            todos={sidebarTodos}
-            studentId={id}
-            onStudentChange={onSidebarTodoChange}
-            allowEdit
-          />
-        </div>
-        <div
-          className="bg-white rounded-2xl p-4"
-          style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
-        >
-          <StudentFollowupsCard
-            followups={followups}
-            studentId={id}
-            onFollowupChange={() => refetchFollowups()}
-          />
-        </div>
+          </div>
+        )}
       </div>
-    )}
-    </div>
+
+      {/* Delete confirmation dialog */}
+      {isEdit && id && (
+        <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete this student?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will permanently remove this student profile. This action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => doDelete(id)}
+                disabled={isDeleting}
+                className="bg-red-600 hover:bg-red-700 text-white"
+                data-testid="confirm-delete"
+              >
+                {isDeleting ? 'Deleting...' : 'Delete'}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </>
   )
 }

--- a/frontend/src/pages/Students.test.tsx
+++ b/frontend/src/pages/Students.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -96,20 +96,11 @@ describe('Students page', () => {
     await screen.findByText('Failed to load students. Please try again.')
   })
 
-  it('shows inline error when delete mutation fails', async () => {
+  it('does not render a delete button in the student list row (delete moved to edit page)', async () => {
     vi.mocked(studentsApi.getStudents).mockResolvedValue(makeListResponse([makeStudent()]))
-    vi.mocked(studentsApi.deleteStudent).mockRejectedValue(new Error('Server error'))
-
     wrapper(<Students />)
     await screen.findByTestId('student-name')
-    fireEvent.click(screen.getByTestId('delete-student'))
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument()
-    fireEvent.click(screen.getByTestId('confirm-delete'))
-
-    await waitFor(() => {
-      expect(screen.getByTestId('delete-error')).toBeInTheDocument()
-    })
-    expect(screen.getByTestId('delete-error')).toHaveTextContent('Failed to delete student. Please try again.')
+    expect(screen.queryByTestId('delete-student')).not.toBeInTheDocument()
   })
 
   it('renders student list when fetch succeeds', async () => {

--- a/frontend/src/pages/Students.tsx
+++ b/frontend/src/pages/Students.tsx
@@ -1,11 +1,10 @@
 import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Pencil, Search, Trash2, UserPlus, Users } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+import { Pencil, Search, UserPlus, Users } from 'lucide-react'
 import { PageHeader } from '@/components/PageHeader'
-import { getStudents, deleteStudent, type Student } from '../api/students'
+import { getStudents, type Student } from '../api/students'
 import { getDashboard, type ActiveStudent } from '../api/dashboard'
-import { logger } from '../lib/logger'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -13,16 +12,6 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 import { CEFR_LEVELS } from '@/lib/cefr-colors'
 import { CefrBadge } from '@/components/dashboard/CefrBadge'
 import { cn } from '@/lib/utils'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog'
 
 // ── Avatar helpers ──────────────────────────────────────────────────────────
 
@@ -208,10 +197,7 @@ const TABLE_HEADERS = ['', 'Name', 'Level', 'Native Language', 'Last Session', '
 // ── Component ───────────────────────────────────────────────────────────────
 
 export default function Students() {
-  const queryClient = useQueryClient()
   const navigate = useNavigate()
-  const [studentToDelete, setStudentToDelete] = useState<Student | null>(null)
-  const [deleteError, setDeleteError] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [cefrFilter, setCefrFilter] = useState<string>('All')
   const [sortBy, setSortBy] = useState<SortOption>('nextSession')
@@ -229,22 +215,6 @@ export default function Students() {
   const { data: dashboardData } = useQuery({
     queryKey: ['dashboard'],
     queryFn: getDashboard,
-  })
-
-  const { mutate: doDelete, isPending: isDeleting } = useMutation({
-    mutationFn: (id: string) => deleteStudent(id),
-    onSuccess: () => {
-      logger.info('Students', 'student deleted')
-      queryClient.invalidateQueries({ queryKey: ['students'] })
-      queryClient.invalidateQueries({ queryKey: ['dashboard'] })
-      setStudentToDelete(null)
-      setDeleteError(null)
-    },
-    onError: (err) => {
-      logger.error('Students', 'delete failed', err)
-      setDeleteError('Failed to delete student. Please try again.')
-      setStudentToDelete(null)
-    },
   })
 
   const dashboardMap = new Map<string, ActiveStudent>(
@@ -322,10 +292,6 @@ export default function Students() {
           </Link>
         }
       />
-
-      {deleteError && (
-        <span className="text-sm text-red-600 font-medium" data-testid="delete-error">{deleteError}</span>
-      )}
 
       {/* Search, filter and sort bar */}
       {allStudents.length > 0 && (
@@ -508,21 +474,6 @@ export default function Students() {
                         </TooltipTrigger>
                         <TooltipContent>Edit</TooltipContent>
                       </Tooltip>
-                      <Tooltip>
-                        <TooltipTrigger render={<span />}>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-7 w-7"
-                            onClick={() => setStudentToDelete(student)}
-                            aria-label={`Delete ${student.name}`}
-                            data-testid="delete-student"
-                          >
-                            <Trash2 className="h-3.5 w-3.5 text-zinc-400" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>Delete</TooltipContent>
-                      </Tooltip>
                     </div>
 
                     {/* Hidden interests for e2e compatibility */}
@@ -558,28 +509,6 @@ export default function Students() {
         </div>
       )}
 
-      {/* Delete confirmation dialog */}
-      <AlertDialog open={!!studentToDelete} onOpenChange={(open) => !open && setStudentToDelete(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete {studentToDelete?.name}?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will permanently remove this student profile. This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => studentToDelete && doDelete(studentToDelete.id)}
-              disabled={isDeleting}
-              className="bg-red-600 hover:bg-red-700 text-white"
-              data-testid="confirm-delete"
-            >
-              {isDeleting ? 'Deleting...' : 'Delete'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </div>
   )
 }

--- a/plan/langteach-beta/task681-edit-form-redesign.md
+++ b/plan/langteach-beta/task681-edit-form-redesign.md
@@ -1,0 +1,135 @@
+# Task 681 + 666: Edit Student Form Redesign + Commercial Fields
+
+## Issues
+- #681: Edit Student form layout redesign (section nav, grouping, sticky save)
+- #666: Commercial fields (IsActive, IsCorporate, Rate) in edit form
+
+## Approach
+
+Single PR touching `frontend/src/pages/StudentForm.tsx` and its test.
+
+No backend changes needed -- `isActive`, `isCorporate`, `rate` already exist on `StudentFormData` and `Student` interfaces in `students.ts`.
+
+## Changes
+
+### 1. State additions (commercial fields)
+Add to StudentForm:
+```tsx
+const [isActive, setIsActive] = useState(true)
+const [isCorporate, setIsCorporate] = useState(false)
+const [rate, setRate] = useState('')
+```
+
+Sync in `useEffect([existing])`:
+```tsx
+setIsActive(existing.isActive ?? true)
+setIsCorporate(existing.isCorporate ?? false)
+setRate(existing.rate ?? '')
+```
+
+Include in `handleSubmit` mutate call:
+```tsx
+isActive,
+isCorporate,
+rate: rate.trim() || null,
+```
+
+### 2. Scrollspy state + effect (edit mode only)
+```tsx
+const sectionIds = ['section-basic','section-background','section-proficiency','section-teaching-goals','section-difficulties','section-notes','section-commercial']
+const [activeSection, setActiveSection] = useState('section-basic')
+
+useEffect(() => {
+  if (!isEdit) return
+  const container = document.querySelector('main')
+  if (!container) return
+  function onScroll() {
+    const offset = 80
+    let current = sectionIds[0]
+    for (const id of sectionIds) {
+      const el = document.getElementById(id)
+      if (el && el.getBoundingClientRect().top <= offset) current = id
+    }
+    setActiveSection(current)
+  }
+  container.addEventListener('scroll', onScroll, { passive: true })
+  return () => container.removeEventListener('scroll', onScroll)
+}, [isEdit])
+
+function scrollToSection(id: string) {
+  const container = document.querySelector('main')
+  const el = document.getElementById(id)
+  if (!el || !container) return
+  // getBoundingClientRect().top is viewport-relative; adjust by container's own top offset
+  const elTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop
+  container.scrollTo({ top: elTop - 60, behavior: 'smooth' })
+}
+```
+
+### 3. Sticky section nav (edit mode only, ABOVE the grid)
+Placed immediately before the outer grid div.
+
+Nav sections: Basic Info | Background | Proficiency | Teaching Goals | Difficulties | Notes | Commercial
+
+Also contains sticky Cancel + Save Profile buttons (satisfies AC4 from #681).
+
+### 4. Form structure restructure
+Section anchors are `<div id="section-xxx" />` placed immediately before each card group.
+
+New groupings:
+- **section-basic**: 2-column row: Basic Info+Languages card (left col, 7/12) + Skill Overrides card (right col, 5/12) — implements "Basic Info + Proficiency side by side" AC
+- **section-background**: Personal Background + Reason for Studying + Interests cards (unchanged content). Origin/Residence fields grouped as "From" + "Now" pairs for visual clarity.
+- **section-teaching-goals**: Merged card with Learning Goals + Short-Term Objectives (currently split across two cards)
+- **section-difficulties**: Merged card with Weaknesses + Structured Difficulties (currently inside "Teaching Context")
+- **section-notes**: Notes card, changed to 2-column side-by-side layout
+- **section-commercial**: NEW card with IsActive toggle, IsCorporate toggle, Rate text input
+
+Requires splitting "Teaching Context" card (currently has learning goals + weaknesses + difficulties) into:
+- A Teaching Goals section (learning goals + objectives)
+- A Difficulties section (weaknesses + structured difficulties)
+
+All `data-testid` attributes preserved.
+
+Note: Rate is already displayed in StudentProfileTab.tsx (line 673) and StudentDetail.tsx already stores isActive/isCorporate/rate. No changes needed to those files.
+
+### 5. Active/Inactive badge in header
+In edit mode, show a small badge after the PageHeader reflecting `isActive` state. Updates dynamically as user toggles.
+
+### 6. Commercial card UI
+```
+[Card] Commercial Info
+  [Toggle row] Account Status: Active/Inactive
+  [Toggle row] Student Type: Private/Corporate
+  [Input row] Rate (free text): "e.g. 45/hr"
+```
+
+Toggle is implemented as a button with `role="switch"` and ARIA (no Switch component in the UI library).
+
+### 7. Tests
+**Unit tests (StudentForm.test.tsx):**
+- Add test: commercial fields rendered in edit mode (isActive toggle visible, isCorporate toggle visible, rate input visible)
+- Add test: toggling isActive and submitting includes updated value
+- Existing mocks already include `isActive: true, isCorporate: false, rate: null`
+
+**E2E tests (students.spec.ts):**
+- Add test: commercial fields round-trip (edit form shows isActive toggle, toggle to inactive, save, verify INACTIVE badge in profile/header)
+
+## Acceptance Criteria Mapping
+
+| AC (from issues) | How addressed |
+|---|---|
+| #666: IsActive toggle in edit form, reflected in badges | Toggle in Commercial card; badge in form header |
+| #666: IsCorporate toggle in edit form, reflected in badges | Toggle in Commercial card; reflected in profile via server round-trip |
+| #666: Rate field in edit form, visible in Profile tab when populated | Rate text input in Commercial card; Profile tab reads from server |
+| #666: Deactivating visually distinguishes student | isActive=false -> grey "Inactive" badge in header |
+| #666: Round-trip works for all fields | Synced in useEffect + included in mutate call |
+| #681: App sidebar present | Already present via AppShell, no change needed |
+| #681: Horizontal section nav with scrollspy | Sticky nav bar with scroll event listener |
+| #681: Form sections follow Stitch grouping | Section restructure as above |
+| #681: Cancel/Save visible at any scroll position | Duplicate buttons in sticky nav bar |
+| #681: No e2e tests break | Preserve all data-testid attrs |
+
+## Files Changed
+- `frontend/src/pages/StudentForm.tsx` (main implementation)
+- `frontend/src/pages/StudentForm.test.tsx` (unit tests)
+- `e2e/tests/students.spec.ts` (e2e tests)


### PR DESCRIPTION
## Summary

- **#666**: Add `isActive`, `isCorporate`, `rate` commercial fields to edit form with toggle switches; inactive badge in header; Commercial section visible in Profile tab
- **#681**: Edit form layout redesign: sticky horizontal scrollspy section nav (Basic Info | Background | Proficiency | Teaching Goals | Difficulties | Notes | Commercial) with Cancel/Save on right; 2-col Basic Info+Proficiency layout; merged Teaching Goals; merged Difficulties; 2-col Notes
- **#699**: Move student delete from roster rows to edit page; AlertDialog confirmation; trash icon removed from student list; all 10 e2e cleanup sequences updated

## Test plan

- [x] 1098 unit tests pass (Vitest + RTL)
- [x] npm lint and npm build pass
- [x] QA verify: PASS WITH GAPS (sticky/scrollspy behavior covered by UI review)
- [x] Architecture review: fixed missing `['dashboard']` cache invalidation on delete; replaced hardcoded e2e timeouts with constants
- [x] UI review: PASS - section nav renders below header, exactly one Cancel/Save set, Delete red button in header, no delete icon in roster
- [x] New e2e test: commercial fields round-trip (isActive, isCorporate, rate)

Closes #666, #681, #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commercial information fields to student profiles (accessible in edit mode)
  * Implemented section navigation for student form allowing smooth scrolling between sections

* **Changes**
  * Student deletion functionality relocated from student list to student edit form

<!-- end of auto-generated comment: release notes by coderabbit.ai -->