### PR TITLE
feat(t721): Student Detail Profile tab - Stitch alignment and inline-add

### DIFF
--- a/e2e/tests/student-detail.spec.ts
+++ b/e2e/tests/student-detail.spec.ts
@@ -167,3 +167,43 @@ test('student detail overview tab: Followups card amber when pending followups e
     await context.close()
   }
 })
+
+test('student detail profile tab: inline-add learning goal', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    // Navigate to Ana Visual (has minimal profile data, no learning goals)
+    await page.goto('/students')
+    await expect(page.locator('h1')).toHaveText('Students', { timeout: NAV_TIMEOUT })
+    const anaVisual = page.getByText('Ana Visual').first()
+    await expect(anaVisual).toBeVisible({ timeout: UI_TIMEOUT })
+    await anaVisual.click()
+    await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
+
+    // Switch to Profile tab
+    await page.getByTestId('tab-profile').click()
+    await expect(page.getByTestId('student-profile-tab')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // Click + button on Learning Goals section
+    await expect(page.getByTestId('goal-add-btn')).toBeVisible({ timeout: UI_TIMEOUT })
+    await page.getByTestId('goal-add-btn').click()
+
+    // Inline input appears
+    const goalInput = page.getByTestId('goal-add-btn-input')
+    await expect(goalInput).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // Type a new goal and press Enter
+    const goalText = `E2E goal ${Date.now()}`
+    await goalInput.fill(goalText)
+    await goalInput.press('Enter')
+
+    // New goal appears in the list
+    await expect(page.getByText(goalText)).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // Input is closed
+    await expect(page.getByTestId('goal-add-btn-input')).not.toBeVisible()
+  } finally {
+    await context.close()
+  }
+})

--- a/e2e/tests/student-detail.spec.ts
+++ b/e2e/tests/student-detail.spec.ts
@@ -207,3 +207,67 @@ test('student detail profile tab: inline-add learning goal', async ({ browser })
     await context.close()
   }
 })
+
+test('student detail profile tab: inline-add short-term objective', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    await page.goto('/students')
+    await expect(page.locator('h1')).toHaveText('Students', { timeout: NAV_TIMEOUT })
+    const anaVisual = page.getByText('Ana Visual').first()
+    await expect(anaVisual).toBeVisible({ timeout: UI_TIMEOUT })
+    await anaVisual.click()
+    await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
+
+    await page.getByTestId('tab-profile').click()
+    await expect(page.getByTestId('student-profile-tab')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await expect(page.getByTestId('objective-add-btn')).toBeVisible({ timeout: UI_TIMEOUT })
+    await page.getByTestId('objective-add-btn').click()
+
+    const objInput = page.getByTestId('objective-add-btn-input')
+    await expect(objInput).toBeVisible({ timeout: UI_TIMEOUT })
+
+    const objText = `E2E objective ${Date.now()}`
+    await objInput.fill(objText)
+    await objInput.press('Enter')
+
+    await expect(page.getByText(objText)).toBeVisible({ timeout: UI_TIMEOUT })
+    await expect(page.getByTestId('objective-add-btn-input')).not.toBeVisible()
+  } finally {
+    await context.close()
+  }
+})
+
+test('student detail profile tab: inline-add focus area difficulty', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    await page.goto('/students')
+    await expect(page.locator('h1')).toHaveText('Students', { timeout: NAV_TIMEOUT })
+    const anaVisual = page.getByText('Ana Visual').first()
+    await expect(anaVisual).toBeVisible({ timeout: UI_TIMEOUT })
+    await anaVisual.click()
+    await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
+
+    await page.getByTestId('tab-profile').click()
+    await expect(page.getByTestId('student-profile-tab')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await expect(page.getByTestId('difficulty-add-btn')).toBeVisible({ timeout: UI_TIMEOUT })
+    await page.getByTestId('difficulty-add-btn').click()
+
+    await expect(page.getByTestId('difficulty-add-competency')).toBeVisible({ timeout: UI_TIMEOUT })
+    await page.getByTestId('difficulty-add-competency').fill('Pronunciation')
+
+    const descText = `E2E difficulty ${Date.now()}`
+    await page.getByTestId('difficulty-add-description').fill(descText)
+    await page.getByTestId('difficulty-add-description').press('Enter')
+
+    await expect(page.getByText(descText)).toBeVisible({ timeout: UI_TIMEOUT })
+    await expect(page.getByTestId('difficulty-add-description')).not.toBeVisible()
+  } finally {
+    await context.close()
+  }
+})

--- a/frontend/src/components/student/LearningGoalTreeEditor.tsx
+++ b/frontend/src/components/student/LearningGoalTreeEditor.tsx
@@ -3,16 +3,11 @@ import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { ChevronDown, ChevronRight, Plus, Trash2 } from 'lucide-react'
 import type { LearningGoalItem } from '../../api/students'
