### PR TITLE
fix: show inline validation error for partial difficulty rows (#604)

### DIFF
--- a/e2e/tests/students.spec.ts
+++ b/e2e/tests/students.spec.ts
@@ -1088,3 +1088,40 @@ test('nested learning goal with sub-goal persists after save', async ({ browser 
 
   await context.close()
 })
+
+test('partial difficulty row shows inline validation error and blocks save', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  await page.goto('/students/new')
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: NAV_TIMEOUT })
+
+  // Fill required fields
+  await page.getByTestId('student-name').fill(`Partial Diff Test ${Date.now()}`)
+  await page.getByTestId('student-language').click()
+  await page.getByRole('option', { name: 'Spanish' }).click()
+  await page.getByTestId('student-cefr').click()
+  await page.getByRole('option', { name: 'B1' }).click()
+
+  // Add a difficulty row and fill only description (no competency)
+  const addDiffBtn = page.getByTestId('add-difficulty')
+  await addDiffBtn.scrollIntoViewIfNeeded()
+  await addDiffBtn.click()
+  const diffRow = page.getByTestId('difficulty-row').first()
+  await expect(diffRow).toBeVisible({ timeout: UI_TIMEOUT })
+  await diffRow.getByTestId('difficulty-description').fill('Confuses ser/estar')
+
+  // Attempt to save
+  await page.getByRole('button', { name: 'Save Student' }).click()
+
+  // Inline error should appear
+  await expect(page.getByTestId('difficulty-error')).toBeVisible({ timeout: UI_TIMEOUT })
+  await expect(page.getByTestId('difficulty-error')).toContainText('Both type and description are required')
+
+  // Completing the row clears the error
+  await diffRow.getByTestId('difficulty-competency').click()
+  await page.getByRole('option', { name: 'Grammar' }).click()
+  await expect(page.getByTestId('difficulty-error')).not.toBeVisible({ timeout: UI_TIMEOUT })
+
+  await context.close()
+})

