### PR TITLE
fix: voice recording merges into existing session, no duplicate drafts (#674)

### DIFF
--- a/e2e/tests/session-log-voice.spec.ts
+++ b/e2e/tests/session-log-voice.spec.ts
@@ -185,3 +185,77 @@ test('editing a Draft session and saving confirms it', async ({ browser }) => {
 
   await context.close()
 })
+
+test('voice recorder is accessible in edit mode', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  const student = await createStudent(page, `Edit Mode Voice Student ${Date.now()}`)
+
+  // Create a Draft session via API
+  const sessionRes = await page.request.post(`${API_BASE}/api/students/${student.id}/sessions`, {
+    headers: AUTH_HEADER,
+    data: {
+      actualContent: 'Initial draft content',
+      previousHomeworkStatus: 'NotApplicable',
+      status: 'Draft',
+    },
+  })
+  expect(sessionRes.ok()).toBeTruthy()
+
+  await page.goto(`/students/${student.id}`)
+  await expect(page.getByTestId('student-detail-name')).toBeVisible({ timeout: 15000 })
+
+  await page.getByRole('tab', { name: /history/i }).click()
+  await expect(page.getByTestId('session-history-list')).toBeVisible({ timeout: 10000 })
+
+  // Open edit dialog
+  await page.getByTestId('session-entry-toggle').click()
+  await page.getByTestId('edit-session-button').click()
+  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
+
+  // Voice recorder section should be visible in edit mode (bug fix)
+  await expect(page.getByTestId('voice-recorder-section')).toBeVisible({ timeout: 5000 })
+
+  await context.close()
+})
+
+test('second voice note updates draft, does not create a duplicate', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  const student = await createStudent(page, `No Duplicate Draft Student ${Date.now()}`)
+
+  await page.goto(`/students/${student.id}`)
+  await expect(page.getByTestId('student-detail-name')).toBeVisible({ timeout: 15000 })
+
+  // Open Log Session dialog
+  await page.getByTestId('log-session-button').click()
+  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
+
+  const audioPath = path.join(__dirname, '../fixtures/test-audio.webm')
+
+  // First voice note: creates a Draft
+  await page.getByTestId('audio-file-input').setInputFiles(audioPath)
+  await expect(page.getByTestId('submit-session-log')).toHaveText('Confirm', { timeout: 20000 })
+
+  // Second voice note: should update the same Draft, not create a new one
+  await page.getByTestId('audio-file-input').setInputFiles(audioPath)
+  await expect(page.getByTestId('submit-session-log')).toHaveText('Confirm', { timeout: 20000 })
+
+  // Close the dialog without confirming
+  await page.keyboard.press('Escape')
+  // Dismiss the discard dialog if it appears
+  const discardBtn = page.getByTestId('discard-btn')
+  if (await discardBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await discardBtn.click()
+  }
+
+  // Navigate to session history tab and verify only ONE Draft exists
+  await page.getByRole('tab', { name: /history/i }).click()
+  await expect(page.getByTestId('session-history-list')).toBeVisible({ timeout: 10000 })
+  const draftBadges = page.getByTestId('draft-badge')
+  await expect(draftBadges).toHaveCount(1, { timeout: 5000 })
+
+  await context.close()
+})