+import { newId } from '@/lib/newId'
 
 interface Props {
   value: LearningGoalItem[]
   onChange: (goals: LearningGoalItem[]) => void
-}
-
-function newId(): string {
-  return typeof crypto !== 'undefined' && crypto.randomUUID
-    ? crypto.randomUUID()
-    : `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
 }
 
 function newGoal(text: string): LearningGoalItem {

--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -100,6 +100,9 @@ function renderProfile(
     onToggle?: (id: string, status: 'Active' | 'Covered') => void
     onSaveReason?: (value: string) => Promise<void>
     onSaveInterests?: (value: string[]) => Promise<void>
+    onSaveLearningGoal?: (text: string) => Promise<void>
+    onSaveShortTermObjective?: (text: string) => Promise<void>
+    onSaveDifficulty?: (vars: { competency: string; description: string }) => Promise<void>
     followups?: TeacherFollowup[]
   }
 ) {
@@ -113,6 +116,9 @@ function renderProfile(
           onToggleDifficultyStatus={opts?.onToggle}
           onSaveReasonForStudying={opts?.onSaveReason}
           onSaveInterests={opts?.onSaveInterests}
+          onSaveLearningGoal={opts?.onSaveLearningGoal}
+          onSaveShortTermObjective={opts?.onSaveShortTermObjective}
+          onSaveDifficulty={opts?.onSaveDifficulty}
           followups={opts?.followups}
         />
       </MemoryRouter>
@@ -133,9 +139,9 @@ describe('StudentProfileTab', () => {
       expect(quote).toHaveTextContent('Vive en Barcelona')
     })
 
-    it('shows empty state when no reason', () => {
+    it('shows empty state prompt when no reason', () => {
       renderProfile(EMPTY_STUDENT)
-      expect(screen.getByTestId('reason-quote')).toHaveTextContent('No reason for studying added yet.')
+      expect(screen.getByTestId('reason-quote')).toHaveTextContent('Why is this student learning Spanish?')
     })
 
     it('shows interests beside the quote', () => {
@@ -188,17 +194,27 @@ describe('StudentProfileTab', () => {
     })
   })
 
-  describe('Identity Details section', () => {
+  describe('Working Memory sidebar (right col top)', () => {
     it('shows identity fields when populated', () => {
       renderProfile(FULL_STUDENT)
       expect(screen.getByText('Rome, Italy')).toBeInTheDocument()
       expect(screen.getByText('Barcelona, Spain')).toBeInTheDocument()
-      expect(screen.getByText(/^1998 \(\d+ years\)$/)).toBeInTheDocument()
+      // Born shows year and age (no "years" suffix)
+      expect(screen.getByText(/^1998 \(\d+\)$/)).toBeInTheDocument()
       expect(screen.getByText('Film student')).toBeInTheDocument()
     })
 
-    it('shows empty state when no identity data', () => {
+    it('is hidden when no identity data (empty state collapse)', () => {
       renderProfile(EMPTY_STUDENT)
+      // section is not rendered when empty by default
+      expect(screen.queryByTestId('profile-about')).not.toBeInTheDocument()
+    })
+
+    it('shows empty state when revealed via show-all toggle', () => {
+      renderProfile(EMPTY_STUDENT)
+      const toggle = screen.getByTestId('show-empty-sections-btn')
+      fireEvent.click(toggle)
+      expect(screen.getByTestId('profile-about')).toBeInTheDocument()
       expect(screen.getByText('No identity details added yet')).toBeInTheDocument()
     })
   })
@@ -259,17 +275,16 @@ describe('StudentProfileTab', () => {
       expect(section).toHaveTextContent('C1')
     })
 
-    it('shows both CEFR levels when officialCefrLevel is set', () => {
+    it('shows official CEFR level when set', () => {
       renderProfile({ ...FULL_STUDENT, officialCefrLevel: 'B2' })
       const section = screen.getByTestId('profile-language-ecosystem')
-      expect(section).toHaveTextContent("Teacher's Assessment")
       expect(section).toHaveTextContent('Official')
       expect(section).toHaveTextContent('B2')
     })
   })
 
-  describe('Skill Assessment section', () => {
-    it('shows skill overrides as CEFR badges', () => {
+  describe('Skill Assessment section (inside Pedagogical Diagnostic)', () => {
+    it('shows skill overrides as square CEFR badges', () => {
       renderProfile(FULL_STUDENT)
       const section = screen.getByTestId('profile-skill-assessment')
       expect(section).toHaveTextContent('Reading')
@@ -278,13 +293,13 @@ describe('StudentProfileTab', () => {
       expect(section).toHaveTextContent('B1')
     })
 
-    it('shows empty state when no skill overrides', () => {
+    it('does not render skill assessment when no overrides', () => {
       renderProfile(EMPTY_STUDENT)
-      expect(screen.getByText('No skill overrides set')).toBeInTheDocument()
+      expect(screen.queryByTestId('profile-skill-assessment')).not.toBeInTheDocument()
     })
   })
 
-  describe('Notes sections', () => {
+  describe('Teacher\'s Working Memory (unified notes, dark section)', () => {
     it('renders personal notes', () => {
       renderProfile(FULL_STUDENT)
       expect(screen.getByText(/Muy motivado/)).toBeInTheDocument()
@@ -295,10 +310,16 @@ describe('StudentProfileTab', () => {
       expect(screen.getByText(/Nivel alto/)).toBeInTheDocument()
     })
 
-    it('shows empty states for missing notes', () => {
+    it('is hidden when both notes are empty (empty state collapse)', () => {
       renderProfile(EMPTY_STUDENT)
-      expect(screen.getByText('No personal notes')).toBeInTheDocument()
-      expect(screen.getByText('No pedagogical observations')).toBeInTheDocument()
+      expect(screen.queryByTestId('profile-teachers-working-memory')).not.toBeInTheDocument()
+    })
+
+    it('shows when revealed via show-all toggle', () => {
+      renderProfile(EMPTY_STUDENT)
+      const toggle = screen.getByTestId('show-empty-sections-btn')
+      fireEvent.click(toggle)
+      expect(screen.getByTestId('profile-teachers-working-memory')).toBeInTheDocument()
     })
   })
 
@@ -317,6 +338,44 @@ describe('StudentProfileTab', () => {
     it('shows empty state when no goals', () => {
       renderProfile(EMPTY_STUDENT)
       expect(screen.getByText('No learning goals set')).toBeInTheDocument()
+    })
+
+    it('shows + button when onSaveLearningGoal is provided', () => {
+      renderProfile(FULL_STUDENT, { onSaveLearningGoal: vi.fn().mockResolvedValue(undefined) })
+      expect(screen.getByTestId('goal-add-btn')).toBeInTheDocument()
+    })
+
+    it('opens inline input when + is clicked', () => {
+      renderProfile(FULL_STUDENT, { onSaveLearningGoal: vi.fn().mockResolvedValue(undefined) })
+      fireEvent.click(screen.getByTestId('goal-add-btn'))
+      expect(screen.getByTestId('goal-add-btn-input')).toBeInTheDocument()
+    })
+
+    it('calls onSaveLearningGoal on Enter key', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      renderProfile(FULL_STUDENT, { onSaveLearningGoal: onSave })
+      fireEvent.click(screen.getByTestId('goal-add-btn'))
+      const input = screen.getByTestId('goal-add-btn-input')
+      fireEvent.change(input, { target: { value: 'New goal text' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+      await waitFor(() => expect(onSave).toHaveBeenCalledWith('New goal text'))
+    })
+
+    it('calls onSaveLearningGoal on save button click', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      renderProfile(FULL_STUDENT, { onSaveLearningGoal: onSave })
+      fireEvent.click(screen.getByTestId('goal-add-btn'))
+      fireEvent.change(screen.getByTestId('goal-add-btn-input'), { target: { value: 'Another goal' } })
+      fireEvent.click(screen.getByTestId('goal-add-btn-save'))
+      await waitFor(() => expect(onSave).toHaveBeenCalledWith('Another goal'))
+    })
+
+    it('closes input on Escape', () => {
+      renderProfile(FULL_STUDENT, { onSaveLearningGoal: vi.fn().mockResolvedValue(undefined) })
+      fireEvent.click(screen.getByTestId('goal-add-btn'))
+      const input = screen.getByTestId('goal-add-btn-input')
+      fireEvent.keyDown(input, { key: 'Escape' })
+      expect(screen.queryByTestId('goal-add-btn-input')).not.toBeInTheDocument()
     })
   })
 
@@ -365,6 +424,21 @@ describe('StudentProfileTab', () => {
       expect(screen.queryByTestId('objective-overdue-label')).not.toBeInTheDocument()
       expect(screen.queryByTestId('objective-critical-label')).not.toBeInTheDocument()
     })
+
+    it('shows + button when onSaveShortTermObjective is provided', () => {
+      renderProfile(FULL_STUDENT, { onSaveShortTermObjective: vi.fn().mockResolvedValue(undefined) })
+      expect(screen.getByTestId('objective-add-btn')).toBeInTheDocument()
+    })
+
+    it('opens inline input and saves on Enter', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      renderProfile(FULL_STUDENT, { onSaveShortTermObjective: onSave })
+      fireEvent.click(screen.getByTestId('objective-add-btn'))
+      const input = screen.getByTestId('objective-add-btn-input')
+      fireEvent.change(input, { target: { value: 'New objective' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+      await waitFor(() => expect(onSave).toHaveBeenCalledWith('New objective'))
+    })
   })
 
   describe('Focus Areas & Difficulties section', () => {
@@ -381,7 +455,6 @@ describe('StudentProfileTab', () => {
     it('renders difficulty area (competency) and subcategory', () => {
       renderProfile(FULL_STUDENT)
       expect(screen.getByText('Grammar')).toBeInTheDocument()
-      // Subcategory column shows d.subcategory when present
       expect(screen.getByText('subjuntivo')).toBeInTheDocument()
     })
 
@@ -433,6 +506,30 @@ describe('StudentProfileTab', () => {
       renderProfile({ ...EMPTY_STUDENT, weaknesses: FULL_STUDENT.weaknesses })
       expect(screen.getByTestId('profile-weaknesses')).toBeInTheDocument()
       expect(screen.queryByText('No focus areas tracked')).not.toBeInTheDocument()
+    })
+
+    it('shows + button when onSaveDifficulty is provided', () => {
+      renderProfile(FULL_STUDENT, { onSaveDifficulty: vi.fn().mockResolvedValue(undefined) })
+      expect(screen.getByTestId('difficulty-add-btn')).toBeInTheDocument()
+    })
+
+    it('opens two-field inline input when + is clicked', () => {
+      renderProfile(FULL_STUDENT, { onSaveDifficulty: vi.fn().mockResolvedValue(undefined) })
+      fireEvent.click(screen.getByTestId('difficulty-add-btn'))
+      expect(screen.getByTestId('difficulty-add-competency')).toBeInTheDocument()
+      expect(screen.getByTestId('difficulty-add-description')).toBeInTheDocument()
+    })
+
+    it('calls onSaveDifficulty with both fields on Enter', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      renderProfile(FULL_STUDENT, { onSaveDifficulty: onSave })
+      fireEvent.click(screen.getByTestId('difficulty-add-btn'))
+      fireEvent.change(screen.getByTestId('difficulty-add-competency'), { target: { value: 'Pronunciation' } })
+      fireEvent.change(screen.getByTestId('difficulty-add-description'), { target: { value: 'Rolling R' } })
+      fireEvent.keyDown(screen.getByTestId('difficulty-add-description'), { key: 'Enter' })
+      await waitFor(() =>
+        expect(onSave).toHaveBeenCalledWith({ competency: 'Pronunciation', description: 'Rolling R' })
+      )
     })
   })
 
@@ -496,6 +593,33 @@ describe('StudentProfileTab', () => {
     it('shows Corporate badge when corporate', () => {
       renderProfile({ ...FULL_STUDENT, isCorporate: true })
       expect(screen.getByText('Corporate')).toBeInTheDocument()
+    })
+  })
+
+  describe('Empty state progressive disclosure', () => {
+    it('shows "show all sections" toggle when some sections are empty', () => {
+      renderProfile(EMPTY_STUDENT)
+      expect(screen.getByTestId('show-empty-sections-btn')).toBeInTheDocument()
+    })
+
+    it('does not show the toggle when all sections have data', () => {
+      renderProfile(FULL_STUDENT)
+      // FULL_STUDENT has profession/birthYear/notes, so no sections collapsed
+      expect(screen.queryByTestId('show-empty-sections-btn')).not.toBeInTheDocument()
+    })
+
+    it('reveals hidden sections after clicking show-all', () => {
+      renderProfile(EMPTY_STUDENT)
+      expect(screen.queryByTestId('profile-about')).not.toBeInTheDocument()
+      fireEvent.click(screen.getByTestId('show-empty-sections-btn'))
+      expect(screen.getByTestId('profile-about')).toBeInTheDocument()
+      expect(screen.getByTestId('profile-teachers-working-memory')).toBeInTheDocument()
+    })
+
+    it('hides the toggle after expanding', () => {
+      renderProfile(EMPTY_STUDENT)
+      fireEvent.click(screen.getByTestId('show-empty-sections-btn'))
+      expect(screen.queryByTestId('show-empty-sections-btn')).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -141,7 +141,7 @@ describe('StudentProfileTab', () => {
 
     it('shows empty state prompt when no reason', () => {
       renderProfile(EMPTY_STUDENT)
-      expect(screen.getByTestId('reason-quote')).toHaveTextContent('Why is this student learning Spanish?')
+      expect(screen.getByTestId('reason-quote')).toHaveTextContent(`Why is this student learning ${EMPTY_STUDENT.learningLanguage}?`)
     })
 
     it('shows interests beside the quote', () => {

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -34,24 +34,15 @@ function EmptyState({ text }: { text: string }) {
 // ------------------------------------------------------------------
 // Skill badge (large square, for horizontal Skill Assessment row)
 // ------------------------------------------------------------------
-function cefrBgText(level: string): string {
-  const prefix = level[0]?.toUpperCase()
-  if (prefix === 'A') return 'bg-[#DDE8F5] text-[#1A4B7A]'
-  if (prefix === 'B') return 'bg-[#ECEAFD] text-[#3525CD]'
-  if (prefix === 'C') return 'bg-[#F8E9D6] text-[#7E3000]'
-  return 'bg-zinc-100 text-zinc-700'
-}
-
 function SkillBadgeSquare({ skill, level }: { skill: string; level: string }) {
   return (
     <div className="flex flex-col items-center gap-1.5">
       <span className="text-[0.625rem] font-bold uppercase tracking-wide text-zinc-500">{skill}</span>
-      <div
-        className={`w-12 h-12 rounded-lg flex items-center justify-center font-bold text-base ${cefrBgText(level)}`}
+      <CefrBadge
+        level={level}
+        className="w-12 h-12 rounded-lg text-base px-0 py-0"
         data-testid={`skill-badge-${skill.toLowerCase()}`}
-      >
-        {level}
-      </div>
+      />
     </div>
   )
 }

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -12,12 +12,6 @@ import { SectionHeader } from './SectionHeader'
 import { CefrBadge } from '@/components/dashboard/CefrBadge'
 import { langCode } from './langUtils'
 
-function newId() {
-  return typeof crypto !== 'undefined' && crypto.randomUUID
-    ? crypto.randomUUID()
-    : `${Date.now()}-${Math.random()}`
-}
-
 const SKILL_ORDER = ['Reading', 'Writing', 'Speaking', 'Listening']
 
 interface Props {

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -247,9 +247,11 @@ function MotivationHero({
 
   async function handleSave() {
     if (!onSave) return
+    const value = draft.trim()
     setSaving(true)
     try {
-      await onSave(draft)
+      await onSave(value)
+      setDraft(value)
       setEditing(false)
     } catch {
       // keep editor open

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from 'react'
-import { Pencil, X, Plus, Check } from 'lucide-react'
+import { Pencil, X, Plus, Check, GraduationCap, ChevronDown } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import type { Student } from '@/api/students'
@@ -12,6 +12,12 @@ import { SectionHeader } from './SectionHeader'
 import { CefrBadge } from '@/components/dashboard/CefrBadge'
 import { langCode } from './langUtils'
 
+function newId() {
+  return typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random()}`
+}
+
 const SKILL_ORDER = ['Reading', 'Writing', 'Speaking', 'Listening']
 
 interface Props {
@@ -22,23 +28,228 @@ interface Props {
   onToggleDifficultyStatus?: (id: string, status: 'Active' | 'Covered') => void
   onSaveReasonForStudying?: (value: string) => Promise<void>
   onSaveInterests?: (value: string[]) => Promise<void>
-}
-
-function FieldValue({ label, value }: { label: string; value: string | number | null | undefined }) {
-  if (value == null || value === '') return null
-  return (
-    <div className="flex items-baseline gap-2 py-1">
-      <span className="text-xs text-zinc-400 shrink-0 w-28">{label}</span>
-      <span className="text-sm text-[#1A1B22]">{value}</span>
-    </div>
-  )
+  onSaveLearningGoal?: (text: string) => Promise<void>
+  onSaveShortTermObjective?: (text: string) => Promise<void>
+  onSaveDifficulty?: (vars: { competency: string; description: string }) => Promise<void>
 }
 
 function EmptyState({ text }: { text: string }) {
   return <p className="text-sm text-zinc-400 italic">{text}</p>
 }
 
-function ReasonHero({
+// ------------------------------------------------------------------
+// Skill badge (large square, for horizontal Skill Assessment row)
+// ------------------------------------------------------------------
+function cefrBgText(level: string): string {
+  const prefix = level[0]?.toUpperCase()
+  if (prefix === 'A') return 'bg-[#DDE8F5] text-[#1A4B7A]'
+  if (prefix === 'B') return 'bg-[#ECEAFD] text-[#3525CD]'
+  if (prefix === 'C') return 'bg-[#F8E9D6] text-[#7E3000]'
+  return 'bg-zinc-100 text-zinc-700'
+}
+
+function SkillBadgeSquare({ skill, level }: { skill: string; level: string }) {
+  return (
+    <div className="flex flex-col items-center gap-1.5">
+      <span className="text-[0.625rem] font-bold uppercase tracking-wide text-zinc-500">{skill}</span>
+      <div
+        className={`w-12 h-12 rounded-lg flex items-center justify-center font-bold text-base ${cefrBgText(level)}`}
+        data-testid={`skill-badge-${skill.toLowerCase()}`}
+      >
+        {level}
+      </div>
+    </div>
+  )
+}
+
+// ------------------------------------------------------------------
+// Inline-add components
+// ------------------------------------------------------------------
+function InlineAddInput({
+  placeholder,
+  onSave,
+  'data-testid': testId,
+}: {
+  placeholder: string
+  onSave: (text: string) => Promise<void>
+  'data-testid'?: string
+}) {
+  const [open, setOpen] = useState(false)
+  const [text, setText] = useState('')
+  const [saving, setSaving] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  function handleOpen() {
+    setOpen(true)
+    setTimeout(() => inputRef.current?.focus(), 50)
+  }
+
+  async function handleSave() {
+    const val = text.trim()
+    if (!val || saving) return
+    setSaving(true)
+    try {
+      await onSave(val)
+      setText('')
+      setOpen(false)
+    } catch {
+      // keep open on error
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={handleOpen}
+        className="p-1 text-zinc-400 hover:text-indigo-600 rounded transition-colors"
+        aria-label={`Add ${placeholder}`}
+        data-testid={testId}
+      >
+        <Plus className="h-3.5 w-3.5" />
+      </button>
+    )
+  }
+
+  return (
+    <div className="flex gap-2 mt-2" data-testid={`${testId}-row`}>
+      <input
+        ref={inputRef}
+        type="text"
+        value={text}
+        onChange={e => setText(e.target.value)}
+        onKeyDown={e => {
+          if (e.key === 'Enter') handleSave()
+          if (e.key === 'Escape') { setText(''); setOpen(false) }
+        }}
+        placeholder={placeholder}
+        maxLength={500}
+        className="flex-1 rounded-lg border border-zinc-200 bg-indigo-50 px-3 py-1.5 text-sm text-[#1A1B22] placeholder:text-zinc-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+        data-testid={`${testId}-input`}
+      />
+      <button
+        type="button"
+        onClick={handleSave}
+        disabled={saving || !text.trim()}
+        className="shrink-0 rounded-lg bg-indigo-600 p-1.5 text-white hover:bg-indigo-700 disabled:opacity-40 transition-colors"
+        data-testid={`${testId}-save`}
+      >
+        <Check className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        onClick={() => { setText(''); setOpen(false) }}
+        className="shrink-0 rounded-lg bg-zinc-100 p-1.5 text-zinc-500 hover:bg-zinc-200 transition-colors"
+        data-testid={`${testId}-cancel`}
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}
+
+function InlineAddDifficulty({
+  onSave,
+}: {
+  onSave: (vars: { competency: string; description: string }) => Promise<void>
+}) {
+  const [open, setOpen] = useState(false)
+  const [competency, setCompetency] = useState('')
+  const [description, setDescription] = useState('')
+  const [saving, setSaving] = useState(false)
+  const competencyRef = useRef<HTMLInputElement>(null)
+
+  function handleOpen() {
+    setOpen(true)
+    setTimeout(() => competencyRef.current?.focus(), 50)
+  }
+
+  async function handleSave() {
+    const comp = competency.trim()
+    const desc = description.trim()
+    if (!comp || !desc || saving) return
+    setSaving(true)
+    try {
+      await onSave({ competency: comp, description: desc })
+      setCompetency('')
+      setDescription('')
+      setOpen(false)
+    } catch {
+      // keep open
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={handleOpen}
+        className="p-1 text-zinc-400 hover:text-indigo-600 rounded transition-colors"
+        aria-label="Add focus area"
+        data-testid="difficulty-add-btn"
+      >
+        <Plus className="h-3.5 w-3.5" />
+      </button>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2 mt-2" data-testid="difficulty-add-row">
+      <div className="flex gap-2">
+        <input
+          ref={competencyRef}
+          type="text"
+          value={competency}
+          onChange={e => setCompetency(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Escape') { setCompetency(''); setDescription(''); setOpen(false) } }}
+          placeholder="Area (e.g. Grammar)"
+          maxLength={100}
+          className="w-32 rounded-lg border border-zinc-200 bg-indigo-50 px-3 py-1.5 text-sm text-[#1A1B22] placeholder:text-zinc-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+          data-testid="difficulty-add-competency"
+        />
+        <input
+          type="text"
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') handleSave()
+            if (e.key === 'Escape') { setCompetency(''); setDescription(''); setOpen(false) }
+          }}
+          placeholder="Description"
+          maxLength={300}
+          className="flex-1 rounded-lg border border-zinc-200 bg-indigo-50 px-3 py-1.5 text-sm text-[#1A1B22] placeholder:text-zinc-400 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+          data-testid="difficulty-add-description"
+        />
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving || !competency.trim() || !description.trim()}
+          className="shrink-0 rounded-lg bg-indigo-600 p-1.5 text-white hover:bg-indigo-700 disabled:opacity-40 transition-colors"
+          data-testid="difficulty-add-save"
+        >
+          <Check className="h-4 w-4" />
+        </button>
+        <button
+          type="button"
+          onClick={() => { setCompetency(''); setDescription(''); setOpen(false) }}
+          className="shrink-0 rounded-lg bg-zinc-100 p-1.5 text-zinc-500 hover:bg-zinc-200 transition-colors"
+          data-testid="difficulty-add-cancel"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ------------------------------------------------------------------
+// Motivation Hero (banner with Manrope quote + interest chips inside)
+// ------------------------------------------------------------------
+function MotivationHero({
   student,
   onSave,
 }: {
@@ -56,7 +267,7 @@ function ReasonHero({
       await onSave(draft)
       setEditing(false)
     } catch {
-      // caller logs the failure; keep editor open so user can retry
+      // keep editor open
     } finally {
       setSaving(false)
     }
@@ -69,73 +280,120 @@ function ReasonHero({
 
   return (
     <div
-      className="group relative bg-indigo-50/60 rounded-xl px-4 py-3"
+      className="group relative bg-indigo-50/60 rounded-xl px-6 py-5 overflow-hidden"
       data-testid="reason-hero"
     >
-      {editing ? (
-        <div className="space-y-2">
-          <textarea
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            className="w-full text-lg italic text-[#1A1B22] bg-white border border-indigo-300 rounded-xl px-4 py-3 resize-none focus:outline-none focus:ring-2 focus:ring-indigo-300"
-            rows={3}
-            maxLength={512}
-            placeholder="Why is this student learning?"
-            autoFocus
-            data-testid="reason-textarea"
-          />
-          <div className="flex gap-2">
-            <Button
-              type="button"
-              size="sm"
-              onClick={handleSave}
-              disabled={saving}
-              className="bg-indigo-600 hover:bg-indigo-700 text-white h-7 px-3 text-xs"
-              data-testid="reason-save-btn"
-            >
-              <Check className="h-3 w-3 mr-1" />
-              {saving ? 'Saving...' : 'Save'}
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant="ghost"
-              onClick={handleCancel}
-              className="h-7 px-3 text-xs text-zinc-500"
-              data-testid="reason-cancel-btn"
-            >
-              Cancel
-            </Button>
+      {/* Decorative circle */}
+      <div className="absolute top-0 right-0 w-40 h-40 bg-indigo-100/50 rounded-full -mr-20 -mt-20 pointer-events-none" />
+
+      <div className="relative z-10">
+        <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-indigo-600 mb-3 opacity-70">
+          The Why / Motivation
+        </p>
+
+        {editing ? (
+          <div className="space-y-2">
+            <textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              className="w-full font-manrope text-xl italic text-[#1A1B22] bg-white border border-indigo-300 rounded-xl px-4 py-3 resize-none focus:outline-none focus:ring-2 focus:ring-indigo-300"
+              rows={3}
+              maxLength={512}
+              placeholder="Why is this student learning?"
+              autoFocus
+              data-testid="reason-textarea"
+            />
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                size="sm"
+                onClick={handleSave}
+                disabled={saving}
+                className="bg-indigo-600 hover:bg-indigo-700 text-white h-7 px-3 text-xs"
+                data-testid="reason-save-btn"
+              >
+                <Check className="h-3 w-3 mr-1" />
+                {saving ? 'Saving...' : 'Save'}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={handleCancel}
+                className="h-7 px-3 text-xs text-zinc-500"
+                data-testid="reason-cancel-btn"
+              >
+                Cancel
+              </Button>
+            </div>
           </div>
-        </div>
-      ) : (
-        <div className="flex items-start gap-2">
-          {student.reasonForStudying ? (
-            <p className="text-lg italic text-[#1A1B22] leading-relaxed flex-1" data-testid="reason-quote">
-              &ldquo;{student.reasonForStudying}&rdquo;
-            </p>
-          ) : (
-            <p className="text-sm text-zinc-400 italic flex-1" data-testid="reason-quote">
-              No reason for studying added yet.
-            </p>
-          )}
-          {onSave && (
-            <button
-              type="button"
-              onClick={() => setEditing(true)}
-              className="opacity-0 group-hover:opacity-100 transition-opacity p-1 text-zinc-400 hover:text-indigo-600 rounded"
-              aria-label="Edit reason for studying"
-              data-testid="reason-edit-btn"
-            >
-              <Pencil className="h-4 w-4" />
-            </button>
-          )}
-        </div>
-      )}
+        ) : (
+          <div className="flex flex-col lg:flex-row lg:items-start gap-4">
+            <div className="flex-1 min-w-0">
+              {student.reasonForStudying ? (
+                <div className="flex items-start gap-2">
+                  <p
+                    className="font-manrope text-2xl font-extrabold text-primary italic leading-snug flex-1"
+                    data-testid="reason-quote"
+                  >
+                    &ldquo;{student.reasonForStudying}&rdquo;
+                  </p>
+                  {onSave && (
+                    <button
+                      type="button"
+                      onClick={() => setEditing(true)}
+                      className="opacity-0 group-hover:opacity-100 transition-opacity p-1 text-zinc-400 hover:text-indigo-600 rounded shrink-0 mt-1"
+                      aria-label="Edit reason for studying"
+                      data-testid="reason-edit-btn"
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
+              ) : (
+                <div className="flex items-center gap-2">
+                  <p className="font-manrope text-lg italic text-zinc-400 flex-1" data-testid="reason-quote">
+                    Why is this student learning Spanish?
+                  </p>
+                  {onSave && (
+                    <button
+                      type="button"
+                      onClick={() => setEditing(true)}
+                      className="opacity-0 group-hover:opacity-100 transition-opacity p-1 text-zinc-400 hover:text-indigo-600 rounded shrink-0"
+                      aria-label="Edit reason for studying"
+                      data-testid="reason-edit-btn"
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Interest chips pulled into banner */}
+            {student.interests.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 lg:max-w-[180px]" data-testid="hero-interests">
+                {student.interests.map((interest) => (
+                  <span
+                    key={interest}
+                    className="inline-block bg-indigo-100 text-indigo-700 text-xs font-semibold rounded-full px-3 py-1"
+                    data-testid="hero-interest-tag"
+                  >
+                    {interest}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   )
 }
 
+// ------------------------------------------------------------------
+// Interests section (right column, editable)
+// ------------------------------------------------------------------
 function InterestsSection({
   student,
   onSave,
@@ -174,8 +432,7 @@ function InterestsSection({
   async function handleSave() {
     if (!onSave) return
     const trimmed = inputValue.trim()
-    const finalList =
-      trimmed && !draft.includes(trimmed) ? [...draft, trimmed] : draft
+    const finalList = trimmed && !draft.includes(trimmed) ? [...draft, trimmed] : draft
     setSaving(true)
     try {
       await onSave(finalList)
@@ -183,7 +440,7 @@ function InterestsSection({
       setEditing(false)
       setInputValue('')
     } catch {
-      // caller logs the failure; keep editor open so user can retry
+      // keep open
     } finally {
       setSaving(false)
     }
@@ -299,15 +556,53 @@ function InterestsSection({
   )
 }
 
-export function StudentProfileTab({ student, followups = [], onFollowupChange, onStudentChange, onToggleDifficultyStatus, onSaveReasonForStudying, onSaveInterests }: Props) {
+// ------------------------------------------------------------------
+// FieldValue (used in Working Memory sidebar)
+// ------------------------------------------------------------------
+function FieldValue({ label, value }: { label: string; value: string | number | null | undefined }) {
+  if (value == null || value === '') return null
+  return (
+    <div className="flex items-baseline justify-between py-2 border-b border-[#F4F2FD] last:border-0">
+      <span className="text-sm font-medium text-zinc-500">{label}</span>
+      <span className="text-sm font-bold text-[#1A1B22] text-right">{value}</span>
+    </div>
+  )
+}
+
+// ------------------------------------------------------------------
+// Main component
+// ------------------------------------------------------------------
+export function StudentProfileTab({
+  student,
+  followups = [],
+  onFollowupChange,
+  onStudentChange,
+  onToggleDifficultyStatus,
+  onSaveReasonForStudying,
+  onSaveInterests,
+  onSaveLearningGoal,
+  onSaveShortTermObjective,
+  onSaveDifficulty,
+}: Props) {
+  const [showEmptySections, setShowEmptySections] = useState(false)
+
   const parsedPersonalNotes = parseNotes(student.personalNotes)
   const parsedTeachingNotes = parseNotes(student.teachingNotes)
 
-  const hasAbout = student.birthYear || student.profession || student.countryOfOrigin ||
-    student.cityOfOrigin || student.countryOfResidence || student.cityOfResidence
+  const hasAbout = !!(
+    student.birthYear ||
+    student.profession ||
+    student.countryOfOrigin ||
+    student.cityOfOrigin ||
+    student.countryOfResidence ||
+    student.cityOfResidence
+  )
+  const hasWorkingMemory = !!(student.personalNotes || student.teachingNotes)
 
   const location = [student.cityOfResidence, student.countryOfResidence].filter(Boolean).join(', ')
   const origin = [student.cityOfOrigin, student.countryOfOrigin].filter(Boolean).join(', ')
+
+  const anySectionCollapsed = (!hasAbout || !hasWorkingMemory) && !showEmptySections
 
   return (
     <div
@@ -315,292 +610,344 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
       style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
       data-testid="student-profile-tab"
     >
-      {/* Hero: The Why / Motivation */}
-      <section className="mb-8 pb-8 border-b border-zinc-100" data-testid="profile-hero">
-        <SectionHeader>The Why / Motivation</SectionHeader>
-        <div className="flex flex-col sm:flex-row gap-4 sm:gap-8 items-start">
-          <div className="flex-1 min-w-0">
-            <ReasonHero key={student.id} student={student} onSave={onSaveReasonForStudying} />
-          </div>
-          {student.interests.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 sm:max-w-[200px]" data-testid="hero-interests">
-              {student.interests.map((interest) => (
-                <span
-                  key={interest}
-                  className="inline-block bg-zinc-100 text-zinc-600 text-xs font-medium rounded-full px-2.5 py-1"
-                  data-testid="hero-interest-tag"
-                >
-                  {interest}
-                </span>
-              ))}
-            </div>
-          )}
-        </div>
-      </section>
+      {/* Hero: Motivation Banner */}
+      <div className="mb-8" data-testid="profile-hero">
+        <MotivationHero key={student.id} student={student} onSave={onSaveReasonForStudying} />
+      </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-5 gap-8 lg:gap-12">
-        {/* Left column (3/5) */}
-        <div className="lg:col-span-3 space-y-6">
-          {/* Pedagogical Diagnostic */}
-          <section data-testid="profile-pedagogical-diagnostic">
-            <SectionHeader>Pedagogical Diagnostic</SectionHeader>
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-10">
+        {/* ============================================================
+            LEFT COLUMN (8/12)
+            ============================================================ */}
+        <div className="lg:col-span-8 space-y-6">
 
-            {/* Learning Goals */}
-            <div className="mb-4" data-testid="profile-learning-goals">
-              <p className="text-xs text-zinc-400 font-medium mb-1.5">Learning Goals</p>
-              {student.learningGoals.length > 0 ? (
-                <ul className="space-y-1 list-none">
-                  {student.learningGoals.map((goal) => (
-                    <li key={goal.id}>
-                      <div className="flex items-start gap-2 text-sm text-[#1A1B22]">
-                        <span className="mt-1.5 h-1.5 w-1.5 rounded-full bg-indigo-500 shrink-0" />
-                        {goal.text}
-                      </div>
-                      {goal.children.length > 0 && (
-                        <ul className="mt-0.5 space-y-0.5 list-none pl-5">
-                          {goal.children.map((child) => (
-                            <li key={child.id} className="flex items-start gap-2 text-sm text-zinc-600">
-                              <span className="mt-1.5 h-1 w-1 rounded-full bg-indigo-300 shrink-0" />
-                              {child.text}
-                            </li>
-                          ))}
-                        </ul>
-                      )}
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <EmptyState text="No learning goals set" />
-              )}
+          {/* Pedagogical Diagnostic card */}
+          <section
+            className="bg-[#FAFAFA] rounded-xl p-6"
+            style={{ boxShadow: '0 2px 12px rgba(26,27,34,0.06)' }}
+            data-testid="profile-pedagogical-diagnostic"
+          >
+            {/* Card header */}
+            <div className="flex items-center gap-2 mb-6">
+              <GraduationCap className="h-5 w-5 text-indigo-600 shrink-0" />
+              <h3 className="font-manrope text-base font-bold text-[#1A1B22]">Pedagogical Diagnostic</h3>
             </div>
 
-            {/* Short-Term Objectives */}
-            <div data-testid="profile-objectives">
-              <p className="text-xs text-zinc-400 font-medium mb-1.5">Short-Term Objectives</p>
-              {student.shortTermObjectives.length > 0 ? (
-                <ul className="space-y-2">
-                  {student.shortTermObjectives.map((obj) => {
-                    const urgency = getObjectiveUrgency(obj.targetDate)
-                    return (
-                      <li
-                        key={obj.id}
-                        className={`rounded-lg px-3 py-2 text-sm ${
-                          urgency === 'overdue'
-                            ? 'border-2 border-red-300 bg-red-50'
-                            : urgency === 'critical'
-                              ? 'border-2 border-orange-300 bg-orange-50'
-                              : 'bg-zinc-50'
-                        }`}
-                        data-testid="objective-row"
-                      >
-                        <div className="flex items-start justify-between gap-2">
-                          <span className="text-[#1A1B22]">{obj.text}</span>
-                          {urgency === 'overdue' && (
-                            <span className="text-xs font-bold text-red-600 shrink-0 uppercase" data-testid="objective-overdue-label">
-                              OVERDUE
-                            </span>
-                          )}
-                          {urgency === 'critical' && (
-                            <span className="text-xs font-bold text-orange-600 shrink-0 uppercase" data-testid="objective-critical-label">
-                              Critical
-                            </span>
-                          )}
+            <div className="space-y-6">
+              {/* Learning Goals */}
+              <div data-testid="profile-learning-goals">
+                <div className="flex items-center justify-between mb-2">
+                  <p className="text-xs font-bold uppercase tracking-widest text-zinc-500">Learning Goals</p>
+                  {onSaveLearningGoal && (
+                    <InlineAddInput
+                      placeholder="Add a learning goal"
+                      onSave={onSaveLearningGoal}
+                      data-testid="goal-add-btn"
+                    />
+                  )}
+                </div>
+                {student.learningGoals.length > 0 ? (
+                  <ul className="space-y-1 list-none">
+                    {student.learningGoals.map((goal) => (
+                      <li key={goal.id}>
+                        <div className="flex items-start gap-2 text-sm text-[#1A1B22]">
+                          <span className="mt-1.5 h-1.5 w-1.5 rounded-full bg-indigo-500 shrink-0" />
+                          {goal.text}
                         </div>
-                        {obj.targetDate && (
-                          <span className="text-xs text-zinc-400 mt-0.5 block">
-                            Target: {new Date(obj.targetDate + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
-                          </span>
+                        {goal.children.length > 0 && (
+                          <ul className="mt-0.5 space-y-0.5 list-none pl-5">
+                            {goal.children.map((child) => (
+                              <li key={child.id} className="flex items-start gap-2 text-sm text-zinc-600">
+                                <span className="mt-1.5 h-1 w-1 rounded-full bg-indigo-300 shrink-0" />
+                                {child.text}
+                              </li>
+                            ))}
+                          </ul>
                         )}
                       </li>
-                    )
-                  })}
-                </ul>
-              ) : (
-                <EmptyState text="No objectives set" />
+                    ))}
+                  </ul>
+                ) : (
+                  <EmptyState text="No learning goals set" />
+                )}
+              </div>
+
+              {/* Short-Term Objectives */}
+              <div data-testid="profile-objectives">
+                <div className="flex items-center justify-between mb-2">
+                  <p className="text-xs font-bold uppercase tracking-widest text-zinc-500">Short-Term Objectives</p>
+                  {onSaveShortTermObjective && (
+                    <InlineAddInput
+                      placeholder="Add an objective"
+                      onSave={onSaveShortTermObjective}
+                      data-testid="objective-add-btn"
+                    />
+                  )}
+                </div>
+                {student.shortTermObjectives.length > 0 ? (
+                  <ul className="space-y-2">
+                    {student.shortTermObjectives.map((obj) => {
+                      const urgency = getObjectiveUrgency(obj.targetDate)
+                      return (
+                        <li
+                          key={obj.id}
+                          className={`rounded-lg px-3 py-2 text-sm ${
+                            urgency === 'overdue'
+                              ? 'border-l-4 border-red-400 bg-red-50'
+                              : urgency === 'critical'
+                                ? 'border-l-4 border-amber-400 bg-amber-50'
+                                : 'bg-zinc-50'
+                          }`}
+                          data-testid="objective-row"
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <span className="text-[#1A1B22] font-medium">{obj.text}</span>
+                            {urgency === 'overdue' && (
+                              <span className="text-xs font-bold text-red-600 shrink-0 uppercase" data-testid="objective-overdue-label">
+                                OVERDUE
+                              </span>
+                            )}
+                            {urgency === 'critical' && (
+                              <span className="text-xs font-bold text-amber-600 shrink-0 uppercase" data-testid="objective-critical-label">
+                                Critical
+                              </span>
+                            )}
+                          </div>
+                          {obj.targetDate && (
+                            <span className="text-xs text-zinc-400 mt-0.5 block">
+                              Target: {new Date(obj.targetDate + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                            </span>
+                          )}
+                        </li>
+                      )
+                    })}
+                  </ul>
+                ) : (
+                  <EmptyState text="No objectives set" />
+                )}
+              </div>
+
+              {/* Skill Assessment - horizontal large square badges */}
+              {Object.keys(student.skillLevelOverrides ?? {}).length > 0 && (
+                <div data-testid="profile-skill-assessment">
+                  <p className="text-xs font-bold uppercase tracking-widest text-zinc-500 mb-3">Skill Assessment</p>
+                  <div className="grid grid-cols-4 gap-3">
+                    {SKILL_ORDER.filter((s) => student.skillLevelOverrides?.[s]).map((skill) => (
+                      <SkillBadgeSquare key={skill} skill={skill} level={student.skillLevelOverrides[skill]} />
+                    ))}
+                  </div>
+                </div>
               )}
+
+              {/* Focus Areas & Difficulties */}
+              <div data-testid="profile-focus-areas">
+                <div className="flex items-center justify-between mb-2">
+                  <p className="text-xs font-bold uppercase tracking-widest text-zinc-500">Focus Areas &amp; Difficulties</p>
+                  {onSaveDifficulty && <InlineAddDifficulty onSave={onSaveDifficulty} />}
+                </div>
+                {student.difficulties.length === 0 && student.weaknesses.length === 0 ? (
+                  <EmptyState text="No focus areas tracked" />
+                ) : (
+                  <>
+                    {student.difficulties.length > 0 && (
+                      <div className="overflow-x-auto rounded-lg border border-[#F4F2FD]">
+                        <table className="w-full text-sm">
+                          <thead className="bg-[#F4F2FD]">
+                            <tr>
+                              <th className="px-4 py-2 text-left text-xs font-bold uppercase text-zinc-500">Area</th>
+                              <th className="px-4 py-2 text-left text-xs font-bold uppercase text-zinc-500">Subcategory</th>
+                              <th className="px-4 py-2 text-left text-xs font-bold uppercase text-zinc-500">Trend</th>
+                              <th className="px-4 py-2 text-left text-xs font-bold uppercase text-zinc-500">Status</th>
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-[#F4F2FD]">
+                            {student.difficulties.map((d) => {
+                              const isCovered = d.status === 'Covered'
+                              const trendLabel = d.trend.charAt(0).toUpperCase() + d.trend.slice(1)
+                              const trendColor =
+                                d.trend.toLowerCase() === 'improving'
+                                  ? 'bg-green-100 text-green-700'
+                                  : d.trend.toLowerCase() === 'regressing' || d.trend.toLowerCase() === 'worsening'
+                                    ? 'bg-red-100 text-red-700'
+                                    : 'bg-zinc-100 text-zinc-600'
+                              return (
+                                <tr key={d.id} data-testid="difficulty-row" className="hover:bg-[#FAFAFA] transition-colors">
+                                  <td className="px-4 py-3 font-semibold text-[#1A1B22] align-top">{d.competency}</td>
+                                  <td className="px-4 py-3 text-zinc-600 align-top">{d.subcategory || d.description}</td>
+                                  <td className="px-4 py-3 align-top">
+                                    <span className={`inline-block text-xs font-bold rounded px-1.5 py-0.5 ${trendColor}`}>
+                                      {trendLabel}
+                                    </span>
+                                  </td>
+                                  <td className="px-4 py-3 align-top">
+                                    <div className="flex items-center gap-1.5">
+                                      <span
+                                        className={`inline-flex items-center gap-1 text-xs font-bold uppercase ${
+                                          isCovered ? 'text-zinc-400' : 'text-indigo-600'
+                                        }`}
+                                        data-testid={`difficulty-status-${d.id}`}
+                                      >
+                                        <span
+                                          className={`h-1.5 w-1.5 rounded-full ${
+                                            isCovered ? 'bg-zinc-400' : 'bg-indigo-500'
+                                          }`}
+                                        />
+                                        {isCovered ? 'Covered' : 'Working'}
+                                      </span>
+                                      {onToggleDifficultyStatus && (
+                                        <button
+                                          type="button"
+                                          className="text-xs text-zinc-300 hover:text-zinc-600 transition-colors ml-1"
+                                          onClick={() => onToggleDifficultyStatus(d.id, isCovered ? 'Active' : 'Covered')}
+                                          data-testid={`toggle-difficulty-status-${d.id}`}
+                                          aria-label={isCovered ? 'Mark as working' : 'Mark as covered'}
+                                        >
+                                          ↕
+                                        </button>
+                                      )}
+                                    </div>
+                                  </td>
+                                </tr>
+                              )
+                            })}
+                          </tbody>
+                        </table>
+                      </div>
+                    )}
+                    {student.weaknesses.length > 0 && (
+                      <div className="mt-3" data-testid="profile-weaknesses">
+                        <p className="text-xs text-zinc-400 font-medium mb-1.5">Areas to Improve</p>
+                        <div className="space-y-1.5">
+                          {student.weaknesses.map((w, i) => {
+                            const typeLabel = w.weaknessType.charAt(0).toUpperCase() + w.weaknessType.slice(1)
+                            const typeColor =
+                              w.weaknessType === 'grammatical'
+                                ? 'bg-indigo-100 text-indigo-700'
+                                : w.weaknessType === 'lexical'
+                                  ? 'bg-amber-100 text-amber-700'
+                                  : 'bg-zinc-100 text-zinc-600'
+                            return (
+                              <div key={`weakness-${i}-${w.weaknessType}`} className="flex items-center gap-2" data-testid="weakness-row">
+                                <span className={`text-xs font-medium rounded px-1.5 py-0.5 shrink-0 ${typeColor}`} data-testid="weakness-type-badge">
+                                  {typeLabel}
+                                </span>
+                                <span className="text-sm text-[#1A1B22]">{w.description}</span>
+                              </div>
+                            )
+                          })}
+                        </div>
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
             </div>
           </section>
 
-          {/* Focus Areas & Difficulties */}
-          <section data-testid="profile-focus-areas">
-            <SectionHeader>Focus Areas &amp; Difficulties</SectionHeader>
-            {student.difficulties.length === 0 && student.weaknesses.length === 0 ? (
-              <EmptyState text="No focus areas tracked" />
-            ) : (
-              <>
-                {student.difficulties.length > 0 && (
-                  <div className="mb-4 overflow-x-auto">
-                    <table className="w-full text-sm">
-                      <thead>
-                        <tr className="text-left">
-                          <th className="text-xs font-medium text-zinc-400 pb-2 pr-4">Area</th>
-                          <th className="text-xs font-medium text-zinc-400 pb-2 pr-4">Subcategory</th>
-                          <th className="text-xs font-medium text-zinc-400 pb-2 pr-4">Trend</th>
-                          <th className="text-xs font-medium text-zinc-400 pb-2">Status</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {student.difficulties.map((d) => {
-                          const isCovered = d.status === 'Covered'
-                          const trendLabel = d.trend.charAt(0).toUpperCase() + d.trend.slice(1)
-                          const trendColor =
-                            d.trend.toLowerCase() === 'improving'
-                              ? 'bg-green-100 text-green-700'
-                              : d.trend.toLowerCase() === 'regressing' || d.trend.toLowerCase() === 'worsening'
-                                ? 'bg-red-100 text-red-700'
-                                : 'bg-zinc-100 text-zinc-600'
-                          return (
-                            <tr key={d.id} data-testid="difficulty-row" className="border-t border-zinc-50">
-                              <td className="py-2 pr-4 text-[#1A1B22] align-top">{d.competency}</td>
-                              <td className="py-2 pr-4 text-[#1A1B22] align-top">{d.subcategory || d.description}</td>
-                              <td className="py-2 pr-4 align-top">
-                                <span className={`inline-block text-xs font-medium rounded px-1.5 py-0.5 ${trendColor}`}>
-                                  {trendLabel}
-                                </span>
-                              </td>
-                              <td className="py-2 align-top">
-                                <div className="flex items-center gap-1.5">
-                                  <span
-                                    className={`inline-flex items-center gap-1 text-xs font-medium ${
-                                      isCovered ? 'text-zinc-400' : 'text-green-600'
-                                    }`}
-                                    data-testid={`difficulty-status-${d.id}`}
-                                  >
-                                    <span
-                                      className={`h-1.5 w-1.5 rounded-full ${
-                                        isCovered ? 'bg-zinc-400' : 'bg-green-500'
-                                      }`}
-                                    />
-                                    {isCovered ? 'Covered' : 'Working'}
-                                  </span>
-                                  {onToggleDifficultyStatus && (
-                                    <button
-                                      type="button"
-                                      className="text-xs text-zinc-300 hover:text-zinc-600 transition-colors ml-1"
-                                      onClick={() => onToggleDifficultyStatus(d.id, isCovered ? 'Active' : 'Covered')}
-                                      data-testid={`toggle-difficulty-status-${d.id}`}
-                                      aria-label={isCovered ? 'Mark as working' : 'Mark as covered'}
-                                    >
-                                      ↕
-                                    </button>
-                                  )}
-                                </div>
-                              </td>
-                            </tr>
-                          )
-                        })}
-                      </tbody>
-                    </table>
-                  </div>
-                )}
-                {student.weaknesses.length > 0 && (
-                  <div data-testid="profile-weaknesses">
-                    <p className="text-xs text-zinc-400 font-medium mb-1.5">Areas to Improve</p>
-                    <div className="space-y-1.5">
-                      {student.weaknesses.map((w, i) => {
-                        const typeLabel = w.weaknessType.charAt(0).toUpperCase() + w.weaknessType.slice(1)
-                        const typeColor =
-                          w.weaknessType === 'grammatical'
-                            ? 'bg-indigo-100 text-indigo-700'
-                            : w.weaknessType === 'lexical'
-                              ? 'bg-amber-100 text-amber-700'
-                              : 'bg-zinc-100 text-zinc-600'
-                        return (
-                          <div key={`weakness-${i}-${w.weaknessType}`} className="flex items-center gap-2" data-testid="weakness-row">
-                            <span className={`text-xs font-medium rounded px-1.5 py-0.5 shrink-0 ${typeColor}`} data-testid="weakness-type-badge">
-                              {typeLabel}
-                            </span>
-                            <span className="text-sm text-[#1A1B22]">{w.description}</span>
+          {/* Teacher's Working Memory (dark, private teacher space) */}
+          {(hasWorkingMemory || showEmptySections) && (
+            <section
+              className="rounded-2xl p-6 text-white"
+              style={{ background: '#1A1B22' }}
+              data-testid="profile-teachers-working-memory"
+            >
+              <h3 className="text-[0.6875rem] font-bold uppercase tracking-widest text-[#C3C0FF] mb-5 flex items-center gap-2">
+                Teacher&apos;s Working Memory
+              </h3>
+
+              <div className="space-y-6">
+                {/* Personal notes (Sensitivities / Life Context) */}
+                {(parsedPersonalNotes || student.personalNotes) && (
+                  <div>
+                    <p className="text-[0.625rem] font-bold uppercase tracking-widest text-white/50 mb-2">
+                      Sensitivities / Life Context
+                    </p>
+                    {parsedPersonalNotes ? (
+                      <div className="space-y-2">
+                        {parsedPersonalNotes.sections.map((section, i) => (
+                          <div key={`pn-${i}-${section.label}`}>
+                            {section.label && (
+                              <p className="text-xs font-medium text-white/60 mb-0.5">{section.label}</p>
+                            )}
+                            <p className="text-sm text-white/90 whitespace-pre-wrap leading-relaxed">{section.text}</p>
                           </div>
-                        )
-                      })}
-                    </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="text-sm text-white/90 whitespace-pre-wrap leading-relaxed">{student.personalNotes}</p>
+                    )}
                   </div>
                 )}
-              </>
-            )}
-          </section>
 
-          {/* Personal notes */}
-          <section data-testid="profile-personal-notes">
-            <SectionHeader>Sensitivities / Life Context</SectionHeader>
-            {parsedPersonalNotes ? (
-              <div className="space-y-2">
-                {parsedPersonalNotes.sections.map((section, i) => (
-                  <div key={`pn-${i}-${section.label}`}>
-                    {section.label && (
-                      <p className="text-xs font-medium text-zinc-500 mb-0.5">{section.label}</p>
+                {/* Teaching notes (Pedagogical Observations) */}
+                {(parsedTeachingNotes || student.teachingNotes) && (
+                  <div className={parsedPersonalNotes || student.personalNotes ? 'pt-4 border-t border-white/10' : ''}>
+                    <p className="text-[0.625rem] font-bold uppercase tracking-widest text-white/50 mb-2">
+                      Pedagogical Observations
+                    </p>
+                    {parsedTeachingNotes ? (
+                      <div className="space-y-2 border-l-2 border-indigo-400/50 pl-3">
+                        {parsedTeachingNotes.sections.map((section, i) => (
+                          <div key={`tn-${i}-${section.label}`}>
+                            {section.label && (
+                              <p className="text-xs font-medium text-white/60 mb-0.5">{section.label}</p>
+                            )}
+                            <p className="text-sm text-white/90 whitespace-pre-wrap leading-relaxed">{section.text}</p>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="text-sm text-white/90 whitespace-pre-wrap leading-relaxed border-l-2 border-indigo-400/50 pl-3">
+                        {student.teachingNotes}
+                      </p>
                     )}
-                    <p className="text-sm text-[#1A1B22] whitespace-pre-wrap">{section.text}</p>
                   </div>
-                ))}
-              </div>
-            ) : student.personalNotes ? (
-              <p className="text-sm text-[#1A1B22] whitespace-pre-wrap">{student.personalNotes}</p>
-            ) : (
-              <EmptyState text="No personal notes" />
-            )}
-          </section>
+                )}
 
-          {/* Teaching notes */}
-          <section data-testid="profile-teaching-notes">
-            <SectionHeader>Pedagogical Observations</SectionHeader>
-            {parsedTeachingNotes ? (
-              <div className="space-y-2 border-l-2 border-indigo-200 pl-3">
-                {parsedTeachingNotes.sections.map((section, i) => (
-                  <div key={`tn-${i}-${section.label}`}>
-                    {section.label && (
-                      <p className="text-xs font-medium text-zinc-500 mb-0.5">{section.label}</p>
-                    )}
-                    <p className="text-sm text-[#1A1B22] whitespace-pre-wrap">{section.text}</p>
-                  </div>
-                ))}
+                {!student.personalNotes && !student.teachingNotes && (
+                  <p className="text-sm text-white/40 italic">No notes added yet</p>
+                )}
               </div>
-            ) : student.teachingNotes ? (
-              <p className="text-sm text-[#1A1B22] whitespace-pre-wrap border-l-2 border-indigo-200 pl-3">{student.teachingNotes}</p>
-            ) : (
-              <EmptyState text="No pedagogical observations" />
-            )}
-          </section>
+            </section>
+          )}
         </div>
 
-        {/* Right column (2/5) */}
-        <div className="lg:col-span-2 space-y-6">
-          {/* Identity Details */}
-          <section data-testid="profile-about">
-            <SectionHeader>Identity Details</SectionHeader>
-            {hasAbout ? (
-              <div>
-                {origin && <FieldValue label="Origin" value={origin} />}
-                {location && <FieldValue label="Lives in" value={location} />}
-                {student.birthYear != null && (() => {
-                  const currentYear = new Date().getFullYear()
-                  return (
-                    <FieldValue
-                      label="Birth year"
-                      value={student.birthYear <= currentYear
-                        ? `${student.birthYear} (${currentYear - student.birthYear} years)`
-                        : `${student.birthYear}`}
-                    />
-                  )
-                })()}
-                <FieldValue label="Profession" value={student.profession} />
-              </div>
-            ) : (
-              <EmptyState text="No identity details added yet" />
-            )}
-          </section>
+        {/* ============================================================
+            RIGHT COLUMN (4/12)
+            ============================================================ */}
+        <div className="lg:col-span-4 space-y-6">
 
-          {/* Interests (dedicated editable section) */}
-          <InterestsSection key={student.id} student={student} onSave={onSaveInterests} />
+          {/* 1. Working Memory sidebar (Profession, Born+age, Origin, Residence) */}
+          {(hasAbout || showEmptySections) && (
+            <section
+              className="bg-white rounded-xl p-5"
+              style={{ boxShadow: '0 2px 12px rgba(26,27,34,0.06)' }}
+              data-testid="profile-about"
+            >
+              <SectionHeader>Teacher&apos;s Working Memory</SectionHeader>
+              {hasAbout ? (
+                <div>
+                  {student.profession && <FieldValue label="Profession" value={student.profession} />}
+                  {student.birthYear != null && (() => {
+                    const age = new Date().getFullYear() - student.birthYear!
+                    return <FieldValue label="Born" value={`${student.birthYear} (${age})`} />
+                  })()}
+                  {origin && <FieldValue label="Origin" value={origin} />}
+                  {location && <FieldValue label="Residence" value={location} />}
+                </div>
+              ) : (
+                <EmptyState text="No identity details added yet" />
+              )}
+            </section>
+          )}
 
-          {/* Language Ecosystem */}
+          {/* 2. Language Ecosystem */}
           <section data-testid="profile-language-ecosystem">
             <SectionHeader>Language Ecosystem</SectionHeader>
             <div className="space-y-2">
               {student.nativeLanguages.length > 0 && (
                 <div className="flex items-baseline gap-2 py-1">
-                  <span className="text-xs text-zinc-400 shrink-0 w-28">Native</span>
+                  <span className="text-xs text-zinc-400 shrink-0 w-20">Native</span>
                   <div className="flex flex-wrap gap-1.5">
                     {student.nativeLanguages.map((lang) => (
                       <span key={lang} className="inline-flex items-center gap-1 text-sm text-[#1A1B22]">
@@ -614,10 +961,13 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
                 </div>
               )}
               {student.spokenLanguages.length > 0 && (
-                <FieldValue label="Spoken Languages" value={student.spokenLanguages.join(', ')} />
+                <div className="flex items-baseline gap-2 py-1">
+                  <span className="text-xs text-zinc-400 shrink-0 w-20">Spoken</span>
+                  <span className="text-sm text-[#1A1B22]">{student.spokenLanguages.join(', ')}</span>
+                </div>
               )}
               <div className="flex items-baseline gap-2 py-1">
-                <span className="text-xs text-zinc-400 shrink-0 w-28">Learning</span>
+                <span className="text-xs text-zinc-400 shrink-0 w-20">Learning</span>
                 <span className="text-sm text-[#1A1B22] flex items-center gap-2">
                   {student.learningLanguage}
                   <CefrBadge level={student.cefrLevel} />
@@ -625,16 +975,10 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
               </div>
               {student.officialCefrLevel && (
                 <div className="flex items-baseline gap-2 py-1">
-                  <span className="text-xs text-zinc-400 shrink-0 w-28">Levels</span>
-                  <span className="text-sm text-[#1A1B22] flex items-center gap-3">
-                    <span className="flex items-center gap-1">
-                      <span className="text-xs text-zinc-500">Teacher's Assessment:</span>
-                      <CefrBadge level={student.cefrLevel} />
-                    </span>
-                    <span className="flex items-center gap-1">
-                      <span className="text-xs text-zinc-500">Official:</span>
-                      <CefrBadge level={student.officialCefrLevel} />
-                    </span>
+                  <span className="text-xs text-zinc-400 shrink-0 w-20">Official</span>
+                  <span className="text-sm text-[#1A1B22] flex items-center gap-1">
+                    <span className="text-xs text-zinc-500">Official:</span>
+                    <CefrBadge level={student.officialCefrLevel} />
                   </span>
                 </div>
               )}
@@ -644,24 +988,10 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
             </div>
           </section>
 
-          {/* Skill Assessment */}
-          <section data-testid="profile-skill-assessment">
-            <SectionHeader>Skill Assessment</SectionHeader>
-            {Object.keys(student.skillLevelOverrides ?? {}).length > 0 ? (
-              <div className="space-y-1.5">
-                {SKILL_ORDER.filter((s) => student.skillLevelOverrides?.[s]).map((skill) => (
-                  <div key={skill} className="flex items-center gap-3 py-0.5">
-                    <span className="text-xs text-zinc-400 w-20 shrink-0">{skill}</span>
-                    <CefrBadge level={student.skillLevelOverrides[skill]} data-testid={`skill-badge-${skill.toLowerCase()}`} />
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <EmptyState text="No skill overrides set" />
-            )}
-          </section>
+          {/* 3. Interests */}
+          <InterestsSection key={student.id} student={student} onSave={onSaveInterests} />
 
-          {/* Commercial */}
+          {/* 4. Commercial */}
           <section data-testid="profile-commercial">
             <SectionHeader>Commercial</SectionHeader>
             <div className="flex flex-wrap items-center gap-2">
@@ -688,7 +1018,7 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
             </div>
           </section>
 
-          {/* Teaching Todos */}
+          {/* 5. Teaching Todos */}
           <section data-testid="profile-teaching-todos">
             <SectionHeader>Teaching Todos</SectionHeader>
             <TeachingTodosCard
@@ -698,7 +1028,7 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
             />
           </section>
 
-          {/* Pending Followups */}
+          {/* 6. Pending Followups */}
           <section data-testid="profile-followups">
             <StudentFollowupsCard
               followups={followups}
@@ -708,6 +1038,21 @@ export function StudentProfileTab({ student, followups = [], onFollowupChange, o
           </section>
         </div>
       </div>
+
+      {/* Show all sections toggle */}
+      {anySectionCollapsed && (
+        <div className="mt-6 flex justify-center">
+          <button
+            type="button"
+            onClick={() => setShowEmptySections(true)}
+            className="flex items-center gap-1.5 text-xs text-zinc-400 hover:text-indigo-600 transition-colors"
+            data-testid="show-empty-sections-btn"
+          >
+            <ChevronDown className="h-3.5 w-3.5" />
+            Show all sections
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -338,7 +338,7 @@ function MotivationHero({
               ) : (
                 <div className="flex items-center gap-2">
                   <p className="font-manrope text-lg italic text-zinc-400 flex-1" data-testid="reason-quote">
-                    Why is this student learning Spanish?
+                    Why is this student learning {student.learningLanguage}?
                   </p>
                   {onSave && (
                     <button

--- a/frontend/src/lib/newId.ts
+++ b/frontend/src/lib/newId.ts
@@ -1,0 +1,5 @@
+export function newId(): string {
+  return typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
+}

--- a/frontend/src/pages/StudentDetail.test.tsx
+++ b/frontend/src/pages/StudentDetail.test.tsx
@@ -474,7 +474,7 @@ describe('StudentDetail - Profile tab sections', () => {
     await screen.findByTestId('profile-about')
     expect(screen.getByText('London, United Kingdom')).toBeInTheDocument()
     expect(screen.getByText('Barcelona, Spain')).toBeInTheDocument()
-    expect(screen.getByText(/^1995 \(\d+ years\)$/)).toBeInTheDocument()
+    expect(screen.getByText(/^1995 \(\d+\)$/)).toBeInTheDocument()
     expect(screen.getAllByText('Designer').length).toBeGreaterThanOrEqual(1)
   })
 
@@ -528,8 +528,10 @@ describe('StudentDetail - Profile tab sections', () => {
       teachingTodos: [],
     })
     await openProfileTab()
-    await screen.findByTestId('profile-about')
-    expect(screen.getByText('No identity details added yet')).toBeInTheDocument()
+    // identity sidebar is collapsed (no data) — show-empty-sections toggle is visible instead
+    await screen.findByTestId('show-empty-sections-btn')
+    expect(screen.queryByTestId('profile-about')).not.toBeInTheDocument()
+    // these sections are always shown (inside Pedagogical Diagnostic card)
     expect(screen.getByText('No learning goals set')).toBeInTheDocument()
     expect(screen.getByText('No objectives set')).toBeInTheDocument()
     expect(screen.getByTestId('teaching-todos-empty')).toBeInTheDocument()

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -18,6 +18,12 @@ import { SessionHistoryTab } from '@/components/session/SessionHistoryTab'
 import { ProgressDashboard } from '@/components/student/ProgressDashboard'
 import { getObjectiveUrgency, getDaysRemaining, formatDaysRemaining } from '@/lib/objectiveUrgency'
 
+function newId() {
+  return typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random()}`
+}
+
 function getInitials(name: string): string {
   return name
     .split(' ')
@@ -215,6 +221,45 @@ export default function StudentDetail() {
     },
     onError: (err) => {
       logger.error('StudentDetail', 'Failed to update teaching notes', err)
+    },
+  })
+
+  const { mutateAsync: saveLearningGoal } = useMutation({
+    mutationFn: (text: string) => {
+      const newGoal = { id: newId(), text, children: [] }
+      return updateStudent(id!, { ...buildStudentPayload(), learningGoals: [...student!.learningGoals, newGoal] })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['student', id] })
+    },
+    onError: (err) => {
+      logger.error('StudentDetail', 'Failed to add learning goal', err)
+    },
+  })
+
+  const { mutateAsync: saveShortTermObjective } = useMutation({
+    mutationFn: (text: string) => {
+      const newObj = { id: newId(), text, targetDate: null }
+      return updateStudent(id!, { ...buildStudentPayload(), shortTermObjectives: [...student!.shortTermObjectives, newObj] })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['student', id] })
+    },
+    onError: (err) => {
+      logger.error('StudentDetail', 'Failed to add objective', err)
+    },
+  })
+
+  const { mutateAsync: saveDifficulty } = useMutation({
+    mutationFn: ({ competency, description }: { competency: string; description: string }) => {
+      const newDiff = { id: newId(), competency, description, subcategory: '', severity: 'medium', trend: 'stable', status: 'Active' }
+      return updateStudent(id!, { ...buildStudentPayload(), difficulties: [...student!.difficulties, newDiff] })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['student', id] })
+    },
+    onError: (err) => {
+      logger.error('StudentDetail', 'Failed to add difficulty', err)
     },
   })
 
@@ -444,6 +489,9 @@ export default function StudentDetail() {
           }
           onSaveReasonForStudying={(v) => saveReasonForStudying(v).then(() => {})}
           onSaveInterests={(v) => saveInterests(v).then(() => {})}
+          onSaveLearningGoal={(text) => saveLearningGoal(text).then(() => {})}
+          onSaveShortTermObjective={(text) => saveShortTermObjective(text).then(() => {})}
+          onSaveDifficulty={(vars) => saveDifficulty(vars).then(() => {})}
         />
       )}
 

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, NotebookPen, Pencil, CalendarClock } from 'lucide-react'
 import { getStudent, updateStudent } from '../api/students'
 import type { Student } from '../api/students'
 import { logger } from '../lib/logger'
+import { newId } from '@/lib/newId'
 import { getFollowups } from '@/api/followups'
 import { listSessions } from '@/api/sessionLogs'
 import type { SessionLog } from '@/api/sessionLogs'
@@ -17,12 +18,6 @@ import { StudentOverviewTab } from '@/components/student/StudentOverviewTab'
 import { SessionHistoryTab } from '@/components/session/SessionHistoryTab'
 import { ProgressDashboard } from '@/components/student/ProgressDashboard'
 import { getObjectiveUrgency, getDaysRemaining, formatDaysRemaining } from '@/lib/objectiveUrgency'
-
-function newId() {
-  return typeof crypto !== 'undefined' && crypto.randomUUID
-    ? crypto.randomUUID()
-    : `${Date.now()}-${Math.random()}`
-}
 
 function getInitials(name: string): string {
   return name

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -7,6 +7,7 @@ import { TeachingTodosCard } from '@/components/student/TeachingTodosCard'
 import { getObjectiveUrgency } from '@/lib/objectiveUrgency'
 import { COMPETENCY_OPTIONS } from '../lib/studentOptions'
 import { logger } from '../lib/logger'
+import { newId } from '@/lib/newId'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -288,12 +289,9 @@ export default function StudentForm() {
   }
 
   function addDifficulty() {
-    const newId = typeof crypto !== 'undefined' && crypto.randomUUID
-      ? crypto.randomUUID()
-      : `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
     setDifficulties((prev) => [
       ...prev,
-      { id: newId, description: '', competency: '', subcategory: '', severity: 'medium', trend: 'stable', status: 'Active' },
+      { id: newId(), description: '', competency: '', subcategory: '', severity: 'medium', trend: 'stable', status: 'Active' },
     ])
   }
 
@@ -330,10 +328,7 @@ export default function StudentForm() {
   }
 
   function addObjective() {
-    const newId = typeof crypto !== 'undefined' && crypto.randomUUID
-      ? crypto.randomUUID()
-      : `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`
-    setShortTermObjectives((prev) => [...prev, { id: newId, text: '', targetDate: null }])
+    setShortTermObjectives((prev) => [...prev, { id: newId(), text: '', targetDate: null }])
   }
 
   function updateObjective(objId: string, field: 'text' | 'targetDate', value: string | null) {

--- a/plan/langteach-beta/t721-student-detail-profile-tab-polish/task721-student-detail-profile-tab-polish.md
+++ b/plan/langteach-beta/t721-student-detail-profile-tab-polish/task721-student-detail-profile-tab-polish.md
@@ -1,0 +1,151 @@
+# Task 721: Student Detail Profile Tab - Stitch Alignment & Inline-Add
+
+## Issue
+[#721](https://github.com/Robert-Freire/langTeachSaaS/issues/721) - polish: Student Detail Profile tab Stitch alignment and inline-add
+
+## Stitch Reference
+`plan/langteach-beta/stitch-design-system/student-detail/2. profile/` (DESIGN.md, code.html, screen.png)
+
+## Acceptance Criteria Checklist
+
+- [ ] Column proportions ~60-65% left, ~35-40% right (grid-cols-12, col-span-8 / col-span-4)
+- [ ] Right column order: (1) Working Memory sidebar, (2) Language Ecosystem, (3) Interests, (4) Commercial, (5) Teaching Todos, (6) Pending Followups
+- [ ] Motivation banner: Manrope large typography, key phrase highlighted in indigo italic, interest chips inside banner
+- [ ] Pedagogical Diagnostic tonal card with graduation-cap/analytics icon, containing: Learning Goals, Short-Term Objectives, Skill Assessment, Focus Areas & Difficulties
+- [ ] Skill Assessment as horizontal 4-column large square CEFR badges inside Pedagogical Diagnostic card
+- [ ] Focus Areas & Difficulties table inside the Pedagogical Diagnostic tonal card
+- [ ] Teacher's Working Memory: unified section merging Sensitivities + Pedagogical Observations, dark tonal background
+- [ ] Right column: Working Memory sidebar card (Profession, Born+age, Origin, Residence) at top
+- [ ] Section header visual weight differentiated via tonal layering
+- [ ] Inline-add for Learning Goals (+ icon in header, inline text input; LearningGoalTreeEditor remains for full-form edit)
+- [ ] Inline-add for Short-Term Objectives (+ icon in header, inline text input; date not required for quick add)
+- [ ] Inline-add for Focus Areas & Difficulties (+ icon in header, inline competency + description inputs)
+- [ ] Collapse unpopulated secondary sections with expand toggle (keep Motivation, Language Ecosystem, Pedagogical Diagnostic always visible)
+- [ ] Unit tests updated for new layout, new inline-add interactions
+- [ ] E2E test: inline-add Learning Goal on profile tab
+
+## Architecture
+
+### No infrastructure gap
+The inline-add for Learning Goals, Short-Term Objectives, and Difficulties will follow the same pattern as Interests and Reason (existing): call `updateStudent` via `buildStudentPayload()` with the appended item. The PUT endpoint supports all fields.
+
+New callbacks wired in `StudentDetail.tsx`:
+- `onSaveLearningGoal(text: string): Promise<void>` - appends `{ id: newId(), text, children: [] }` (use existing `newId()` helper from LearningGoalTreeEditor or inline same fallback)
+- `onSaveShortTermObjective(text: string): Promise<void>` - appends `{ id: newId(), text, targetDate: null }`
+- `onSaveDifficulty(vars: { competency: string; description: string }): Promise<void>` - appends with defaults (severity: 'medium', trend: 'stable', status: 'Active', subcategory: '')
+
+Note: All three callbacks must use `mutateAsync` (not `mutate`) so they return a `Promise<void>`, consistent with existing `saveReasonForStudying` / `saveInterests` pattern.
+
+### Key design decisions
+
+**Hero banner shape:** Stitch uses `rounded-full` (= 0.75rem per custom config, not full pill) with a decorative circle in top-right corner. Replicate with `rounded-xl` + relative overflow-hidden + decorative bleed.
+
+**Motivation key phrase highlight:** The highlighted phrase uses `text-primary italic`. Since we don't have NLP to auto-detect key phrases, we highlight the first sentence or the student's stated core goal. For simplicity: highlight the **last sentence** (or the whole quote if it's short). An alternative: the teacher can click to toggle which part is highlighted - out of scope for this task. Simple approach: apply indigo italic to the entire quote text (keeps the spirit without requiring phrase detection).
+
+Actually, re-reading the AC: "key phrase highlighted in indigo italic" - looking at the Stitch HTML, the whole quote is in large Manrope, and a span within it is `text-primary italic`. Since we can't programmatically determine the key phrase, we'll render the full quote in Manrope large and apply indigo italic to the entire thing (consistent with the spirit). No need for phrase detection.
+
+**Skill Assessment location:** Moves from right column to inside Pedagogical Diagnostic card (left column). The right column no longer has a separate Skill Assessment section.
+
+**Empty state collapse:** A section is "collapsible" if it has no data AND is not in the priority set (Motivation, Language Ecosystem, Pedagogical Diagnostic). Collapsible sections start collapsed. A "Show more sections" expander at the bottom of each column reveals them. Implementation: `useState<boolean>` for `showEmptySections` defaulting to `false`.
+
+## Files to Change
+
+### 1. `frontend/src/components/student/StudentProfileTab.tsx`
+Major restructure:
+- Change outer grid from `grid-cols-1 lg:grid-cols-5` to `grid-cols-1 lg:grid-cols-12`
+- Left col: `lg:col-span-8`, right col: `lg:col-span-4`
+- Hero: Manrope `text-2xl lg:text-3xl font-extrabold`, indigo italic for whole quote text, interests chips inside banner
+- Left column layout (top to bottom):
+  1. Pedagogical Diagnostic card (white, shadow, rounded-xl, `GraduationCap` or `BookOpen` icon): contains Learning Goals (with inline-add), Short-Term Objectives (with inline-add), Skill Assessment (4-col horizontal badges), Focus Areas & Difficulties (with inline-add)
+  2. Teacher's Working Memory (dark tonal bg, merged personalNotes + teachingNotes)
+- Right column layout (top to bottom):
+  1. Working Memory sidebar: Profession, Born (age calc), Origin, Residence
+  2. Language Ecosystem
+  3. Interests (with existing inline-edit)
+  4. Commercial
+  5. Teaching Todos
+  6. Pending Followups
+- Inline-add affordances (+ button in section header for Learning Goals, Short-Term Objectives, Difficulties)
+- Empty state collapse for sections with no data
+
+New props on `StudentProfileTab`:
+```tsx
+onSaveLearningGoal?: (text: string) => Promise<void>
+onSaveShortTermObjective?: (text: string) => Promise<void>
+onSaveDifficulty?: (vars: { competency: string; description: string }) => Promise<void>
+```
+
+### 2. `frontend/src/pages/StudentDetail.tsx`
+Add three new save callbacks using `mutateAsync` (same pattern as `saveReasonForStudying`/`saveInterests`):
+```tsx
+const saveLearningGoalMutation = useMutation({
+  mutationFn: (text: string) => {
+    const newGoal = { id: newId(), text, children: [] }
+    return updateStudent(id!, { ...buildStudentPayload(), learningGoals: [...student!.learningGoals, newGoal] })
+  },
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['student', id] }),
+})
+
+const saveShortTermObjectiveMutation = useMutation({
+  mutationFn: (text: string) => {
+    const newObj = { id: newId(), text, targetDate: null }
+    return updateStudent(id!, { ...buildStudentPayload(), shortTermObjectives: [...student!.shortTermObjectives, newObj] })
+  },
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['student', id] }),
+})
+
+const saveDifficultyMutation = useMutation({
+  mutationFn: ({ competency, description }: { competency: string; description: string }) => {
+    const newDiff = { id: newId(), competency, description, subcategory: '', severity: 'medium', trend: 'stable', status: 'Active' }
+    return updateStudent(id!, { ...buildStudentPayload(), difficulties: [...student!.difficulties, newDiff] })
+  },
+  onSuccess: () => queryClient.invalidateQueries({ queryKey: ['student', id] }),
+})
+```
+
+Wire as props (using `.then(() => {})` wrapper like existing patterns):
+```tsx
+onSaveLearningGoal={(text) => saveLearningGoalMutation.mutateAsync(text).then(() => {})}
+onSaveShortTermObjective={(text) => saveShortTermObjectiveMutation.mutateAsync(text).then(() => {})}
+onSaveDifficulty={(vars) => saveDifficultyMutation.mutateAsync(vars).then(() => {})}
+```
+
+The `newId()` helper: inline the same fallback used in LearningGoalTreeEditor:
+```tsx
+function newId() {
+  return typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`
+}
+
+### 3. `frontend/src/components/student/StudentProfileTab.test.tsx`
+- Update layout assertions (col-span-8 / col-span-4 not 3/2)
+- Add tests for: inline-add goal shows input on + click, confirms save, hides on cancel
+- Add tests for: inline-add objective, inline-add difficulty
+- Add test for empty state collapse (secondary empty sections hidden initially, show after toggle)
+
+### 4. `e2e/tests/student-detail.spec.ts`
+- Add test: navigate to profile tab for Ana Visual, click + on Learning Goals, type goal, press Enter, verify it appears in the list
+
+## Implementation Steps
+
+1. Add new callbacks in `StudentDetail.tsx`
+2. Implement inline-add sub-components in `StudentProfileTab.tsx`:
+   - `InlineAddGoal` - text input, Enter to save, Escape to cancel
+   - `InlineAddObjective` - text input (date optional, out of scope for now)
+   - `InlineAddDifficulty` - two inputs: competency (select or text) + description
+3. Restructure `StudentProfileTab.tsx` layout (grid-cols-12, left 8 / right 4)
+4. Redesign Motivation hero banner (Manrope, indigo italic, chips inside)
+5. Create Pedagogical Diagnostic tonal card with horizontal skill badges inside
+6. Move Skill Assessment into Pedagogical Diagnostic card
+7. Move Focus Areas & Difficulties into Pedagogical Diagnostic card (tonal sub-card)
+8. Unify Teacher's Working Memory (merge personal + teaching notes, dark bg)
+9. Reorder right column per Isaac's pedagogical order
+10. Add Working Memory sidebar card (top of right column)
+11. Implement empty state progressive disclosure
+12. Update unit tests
+13. Add e2e test
+
+## E2E Student
+Use "Ana Visual" for the profile tab e2e inline-add test. Note: Ana Visual starts with no LearningGoals in the seeder (only Difficulties/Weaknesses), so the test will add to an empty list - that is fine and actually tests the empty-state + inline-add path together. For verifying existing goals rendering, "Ana Seed" is the correct rich-profile student.
+
+## Test Data Note
+The inline-add e2e test will create a new learning goal and verify it appears. The test should clean up (or use a fresh student). Since e2e uses the full stack, the save will persist to the DB for the duration of the test run - acceptable.

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -3,6 +3,8 @@
 Out-of-scope observations logged by agents during implementation. Each row is something an agent noticed but did not fix because it was outside the current task's scope. These get batched into future GitHub issues by the PM.
 
 | Source issue | Date | Severity | Observation |
+| #721 | 2026-04-14 | low | Ana Seed has no SkillLevelOverrides in seeder so horizontal Skill Assessment badges on Profile tab cannot be visually verified. Consider adding skill overrides to Ana Seed seeder entry. |
+| #721 | 2026-04-14 | low | Ana Seed has PersonalNotes but no TeachingNotes in seeder; Teacher's Working Memory dark section only shows Sensitivities subsection. Consider adding TeachingNotes to Ana Seed for fuller visual verification. |
 | #674 | 2026-04-12 | low | review-ui agent could not find `log-session-button` testid on student detail page in create mode. Pre-existing selector mismatch, unrelated to this PR. Should be investigated and fixed in a future task. |
 | #626 | 2026-04-10 | medium | DemoSeeder uses PersonalNotes as seed-detection marker; if teacher edits that field the seeder loses track and may create duplicates. Pre-existing pattern (was Notes before this PR). Should use a dedicated IsDemo flag or deterministic seed name matching. |
 | #627 | 2026-04-10 | low | CodeRabbit suggested validating sourceSessionLogId/coveredInSessionLogId against DB. Dismissed: issue spec explicitly chose soft-backlink (stored UUID, no FK), Sophy approved. If referential integrity becomes a requirement, it can be added later. |

--- a/plan/ui-review-backlog.md
+++ b/plan/ui-review-backlog.md
@@ -12,6 +12,15 @@ Non-blocking findings from review-ui runs. Periodically review this file and bat
 |----------|--------|---------|
 | Low | Sessions list | Demo seeder creates sessions at now-7 and now-14 days at seeding time. By the time review-ui runs days later, sessions fall outside the 7-day Recent window, so the visual spec only verifies empty state. Row layout (CefrBadge, Label-SM headers, no-divider rows) cannot be visually verified until seeder is updated to use -1/-3 day offsets or a fresh seed is done close to review time. |
 
+## 2026-04-14 (task #721 review-ui)
+
+| Severity | Screen | Finding |
+|----------|--------|---------|
+| Low | Student Detail / Profile tab | Ana Seed has no `SkillLevelOverrides` in seeder so horizontal Skill Assessment badges cannot be visually verified. Would need seeder update to add skill overrides to Ana Seed. Unit tests verify the badge layout. |
+| Low | Student Detail / Profile tab | Ana Seed has `PersonalNotes` but no `TeachingNotes` in seeder, so Teacher's Working Memory dark section shows only Sensitivities subsection. To verify both subsections, add TeachingNotes to Ana Seed seeder entry. |
+| Info | Student Detail / Profile tab | Right-column "Teacher's Working Memory" sidebar (white card with Profession/Born/Origin/Residence) has same label as left-column dark notes section. Both labeled per Stitch spec. Naming duplication may confuse reviewers but is intentional design distinction. |
+| Low | Student Detail / Profile tab | Ana Visual's Teacher's Working Memory dark section shows VisualTag marker string as content (expected seeder data artifact). Not a code issue; personalNotes = VisualTag is intentionally set in seeder as a marker. |
+
 ## 2026-04-14 (task #718 review-ui)
 
 | Severity | Screen | Finding |


### PR DESCRIPTION
## Summary

- Restructures Profile tab to 12-column grid (66% left pedagogical / 33% right admin sidebar) matching Stitch proportions
- Redesigns Motivation hero banner with large Manrope quote in indigo italic, interest chips pulled inside the banner
- Wraps Pedagogical Diagnostic in a tonal card with graduation cap icon, containing Learning Goals, Short-Term Objectives, horizontal large-square CEFR skill badges, and Focus Areas & Difficulties table
- Unifies Teacher's Working Memory into one dark (#1A1B22) section merging personal notes and teaching notes
- Reorders right column per Isaac's pedagogical priority (Working Memory identity sidebar at top, then Language Ecosystem, Interests, Commercial, Teaching Todos, Followups)
- Adds inline-add affordances (+ icon in section header) for Learning Goals, Short-Term Objectives, and Focus Areas & Difficulties - all wired via `updateStudent` PUT in StudentDetail.tsx
- Implements empty state progressive disclosure: identity sidebar and teacher notes section collapse when empty, with a "Show all sections" toggle
- Extracts `newId()` to `frontend/src/lib/newId.ts` (was duplicated 4x across codebase)
- Replaces duplicate CEFR color logic in SkillBadgeSquare with `CefrBadge` composition

## Test plan

- [ ] Profile tab renders correctly on Ana Seed (rich-profile: goals, interests, difficulties, notes)
- [ ] Inline-add Learning Goal: click +, type goal, press Enter - goal appears in list
- [ ] Inline-add Short-Term Objective: click +, type, Enter - objective appears
- [ ] Inline-add Difficulty: click +, fill competency + description, Enter - row appears in table
- [ ] Empty state: new student (no identity/notes) shows "Show all sections" toggle; clicking reveals hidden sections
- [ ] Teacher's Working Memory dark section shows both personal notes and teaching notes subsections when both are set
- [ ] Unit tests: `npx vitest run` - 1184 tests pass
- [ ] Build: `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added inline editing for Learning Goals, Short-term Objectives, and Focus Area Difficulties on the Student Profile tab.
  * Introduced a "Show all sections" toggle to reveal empty profile sections.
  * Added new "Teacher's Working Memory" section for additional student context.

* **Tests**
  * Added E2E tests validating inline creation flows on the Student Profile tab.
  * Expanded unit tests for new interactive features and empty-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->