### PR TITLE
feat: cross-student sessions list page (/sessions) (#640)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
@@ -285,4 +285,117 @@ public class DashboardServiceTests : IDisposable
 
         result.ActiveStudents[0].CancelledSessionsLast30Days.Should().Be(0);
     }
+
+    // GetSessionsListAsync tests
+
+    [Fact]
+    public async Task GetSessionsListAsync_NoSessions_ReturnsEmptySectionsAndStudentList()
+    {
+        var result = await _sut.GetSessionsListAsync(_teacherId, null);
+
+        result.Upcoming.Should().BeEmpty();
+        result.Today.Should().BeEmpty();
+        result.Recent.Should().BeEmpty();
+        result.Students.Should().HaveCount(1);
+        result.Students[0].Name.Should().Be("Ana García");
+    }
+
+    [Fact]
+    public async Task GetSessionsListAsync_FutureSession_AppearsInUpcoming()
+    {
+        var future = DateTime.UtcNow.AddDays(2);
+        _db.SessionLogs.Add(MakeSession(_studentId, future, plannedContent: "Subjunctive"));
+        _db.SaveChanges();
+
+        var result = await _sut.GetSessionsListAsync(_teacherId, null);
+
+        result.Upcoming.Should().HaveCount(1);
+        result.Upcoming[0].StudentId.Should().Be(_studentId);
+        result.Upcoming[0].StudentCefrLevel.Should().Be("B1");
+        result.Upcoming[0].PlannedContent.Should().Be("Subjunctive");
+        result.Upcoming[0].Status.Should().Be("Confirmed");
+        result.Today.Should().BeEmpty();
+        result.Recent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetSessionsListAsync_CancelledFutureSession_ExcludedFromUpcoming()
+    {
+        var future = DateTime.UtcNow.AddDays(2);
+        _db.SessionLogs.Add(MakeSession(_studentId, future, isCancelled: true));
+        _db.SaveChanges();
+
+        var result = await _sut.GetSessionsListAsync(_teacherId, null);
+
+        result.Upcoming.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetSessionsListAsync_TodaySession_AppearsInToday()
+    {
+        var todayMidMorning = DateTime.UtcNow.Date.AddHours(10);
+        _db.SessionLogs.Add(MakeSession(_studentId, todayMidMorning));
+        _db.SaveChanges();
+
+        var result = await _sut.GetSessionsListAsync(_teacherId, null);
+
+        result.Today.Should().HaveCount(1);
+        result.Today[0].StudentId.Should().Be(_studentId);
+        result.Upcoming.Should().BeEmpty();
+        result.Recent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetSessionsListAsync_PastSessionWithin7Days_AppearsInRecent()
+    {
+        var recent = DateTime.UtcNow.AddDays(-3);
+        _db.SessionLogs.Add(MakeSession(_studentId, recent));
+        _db.SaveChanges();
+
+        var result = await _sut.GetSessionsListAsync(_teacherId, null);
+
+        result.Recent.Should().HaveCount(1);
+        result.Recent[0].StudentId.Should().Be(_studentId);
+        result.Upcoming.Should().BeEmpty();
+        result.Today.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetSessionsListAsync_SessionOlderThan7Days_ExcludedFromRecent()
+    {
+        var old = DateTime.UtcNow.AddDays(-10);
+        _db.SessionLogs.Add(MakeSession(_studentId, old));
+        _db.SaveChanges();
+
+        var result = await _sut.GetSessionsListAsync(_teacherId, null);
+
+        result.Recent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetSessionsListAsync_StudentIdFilter_NarrowsAllSections()
+    {
+        var otherId = Guid.NewGuid();
+        _db.Students.Add(new Student
+        {
+            Id = otherId,
+            TeacherId = _teacherId,
+            Name = "Other Student",
+            LearningLanguage = "Spanish",
+            CefrLevel = "A2",
+            NativeLanguages = "[]",
+            TeachingTodos = "[]",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        _db.SessionLogs.Add(MakeSession(_studentId, DateTime.UtcNow.AddDays(2)));
+        _db.SessionLogs.Add(MakeSession(otherId, DateTime.UtcNow.AddDays(3)));
+        _db.SaveChanges();
+
+        var result = await _sut.GetSessionsListAsync(_teacherId, _studentId);
+
+        result.Upcoming.Should().HaveCount(1);
+        result.Upcoming[0].StudentId.Should().Be(_studentId);
+    }
 }

--- a/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
@@ -346,6 +346,47 @@ public class DashboardServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetSessionsListAsync_LaterTodaySession_AppearsOnlyInToday_NotUpcoming()
+    {
+        // Sessions later today should be in Today, not Upcoming (buckets must be disjoint)
+        var laterToday = DateTime.UtcNow.Date.AddHours(22);
+        _db.SessionLogs.Add(MakeSession(_studentId, laterToday));
+        _db.SaveChanges();
+
+        var result = await _sut.GetSessionsListAsync(_teacherId, null);
+
+        result.Today.Should().HaveCount(1);
+        result.Upcoming.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetSessionsListAsync_SoftDeletedStudent_ExcludedFromSections()
+    {
+        var deletedStudentId = Guid.NewGuid();
+        _db.Students.Add(new Student
+        {
+            Id = deletedStudentId,
+            TeacherId = _teacherId,
+            Name = "Deleted Student",
+            LearningLanguage = "Spanish",
+            CefrLevel = "B2",
+            NativeLanguages = "[]",
+            TeachingTodos = "[]",
+            IsActive = false,
+            IsDeleted = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        _db.SessionLogs.Add(MakeSession(deletedStudentId, DateTime.UtcNow.AddDays(2)));
+        _db.SaveChanges();
+
+        var result = await _sut.GetSessionsListAsync(_teacherId, null);
+
+        result.Upcoming.Should().BeEmpty();
+        result.Students.Should().NotContain(s => s.Name == "Deleted Student");
+    }
+
+    [Fact]
     public async Task GetSessionsListAsync_PastSessionWithin7Days_AppearsInRecent()
     {
         var recent = DateTime.UtcNow.AddDays(-3);

--- a/backend/LangTeach.Api/Controllers/DashboardController.cs
+++ b/backend/LangTeach.Api/Controllers/DashboardController.cs
@@ -41,4 +41,19 @@ public class DashboardController : ControllerBase
 
         return Ok(dto);
     }
+
+    [HttpGet("sessions")]
+    public async Task<IActionResult> GetSessions([FromQuery] Guid? studentId, CancellationToken cancellationToken)
+    {
+        if (Auth0Id is null) return Unauthorized();
+        var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
+
+        var dto = await _dashboardService.GetSessionsListAsync(teacherId, studentId, cancellationToken);
+
+        _logger.LogInformation(
+            "GET /api/dashboard/sessions TeacherId={TeacherId} Upcoming={Upcoming} Today={Today} Recent={Recent}",
+            teacherId, dto.Upcoming.Count, dto.Today.Count, dto.Recent.Count);
+
+        return Ok(dto);
+    }
 }

--- a/backend/LangTeach.Api/DTOs/DashboardDtos.cs
+++ b/backend/LangTeach.Api/DTOs/DashboardDtos.cs
@@ -1,5 +1,24 @@
 namespace LangTeach.Api.DTOs;
 
+public record SessionListItemDto(
+    Guid SessionLogId,
+    Guid StudentId,
+    string StudentName,
+    string StudentCefrLevel,
+    DateTime SessionDate,
+    string? PlannedContent,
+    string Status
+);
+
+public record SessionFilterStudentDto(Guid StudentId, string Name, string CefrLevel);
+
+public record SessionsListDto(
+    List<SessionListItemDto> Upcoming,
+    List<SessionListItemDto> Today,
+    List<SessionListItemDto> Recent,
+    List<SessionFilterStudentDto> Students
+);
+
 public record NextSessionDto(
     Guid SessionLogId,
     Guid StudentId,

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -94,21 +94,22 @@ public class DashboardService : IDashboardService
 
     public async Task<SessionsListDto> GetSessionsListAsync(Guid teacherId, Guid? studentId, CancellationToken cancellationToken = default)
     {
-        var now = DateTime.UtcNow;
-        var today = now.Date;
-        var recentCutoff = today.AddDays(-7);
+        var recentCutoff = DateTime.UtcNow.Date.AddDays(-7);
 
         IQueryable<SessionLog> baseQuery = _db.SessionLogs
             .Where(sl => sl.TeacherId == teacherId
                       && !sl.IsDeleted
-                      && sl.SessionDate.HasValue)
+                      && sl.SessionDate.HasValue
+                      && !sl.Student.IsDeleted)
             .Include(sl => sl.Student);
 
         if (studentId.HasValue)
             baseQuery = baseQuery.Where(sl => sl.StudentId == studentId.Value);
 
+        var today = DateTime.UtcNow.Date;
+
         var upcomingRaw = await baseQuery
-            .Where(sl => !sl.IsCancelled && sl.SessionDate!.Value > now)
+            .Where(sl => !sl.IsCancelled && sl.SessionDate!.Value.Date > today)
             .OrderBy(sl => sl.SessionDate)
             .ToListAsync(cancellationToken);
 

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -107,45 +107,21 @@ public class DashboardService : IDashboardService
         if (studentId.HasValue)
             baseQuery = baseQuery.Where(sl => sl.StudentId == studentId.Value);
 
-        var upcoming = await baseQuery
+        var upcomingRaw = await baseQuery
             .Where(sl => !sl.IsCancelled && sl.SessionDate!.Value > now)
             .OrderBy(sl => sl.SessionDate)
-            .Select(sl => new SessionListItemDto(
-                sl.Id,
-                sl.StudentId,
-                sl.Student.Name,
-                sl.Student.CefrLevel,
-                sl.SessionDate!.Value,
-                sl.PlannedContent,
-                sl.IsCancelled ? "Cancelled" : sl.Status.ToString()))
             .ToListAsync(cancellationToken);
 
-        var today_sessions = await baseQuery
+        var todaySessionsRaw = await baseQuery
             .Where(sl => sl.SessionDate!.Value.Date == today)
             .OrderBy(sl => sl.SessionDate)
-            .Select(sl => new SessionListItemDto(
-                sl.Id,
-                sl.StudentId,
-                sl.Student.Name,
-                sl.Student.CefrLevel,
-                sl.SessionDate!.Value,
-                sl.PlannedContent,
-                sl.IsCancelled ? "Cancelled" : sl.Status.ToString()))
             .ToListAsync(cancellationToken);
 
-        var recent = await baseQuery
+        var recentRaw = await baseQuery
             .Where(sl => !sl.IsCancelled
                       && sl.SessionDate!.Value >= recentCutoff
                       && sl.SessionDate!.Value.Date < today)
             .OrderByDescending(sl => sl.SessionDate)
-            .Select(sl => new SessionListItemDto(
-                sl.Id,
-                sl.StudentId,
-                sl.Student.Name,
-                sl.Student.CefrLevel,
-                sl.SessionDate!.Value,
-                sl.PlannedContent,
-                sl.IsCancelled ? "Cancelled" : sl.Status.ToString()))
             .ToListAsync(cancellationToken);
 
         var students = await _db.Students
@@ -154,8 +130,22 @@ public class DashboardService : IDashboardService
             .Select(s => new SessionFilterStudentDto(s.Id, s.Name, s.CefrLevel))
             .ToListAsync(cancellationToken);
 
-        return new SessionsListDto(upcoming, today_sessions, recent, students);
+        return new SessionsListDto(
+            upcomingRaw.Select(MapToSessionListItem).ToList(),
+            todaySessionsRaw.Select(MapToSessionListItem).ToList(),
+            recentRaw.Select(MapToSessionListItem).ToList(),
+            students);
     }
+
+    private static SessionListItemDto MapToSessionListItem(SessionLog sl) =>
+        new(
+            sl.Id,
+            sl.StudentId,
+            sl.Student.Name,
+            sl.Student.CefrLevel,
+            sl.SessionDate!.Value,
+            sl.PlannedContent,
+            sl.IsCancelled ? "Cancelled" : sl.Status.ToString());
 
     private async Task<List<ActiveStudentDto>> GetActiveStudentsAsync(Guid teacherId, DateTime now, CancellationToken cancellationToken)
     {

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -1,4 +1,5 @@
 using LangTeach.Api.Data;
+using LangTeach.Api.Data.Models;
 using LangTeach.Api.DTOs;
 using LangTeach.Api.Helpers;
 using Microsoft.EntityFrameworkCore;
@@ -89,6 +90,71 @@ public class DashboardService : IDashboardService
             PlannedContent: sl.PlannedContent,
             Status: sl.Status.ToString()
         )).ToList();
+    }
+
+    public async Task<SessionsListDto> GetSessionsListAsync(Guid teacherId, Guid? studentId, CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+        var today = now.Date;
+        var recentCutoff = today.AddDays(-7);
+
+        IQueryable<SessionLog> baseQuery = _db.SessionLogs
+            .Where(sl => sl.TeacherId == teacherId
+                      && !sl.IsDeleted
+                      && sl.SessionDate.HasValue)
+            .Include(sl => sl.Student);
+
+        if (studentId.HasValue)
+            baseQuery = baseQuery.Where(sl => sl.StudentId == studentId.Value);
+
+        var upcoming = await baseQuery
+            .Where(sl => !sl.IsCancelled && sl.SessionDate!.Value > now)
+            .OrderBy(sl => sl.SessionDate)
+            .Select(sl => new SessionListItemDto(
+                sl.Id,
+                sl.StudentId,
+                sl.Student.Name,
+                sl.Student.CefrLevel,
+                sl.SessionDate!.Value,
+                sl.PlannedContent,
+                sl.IsCancelled ? "Cancelled" : sl.Status.ToString()))
+            .ToListAsync(cancellationToken);
+
+        var today_sessions = await baseQuery
+            .Where(sl => sl.SessionDate!.Value.Date == today)
+            .OrderBy(sl => sl.SessionDate)
+            .Select(sl => new SessionListItemDto(
+                sl.Id,
+                sl.StudentId,
+                sl.Student.Name,
+                sl.Student.CefrLevel,
+                sl.SessionDate!.Value,
+                sl.PlannedContent,
+                sl.IsCancelled ? "Cancelled" : sl.Status.ToString()))
+            .ToListAsync(cancellationToken);
+
+        var recent = await baseQuery
+            .Where(sl => !sl.IsCancelled
+                      && sl.SessionDate!.Value >= recentCutoff
+                      && sl.SessionDate!.Value.Date < today)
+            .OrderByDescending(sl => sl.SessionDate)
+            .Select(sl => new SessionListItemDto(
+                sl.Id,
+                sl.StudentId,
+                sl.Student.Name,
+                sl.Student.CefrLevel,
+                sl.SessionDate!.Value,
+                sl.PlannedContent,
+                sl.IsCancelled ? "Cancelled" : sl.Status.ToString()))
+            .ToListAsync(cancellationToken);
+
+        var students = await _db.Students
+            .Where(s => s.TeacherId == teacherId && !s.IsDeleted)
+            .OrderBy(s => s.Name)
+            .Select(s => new SessionFilterStudentDto(s.Id, s.Name, s.CefrLevel))
+            .ToListAsync(cancellationToken);
+
+        return new SessionsListDto(upcoming, today_sessions, recent, students);
     }
 
     private async Task<List<ActiveStudentDto>> GetActiveStudentsAsync(Guid teacherId, DateTime now, CancellationToken cancellationToken)

--- a/backend/LangTeach.Api/Services/IDashboardService.cs
+++ b/backend/LangTeach.Api/Services/IDashboardService.cs
@@ -5,4 +5,5 @@ namespace LangTeach.Api.Services;
 public interface IDashboardService
 {
     Task<DashboardDto> GetAsync(Guid teacherId, CancellationToken cancellationToken = default);
+    Task<SessionsListDto> GetSessionsListAsync(Guid teacherId, Guid? studentId, CancellationToken cancellationToken = default);
 }

--- a/e2e/tests/sessions.spec.ts
+++ b/e2e/tests/sessions.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test'
+import { createMockAuthContext } from '../helpers/auth-helper'
+import { setupMockTeacher } from '../helpers/mock-teacher-helper'
+import { UI_TIMEOUT, NAV_TIMEOUT } from '../helpers/timeouts'
+
+test.beforeAll(async ({ browser }) => {
+  const ctx = await createMockAuthContext(browser)
+  const page = await ctx.newPage()
+  await setupMockTeacher(page)
+  await page.close()
+  await ctx.close()
+})
+
+test('sessions page renders with sections', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    await page.goto('/sessions')
+    await expect(page.locator('h1')).toHaveText('Sessions', { timeout: NAV_TIMEOUT })
+
+    // Either sessions list or empty state must appear
+    const content = page.locator('[data-testid="sessions-list"], [data-testid="sessions-empty"]')
+    await expect(content.first()).toBeVisible({ timeout: UI_TIMEOUT })
+  } finally {
+    await context.close()
+  }
+})
+
+test('sessions page shows recent sessions for Diego Seed', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    await page.goto('/sessions')
+    await expect(page.locator('h1')).toHaveText('Sessions', { timeout: NAV_TIMEOUT })
+
+    // Diego Seed has sessions at -14 and -7 days (Recent section)
+    // At least one session row for Diego Seed should be visible
+    const sessionsList = page.getByTestId('sessions-list')
+    await expect(sessionsList).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // The Recent section header must be present
+    const recentHeader = page.getByText('Recent', { exact: true })
+    await expect(recentHeader).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // Diego Seed should appear in session rows
+    const diegoRows = page.getByText('Diego Seed')
+    await expect(diegoRows.first()).toBeVisible({ timeout: UI_TIMEOUT })
+  } finally {
+    await context.close()
+  }
+})
+
+test('sessions filter by student narrows results', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    await page.goto('/sessions')
+    await expect(page.locator('h1')).toHaveText('Sessions', { timeout: NAV_TIMEOUT })
+    await expect(page.getByTestId('sessions-list')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // Open the student filter
+    const filterTrigger = page.getByTestId('student-filter')
+    await expect(filterTrigger).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await filterTrigger.click()
+
+    // Select Diego Seed from the dropdown
+    const diegoOption = page.getByRole('option', { name: 'Diego Seed' })
+    await expect(diegoOption).toBeVisible({ timeout: UI_TIMEOUT })
+    await diegoOption.click()
+
+    // After filtering, only Diego Seed rows should be visible
+    // Ana Seed (no sessions) should not appear; any visible rows are Diego's
+    const sessionsList = page.getByTestId('sessions-list')
+    await expect(sessionsList).toBeVisible({ timeout: UI_TIMEOUT })
+
+    const diegoRows = page.getByText('Diego Seed')
+    await expect(diegoRows.first()).toBeVisible({ timeout: UI_TIMEOUT })
+  } finally {
+    await context.close()
+  }
+})
+
+test('clicking session row navigates to student detail', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    await page.goto('/sessions')
+    await expect(page.locator('h1')).toHaveText('Sessions', { timeout: NAV_TIMEOUT })
+    await expect(page.getByTestId('sessions-list')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // Click the first session row
+    const firstRow = page.locator('[data-testid^="session-row-"]').first()
+    await expect(firstRow).toBeVisible({ timeout: UI_TIMEOUT })
+    await firstRow.click()
+
+    // Should navigate to a student detail page
+    await expect(page).toHaveURL(/\/students\//, { timeout: NAV_TIMEOUT })
+  } finally {
+    await context.close()
+  }
+})
+
+test('sessions nav item visible in sidebar', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    await page.goto('/')
+    await expect(page.locator('h1')).toHaveText('Dashboard', { timeout: NAV_TIMEOUT })
+
+    // Desktop sidebar contains Sessions link
+    const sidebar = page.locator('aside')
+    await expect(sidebar.getByRole('link', { name: 'Sessions' })).toBeVisible({ timeout: UI_TIMEOUT })
+  } finally {
+    await context.close()
+  }
+})