--- a/e2e/tests/session-log-voice.spec.ts
+++ b/e2e/tests/session-log-voice.spec.ts
@@ -239,9 +239,11 @@ test('second voice note updates draft, does not create a duplicate', async ({ br
   await page.getByTestId('audio-file-input').setInputFiles(audioPath)
   await expect(page.getByTestId('submit-session-log')).toHaveText('Confirm', { timeout: 20000 })
 
-  // Second voice note: should update the same Draft, not create a new one
+  // Second voice note: should update the same Draft, not create a new one.
+  // Wait for the extracting indicator to appear and clear so we know the second upload ran.
   await page.getByTestId('audio-file-input').setInputFiles(audioPath)
-  await expect(page.getByTestId('submit-session-log')).toHaveText('Confirm', { timeout: 20000 })
+  await expect(page.getByTestId('extracting-indicator')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByTestId('extracting-indicator')).toBeHidden({ timeout: 20000 })
 
   // Close the dialog without confirming
   await page.keyboard.press('Escape')

--- a/frontend/src/components/session/SessionLogDialog.test.tsx
+++ b/frontend/src/components/session/SessionLogDialog.test.tsx
@@ -670,7 +670,7 @@ describe('SessionLogDialog', () => {
       await waitFor(() => expect(screen.getByTestId('mock-audio-recorder-trigger')).toBeInTheDocument())
     })
 
-    it('does not show AudioRecorder in edit mode', async () => {
+    it('shows AudioRecorder in edit mode', async () => {
       wrapper(
         <SessionLogDialog
           studentId={STUDENT_ID}
@@ -680,7 +680,7 @@ describe('SessionLogDialog', () => {
         />
       )
       await waitFor(() => expect(screen.getByText('Edit Session')).toBeInTheDocument())
-      expect(screen.queryByTestId('mock-audio-recorder-trigger')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('mock-audio-recorder-trigger')).toBeInTheDocument()
     })
 
     it('calls extractSessionReflection after voice note received', async () => {
@@ -950,6 +950,148 @@ describe('SessionLogDialog', () => {
             ],
           }),
         )
+      })
+    })
+
+    it('second voice note in create mode calls updateSession on draft, not createSession again', async () => {
+      vi.mocked(sessionLogsApi.updateSession).mockResolvedValue({
+        ...SAMPLE_SESSION,
+        id: 'draft-session-id',
+        status: 1,
+        statusName: 'Draft' as const,
+      })
+
+      wrapper(<SessionLogDialog studentId={STUDENT_ID} open={true} onOpenChange={vi.fn()} />)
+      await waitFor(() => expect(screen.getByTestId('mock-audio-recorder-trigger')).toBeInTheDocument())
+
+      // First voice note: creates Draft
+      fireEvent.click(screen.getByTestId('mock-audio-recorder-trigger'))
+      await waitFor(() => expect(vi.mocked(sessionLogsApi.createSession)).toHaveBeenCalledTimes(1))
+
+      // Second voice note: updates the existing Draft
+      fireEvent.click(screen.getByTestId('mock-audio-recorder-trigger'))
+      await waitFor(() => {
+        expect(vi.mocked(sessionLogsApi.updateSession)).toHaveBeenCalledWith(
+          STUDENT_ID,
+          'draft-session-id',
+          expect.objectContaining({ status: 'Draft' }),
+        )
+      })
+      expect(vi.mocked(sessionLogsApi.createSession)).toHaveBeenCalledTimes(1)
+    })
+
+    it('voice note in edit mode calls updateSession on initialSession, not createSession', async () => {
+      vi.mocked(sessionLogsApi.updateSession).mockResolvedValue({ ...SAMPLE_SESSION })
+
+      wrapper(
+        <SessionLogDialog
+          studentId={STUDENT_ID}
+          open={true}
+          onOpenChange={vi.fn()}
+          initialSession={SAMPLE_SESSION}
+        />
+      )
+      await waitFor(() => expect(screen.getByTestId('mock-audio-recorder-trigger')).toBeInTheDocument())
+
+      fireEvent.click(screen.getByTestId('mock-audio-recorder-trigger'))
+
+      await waitFor(() => {
+        expect(vi.mocked(sessionLogsApi.updateSession)).toHaveBeenCalledWith(
+          STUDENT_ID,
+          SAMPLE_SESSION.id,
+          expect.anything(),
+        )
+      })
+      expect(vi.mocked(sessionLogsApi.createSession)).not.toHaveBeenCalled()
+    })
+
+    it('voice note on confirmed session keeps status Confirmed in auto-save', async () => {
+      const CONFIRMED_SESSION = { ...SAMPLE_SESSION, statusName: 'Confirmed' as const, status: 0 }
+      vi.mocked(sessionLogsApi.updateSession).mockResolvedValue(CONFIRMED_SESSION)
+
+      wrapper(
+        <SessionLogDialog
+          studentId={STUDENT_ID}
+          open={true}
+          onOpenChange={vi.fn()}
+          initialSession={CONFIRMED_SESSION}
+        />
+      )
+      await waitFor(() => expect(screen.getByTestId('mock-audio-recorder-trigger')).toBeInTheDocument())
+
+      fireEvent.click(screen.getByTestId('mock-audio-recorder-trigger'))
+
+      await waitFor(() => {
+        expect(vi.mocked(sessionLogsApi.updateSession)).toHaveBeenCalledWith(
+          STUDENT_ID,
+          CONFIRMED_SESSION.id,
+          expect.objectContaining({ status: 'Confirmed' }),
+        )
+      })
+      expect(vi.mocked(sessionLogsApi.createSession)).not.toHaveBeenCalled()
+    })
+
+    it('second voice note appends to narrative fields instead of replacing', async () => {
+      vi.mocked(sessionLogsApi.extractSessionReflection)
+        .mockResolvedValueOnce({ ...EXTRACTED, whatWasCovered: 'First topic' })
+        .mockResolvedValueOnce({ ...EXTRACTED, whatWasCovered: 'Second topic' })
+      vi.mocked(sessionLogsApi.updateSession).mockResolvedValue({
+        ...SAMPLE_SESSION,
+        id: 'draft-session-id',
+        status: 1,
+        statusName: 'Draft' as const,
+      })
+
+      wrapper(<SessionLogDialog studentId={STUDENT_ID} open={true} onOpenChange={vi.fn()} />)
+      await waitFor(() => expect(screen.getByTestId('mock-audio-recorder-trigger')).toBeInTheDocument())
+
+      fireEvent.click(screen.getByTestId('mock-audio-recorder-trigger'))
+      await waitFor(() => {
+        expect((screen.getByTestId('actual-content') as HTMLTextAreaElement).value).toBe('First topic')
+      })
+
+      fireEvent.click(screen.getByTestId('mock-audio-recorder-trigger'))
+      await waitFor(() => {
+        const value = (screen.getByTestId('actual-content') as HTMLTextAreaElement).value
+        expect(value).toContain('First topic')
+        expect(value).toContain('Second topic')
+      })
+    })
+
+    it('voice note unions topic tags without duplicates', async () => {
+      vi.mocked(sessionLogsApi.extractSessionReflection)
+        .mockResolvedValueOnce({ ...EXTRACTED, topicTags: [{ tag: 'ser/estar' }, { tag: 'subjuntivo' }] })
+        .mockResolvedValueOnce({ ...EXTRACTED, topicTags: [{ tag: 'subjuntivo' }, { tag: 'vocabulario' }] })
+      vi.mocked(sessionLogsApi.updateSession).mockResolvedValue({
+        ...SAMPLE_SESSION,
+        id: 'draft-session-id',
+        status: 1,
+        statusName: 'Draft' as const,
+      })
+
+      wrapper(<SessionLogDialog studentId={STUDENT_ID} open={true} onOpenChange={vi.fn()} />)
+      await waitFor(() => expect(screen.getByTestId('mock-audio-recorder-trigger')).toBeInTheDocument())
+
+      // First voice note: sets topic tags
+      fireEvent.click(screen.getByTestId('mock-audio-recorder-trigger'))
+      await waitFor(() => expect(vi.mocked(sessionLogsApi.createSession)).toHaveBeenCalledTimes(1))
+
+      // Second voice note: unions topic tags
+      fireEvent.click(screen.getByTestId('mock-audio-recorder-trigger'))
+      await waitFor(() => {
+        expect(vi.mocked(sessionLogsApi.updateSession)).toHaveBeenCalledWith(
+          STUDENT_ID,
+          'draft-session-id',
+          expect.objectContaining({
+            topicTags: expect.stringContaining('ser/estar'),
+          }),
+        )
+        // Should contain all three unique tags
+        const call = vi.mocked(sessionLogsApi.updateSession).mock.calls[0]
+        const payload = call[2] as { topicTags: string }
+        const tags = JSON.parse(payload.topicTags) as { tag: string }[]
+        expect(tags.map(t => t.tag)).toEqual(expect.arrayContaining(['ser/estar', 'subjuntivo', 'vocabulario']))
+        expect(tags).toHaveLength(3)
       })
     })
   })

--- a/frontend/src/components/session/SessionLogDialog.tsx
+++ b/frontend/src/components/session/SessionLogDialog.tsx
@@ -55,7 +55,15 @@ function mergeNarrative(existing: string, extracted: string): string {
 
 function mergeTopicTagsUnion(existing: TopicTag[], extracted: TopicTag[]): TopicTag[] {
   const seen = new Set(existing.map(t => t.tag.toLowerCase()))
-  return [...existing, ...extracted.filter(t => !seen.has(t.tag.toLowerCase()))]
+  const result = [...existing]
+  for (const t of extracted) {
+    const key = t.tag.toLowerCase()
+    if (!seen.has(key)) {
+      seen.add(key)
+      result.push(t)
+    }
+  }
+  return result
 }
 
 function mergeSuggestedDifficulties(
@@ -63,7 +71,15 @@ function mergeSuggestedDifficulties(
   extracted: SuggestedDifficulty[],
 ): SuggestedDifficulty[] {
   const seen = new Set(existing.map(d => `${d.competency}|${d.subcategory}`))
-  return [...existing, ...extracted.filter(d => !seen.has(`${d.competency}|${d.subcategory}`))]
+  const result = [...existing]
+  for (const d of extracted) {
+    const key = `${d.competency}|${d.subcategory}`
+    if (!seen.has(key)) {
+      seen.add(key)
+      result.push(d)
+    }
+  }
+  return result
 }
 
 const HOMEWORK_STATUSES = [

--- a/frontend/src/components/session/SessionLogDialog.tsx
+++ b/frontend/src/components/session/SessionLogDialog.tsx
@@ -162,6 +162,9 @@ export function SessionLogDialog({
   const voiceRunRef = useRef(0)
   const sessionDateRef = useRef(sessionDate)
   useEffect(() => { sessionDateRef.current = sessionDate }, [sessionDate])
+  // Track todos/followups submitted during this dialog session to prevent re-submission
+  const submittedTodosRef = useRef<Set<string>>(new Set())
+  const submittedFollowupsRef = useRef<Set<string>>(new Set())
 
   // Pre-populate fields when editing an existing session
   /* eslint-disable react-hooks/set-state-in-effect */
@@ -487,17 +490,30 @@ export function SessionLogDialog({
 
       if (runId !== voiceRunRef.current) return
 
-      // Create teaching todos and followups (non-fatal - errors are logged only)
+      // Create teaching todos and followups (non-fatal - errors are logged only).
+      // Deduplicate by normalized text to avoid re-submitting on a second voice note.
       const todoFollowupErrors: unknown[] = []
       if (extracted.teachingTodos?.length) {
+        const newTodos = extracted.teachingTodos.filter(text => {
+          const key = text.trim().toLowerCase()
+          if (submittedTodosRef.current.has(key)) return false
+          submittedTodosRef.current.add(key)
+          return true
+        })
         const results = await Promise.allSettled(
-          extracted.teachingTodos.map(text => appendTeachingTodo(studentId, text))
+          newTodos.map(text => appendTeachingTodo(studentId, text))
         )
         results.forEach(r => r.status === 'rejected' && todoFollowupErrors.push(r.reason))
       }
       if (extracted.teacherFollowups?.length) {
+        const newFollowups = extracted.teacherFollowups.filter(text => {
+          const key = text.trim().toLowerCase()
+          if (submittedFollowupsRef.current.has(key)) return false
+          submittedFollowupsRef.current.add(key)
+          return true
+        })
         const results = await Promise.allSettled(
-          extracted.teacherFollowups.map(text =>
+          newFollowups.map(text =>
             createFollowup({ text, studentId, sourceSessionLogId: savedSessionId })
           )
         )
@@ -625,6 +641,9 @@ export function SessionLogDialog({
                   </p>
                 )}
             </div>
+
+            {/* Lock all form inputs while extraction is in progress to prevent stale-state overwrites */}
+            <fieldset disabled={isExtracting} className="contents">
 
             {sessionsLoading && (
               <div className="space-y-2">
@@ -1015,6 +1034,8 @@ export function SessionLogDialog({
             {submitError && (
               <p className="text-xs text-red-600" data-testid="session-log-error">{submitError}</p>
             )}
+
+            </fieldset>
 
             <DialogFooter>
               <Button

--- a/frontend/src/components/session/SessionLogDialog.tsx
+++ b/frontend/src/components/session/SessionLogDialog.tsx
@@ -45,6 +45,27 @@ function isSuggestedDifficulty(value: unknown): value is SuggestedDifficulty {
   )
 }
 
+function mergeNarrative(existing: string, extracted: string): string {
+  const a = existing.trim()
+  const b = extracted.trim()
+  if (!a) return b
+  if (!b || a === b) return a
+  return `${a}\n${b}`
+}
+
+function mergeTopicTagsUnion(existing: TopicTag[], extracted: TopicTag[]): TopicTag[] {
+  const seen = new Set(existing.map(t => t.tag.toLowerCase()))
+  return [...existing, ...extracted.filter(t => !seen.has(t.tag.toLowerCase()))]
+}
+
+function mergeSuggestedDifficulties(
+  existing: SuggestedDifficulty[],
+  extracted: SuggestedDifficulty[],
+): SuggestedDifficulty[] {
+  const seen = new Set(existing.map(d => `${d.competency}|${d.subcategory}`))
+  return [...existing, ...extracted.filter(d => !seen.has(`${d.competency}|${d.subcategory}`))]
+}
+
 const HOMEWORK_STATUSES = [
   { value: 'Done', label: 'Done' },
   { value: 'Partial', label: 'Partial' },
@@ -364,18 +385,24 @@ export function SessionLogDialog({
     try {
       const extracted = await extractSessionReflection(studentId, voiceNote.transcription)
       if (runId !== voiceRunRef.current) return
-      const notes = [extracted.areasToImprove, extracted.emotionalSignals]
-        .filter(Boolean)
-        .join('\n')
-      // Pre-fill form fields from extraction
+
+      // Compute merged values before setState to avoid async stale-state reads
+      const notes = [extracted.areasToImprove, extracted.emotionalSignals].filter(Boolean).join('\n')
+      const mergedActualContent = mergeNarrative(actualContent, extracted.whatWasCovered ?? '')
+      const mergedHomework      = mergeNarrative(homeworkAssigned, extracted.homeworkAssigned ?? '')
+      const mergedNextTopics    = mergeNarrative(nextSessionTopics, extracted.nextLessonIdeas ?? '')
+      const mergedNotes         = mergeNarrative(generalNotes, notes)
+      const mergedTopicTags     = mergeTopicTagsUnion(topicTags, extracted.topicTags ?? [])
+      const mergedDifficulties  = mergeSuggestedDifficulties(suggestedDifficulties, extracted.suggestedDifficulties ?? [])
+
       /* eslint-disable react-hooks/set-state-in-effect */
-      setActualContent(extracted.whatWasCovered ?? '')
-      setHomeworkAssigned(extracted.homeworkAssigned ?? '')
-      setNextSessionTopics(extracted.nextLessonIdeas ?? '')
-      setGeneralNotes(notes)
-      setSuggestedDifficulties(extracted.suggestedDifficulties ?? [])
+      setActualContent(mergedActualContent)
+      setHomeworkAssigned(mergedHomework)
+      setNextSessionTopics(mergedNextTopics)
+      setGeneralNotes(mergedNotes)
+      setSuggestedDifficulties(mergedDifficulties)
+      setTopicTags(mergedTopicTags)
       if (!sessionDateRef.current && extracted.sessionDate) setSessionDate(extracted.sessionDate)
-      if (extracted.topicTags?.length && topicTags.length === 0) setTopicTags(extracted.topicTags)
       if (extracted.previousHomeworkStatus) setPrevHomeworkStatus(extracted.previousHomeworkStatus)
       if (extracted.isCancelled === true) setIsCancelled(true)
       if (extracted.levelReassessment) {
@@ -397,39 +424,53 @@ export function SessionLogDialog({
       }
       /* eslint-enable react-hooks/set-state-in-effect */
       if (runId !== voiceRunRef.current) return
-      // Resolve values that may have been updated above
-      const resolvedPrevHomework = extracted.previousHomeworkStatus ?? prevHomeworkStatus
-      const resolvedIsCancelled = extracted.isCancelled === true ? true : isCancelled
-      const resolvedTopicTags = extracted.topicTags?.length && topicTags.length === 0
-        ? extracted.topicTags
-        : topicTags
-      // Reassessment: only include in draft if teacher had already enabled the toggle with a valid skill
-      const resolvedLevelEnabled = reassessmentEnabled
-      const resolvedLevelValue = reassessmentEnabled ? reassessmentLevel || null : null
-      // Auto-save as Draft using full current form state + extracted fields
-      const resolvedDate = sessionDateRef.current || extracted.sessionDate || null
-      const draft = await createSession(studentId, {
+
+      const resolvedPrevHomework  = extracted.previousHomeworkStatus ?? prevHomeworkStatus
+      const resolvedIsCancelled   = extracted.isCancelled === true ? true : isCancelled
+      const resolvedDate          = sessionDateRef.current || extracted.sessionDate || null
+      const resolvedLevelValue    = reassessmentEnabled ? reassessmentLevel || null : null
+
+      // Determine whether to update an existing session or create a new Draft.
+      // Edit mode: always update the open session (including Confirmed sessions).
+      // Create mode with draft: update the draft created by the previous voice note.
+      // Create mode without draft: create a new Draft.
+      const targetSessionId = isEditMode ? initialSession!.id : draftSessionId
+      const isConfirmedSession = isEditMode && initialSession!.statusName === 'Confirmed'
+      const resolvedStatus: 'Draft' | 'Confirmed' = isConfirmedSession ? 'Confirmed' : 'Draft'
+
+      const payload = {
         sessionDate: resolvedDate,
         plannedContent: plannedContent || null,
-        actualContent: extracted.whatWasCovered ?? null,
-        homeworkAssigned: extracted.homeworkAssigned ?? null,
+        actualContent: mergedActualContent || null,
+        homeworkAssigned: mergedHomework || null,
         previousHomeworkStatus: resolvedPrevHomework,
-        nextSessionTopics: extracted.nextLessonIdeas ?? null,
-        generalNotes: notes || null,
-        levelReassessmentSkill: resolvedLevelEnabled ? reassessmentSkill || null : null,
-        levelReassessmentLevel: resolvedLevelEnabled ? resolvedLevelValue : null,
+        nextSessionTopics: mergedNextTopics || null,
+        generalNotes: mergedNotes || null,
+        levelReassessmentSkill: reassessmentEnabled ? reassessmentSkill || null : null,
+        levelReassessmentLevel: resolvedLevelValue,
         linkedLessonId: selectedLessonId || null,
-        topicTags: resolvedTopicTags.length > 0 ? serializeTopicTags(resolvedTopicTags) : null,
+        topicTags: mergedTopicTags.length > 0 ? serializeTopicTags(mergedTopicTags) : null,
         isCancelled: resolvedIsCancelled,
         duration: extracted.durationMinutes ?? null,
-        status: 'Draft',
-        suggestedDifficulties: extracted.suggestedDifficulties?.length ? extracted.suggestedDifficulties : undefined,
+        status: resolvedStatus,
+        suggestedDifficulties: mergedDifficulties.length > 0 ? mergedDifficulties : undefined,
         voiceNoteId: voiceNote.id,
         voiceNoteTranscription: voiceNote.transcription ?? undefined,
         rawExtractionJson: extracted.rawExtractionJson ?? undefined,
-      })
+      }
+
+      let savedSessionId: string
+      if (targetSessionId) {
+        await updateSession(studentId, targetSessionId, payload)
+        savedSessionId = targetSessionId
+      } else {
+        const draft = await createSession(studentId, payload)
+        setDraftSessionId(draft.id)
+        savedSessionId = draft.id
+      }
+
       if (runId !== voiceRunRef.current) return
-      setDraftSessionId(draft.id)
+
       // Create teaching todos and followups (non-fatal - errors are logged only)
       const todoFollowupErrors: unknown[] = []
       if (extracted.teachingTodos?.length) {
@@ -441,7 +482,7 @@ export function SessionLogDialog({
       if (extracted.teacherFollowups?.length) {
         const results = await Promise.allSettled(
           extracted.teacherFollowups.map(text =>
-            createFollowup({ text, studentId, sourceSessionLogId: draft.id })
+            createFollowup({ text, studentId, sourceSessionLogId: savedSessionId })
           )
         )
         results.forEach(r => r.status === 'rejected' && todoFollowupErrors.push(r.reason))
@@ -548,9 +589,8 @@ export function SessionLogDialog({
           </div>
         ) : (
           <form onSubmit={handleSubmit} className="space-y-4">
-            {/* Voice recording — create mode only, hidden after draft is saved */}
-            {!isEditMode && !draftSessionId && (
-              <div className="space-y-1" data-testid="voice-recorder-section">
+            {/* Voice recording */}
+            <div className="space-y-1" data-testid="voice-recorder-section">
                 <Label className="text-sm">Record session notes</Label>
                 {isExtracting ? (
                   <div className="flex items-center gap-2 text-sm text-muted-foreground" data-testid="extracting-indicator">
@@ -568,8 +608,7 @@ export function SessionLogDialog({
                     Could not extract fields from audio. Fill in the form manually.
                   </p>
                 )}
-              </div>
-            )}
+            </div>
 
             {sessionsLoading && (
               <div className="space-y-2">

--- a/plan/langteach-beta/task674-voice-duplicate-drafts.md
+++ b/plan/langteach-beta/task674-voice-duplicate-drafts.md
@@ -1,0 +1,217 @@
+# Task 674 — Fix: voice recording creates duplicate drafts
+
+## Problem
+
+`handleVoiceNote` in `SessionLogDialog.tsx` (line 411) always calls `createSession(..., status: 'Draft')`,
+regardless of whether:
+- A draft was already created by a previous voice note (`draftSessionId` is set), or
+- The dialog is open in edit mode (editing an existing session).
+
+This causes two bugs:
+1. A second voice note on the same create-mode form creates a second Draft session.
+2. A voice note while editing an existing session (including a Confirmed one) creates a new Draft
+   instead of updating the existing session.
+
+Additionally, field merging is currently "replace, not append": a second voice note overwrites
+what the first extracted, instead of appending narrative fields and unioning list fields.
+
+## Scope
+
+**Frontend only.** The backend `updateSession` endpoint already accepts the full payload and supports
+all necessary fields (including `status`). No backend changes required.
+
+## Changes
+
+### 1. Helper functions (add near top of `SessionLogDialog.tsx`)
+
+```ts
+function mergeNarrative(existing: string, extracted: string): string {
+  const a = existing.trim()
+  const b = extracted.trim()
+  if (!a) return b
+  if (!b || a === b) return a
+  return `${a}\n${b}`
+}
+
+function mergeTopicTagsUnion(existing: TopicTag[], extracted: TopicTag[]): TopicTag[] {
+  const seen = new Set(existing.map(t => t.tag.toLowerCase()))
+  return [...existing, ...extracted.filter(t => !seen.has(t.tag.toLowerCase()))]
+}
+
+function mergeSuggestedDifficulties(
+  existing: SuggestedDifficulty[],
+  extracted: SuggestedDifficulty[],
+): SuggestedDifficulty[] {
+  const seen = new Set(existing.map(d => `${d.competency}|${d.subcategory}`))
+  return [...existing, ...extracted.filter(d => !seen.has(`${d.competency}|${d.subcategory}`))]
+}
+```
+
+### 2. Rewrite `handleVoiceNote`
+
+**Step A — Compute merged values before calling setState** (avoids async state read issues):
+
+```ts
+const notes = [extracted.areasToImprove, extracted.emotionalSignals].filter(Boolean).join('\n')
+const mergedActualContent  = mergeNarrative(actualContent, extracted.whatWasCovered ?? '')
+const mergedHomework       = mergeNarrative(homeworkAssigned, extracted.homeworkAssigned ?? '')
+const mergedNextTopics     = mergeNarrative(nextSessionTopics, extracted.nextLessonIdeas ?? '')
+const mergedNotes          = mergeNarrative(generalNotes, notes)
+const mergedTopicTags      = mergeTopicTagsUnion(topicTags, extracted.topicTags ?? [])
+const mergedDifficulties   = mergeSuggestedDifficulties(suggestedDifficulties, extracted.suggestedDifficulties ?? [])
+```
+
+**Step B — Apply merged values to state:**
+
+```ts
+setActualContent(mergedActualContent)
+setHomeworkAssigned(mergedHomework)
+setNextSessionTopics(mergedNextTopics)
+setGeneralNotes(mergedNotes)
+setTopicTags(mergedTopicTags)
+setSuggestedDifficulties(mergedDifficulties)
+// sessionDate, isCancelled, levelReassessment, difficulties: unchanged behaviour
+```
+
+**Step C — Determine target session and save:**
+
+```ts
+const targetSessionId = isEditMode ? initialSession!.id : draftSessionId
+
+const resolvedDate     = sessionDateRef.current || extracted.sessionDate || null
+const resolvedPrevHw   = extracted.previousHomeworkStatus ?? prevHomeworkStatus
+const resolvedCancelled = extracted.isCancelled === true ? true : isCancelled
+const isConfirmed      = isEditMode && initialSession!.statusName === 'Confirmed'
+const resolvedStatus   = isConfirmed ? 'Confirmed' : 'Draft'
+
+const payload = {
+  sessionDate: resolvedDate,
+  plannedContent: plannedContent || null,
+  actualContent: mergedActualContent || null,
+  homeworkAssigned: mergedHomework || null,
+  previousHomeworkStatus: resolvedPrevHw,
+  nextSessionTopics: mergedNextTopics || null,
+  generalNotes: mergedNotes || null,
+  levelReassessmentSkill: resolvedLevelEnabled ? reassessmentSkill || null : null,
+  levelReassessmentLevel: resolvedLevelEnabled ? reassessmentLevel || null : null,
+  linkedLessonId: selectedLessonId || null,
+  topicTags: mergedTopicTags.length > 0 ? serializeTopicTags(mergedTopicTags) : null,
+  isCancelled: resolvedCancelled,
+  duration: extracted.durationMinutes ?? null,
+  status: resolvedStatus,
+  suggestedDifficulties: mergedDifficulties.length > 0 ? mergedDifficulties : undefined,
+  voiceNoteId: voiceNote.id,
+  voiceNoteTranscription: voiceNote.transcription ?? undefined,
+  rawExtractionJson: extracted.rawExtractionJson ?? undefined,
+}
+
+let savedSessionId: string
+if (targetSessionId) {
+  await updateSession(studentId, targetSessionId, payload)
+  savedSessionId = targetSessionId
+} else {
+  const draft = await createSession(studentId, payload)
+  setDraftSessionId(draft.id)
+  savedSessionId = draft.id
+}
+```
+
+**Step D — Teaching todos and followups** (link to the correct session):
+
+```ts
+if (extracted.teachingTodos?.length) {
+  // unchanged: append todos to student record
+}
+if (extracted.teacherFollowups?.length) {
+  // use savedSessionId (not draft.id which is only available in the create path)
+  extracted.teacherFollowups.map(text =>
+    createFollowup({ text, studentId, sourceSessionLogId: savedSessionId })
+  )
+}
+```
+
+## Acceptance criteria verification
+
+| AC | How it is met |
+|----|---------------|
+| Voice in create mode creates Draft (no regression) | `!isEditMode && !draftSessionId` → `createSession(..., status: 'Draft')` |
+| Voice in edit mode merges into existing form state | `isEditMode` → `updateSession(initialSession.id, ...)` |
+| Narrative fields appended with `\n` separator | `mergeNarrative()` helper |
+| List fields unioned (no duplicates) | `mergeTopicTagsUnion()`, `mergeSuggestedDifficulties()` |
+| Second voice note appends/merges | `draftSessionId` is set after first; second note calls `updateSession` |
+| Voice on confirmed session auto-confirms | `resolvedStatus = 'Confirmed'` when `initialSession.statusName === 'Confirmed'` |
+| No duplicate Draft sessions | `targetSessionId` branches: update if exists, create only when both are null |
+
+## Tests to add (unit)
+
+In `SessionLogDialog.test.tsx`:
+
+1. **`voice note in create mode creates a Draft session`** — existing mock triggers voice note,
+   verify `createSession` called with `status: 'Draft'`.
+
+2. **`second voice note in create mode updates the draft, not creates a new session`** — trigger
+   voice note twice; verify `createSession` called once, `updateSession` called once with
+   `draftSessionId`.
+
+3. **`voice note in edit mode calls updateSession on initialSession, not createSession`** — open
+   in edit mode, trigger voice note; verify `updateSession` called with `initialSession.id` and
+   `createSession` NOT called.
+
+4. **`voice note in edit mode on confirmed session keeps Confirmed status`** — `initialSession.statusName = 'Confirmed'`;
+   verify `updateSession` called with `status: 'Confirmed'`.
+
+5. **`second voice note appends narrative fields, not replaces`** — pre-fill `actualContent`;
+   mock two different extraction results; trigger voice note; verify merged text contains both.
+
+6. **`voice note unions topic tags, no duplicates`** — initial tags + extracted tags with overlap;
+   verify result has union.
+
+## E2E coverage
+
+Add a test in `e2e/tests/students.spec.ts` under a `voice note session logging` group:
+- Open the SessionLogDialog for a student
+- Trigger voice note (mock the recorder via the same approach used for LogSession)
+- Confirm that only one Draft session exists after two voice notes
+
+Note: The AudioRecorder is hard to drive in e2e without browser audio access. Use the existing
+e2e pattern: set `VITE_E2E_TEST_MODE=true` stub or check how `LogSession.spec.ts`/`log-session.visual.spec.ts`
+handle voice in e2e context to decide approach.
+
+## Additional change: AudioRecorder render guard
+
+**Current condition** (line 552):
+```tsx
+{!isEditMode && !draftSessionId && (
+  <div data-testid="voice-recorder-section">...
+```
+
+This hides the recorder in edit mode entirely, and hides it after the first voice note in create mode. Both constraints prevent the AC scenarios from being reachable. Change to:
+```tsx
+{(
+  <div data-testid="voice-recorder-section">...
+```
+i.e., remove the guard entirely. The recorder is already inside the `!success` block. The
+`isExtracting` state already handles preventing concurrent recordings (shows spinner instead of
+recorder while extraction is running).
+
+**Note on topicTags guard** (line 378): The current code `if (extracted.topicTags?.length && topicTags.length === 0) setTopicTags(...)` is replaced by the union merge. For a fresh form this is equivalent (mergeTopicTagsUnion([], extracted) = extracted). For an existing form (edit mode or second voice note), the union is the correct new behaviour. Existing tests that rely on the length-0 guard will continue to pass since they start with `topicTags = []`.
+
+**Note on resolvedLevelEnabled** (line 407 naming): Use existing variable `reassessmentEnabled` directly (not `resolvedLevelEnabled` which does not exist). Plan Step C corrects this.
+
+**Note on savedSessionId scope** (Step D): Declare `savedSessionId` before the `if (targetSessionId)` branch so it is in scope for the followup creation in both paths.
+
+## E2E approach
+
+Voice note e2e is not easily testable via the real AudioRecorder (browser audio permission required). Use the approach from `e2e/tests/visual/log-session.visual.spec.ts`: check whether an existing e2e stub or mock audio approach is already present. If not, add a focused test that:
+- Opens the SessionLogDialog (via students page "Log Session" button)
+- Verifies the voice recorder section is visible in edit mode (new) and in create mode after a draft exists
+
+If driving the AudioRecorder itself is not feasible in e2e, defer with a GitHub issue (create it before PR). Do not leave E2E coverage unresolved.
+
+## Files to change
+
+| File | Change |
+|------|--------|
+| `frontend/src/components/session/SessionLogDialog.tsx` | Remove AudioRecorder render guard; add 3 helpers; rewrite `handleVoiceNote` merge/save logic |
+| `frontend/src/components/session/SessionLogDialog.test.tsx` | Add 6 unit tests for voice note scenarios |
+| `e2e/tests/students.spec.ts` | Add voice recorder visibility test; defer extraction test with issue if needed |

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -3,6 +3,7 @@
 Out-of-scope observations logged by agents during implementation. Each row is something an agent noticed but did not fix because it was outside the current task's scope. These get batched into future GitHub issues by the PM.
 
 | Source issue | Date | Severity | Observation |
+| #674 | 2026-04-12 | low | review-ui agent could not find `log-session-button` testid on student detail page in create mode. Pre-existing selector mismatch, unrelated to this PR. Should be investigated and fixed in a future task. |
 | #626 | 2026-04-10 | medium | DemoSeeder uses PersonalNotes as seed-detection marker; if teacher edits that field the seeder loses track and may create duplicates. Pre-existing pattern (was Notes before this PR). Should use a dedicated IsDemo flag or deterministic seed name matching. |
 | #627 | 2026-04-10 | low | CodeRabbit suggested validating sourceSessionLogId/coveredInSessionLogId against DB. Dismissed: issue spec explicitly chose soft-backlink (stored UUID, no FK), Sophy approved. If referential integrity becomes a requirement, it can be added later. |
 | #636 | 2026-04-10 | low | All controllers use `Auth0Id is null` check instead of `IsNullOrWhiteSpace`, and none wrap `UpsertTeacherAsync` in a try/catch for `InvalidOperationException`. Pre-existing pattern across 16 controllers. Could be addressed in a future controller hardening sweep. |


### PR DESCRIPTION
## Summary
- `handleVoiceNote` now calls `updateSession` when a target session exists (edit mode or existing draft), instead of always calling `createSession`
- Three merge helpers (`mergeNarrative`, `mergeTopicTagsUnion`, `mergeSuggestedDifficulties`) ensure successive voice notes append narrative fields and union list fields
- AudioRecorder render guard removed so the recorder is available in edit mode and after the first voice note on a create form
- Voice note on a Confirmed session keeps `status: 'Confirmed'` in the auto-save payload

## Test plan
- [ ] All 1114 frontend unit tests pass (includes 6 new voice-note scenarios)
- [ ] Architecture review: PASS
- [ ] QA verify: PASS
- [ ] UI review: PASS (recorder visible in edit mode dialog)
- [ ] Build verify: PASS (bicep, dotnet build, dotnet test, npm lint)

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced voice recording in draft and edit session modes with improved handling of multiple voice notes.

* **Bug Fixes**
  * Fixed voice note extraction to append content instead of replacing existing session data.
  * Improved topic tag deduplication when extracting multiple voice notes.
  * Enhanced draft session persistence during voice recording operations.

* **Tests**
  * Added E2E tests validating voice recorder visibility and functionality in draft sessions.
  * Expanded unit test coverage for voice note merging and session auto-save behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->