### PR TITLE
refactor: extract LearningGoalHelper to eliminate duplicated goal deserialization (#707)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/LearningGoalHelperTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/LearningGoalHelperTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using LangTeach.Api.Helpers;
+
+namespace LangTeach.Api.Tests.Services;
+
+public class LearningGoalHelperTests
+{
+    [Fact]
+    public void Deserialize_NullInput_ReturnsEmptyList()
+    {
+        var result = LearningGoalHelper.Deserialize(null);
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Deserialize_LegacyStringArray_ReturnsSingleGoalWithText()
+    {
+        var result = LearningGoalHelper.Deserialize("""["speak confidently"]""");
+        result.Should().ContainSingle();
+        result[0].Text.Should().Be("speak confidently");
+        result[0].Children.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Deserialize_JsonArray_ReturnsStructuredGoals()
+    {
+        var json = """[{"id":"1","text":"grammar","children":[{"id":"2","text":"subjunctive","children":[]}]}]""";
+        var result = LearningGoalHelper.Deserialize(json);
+        result.Should().ContainSingle();
+        result[0].Text.Should().Be("grammar");
+        result[0].Children.Should().ContainSingle().Which.Text.Should().Be("subjunctive");
+    }
+
+    [Fact]
+    public void FlattenGoals_NullInput_ReturnsEmptyArray()
+    {
+        var result = LearningGoalHelper.FlattenGoals(null);
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FlattenGoals_LegacyStringArray_ReturnsSingleElement()
+    {
+        var result = LearningGoalHelper.FlattenGoals("""["speak confidently"]""");
+        result.Should().Equal("speak confidently");
+    }
+
+    [Fact]
+    public void FlattenGoals_JsonArrayWithChildren_FlattensParentAndChildren()
+    {
+        var json = """[{"id":"1","text":"grammar","children":[{"id":"2","text":"subjunctive","children":[]}]},{"id":"3","text":"vocabulary","children":[]}]""";
+        var result = LearningGoalHelper.FlattenGoals(json);
+        result.Should().Equal("grammar", "subjunctive", "vocabulary");
+    }
+}

--- a/backend/LangTeach.Api/Helpers/LearningGoalHelper.cs
+++ b/backend/LangTeach.Api/Helpers/LearningGoalHelper.cs
@@ -1,0 +1,16 @@
+using LangTeach.Api.DTOs;
+
+namespace LangTeach.Api.Helpers;
+
+public static class LearningGoalHelper
+{
+    public static List<LearningGoalDto> Deserialize(string? json) =>
+        JsonStorageHelper.DeserializeListWithStringFallback<LearningGoalDto>(
+            json,
+            text => new LearningGoalDto(Guid.NewGuid().ToString(), text, []));
+
+    public static string[] FlattenGoals(string? json) =>
+        Deserialize(json)
+            .SelectMany(g => new[] { g.Text }.Concat(g.Children.Select(c => c.Text)))
+            .ToArray();
+}

--- a/backend/LangTeach.Api/Helpers/LearningGoalHelper.cs
+++ b/backend/LangTeach.Api/Helpers/LearningGoalHelper.cs
@@ -11,6 +11,9 @@ public static class LearningGoalHelper
 
     public static string[] FlattenGoals(string? json) =>
         Deserialize(json)
-            .SelectMany(g => new[] { g.Text }.Concat(g.Children.Select(c => c.Text)))
+            .Where(g => g is not null)
+            .SelectMany(g => new[] { g.Text }
+                .Concat((g.Children ?? []).Where(c => c is not null).Select(c => c.Text))
+                .Where(t => t is not null))
             .ToArray();
 }

--- a/backend/LangTeach.Api/Services/CourseService.cs
+++ b/backend/LangTeach.Api/Services/CourseService.cs
@@ -342,10 +342,7 @@ public class CourseService : ICourseService
                 ? JsonStorageHelper.DeserializeList<string>(student.Interests).ToArray()
                 : null,
             StudentGoals: student is not null
-                ? JsonStorageHelper.DeserializeListWithStringFallback<LearningGoalDto>(
-                    student.LearningGoals,
-                    text => new LearningGoalDto(Guid.NewGuid().ToString(), text, []))
-                    .SelectMany(g => new[] { g.Text }.Concat(g.Children.Select(c => c.Text))).ToArray()
+                ? LearningGoalHelper.FlattenGoals(student.LearningGoals)
                 : null,
             TemplateLevel: string.IsNullOrWhiteSpace(req.TemplateLevel) ? null : req.TemplateLevel,
             TemplateUnits: null,

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -225,9 +225,7 @@ public class StudentService : IStudentService
         s.PersonalNotes,
         s.TeachingNotes,
         JsonStorageHelper.DeserializeList<string>(s.NativeLanguages),
-        JsonStorageHelper.DeserializeListWithStringFallback<LearningGoalDto>(
-            s.LearningGoals,
-            text => new LearningGoalDto(Guid.NewGuid().ToString(), text, [])),
+        LearningGoalHelper.Deserialize(s.LearningGoals),
         JsonStorageHelper.DeserializeListWithStringFallback<StudentWeaknessDto>(
             s.Weaknesses,
             str => new StudentWeaknessDto(str, "grammatical")),

--- a/plan/langteach-beta/task707-flatten-goals-helper.md
+++ b/plan/langteach-beta/task707-flatten-goals-helper.md
@@ -1,0 +1,28 @@
+# Task 707: Extract FlattenGoals helper
+
+## Goal
+Extract shared `LearningGoalHelper` to eliminate duplicated `DeserializeListWithStringFallback<LearningGoalDto>` logic across `CourseService` and `StudentService`.
+
+## Approach
+
+### 1. Create `backend/LangTeach.Api/Helpers/LearningGoalHelper.cs`
+- `Deserialize(string? json): List<LearningGoalDto>` - wraps `JsonStorageHelper.DeserializeListWithStringFallback<LearningGoalDto>` with the standard string fallback factory
+- `FlattenGoals(string? json): string[]` - calls Deserialize, then flattens parent + children texts
+
+### 2. Update `StudentService.cs`
+- `MapToDto` line 228-230: replace inline call with `LearningGoalHelper.Deserialize(s.LearningGoals)`
+
+### 3. Update `CourseService.cs`
+- Lines 345-348: replace inline deserialize+flatten with `LearningGoalHelper.FlattenGoals(student.LearningGoals)`
+
+### 4. Unit test in `backend/LangTeach.Api.Tests/Services/LearningGoalHelperTests.cs`
+- Null input
+- Plain string (legacy fallback)
+- JSON array with parent + children
+
+## Acceptance Criteria
+- [x] `LearningGoalHelper.FlattenGoals(string? json): string[]` exists
+- [x] `CourseService` uses it
+- [x] `StudentService.MapToDto` uses `LearningGoalHelper.Deserialize`
+- [x] No duplicate call sites remain
+- [x] Unit tests covering null, plain string, JSON array


### PR DESCRIPTION
## Summary
- Adds `LearningGoalHelper` in `backend/LangTeach.Api/Helpers/` with `Deserialize(string?)` and `FlattenGoals(string?)` static methods
- `CourseService` replaces inline deserialize+flatten with `LearningGoalHelper.FlattenGoals`
- `StudentService.MapToDto` replaces inline deserialize with `LearningGoalHelper.Deserialize`
- 6 unit tests covering null, legacy string array, and structured JSON array for both methods

## Test plan
- [x] `dotnet test` passes (all existing + 6 new unit tests)
- [x] `dotnet build` passes
- [x] No other call sites duplicate the pattern (verified by grep)

Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for learning goal deserialization and flattening functionality, supporting both legacy string-based and structured JSON formats with nested hierarchies, and verifying edge cases.

* **Refactor**
  * Centralized learning goal processing logic into a dedicated helper class to ensure consistent deserialization and hierarchical flattening behavior across all services, improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->