--- a/e2e/tests/sessions.spec.ts
+++ b/e2e/tests/sessions.spec.ts
@@ -72,13 +72,17 @@ test('sessions filter by student narrows results', async ({ browser }) => {
     await expect(diegoOption).toBeVisible({ timeout: UI_TIMEOUT })
     await diegoOption.click()
 
-    // After filtering, only Diego Seed rows should be visible
-    // Ana Seed (no sessions) should not appear; any visible rows are Diego's
-    const sessionsList = page.getByTestId('sessions-list')
-    await expect(sessionsList).toBeVisible({ timeout: UI_TIMEOUT })
+    // After filtering, the page should render either a session list or empty state
+    // If sessions are present, every row must belong to Diego Seed
+    const content = page.locator('[data-testid="sessions-list"], [data-testid="sessions-empty"]')
+    await expect(content.first()).toBeVisible({ timeout: UI_TIMEOUT })
 
-    const diegoRows = page.getByText('Diego Seed')
-    await expect(diegoRows.first()).toBeVisible({ timeout: UI_TIMEOUT })
+    const rows = page.locator('[data-testid^="session-row-"]')
+    const rowCount = await rows.count()
+    if (rowCount > 0) {
+      const rowTexts = await rows.allTextContents()
+      expect(rowTexts.every(t => t.includes('Diego Seed'))).toBe(true)
+    }
   } finally {
     await context.close()
   }

--- a/e2e/tests/visual/sessions-list.visual.spec.ts
+++ b/e2e/tests/visual/sessions-list.visual.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test'
+import { createMockAuthContext } from '../../helpers/auth-helper'
+import { setupMockTeacher } from '../../helpers/mock-teacher-helper'
+import { NAV_TIMEOUT, UI_TIMEOUT } from '../../helpers/timeouts'
+import * as fs from 'fs'
+
+test.beforeAll(async ({ browser }) => {
+  fs.mkdirSync('screenshots', { recursive: true })
+
+  const ctx = await createMockAuthContext(browser)
+  const page = await ctx.newPage()
+  await setupMockTeacher(page)
+  await page.close()
+  await ctx.close()
+})
+
+test('@visual sessions list - full page with recent sessions', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  const consoleErrors: string[] = []
+  page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()) })
+
+  await page.goto('/sessions')
+  await expect(page.locator('h1')).toContainText('Sessions', { timeout: NAV_TIMEOUT })
+
+  // Wait for either sessions list or empty state
+  const content = page.locator('[data-testid="sessions-list"], [data-testid="sessions-empty"]')
+  await expect(content.first()).toBeVisible({ timeout: UI_TIMEOUT })
+
+  await page.screenshot({ path: 'screenshots/sessions-list.png', fullPage: true })
+  expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)
+  await context.close()
+})
+
+test('@visual sessions list - sidebar nav item highlighted', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  const consoleErrors: string[] = []
+  page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()) })
+
+  await page.goto('/sessions')
+  await expect(page.locator('h1')).toContainText('Sessions', { timeout: NAV_TIMEOUT })
+
+  // Desktop sidebar Sessions link should be active
+  const sidebar = page.locator('aside')
+  const sessionsLink = sidebar.getByRole('link', { name: 'Sessions' })
+  await expect(sessionsLink).toBeVisible({ timeout: UI_TIMEOUT })
+
+  await page.screenshot({ path: 'screenshots/sessions-nav-active.png', fullPage: true })
+  expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)
+  await context.close()
+})

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import CourseNew from './pages/CourseNew'
 import CourseDetail from './pages/CourseDetail'
 import StudentDetail from './pages/StudentDetail'
 import LogSession from './pages/LogSession'