--- a/e2e/tests/students.spec.ts
+++ b/e2e/tests/students.spec.ts
@@ -1113,6 +1113,7 @@ test('partial difficulty row shows inline validation error and blocks save', asy
 
   // Attempt to save
   await page.getByRole('button', { name: 'Save Student' }).click()
+  await expect(page).toHaveURL('/students/new', { timeout: UI_TIMEOUT })
 
   // Inline error should appear
   await expect(page.getByTestId('difficulty-error')).toBeVisible({ timeout: UI_TIMEOUT })

--- a/frontend/src/pages/StudentForm.test.tsx
+++ b/frontend/src/pages/StudentForm.test.tsx
@@ -315,7 +315,7 @@ describe('StudentForm', () => {
     expect(screen.getByText('pass DELE B2 exam')).toBeInTheDocument()
   })
 
-  it('includes difficulties in form submission', async () => {
+  it('shows inline error for partial difficulty row (description only) and blocks save', async () => {
     const { default: userEvent } = await import('@testing-library/user-event')
     const user = userEvent.setup()
     mockCreateStudent.mockResolvedValue({ id: 'new-id' })
@@ -323,25 +323,115 @@ describe('StudentForm', () => {
 
     // Fill required fields
     await user.type(screen.getByTestId('student-name'), 'Test Student')
-    // Select language
     await user.click(screen.getByTestId('student-language'))
     await user.click(await screen.findByRole('option', { name: 'Spanish' }))
-    // Select CEFR
     await user.click(screen.getByTestId('student-cefr'))
     await user.click(await screen.findByRole('option', { name: 'B1' }))
 
-    // Add a difficulty and fill description but no competency
+    // Add a difficulty with only description filled
     await user.click(screen.getByTestId('add-difficulty'))
     await user.type(screen.getByTestId('difficulty-description'), 'test difficulty')
 
     // Submit
     await user.click(screen.getByRole('button', { name: 'Save Student' }))
 
-    // The difficulty row with empty competency gets filtered out
+    // Should show inline error and not call createStudent
+    expect(screen.getByTestId('difficulty-error')).toBeInTheDocument()
+    expect(screen.getByTestId('difficulty-error')).toHaveTextContent('Both type and description are required')
+    expect(mockCreateStudent).not.toHaveBeenCalled()
+  })
+
+  it('shows inline error for partial difficulty row (competency only) and blocks save', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+    mockCreateStudent.mockResolvedValue({ id: 'new-id' })
+    renderNew()
+
+    await user.type(screen.getByTestId('student-name'), 'Test Student')
+    await user.click(screen.getByTestId('student-language'))
+    await user.click(await screen.findByRole('option', { name: 'Spanish' }))
+    await user.click(screen.getByTestId('student-cefr'))
+    await user.click(await screen.findByRole('option', { name: 'B1' }))
+
+    // Add a difficulty with only competency filled
+    await user.click(screen.getByTestId('add-difficulty'))
+    await user.click(screen.getByTestId('difficulty-competency'))
+    await user.click(await screen.findByRole('option', { name: /grammar/i }))
+
+    await user.click(screen.getByRole('button', { name: 'Save Student' }))
+
+    expect(screen.getByTestId('difficulty-error')).toBeInTheDocument()
+    expect(mockCreateStudent).not.toHaveBeenCalled()
+  })
+
+  it('clears difficulty error when the row is completed', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+    mockCreateStudent.mockResolvedValue({ id: 'new-id' })
+    renderNew()
+
+    await user.type(screen.getByTestId('student-name'), 'Test Student')
+    await user.click(screen.getByTestId('student-language'))
+    await user.click(await screen.findByRole('option', { name: 'Spanish' }))
+    await user.click(screen.getByTestId('student-cefr'))
+    await user.click(await screen.findByRole('option', { name: 'B1' }))
+
+    await user.click(screen.getByTestId('add-difficulty'))
+    await user.type(screen.getByTestId('difficulty-description'), 'test difficulty')
+    await user.click(screen.getByRole('button', { name: 'Save Student' }))
+
+    // Error appears
+    expect(screen.getByTestId('difficulty-error')).toBeInTheDocument()
+
+    // Select competency to complete the row => error clears
+    await user.click(screen.getByTestId('difficulty-competency'))
+    await user.click(await screen.findByRole('option', { name: /grammar/i }))
+
+    expect(screen.queryByTestId('difficulty-error')).not.toBeInTheDocument()
+  })
+
+  it('clears difficulty error when the row is removed', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+    mockCreateStudent.mockResolvedValue({ id: 'new-id' })
+    renderNew()
+
+    await user.type(screen.getByTestId('student-name'), 'Test Student')
+    await user.click(screen.getByTestId('student-language'))
+    await user.click(await screen.findByRole('option', { name: 'Spanish' }))
+    await user.click(screen.getByTestId('student-cefr'))
+    await user.click(await screen.findByRole('option', { name: 'B1' }))
+
+    await user.click(screen.getByTestId('add-difficulty'))
+    await user.type(screen.getByTestId('difficulty-description'), 'test difficulty')
+    await user.click(screen.getByRole('button', { name: 'Save Student' }))
+
+    expect(screen.getByTestId('difficulty-error')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('remove-difficulty'))
+
+    expect(screen.queryByTestId('difficulty-error')).not.toBeInTheDocument()
+  })
+
+  it('does not show error for fully empty difficulty row on save', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const user = userEvent.setup()
+    mockCreateStudent.mockResolvedValue({ id: 'new-id' })
+    renderNew()
+
+    await user.type(screen.getByTestId('student-name'), 'Test Student')
+    await user.click(screen.getByTestId('student-language'))
+    await user.click(await screen.findByRole('option', { name: 'Spanish' }))
+    await user.click(screen.getByTestId('student-cefr'))
+    await user.click(await screen.findByRole('option', { name: 'B1' }))
+
+    // Add empty row, don't fill anything
+    await user.click(screen.getByTestId('add-difficulty'))
+    await user.click(screen.getByRole('button', { name: 'Save Student' }))
+
+    expect(screen.queryByTestId('difficulty-error')).not.toBeInTheDocument()
     expect(mockCreateStudent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        difficulties: [],
-      }),
+      expect.objectContaining({ difficulties: [] }),
     )
   })
 

--- a/frontend/src/pages/StudentForm.test.tsx
+++ b/frontend/src/pages/StudentForm.test.tsx
@@ -656,7 +656,7 @@ describe('StudentForm', () => {
         }),
       )
     })
-  })
+  }, 15000)
 
   it('renders Reason for Studying textarea', () => {
     renderNew()

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -301,10 +301,24 @@ export default function StudentForm() {
     setDifficulties((prev) =>
       prev.map((d) => (d.id === diffId ? { ...d, [field]: value } : d))
     )
+    setErrors((prev) => {
+      const key = `difficulty-${diffId}`
+      if (!prev[key]) return prev
+      const next = { ...prev }
+      delete next[key]
+      return next
+    })
   }
 
   function removeDifficulty(diffId: string) {
     setDifficulties((prev) => prev.filter((d) => d.id !== diffId))
+    setErrors((prev) => {
+      const key = `difficulty-${diffId}`
+      if (!prev[key]) return prev
+      const next = { ...prev }
+      delete next[key]
+      return next
+    })
   }
 
   function addObjective() {
@@ -329,6 +343,13 @@ export default function StudentForm() {
     if (!name.trim()) errs.name = 'Name is required'
     if (!language) errs.language = 'Language is required'
     if (!cefrLevel) errs.cefrLevel = 'CEFR level is required'
+    difficulties.forEach((d) => {
+      const hasDesc = d.description.trim().length > 0
+      const hasCom = d.competency.length > 0
+      if ((hasDesc || hasCom) && !(hasDesc && hasCom)) {
+        errs[`difficulty-${d.id}`] = 'Both type and description are required'
+      }
+    })
     setErrors(errs)
     return Object.keys(errs).length === 0
   }
@@ -1046,8 +1067,8 @@ export default function StudentForm() {
                     </div>
 
                     {difficulties.map((d) => (
+                      <div key={d.id} className="space-y-1">
                       <div
-                        key={d.id}
                         className="space-y-2 sm:space-y-0 sm:grid sm:grid-cols-[1fr_auto_1fr_auto_auto] sm:gap-2 sm:items-start"
                         data-testid="difficulty-row"
                       >
@@ -1101,6 +1122,12 @@ export default function StudentForm() {
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>
+                      </div>
+                      {errors[`difficulty-${d.id}`] && (
+                        <p className="text-xs text-red-600" data-testid="difficulty-error">
+                          {errors[`difficulty-${d.id}`]}
+                        </p>
+                      )}
                       </div>
                     ))}
 

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -304,6 +304,14 @@ export default function StudentForm() {
     setErrors((prev) => {
       const key = `difficulty-${diffId}`
       if (!prev[key]) return prev
+      const current = difficulties.find((d) => d.id === diffId)
+      if (current) {
+        const nextRow = { ...current, [field]: value }
+        const hasDesc = nextRow.description.trim().length > 0
+        const hasCom = nextRow.competency.length > 0
+        const shouldClear = (hasDesc && hasCom) || (!hasDesc && !hasCom)
+        if (!shouldClear) return prev
+      }
       const next = { ...prev }
       delete next[key]
       return next

--- a/plan/langteach-beta/task604-difficulty-validation.md
+++ b/plan/langteach-beta/task604-difficulty-validation.md
@@ -1,0 +1,60 @@
+# Task 604: StudentForm Difficulty Row Validation
+
+## Issue
+#604 - Partial difficulty rows (one of description/competency filled, the other empty) are silently
+discarded on save. Teacher loses data without feedback.
+
+## Acceptance Criteria
+- Partial row shows inline error on save attempt
+- Error message: "Both type and description are required" (or similar)
+- Error clears when row is completed or removed
+- Fully empty rows still silently ignored
+- Complete rows save normally
+
+## Root Cause
+`handleSubmit` (line 342-344) filters with `d.competency && d.description.trim()`, silently dropping
+partial rows. The `validate()` function (line 327-334) only checks name/language/cefrLevel.
+
+## Implementation Plan
+
+### 1. Validate partial difficulty rows in `validate()`
+Add loop after existing field checks:
+```
+difficulties.forEach((d) => {
+  const hasDesc = d.description.trim().length > 0
+  const hasCom = d.competency.length > 0
+  if ((hasDesc || hasCom) && !(hasDesc && hasCom)) {
+    errs[`difficulty-${d.id}`] = 'Both type and description are required'
+  }
+})
+```
+
+### 2. Clear error in `updateDifficulty()`
+On any field change, clear the per-row error so it does not persist after the user edits the row.
+Error re-appears on next save attempt if still partial.
+
+### 3. Clear error in `removeDifficulty()`
+When a row is removed, clear its error key from `errors` state.
+
+### 4. Render inline error below each difficulty row
+Wrap each row in `<div className="space-y-1">` and show:
+```
+{errors[`difficulty-${d.id}`] && (
+  <p className="text-xs text-red-600" data-testid="difficulty-error">
+    {errors[`difficulty-${d.id}`]}
+  </p>
+)}
+```
+
+## Tests
+Add to `StudentForm.test.tsx`:
+- Save with only description filled => inline error shown, save blocked
+- Save with only competency filled => inline error shown, save blocked  
+- Error clears after completing the row
+- Error clears after removing the row
+- Fully empty row on save => no error, save succeeds
+- Complete rows save normally (regression)
+
+## Files Changed
+- `frontend/src/pages/StudentForm.tsx`
+- `frontend/src/pages/StudentForm.test.tsx`


### PR DESCRIPTION
## Summary
- Partial difficulty rows (one of description/competency filled, the other empty) now show an inline error "Both type and description are required" on save attempt instead of being silently discarded
- Error clears when the row is completed or removed
- Fully empty rows continue to be silently ignored

Fixes #604

## Test plan
- [x] Unit tests: 5 new tests covering description-only, competency-only, error-clear-on-complete, error-clear-on-remove, empty-row-no-error (1142/1142 pass)
- [x] E2e test: `partial difficulty row shows inline validation error and blocks save` added to students.spec.ts
- [x] UI review: PASS (error renders correctly, layout undisturbed, clears on completion)
- [x] Architecture review: PASS (consistent with existing form error patterns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline validation for difficulty rows in the student form. Users now receive an error message when a difficulty row is partially filled, requiring both type and description. The error clears automatically when the row is completed or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->