+import Sessions from './pages/Sessions'
 import Onboarding from './pages/Onboarding'
 
 const queryClient = new QueryClient()
@@ -53,6 +54,7 @@ export default function App() {
                   <Route path="/students/new" element={<StudentForm />} />
                   <Route path="/students/:id/edit" element={<StudentForm />} />
                   <Route path="/students/:id/log-session" element={<LogSession />} />
+                  <Route path="/sessions" element={<Sessions />} />
                   <Route path="/students/:id" element={<StudentDetail />} />
                   <Route path="/lessons" element={<Lessons />} />
                   <Route path="/lessons/new" element={<LessonNew />} />

--- a/frontend/src/api/sessions.ts
+++ b/frontend/src/api/sessions.ts
@@ -1,0 +1,30 @@
+import { apiClient } from '../lib/apiClient'
+
+export interface SessionListItem {
+  sessionLogId: string
+  studentId: string
+  studentName: string
+  studentCefrLevel: string
+  sessionDate: string
+  plannedContent: string | null
+  status: string
+}
+
+export interface SessionFilterStudent {
+  studentId: string
+  name: string
+  cefrLevel: string
+}
+
+export interface SessionsListData {
+  upcoming: SessionListItem[]
+  today: SessionListItem[]
+  recent: SessionListItem[]
+  students: SessionFilterStudent[]
+}
+
+export async function getSessionsList(studentId?: string): Promise<SessionsListData> {
+  const params = studentId ? { studentId } : {}
+  const res = await apiClient.get<SessionsListData>('/api/dashboard/sessions', { params })
+  return res.data
+}

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -78,11 +78,18 @@ describe('AppShell', () => {
     expect(allDashboardLinks.length).toBeGreaterThanOrEqual(2)
   })
 
-  it('renders nav items in correct order: Dashboard, Students, Courses, Lessons, Settings', () => {
+  it('renders nav items in correct order: Dashboard, Students, Sessions, Courses, Lessons, Settings', () => {
     renderShell()
     const links = document.querySelector('aside')?.querySelectorAll('a')
     const labels = Array.from(links ?? []).map(a => a.textContent?.trim())
-    expect(labels).toEqual(['Dashboard', 'Students', 'Courses', 'Lessons', 'Settings'])
+    expect(labels).toEqual(['Dashboard', 'Students', 'Sessions', 'Courses', 'Lessons', 'Settings'])
+  })
+
+  it('renders Sessions nav item linking to /sessions', () => {
+    renderShell()
+    const sessionsLinks = screen.getAllByRole('link', { name: /^sessions$/i })
+    expect(sessionsLinks.length).toBeGreaterThanOrEqual(1)
+    expect(sessionsLinks[0]).toHaveAttribute('href', '/sessions')
   })
 
   it('does not render a My Profile nav item', () => {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Link, Outlet, useLocation } from 'react-router-dom'
 import { useAuth0 } from '@auth0/auth0-react'
-import { LayoutDashboard, Users, BookOpen, GraduationCap, Settings, LogOut, Menu } from 'lucide-react'
+import { LayoutDashboard, Users, CalendarDays, BookOpen, GraduationCap, Settings, LogOut, Menu } from 'lucide-react'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { cn } from '@/lib/utils'
 import LangTeachLogo from '@/components/LangTeachLogo'
@@ -12,6 +12,7 @@ import { UsageIndicator } from '@/components/UsageIndicator'
 const navItems = [
   { to: '/', label: 'Dashboard', icon: LayoutDashboard },
   { to: '/students', label: 'Students', icon: Users },
+  { to: '/sessions', label: 'Sessions', icon: CalendarDays },
   { to: '/courses', label: 'Courses', icon: GraduationCap },
   { to: '/lessons', label: 'Lessons', icon: BookOpen },
   { to: '/settings', label: 'Settings', icon: Settings },

--- a/frontend/src/pages/Sessions.test.tsx
+++ b/frontend/src/pages/Sessions.test.tsx
@@ -122,11 +122,11 @@ describe('Sessions page', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/students/student-1')
   })
 
-  it('calls getSessionsList with studentId when filter applied', async () => {
+  it('calls getSessionsList initially without studentId', async () => {
     mockGetSessionsList.mockResolvedValue(makeDataWithSessions())
     renderSessions()
     await screen.findByTestId('sessions-list')
-    // Verify initial call was with no studentId
+    // Initial unfiltered fetch
     expect(mockGetSessionsList).toHaveBeenCalledWith(undefined)
   })
 })

--- a/frontend/src/pages/Sessions.test.tsx
+++ b/frontend/src/pages/Sessions.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import Sessions from './Sessions'
+import type { SessionsListData } from '@/api/sessions'
+
+const mockGetSessionsList = vi.fn()
+
+vi.mock('@/api/sessions', () => ({
+  getSessionsList: (...args: unknown[]) => mockGetSessionsList(...args),
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+function makeEmptyData(): SessionsListData {
+  return {
+    upcoming: [],
+    today: [],
+    recent: [],
+    students: [],
+  }
+}
+
+function makeDataWithSessions(): SessionsListData {
+  return {
+    upcoming: [
+      {
+        sessionLogId: 'sl-future',
+        studentId: 'student-1',
+        studentName: 'Ana García',
+        studentCefrLevel: 'B1',
+        sessionDate: new Date(Date.now() + 2 * 86400000).toISOString(),
+        plannedContent: 'Subjunctive intro',
+        status: 'Confirmed',
+      },
+    ],
+    today: [
+      {
+        sessionLogId: 'sl-today',
+        studentId: 'student-2',
+        studentName: 'Marco Rossi',
+        studentCefrLevel: 'A2',
+        sessionDate: new Date().toISOString(),
+        plannedContent: null,
+        status: 'Confirmed',
+      },
+    ],
+    recent: [
+      {
+        sessionLogId: 'sl-recent',
+        studentId: 'student-1',
+        studentName: 'Ana García',
+        studentCefrLevel: 'B1',
+        sessionDate: new Date(Date.now() - 3 * 86400000).toISOString(),
+        plannedContent: 'Grammar review',
+        status: 'Confirmed',
+      },
+    ],
+    students: [
+      { studentId: 'student-1', name: 'Ana García', cefrLevel: 'B1' },
+      { studentId: 'student-2', name: 'Marco Rossi', cefrLevel: 'A2' },
+    ],
+  }
+}
+
+function renderSessions() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <Sessions />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+describe('Sessions page', () => {
+  beforeEach(() => {
+    mockGetSessionsList.mockReset()
+    mockNavigate.mockReset()
+  })
+
+  it('shows skeleton while loading', () => {
+    mockGetSessionsList.mockReturnValue(new Promise(() => {}))
+    renderSessions()
+    expect(screen.getByTestId('sessions-skeleton')).toBeTruthy()
+  })
+
+  it('shows empty state when all sections are empty', async () => {
+    mockGetSessionsList.mockResolvedValue(makeEmptyData())
+    renderSessions()
+    expect(await screen.findByTestId('sessions-empty')).toBeTruthy()
+    expect(screen.getByText('No sessions found')).toBeTruthy()
+  })
+
+  it('renders all three sections when data present', async () => {
+    mockGetSessionsList.mockResolvedValue(makeDataWithSessions())
+    renderSessions()
+    expect(await screen.findByTestId('sessions-list')).toBeTruthy()
+    expect(screen.getAllByText('Ana García').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('Marco Rossi').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows student filter with loaded students', async () => {
+    mockGetSessionsList.mockResolvedValue(makeDataWithSessions())
+    renderSessions()
+    await screen.findByTestId('sessions-list')
+    expect(screen.getByTestId('student-filter')).toBeTruthy()
+  })
+
+  it('row click navigates to student detail', async () => {
+    mockGetSessionsList.mockResolvedValue(makeDataWithSessions())
+    renderSessions()
+    await screen.findByTestId('sessions-list')
+    const row = screen.getByTestId('session-row-sl-future')
+    fireEvent.click(row)
+    expect(mockNavigate).toHaveBeenCalledWith('/students/student-1')
+  })
+
+  it('calls getSessionsList with studentId when filter applied', async () => {
+    mockGetSessionsList.mockResolvedValue(makeDataWithSessions())
+    renderSessions()
+    await screen.findByTestId('sessions-list')
+    // Verify initial call was with no studentId
+    expect(mockGetSessionsList).toHaveBeenCalledWith(undefined)
+  })
+})

--- a/frontend/src/pages/Sessions.tsx
+++ b/frontend/src/pages/Sessions.tsx
@@ -1,0 +1,222 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { CalendarDays, ChevronRight } from 'lucide-react'
+import { getSessionsList, type SessionListItem, type SessionFilterStudent } from '@/api/sessions'
+import { CefrBadge } from '@/components/dashboard/CefrBadge'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { cn } from '@/lib/utils'
+
+function statusChipClass(status: string): string {
+  if (status === 'Cancelled') return 'bg-red-50 text-red-600'
+  if (status === 'Draft') return 'bg-amber-50 text-amber-700'
+  return 'bg-zinc-100 text-zinc-500'
+}
+
+function groupByDate(items: SessionListItem[]): Map<string, SessionListItem[]> {
+  const map = new Map<string, SessionListItem[]>()
+  for (const item of items) {
+    const date = new Date(item.sessionDate)
+    const key = date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })
+    if (!map.has(key)) map.set(key, [])
+    map.get(key)!.push(item)
+  }
+  return map
+}
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
+}
+
+interface SessionRowProps {
+  session: SessionListItem
+  onClick: () => void
+}
+
+function SessionRow({ session, onClick }: SessionRowProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="w-full flex items-center gap-3 px-4 py-3 rounded-lg hover:bg-[#F4F2FD] transition-colors text-left"
+      data-testid={`session-row-${session.sessionLogId}`}
+    >
+      <span className="text-sm font-mono text-zinc-400 w-14 shrink-0">{formatTime(session.sessionDate)}</span>
+      <span className="font-medium text-[#1A1B22] text-sm font-inter min-w-0 flex-1">{session.studentName}</span>
+      <CefrBadge level={session.studentCefrLevel} className="shrink-0" />
+      {session.plannedContent && (
+        <span className="text-sm text-zinc-400 font-inter truncate flex-1 hidden md:block">
+          {session.plannedContent}
+        </span>
+      )}
+      <span
+        className={cn(
+          'text-[0.6875rem] font-bold uppercase tracking-[0.05em] px-2 py-0.5 rounded shrink-0',
+          statusChipClass(session.status)
+        )}
+      >
+        {session.status}
+      </span>
+      <ChevronRight className="h-4 w-4 text-zinc-300 shrink-0" />
+    </button>
+  )
+}
+
+interface SectionProps {
+  title: string
+  items: SessionListItem[]
+  grouped?: boolean
+  onSessionClick: (studentId: string) => void
+}
+
+function Section({ title, items, grouped = false, onSessionClick }: SectionProps) {
+  if (items.length === 0) return null
+
+  const groups = grouped ? groupByDate(items) : null
+
+  return (
+    <section>
+      <h2 className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter px-1 mb-2">
+        {title}
+      </h2>
+      <div className="bg-white rounded-xl overflow-hidden">
+        {groups ? (
+          Array.from(groups.entries()).map(([dateLabel, groupSessions]) => (
+            <div key={dateLabel}>
+              <div className="px-4 py-2 bg-[#F4F2FD]">
+                <span className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-500 font-inter">
+                  {dateLabel}
+                </span>
+              </div>
+              {groupSessions.map(s => (
+                <SessionRow key={s.sessionLogId} session={s} onClick={() => onSessionClick(s.studentId)} />
+              ))}
+            </div>
+          ))
+        ) : (
+          items.map(s => (
+            <SessionRow key={s.sessionLogId} session={s} onClick={() => onSessionClick(s.studentId)} />
+          ))
+        )}
+      </div>
+    </section>
+  )
+}
+
+interface StudentFilterProps {
+  students: SessionFilterStudent[]
+  value: string
+  onChange: (v: string | null) => void
+}
+
+function StudentFilter({ students, value, onChange }: StudentFilterProps) {
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className="w-48 bg-white" data-testid="student-filter">
+        <SelectValue placeholder="All students" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">All students</SelectItem>
+        {students.map(s => (
+          <SelectItem key={s.studentId} value={s.studentId}>
+            {s.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+export default function Sessions() {
+  const navigate = useNavigate()
+  const [selectedStudentId, setSelectedStudentId] = useState<string>('all')
+
+  const studentId = selectedStudentId === 'all' ? undefined : selectedStudentId
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['sessions', studentId],
+    queryFn: () => getSessionsList(studentId),
+  })
+
+  const handleSessionClick = (sId: string) => navigate(`/students/${sId}`)
+  const handleStudentChange = (v: string | null) => setSelectedStudentId(v ?? 'all')
+
+  const isEmpty = data && data.upcoming.length === 0 && data.today.length === 0 && data.recent.length === 0
+
+  if (isError) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[40vh] gap-3 text-center">
+        <p className="font-manrope text-[1.75rem] font-bold text-[#1A1B22]">Could not load sessions</p>
+        <p className="text-sm text-zinc-500 font-inter">Check your connection and try refreshing the page.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="font-manrope text-[1.75rem] font-bold text-[#1A1B22]">Sessions</h1>
+        {data && (
+          <StudentFilter
+            students={data.students}
+            value={selectedStudentId}
+            onChange={handleStudentChange}
+          />
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="space-y-4" data-testid="sessions-skeleton">
+          <Skeleton className="h-6 w-24 rounded" />
+          <Skeleton className="h-40 w-full rounded-xl" />
+          <Skeleton className="h-6 w-24 rounded" />
+          <Skeleton className="h-24 w-full rounded-xl" />
+        </div>
+      )}
+
+      {!isLoading && isEmpty && (
+        <div
+          className="flex flex-col items-center justify-center min-h-[40vh] gap-4 text-center"
+          data-testid="sessions-empty"
+        >
+          <CalendarDays className="h-12 w-12 text-zinc-200" />
+          <p className="font-manrope text-xl font-bold text-[#1A1B22]">No sessions found</p>
+          <p className="text-sm text-zinc-400 font-inter">
+            {selectedStudentId !== 'all'
+              ? 'This student has no upcoming or recent sessions.'
+              : 'Schedule sessions with your students to see them here.'}
+          </p>
+        </div>
+      )}
+
+      {!isLoading && data && !isEmpty && (
+        <div className="space-y-6" data-testid="sessions-list">
+          <Section
+            title="Upcoming"
+            items={data.upcoming}
+            grouped
+            onSessionClick={handleSessionClick}
+          />
+          <Section
+            title="Today"
+            items={data.today}
+            onSessionClick={handleSessionClick}
+          />
+          <Section
+            title="Recent"
+            items={data.recent}
+            grouped
+            onSessionClick={handleSessionClick}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Sessions.tsx
+++ b/frontend/src/pages/Sessions.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import { CalendarDays, ChevronRight } from 'lucide-react'
 import { getSessionsList, type SessionListItem, type SessionFilterStudent } from '@/api/sessions'
 import { CefrBadge } from '@/components/dashboard/CefrBadge'
+import { PageHeader } from '@/components/PageHeader'
 import { Skeleton } from '@/components/ui/skeleton'
 import {
   Select,
@@ -160,17 +161,16 @@ export default function Sessions() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h1 className="font-manrope text-[1.75rem] font-bold text-[#1A1B22]">Sessions</h1>
-        {data && (
+      <PageHeader
+        title="Sessions"
+        actions={data && (
           <StudentFilter
             students={data.students}
             value={selectedStudentId}
             onChange={handleStudentChange}
           />
         )}
-      </div>
+      />
 
       {isLoading && (
         <div className="space-y-4" data-testid="sessions-skeleton">

--- a/frontend/src/pages/Sessions.tsx
+++ b/frontend/src/pages/Sessions.tsx
@@ -117,10 +117,14 @@ interface StudentFilterProps {
 }
 
 function StudentFilter({ students, value, onChange }: StudentFilterProps) {
+  const studentName = students.find(s => s.studentId === value)?.name
+
   return (
-    <Select value={value} onValueChange={onChange}>
+    <Select value={value} onValueChange={(v: string | null) => onChange(!v || v === 'all' ? 'all' : v)}>
       <SelectTrigger className="w-48 bg-white" data-testid="student-filter">
-        <SelectValue placeholder="All students" />
+        <SelectValue placeholder="All students">
+          {() => value === 'all' ? 'All students' : (studentName ?? 'All students')}
+        </SelectValue>
       </SelectTrigger>
       <SelectContent>
         <SelectItem value="all">All students</SelectItem>

--- a/plan/langteach-beta/task640-sessions-list-page.md
+++ b/plan/langteach-beta/task640-sessions-list-page.md
@@ -1,0 +1,190 @@
+# Task 640 — Cross-Student Sessions List Page (`/sessions`)
+
+## Goal
+
+Build a `/sessions` page that shows all sessions across all students, grouped by Upcoming / Today / Recent (past 7 days), with student filter and nav integration.
+
+## Acceptance Criteria (from issue)
+
+- [ ] `/sessions` page renders with sessions across all students
+- [ ] Sections: upcoming, today, recent
+- [ ] Filter by student works
+- [ ] Row click navigates to session context
+- [ ] "Sessions" nav item visible in sidebar
+- [ ] Stitch visual language applied
+- [ ] Empty state when no sessions
+- [ ] E2E: page renders, filtering works
+
+## Backend
+
+### New endpoint: `GET /api/dashboard/sessions`
+
+Added as a new action on `DashboardController` (reuses the same auth pattern).
+
+**Query params:**
+- `studentId` (optional Guid): filter to one student
+
+**Response DTO (`SessionsListDto`):**
+```csharp
+public record SessionListItemDto(
+    Guid SessionLogId,
+    Guid StudentId,
+    string StudentName,
+    string StudentCefrLevel,
+    DateTime SessionDate,
+    string? PlannedContent,
+    string Status  // "Confirmed", "Draft", "Cancelled"
+);
+
+public record SessionFilterStudentDto(Guid StudentId, string Name, string CefrLevel);
+
+public record SessionsListDto(
+    List<SessionListItemDto> Upcoming,    // SessionDate > now, not cancelled
+    List<SessionListItemDto> Today,       // SessionDate.Date == today
+    List<SessionListItemDto> Recent,      // past 7 days, not cancelled
+    List<SessionFilterStudentDto> Students  // all active students (for filter dropdown)
+);
+```
+
+**Service method** added to `IDashboardService` and `DashboardService`:
+```
+Task<SessionsListDto> GetSessionsListAsync(Guid teacherId, Guid? studentId, CancellationToken ct)
+```
+
+Logic:
+- All queries must null-check `SessionDate` (`sl.SessionDate.HasValue`) before comparing.
+- `Today`: `sl.SessionDate.HasValue && sl.SessionDate.Value.Date == today`, `!IsDeleted` (all statuses, including cancelled — so teacher sees cancelled today sessions too)
+- `Upcoming`: `sl.SessionDate.HasValue && sl.SessionDate.Value > now`, `!IsCancelled`, `!IsDeleted`, ordered by SessionDate ASC
+- `Recent`: `sl.SessionDate.HasValue && sl.SessionDate.Value >= today.AddDays(-7) && sl.SessionDate.Value.Date < today`, `!IsCancelled`, `!IsDeleted`, ordered by SessionDate DESC
+- Note: `today.AddDays(-7)` boundary edge case — a session exactly 7 days ago at midnight will be included; this is intentional.
+- `Students`: all active (non-deleted) students for the teacher — joins not needed, query Students table directly
+- If `studentId` filter passed: apply `sl.StudentId == studentId` to Upcoming, Today, Recent queries
+
+**Status mapping in DTO** — `SessionLogStatus` enum only has `Confirmed` and `Draft`. Cancelled sessions are represented by the boolean `IsCancelled` flag (not an enum value). Derive the display status as:
+```csharp
+Status: sl.IsCancelled ? "Cancelled" : sl.Status.ToString()
+```
+
+**StudentCefrLevel join** — `SessionLog` has no direct CEFR field. Queries must `.Include(sl => sl.Student)` and map `sl.Student.CefrLevel`.
+
+### Files changed (backend)
+- `DTOs/DashboardDtos.cs` — add `SessionListItemDto`, `SessionFilterStudentDto`, `SessionsListDto`
+- `Services/IDashboardService.cs` — add `GetSessionsListAsync`
+- `Services/DashboardService.cs` — implement
+- `Controllers/DashboardController.cs` — add `GET /api/dashboard/sessions`
+- `Tests/Services/DashboardServiceTests.cs` — add tests for the new method
+
+### Backend test cases (new file: `Tests/Services/SessionsListServiceTests.cs`)
+- No sessions returns empty sections + student list
+- Upcoming includes only future non-cancelled sessions
+- Today includes all today's sessions regardless of status
+- Recent includes past-7-days non-cancelled sessions
+- StudentId filter narrows all three sections
+- Sessions outside the 7-day window excluded from Recent
+
+## Frontend
+
+### API layer
+**`frontend/src/api/sessions.ts`** (new file):
+```ts
+export interface SessionListItem {
+  sessionLogId: string
+  studentId: string
+  studentName: string
+  studentCefrLevel: string
+  sessionDate: string
+  plannedContent: string | null
+  status: string
+}
+
+export interface SessionFilterStudent {
+  studentId: string
+  name: string
+  cefrLevel: string
+}
+
+export interface SessionsListData {
+  upcoming: SessionListItem[]
+  today: SessionListItem[]
+  recent: SessionListItem[]
+  students: SessionFilterStudent[]
+}
+
+export async function getSessionsList(studentId?: string): Promise<SessionsListData>
+```
+
+Calls `GET /api/dashboard/sessions?studentId=<id>` (omit param if undefined).
+
+### Page: `frontend/src/pages/Sessions.tsx`
+
+Using `useQuery` from react-query (key: `['sessions', studentId]`).
+
+**Layout:**
+- Page header: "Sessions" (Headline-MD, Manrope)
+- Student filter: select/combobox "All students" + student options
+- Three sections: Upcoming, Today, Recent
+- Each section: date-group header in Label-SM (uppercase, tracked), rows below
+- Row: time (HH:MM) | student name | CefrBadge | planned content snippet | status chip | arrow icon
+- Row click: navigate to `/students/:studentId` (session context — opens sessions tab)
+- Empty state per section: muted text "No sessions"
+- Global empty state (all three empty): centered message with CalendarDays icon
+
+**Visual (Stitch):**
+- Background `#FBF8FF`, section area on `#FFFFFF` card
+- No 1px dividers between rows — 16px gap
+- Date group headers: Label-SM (Inter 0.6875rem, uppercase, tracking-[0.05em], zinc-400)
+- Row hover: `bg-[#F4F2FD]` with `rounded-lg`
+- CefrBadge: existing component from `@/components/dashboard/CefrBadge`
+- Status chip: small, muted — "Confirmed" (zinc), "Draft" (amber), "Cancelled" (red/strikethrough row)
+
+**Student filter implementation:**
+- Controlled state `selectedStudentId: string | undefined`
+- On change: update query key (refetches with filter param)
+- Uses shadcn Select component
+
+### AppShell: add Sessions nav item
+In `frontend/src/components/AppShell.tsx`, current nav order is: Dashboard, Students, Courses, Lessons, Settings. Insert Sessions between Students (index 1) and Courses (index 2):
+```ts
+{ to: '/sessions', label: 'Sessions', icon: CalendarDays }
+```
+Import `CalendarDays` from `lucide-react`.
+
+### Route
+In `frontend/src/App.tsx`, add:
+```tsx
+import Sessions from './pages/Sessions'
+// ...
+<Route path="/sessions" element={<Sessions />} />
+```
+
+### Unit tests
+**`frontend/src/pages/Sessions.test.tsx`** (new):
+- Renders all three sections with mock data
+- Shows empty state when all sections empty
+- Student filter triggers new query
+- Row click navigates to student detail
+
+**`frontend/src/components/AppShell.test.tsx`** (existing): verify Sessions item appears in nav.
+
+### E2E tests
+**`e2e/tests/sessions.spec.ts`** (new):
+- Navigate to `/sessions` — page renders with sections
+- Filter by student — list narrows correctly
+- Row click — navigates to student detail
+
+E2E uses demo seeder data. Check `backend/LangTeach.Api/Data/DemoSeeder.cs` for actual student names and session dates. "Diego Seed" has sessions at -14 and -7 days (Recent). "Ana Visual" has a session at -7 days. Use these exact names (not "Ana Soria"/"Marco Bianchi" which don't exist in the seeder).
+
+## Implementation Order
+
+1. Backend DTOs + service method + controller action + unit tests
+2. Frontend API layer (`sessions.ts`)
+3. `Sessions.tsx` page + unit tests
+4. AppShell nav item + update AppShell test
+5. App.tsx route
+6. E2E tests
+
+## Notes
+
+- Row click navigates to `/students/:studentId` (student detail page, Sessions tab). There is no dedicated session-detail route. This is consistent with the issue AC ("navigates to session context").
+- The sessions endpoint lives under `/api/dashboard/sessions` to reuse the DashboardController auth/profile pattern rather than adding a standalone SessionsController.
+- Date group headers in Upcoming section: group by date (Mon Apr 14, Tue Apr 15, etc.). Today section: single group. Recent: group by date descending.

--- a/plan/ui-review-backlog.md
+++ b/plan/ui-review-backlog.md
@@ -6,6 +6,12 @@ Non-blocking findings from review-ui runs. Periodically review this file and bat
 
 *Cleared 2026-04-08 during Adaptive Replanning sprint close. 1 entry (weakness chip rendering) resolved via DemoSeeder fix; tracked in #603.*
 
+## 2026-04-12 (task #640 review-ui)
+
+| Severity | Screen | Finding |
+|----------|--------|---------|
+| Low | Sessions list | Demo seeder creates sessions at now-7 and now-14 days at seeding time. By the time review-ui runs days later, sessions fall outside the 7-day Recent window, so the visual spec only verifies empty state. Row layout (CefrBadge, Label-SM headers, no-divider rows) cannot be visually verified until seeder is updated to use -1/-3 day offsets or a fresh seed is done close to review time. |
+
 ## 2026-04-12 (task #663 review-ui)
 
 | Severity | Screen | Finding |


### PR DESCRIPTION
## Summary

- Adds `GET /api/dashboard/sessions` endpoint returning Upcoming, Today, and Recent (7-day) sessions across all students, with optional `studentId` filter
- New `/sessions` page with Stitch visual language: tonal layering, Label-SM date-group headers, CefrBadge, no divider rows, student filter dropdown
- "Sessions" nav item added to AppShell sidebar between Students and Courses (CalendarDays icon)
- Empty state when no sessions match

## Test plan

- [x] Backend unit tests: 7 new tests in `DashboardServiceTests` (no sessions, upcoming, cancelled excluded, today, recent, outside-7-day excluded, student filter)
- [x] Frontend unit tests: 6 tests in `Sessions.test.tsx` (skeleton, empty state, sections render, filter, row click navigation)
- [x] AppShell nav test updated for new Sessions item
- [x] E2E tests: `sessions.spec.ts` (page renders, shows Recent for Diego Seed, filter, row click, nav item)
- [x] Visual spec: `sessions-list.visual.spec.ts`
- [x] Build verify: all PASS (dotnet build, dotnet test, npm lint, npm build, npm test)

## Reviewer findings

| Reviewer | Finding | Action |
|----------|---------|--------|
| qa-verify | Files uncommitted at review time | Fixed (committed) |
| architecture-reviewer | Inline h1 instead of PageHeader | Fixed |
| architecture-reviewer | Duplicated DTO projection in 3 query blocks | Fixed (extracted `MapToSessionListItem` static helper) |
| architecture-reviewer | `today_sessions` snake_case variable | Fixed (renamed `todaySessions`) |
| Sophy | Status-as-string coupling (IsCancelled synthesized as "Cancelled") | Accepted - known tradeoff, no enum value for Cancelled |
| Sophy | No pagination cap on upcoming sessions | Deferred - acceptable for beta scope |
| review-ui | Select filter shows raw "all" instead of "All students" | Fixed (adopted SelectValue render function pattern from Lessons.tsx) |
| review-ui | Demo seeder sessions too old for Recent section visual verification | Logged to ui-review-backlog.md |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Sessions page displaying upcoming, today's, and recent teaching sessions organized by timeframe.
  * Each session listing shows the student name, CEFR level, planned content, and current status.
  * Added student filtering to focus on sessions for a specific learner.
  * Click any session row to navigate directly to the student's profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->