### PR TITLE
feat(t722): Sessions tab polish - kebab menu, HW status icon, layout improvements

### DIFF
--- a/e2e/tests/visual/session-history.visual.spec.ts
+++ b/e2e/tests/visual/session-history.visual.spec.ts
@@ -122,11 +122,11 @@ test('@visual session history tab - edit dialog pre-populated', async ({ browser
   await page.getByRole('tab', { name: /sessions/i }).click()
   await expect(page.getByTestId('session-history-list')).toBeVisible({ timeout: UI_TIMEOUT })
 
-  // Expand the first session entry and open edit dialog
+  // Open kebab menu on the first session entry and click Edit
   const firstEntry = page.getByTestId('session-entry').first()
-  await firstEntry.getByTestId('session-entry-toggle').click()
-  await expect(firstEntry.getByTestId('session-entry-detail')).toBeVisible()
-  await firstEntry.getByTestId('edit-session-button').click()
+  await firstEntry.getByTestId('session-kebab-trigger').click()
+  await expect(page.getByTestId('edit-session-button')).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.getByTestId('edit-session-button').click()
 
   // Dialog opens in edit mode
   await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: UI_TIMEOUT })

--- a/frontend/src/components/session/SessionHistoryTab.test.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.test.tsx
@@ -611,4 +611,23 @@ describe('SessionHistoryTab', () => {
     const grid = detail.querySelector('.grid')
     expect(grid?.className).not.toContain('md:grid-cols-3')
   })
+
+  it('uses full-width layout when only hw status icon exists (no homework assigned, no next plan)', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      {
+        ...SESSION_BASE,
+        homeworkAssigned: null,
+        nextSessionTopics: null,
+        previousHomeworkStatusName: 'Done',
+        previousHomeworkStatus: 1,
+      },
+    ])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    fireEvent.click(screen.getByTestId('session-entry-toggle'))
+    const detail = screen.getByTestId('session-entry-detail')
+    // Right column should not render even when hw status icon is present
+    const grid = detail.querySelector('.grid')
+    expect(grid?.className).not.toContain('md:grid-cols-3')
+  })
 })

--- a/frontend/src/components/session/SessionHistoryTab.test.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.test.tsx
@@ -97,8 +97,10 @@ describe('SessionHistoryTab', () => {
     expect(await screen.findAllByTestId('session-entry')).toHaveLength(1)
   })
 
-  it('shows actualContent snippet in collapsed state with line-clamp-1', async () => {
-    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
+  it('shows actualContent snippet in collapsed state with line-clamp-1 when title exists', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SESSION_BASE, title: 'Preterito Indefinido' },
+    ])
     wrapper()
     await screen.findByTestId('session-entry')
     const actualEl = screen.getByText(/Covered basics and exercises/)
@@ -106,6 +108,16 @@ describe('SessionHistoryTab', () => {
     expect(actualEl.closest('p')).toHaveClass('line-clamp-1')
     // plannedContent is NOT shown in collapsed state
     expect(screen.queryByText(/Preterito indefinido intro/)).not.toBeInTheDocument()
+  })
+
+  it('shows actualContent snippet with line-clamp-2 when no title', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SESSION_BASE, title: null },
+    ])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    const actualEl = screen.getByText(/Covered basics and exercises/)
+    expect(actualEl.closest('p')).toHaveClass('line-clamp-2')
   })
 
   it('hides actualContent snippet when expanded and shows it in detail section', async () => {
@@ -168,28 +180,36 @@ describe('SessionHistoryTab', () => {
     expect(chips[1]).toHaveTextContent('viajes')
   })
 
-  it('shows delete button in expanded view', async () => {
+  it('shows kebab menu trigger in collapsed row', async () => {
     vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
     wrapper()
     await screen.findByTestId('session-entry')
-    fireEvent.click(screen.getByTestId('session-entry-toggle'))
-    expect(screen.getByTestId('delete-session-button')).toBeInTheDocument()
+    expect(screen.getByTestId('session-kebab-trigger')).toBeInTheDocument()
   })
 
-  it('shows edit button in expanded view', async () => {
+  it('shows delete button in kebab menu', async () => {
     vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
     wrapper()
     await screen.findByTestId('session-entry')
-    fireEvent.click(screen.getByTestId('session-entry-toggle'))
-    expect(screen.getByTestId('edit-session-button')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('session-kebab-trigger'))
+    expect(await screen.findByTestId('delete-session-button')).toBeInTheDocument()
+  })
+
+  it('shows edit button in kebab menu', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    fireEvent.click(screen.getByTestId('session-kebab-trigger'))
+    expect(await screen.findByTestId('edit-session-button')).toBeInTheDocument()
   })
 
   it('clicking edit button opens SessionLogDialog in edit mode', async () => {
     vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
     wrapper()
     await screen.findByTestId('session-entry')
-    fireEvent.click(screen.getByTestId('session-entry-toggle'))
-    fireEvent.click(screen.getByTestId('edit-session-button'))
+    fireEvent.click(screen.getByTestId('session-kebab-trigger'))
+    const editBtn = await screen.findByTestId('edit-session-button')
+    fireEvent.click(editBtn)
     await waitFor(() => {
       expect(screen.getByTestId('session-log-dialog')).toBeInTheDocument()
       expect(screen.getByText('Edit Session')).toBeInTheDocument()
@@ -201,8 +221,9 @@ describe('SessionHistoryTab', () => {
     vi.mocked(sessionLogsApi.deleteSession).mockResolvedValue(undefined)
     wrapper()
     await screen.findByTestId('session-entry')
-    fireEvent.click(screen.getByTestId('session-entry-toggle'))
-    fireEvent.click(screen.getByTestId('delete-session-button'))
+    fireEvent.click(screen.getByTestId('session-kebab-trigger'))
+    const deleteBtn = await screen.findByTestId('delete-session-button')
+    fireEvent.click(deleteBtn)
     // Dialog opens but we cancel
     const cancelBtn = await screen.findByRole('button', { name: /cancel/i })
     fireEvent.click(cancelBtn)
@@ -214,8 +235,9 @@ describe('SessionHistoryTab', () => {
     vi.mocked(sessionLogsApi.deleteSession).mockResolvedValue(undefined)
     wrapper()
     await screen.findByTestId('session-entry')
-    fireEvent.click(screen.getByTestId('session-entry-toggle'))
-    fireEvent.click(screen.getByTestId('delete-session-button'))
+    fireEvent.click(screen.getByTestId('session-kebab-trigger'))
+    const deleteBtn = await screen.findByTestId('delete-session-button')
+    fireEvent.click(deleteBtn)
     const confirmBtn = await screen.findByTestId('confirm-delete-session')
     fireEvent.click(confirmBtn)
     await waitFor(() => {
@@ -358,12 +380,14 @@ describe('SessionHistoryTab', () => {
     expect(screen.queryByTestId('next-session-topics-section')).not.toBeInTheDocument()
   })
 
-  it('shows "Start next session" button in expanded view when nextSessionTopics is non-empty', async () => {
+  it('shows "Start next session" button inside the amber card when nextSessionTopics is non-empty', async () => {
     vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
     wrapper()
     await screen.findByTestId('session-entry')
     fireEvent.click(screen.getByTestId('session-entry-toggle'))
-    expect(screen.getByTestId('start-next-session-button')).toBeInTheDocument()
+    const section = screen.getByTestId('next-session-topics-section')
+    const button = section.querySelector('[data-testid="start-next-session-button"]')
+    expect(button).not.toBeNull()
   })
 
   it('does not show "Start next session" button when nextSessionTopics is null', async () => {
@@ -521,5 +545,70 @@ describe('SessionHistoryTab', () => {
     wrapper()
     await screen.findByTestId('session-entry')
     expect(screen.getByText(/Session, Apr 5/)).toBeInTheDocument()
+  })
+
+  it('shows homework status icon in collapsed row when previousHomeworkStatusName is set', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SESSION_BASE, previousHomeworkStatusName: 'Done' },
+    ])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    expect(screen.getByTestId('hw-status-icon')).toBeInTheDocument()
+    expect(screen.getByTestId('hw-status-icon')).toHaveTextContent('✓')
+  })
+
+  it('shows x icon when homework not done', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SESSION_BASE, previousHomeworkStatusName: 'NotDone', previousHomeworkStatus: 2 },
+    ])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    expect(screen.getByTestId('hw-status-icon')).toHaveTextContent('✗')
+  })
+
+  it('shows half-circle icon when homework partially done', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SESSION_BASE, previousHomeworkStatusName: 'Partial', previousHomeworkStatus: 3 },
+    ])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    expect(screen.getByTestId('hw-status-icon')).toHaveTextContent('◑')
+  })
+
+  it('does not show homework status icon when previousHomeworkStatusName is empty', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SESSION_BASE, previousHomeworkStatusName: '', previousHomeworkStatus: 0 },
+    ])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    expect(screen.queryByTestId('hw-status-icon')).not.toBeInTheDocument()
+  })
+
+  it('does not show homework status icon when status is NotApplicable', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SESSION_BASE, previousHomeworkStatusName: 'NotApplicable', previousHomeworkStatus: 3 },
+    ])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    expect(screen.queryByTestId('hw-status-icon')).not.toBeInTheDocument()
+  })
+
+  it('uses full-width layout when no homework and no next plan', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      {
+        ...SESSION_BASE,
+        homeworkAssigned: null,
+        nextSessionTopics: null,
+        previousHomeworkStatusName: '',
+        previousHomeworkStatus: 0,
+      },
+    ])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    fireEvent.click(screen.getByTestId('session-entry-toggle'))
+    const detail = screen.getByTestId('session-entry-detail')
+    // The grid should not have md:grid-cols-3 when no right column content
+    const grid = detail.querySelector('.grid')
+    expect(grid?.className).not.toContain('md:grid-cols-3')
   })
 })

--- a/frontend/src/components/session/SessionHistoryTab.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.tsx
@@ -11,6 +11,7 @@ import {
   Mic,
   CalendarDays,
   Filter,
+  MoreHorizontal,
 } from 'lucide-react'
 import { SessionLogDialog } from './SessionLogDialog'
 import { logger } from '../../lib/logger'
@@ -24,7 +25,6 @@ import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import {
   AlertDialog,
-  AlertDialogTrigger,
   AlertDialogContent,
   AlertDialogHeader,
   AlertDialogTitle,
@@ -89,6 +89,7 @@ function SessionEntry({
   const [expanded, setExpanded] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
+  const [kebabOpen, setKebabOpen] = useState(false)
   const queryClient = useQueryClient()
 
   const { mutate: softDelete, isPending: isDeleting } = useMutation({
@@ -111,342 +112,380 @@ function SessionEntry({
   const hwInfo = (hwStatus ? HOMEWORK_STATUS_INFO[hwStatus] : undefined) ?? HW_STATUS_FALLBACK
   const isCancelled = session.isCancelled
   const isDraft = session.statusName === 'Draft'
+  const showHwIcon = Boolean(hwStatus && hwStatus !== 'NotApplicable')
+
+  // Right column is empty when there's no homework and no next plan
+  const hasRightColumn =
+    Boolean(session.homeworkAssigned) ||
+    Boolean(session.nextSessionTopics) ||
+    showHwIcon
 
   const cardClass = isCancelled
     ? 'bg-[#F4F2FD]/50 opacity-60 grayscale'
     : 'bg-white shadow-sm'
 
   return (
-    <div
-      className={`rounded-2xl ring-1 ring-[#C7C4D8]/10 overflow-hidden transition-all ${cardClass}`}
-      data-testid="session-entry"
-    >
-      {/* Collapsed row / header */}
-      <button
-        onClick={() => setExpanded((v) => !v)}
-        className="w-full text-left p-4 hover:bg-[#F4F2FD]/40 transition-colors"
-        aria-expanded={expanded}
-        data-testid="session-entry-toggle"
+    <>
+      <div
+        className={`rounded-2xl ring-1 ring-[#C7C4D8]/10 overflow-hidden transition-all ${cardClass}`}
+        data-testid="session-entry"
       >
-        <div className="flex items-center justify-between gap-3">
-          {/* Left: date badge + title + snippet */}
-          <div className="flex items-start gap-3 min-w-0 flex-1">
-            {/* Date badge */}
-            <div
-              className={`flex flex-col items-center justify-center shrink-0 rounded-xl w-12 h-12 ${
-                isCancelled ? 'bg-zinc-200 text-zinc-500' : 'bg-[#E2DFFF] text-[#3525CD]'
-              }`}
-            >
-              <span className="text-[8px] font-bold uppercase leading-none">{formatMonth(session.sessionDate)}</span>
-              <span className="text-lg font-extrabold leading-tight">{formatDay(session.sessionDate)}</span>
-            </div>
-
-            {/* Title + content */}
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2 flex-wrap mb-0.5">
-                <h3
-                  className={`font-bold text-sm text-[#1A1B22] ${isCancelled ? 'line-through text-zinc-500' : ''}`}
+        {/* Header row: expand button + kebab menu */}
+        <div className="flex items-stretch">
+          {/* Main expand button */}
+          <button
+            onClick={() => setExpanded((v) => !v)}
+            className="flex-1 min-w-0 text-left p-4 hover:bg-[#F4F2FD]/40 transition-colors"
+            aria-expanded={expanded}
+            data-testid="session-entry-toggle"
+          >
+            <div className="flex items-center gap-3">
+              {/* Left: date badge + title + snippet */}
+              <div className="flex items-start gap-3 min-w-0 flex-1">
+                {/* Date badge */}
+                <div
+                  className={`flex flex-col items-center justify-center shrink-0 rounded-xl w-12 h-12 ${
+                    isCancelled ? 'bg-zinc-200 text-zinc-500' : 'bg-[#E2DFFF] text-[#3525CD]'
+                  }`}
                 >
-                  {sessionTitle(session)}
-                </h3>
-                {isCancelled && (
-                  <span
-                    className="px-2 py-0.5 rounded bg-zinc-200 text-zinc-600 text-[9px] font-bold uppercase"
-                    data-testid="cancelled-badge"
-                  >
-                    Cancelled
-                  </span>
-                )}
-                {isDraft && !isCancelled && (
-                  <span
-                    className="px-2 py-0.5 rounded bg-amber-100 text-amber-700 text-[9px] font-bold uppercase"
-                    data-testid="draft-badge"
-                  >
-                    Pending review
-                  </span>
-                )}
-                {!isCancelled && !isDraft && (
-                  <span className="px-2 py-0.5 rounded bg-emerald-50 text-emerald-600 text-[9px] font-bold uppercase">
-                    Completed
-                  </span>
-                )}
-                {hasActionItem && (
-                  <span className="inline-flex items-center gap-1 text-xs text-amber-600" data-testid="action-item-count">
-                    <span className="bg-amber-400 rounded-full w-1.5 h-1.5 shrink-0" />
-                    1 action item
-                    {expanded ? (
-                      <ChevronUp className="h-3 w-3 shrink-0" />
-                    ) : (
-                      <ChevronDown className="h-3 w-3 shrink-0" />
+                  <span className="text-[8px] font-bold uppercase leading-none">{formatMonth(session.sessionDate)}</span>
+                  <span className="text-lg font-extrabold leading-tight">{formatDay(session.sessionDate)}</span>
+                </div>
+
+                {/* Title + content */}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2 flex-wrap mb-0.5">
+                    <h3
+                      className={`font-bold text-sm text-[#1A1B22] ${isCancelled ? 'line-through text-zinc-500' : ''}`}
+                    >
+                      {sessionTitle(session)}
+                    </h3>
+                    {isCancelled && (
+                      <span
+                        className="px-2 py-0.5 rounded bg-zinc-200 text-zinc-600 text-[9px] font-bold uppercase"
+                        data-testid="cancelled-badge"
+                      >
+                        Cancelled
+                      </span>
                     )}
+                    {isDraft && !isCancelled && (
+                      <span
+                        className="px-2 py-0.5 rounded bg-amber-100 text-amber-700 text-[9px] font-bold uppercase"
+                        data-testid="draft-badge"
+                      >
+                        Pending review
+                      </span>
+                    )}
+                    {!isCancelled && !isDraft && (
+                      <span className="px-2 py-0.5 rounded bg-emerald-50 text-emerald-600 text-[9px] font-bold uppercase">
+                        Completed
+                      </span>
+                    )}
+                    {hasActionItem && (
+                      <span className="inline-flex items-center gap-1 text-xs text-amber-600" data-testid="action-item-count">
+                        <span className="bg-amber-400 rounded-full w-1.5 h-1.5 shrink-0" />
+                        1 action item
+                        {expanded ? (
+                          <ChevronUp className="h-3 w-3 shrink-0" />
+                        ) : (
+                          <ChevronDown className="h-3 w-3 shrink-0" />
+                        )}
+                      </span>
+                    )}
+                    {hasNote && (
+                      <span className="inline-flex items-center gap-1 text-xs text-zinc-400" data-testid="general-note-count">
+                        <span className="bg-zinc-300 rounded-full w-1.5 h-1.5 shrink-0" />
+                        1 note
+                        {expanded ? (
+                          <ChevronUp className="h-3 w-3 shrink-0" />
+                        ) : (
+                          <ChevronDown className="h-3 w-3 shrink-0" />
+                        )}
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Snippet -- actualContent, slightly more prominent when no title */}
+                  {!expanded && session.actualContent && (
+                    <p className={`line-clamp-${session.title ? '1' : '2'} ${session.title ? 'text-xs text-zinc-500' : 'text-xs text-zinc-600'}`}>
+                      {session.actualContent}
+                    </p>
+                  )}
+
+                  {/* Next session topics preview */}
+                  {!expanded && session.nextSessionTopics && (
+                    <p className="text-xs text-amber-700 line-clamp-1" data-testid="next-session-topics-preview">
+                      <span className="font-medium">Next:</span>{' '}
+                      {session.nextSessionTopics}
+                    </p>
+                  )}
+
+                  {/* Topic chips (collapsed) */}
+                  {!expanded && topicTags.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-1">
+                      {topicTags.slice(0, 4).map((tag, i) => (
+                        <span
+                          key={`${tag.tag}-${i}`}
+                          className={`px-2 py-0.5 rounded-full text-[9px] font-bold ${tagCategoryClass(tag.category)}`}
+                        >
+                          {tag.tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Right: hw status icon + duration + mic + chevron */}
+              <div className="flex items-center gap-2 shrink-0">
+                {/* Homework status icon */}
+                {showHwIcon && (
+                  <span
+                    className={`text-sm font-bold leading-none ${hwInfo.color}`}
+                    title={hwInfo.label}
+                    data-testid="hw-status-icon"
+                  >
+                    {hwInfo.icon}
                   </span>
                 )}
-                {hasNote && (
-                  <span className="inline-flex items-center gap-1 text-xs text-zinc-400" data-testid="general-note-count">
-                    <span className="bg-zinc-300 rounded-full w-1.5 h-1.5 shrink-0" />
-                    1 note
-                    {expanded ? (
-                      <ChevronUp className="h-3 w-3 shrink-0" />
-                    ) : (
-                      <ChevronDown className="h-3 w-3 shrink-0" />
-                    )}
+                {(session.duration != null || isCancelled) && (
+                  <span className="text-xs text-zinc-400 font-medium" data-testid="duration-badge">
+                    {isCancelled ? '0' : session.duration} min
                   </span>
+                )}
+                {session.hasVoiceNote && (
+                  <span className="text-zinc-400" data-testid="voice-note-icon">
+                    <Mic className="h-4 w-4" />
+                  </span>
+                )}
+                {expanded ? (
+                  <ChevronUp className="h-4 w-4 text-zinc-400" />
+                ) : (
+                  <ChevronDown className="h-4 w-4 text-zinc-400" />
+                )}
+              </div>
+            </div>
+          </button>
+
+          {/* Kebab menu - outside the expand button */}
+          <div className="flex items-center px-2 shrink-0">
+            <Popover open={kebabOpen} onOpenChange={setKebabOpen}>
+              <PopoverTrigger
+                render={
+                  <button
+                    className="p-1.5 rounded-lg hover:bg-[#F4F2FD] text-zinc-400 hover:text-zinc-600 transition-colors"
+                    aria-label="Session options"
+                    data-testid="session-kebab-trigger"
+                  >
+                    <MoreHorizontal className="h-4 w-4" />
+                  </button>
+                }
+              />
+              <PopoverContent className="w-44 p-1" align="end" side="bottom">
+                <button
+                  className="w-full flex items-center gap-2 px-3 py-2 text-sm rounded-lg hover:bg-[#F4F2FD] text-[#1A1B22] transition-colors"
+                  onClick={() => {
+                    setKebabOpen(false)
+                    onEdit(session)
+                  }}
+                  data-testid="edit-session-button"
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                  Edit
+                </button>
+                <div className="h-px bg-[#C7C4D8]/20 my-1" />
+                <button
+                  className="w-full flex items-center gap-2 px-3 py-2 text-sm rounded-lg hover:bg-red-50 text-red-600 transition-colors"
+                  onClick={() => {
+                    setKebabOpen(false)
+                    setDeleteOpen(true)
+                  }}
+                  disabled={isDeleting}
+                  data-testid="delete-session-button"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Delete
+                </button>
+              </PopoverContent>
+            </Popover>
+          </div>
+        </div>
+
+        {/* Expanded detail */}
+        {expanded && (
+          <div
+            className="border-t border-[#C7C4D8]/10 p-5 bg-[#FBFAFF]"
+            data-testid="session-entry-detail"
+          >
+            <div className={`grid grid-cols-1 gap-6 ${hasRightColumn ? 'md:grid-cols-3' : ''}`}>
+              {/* Left/full: narrative + tags + notes */}
+              <div className={`${hasRightColumn ? 'md:col-span-2' : ''} space-y-5`}>
+                {session.actualContent && (
+                  <div>
+                    <h4 className="text-[10px] font-bold text-zinc-400 uppercase tracking-widest mb-2">
+                      Session Narrative
+                    </h4>
+                    <p className="text-sm leading-relaxed text-[#464455] italic whitespace-pre-wrap">
+                      &ldquo;{session.actualContent}&rdquo;
+                    </p>
+                  </div>
+                )}
+
+                {/* Planned content (only if different from actual) */}
+                {session.plannedContent && session.plannedContent !== session.actualContent && (
+                  <div>
+                    <h4 className="text-[10px] font-bold text-zinc-400 uppercase tracking-widest mb-2">
+                      What was planned
+                    </h4>
+                    <p className="text-sm text-[#1A1B22] whitespace-pre-wrap">{session.plannedContent}</p>
+                  </div>
+                )}
+
+                {/* Topic tags */}
+                {topicTags.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5">
+                    {topicTags.map((tag, i) => {
+                      const catLabel = tag.category
+                        ? (TAG_CATEGORY_LABELS[tag.category] ?? tag.category)
+                        : null
+                      return (
+                        <span
+                          key={`${tag.tag}-${i}`}
+                          className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-[10px] font-bold ${tagCategoryClass(tag.category)}`}
+                          data-testid="topic-tag-chip"
+                        >
+                          {tag.tag}
+                          {catLabel && <span className="opacity-60">({catLabel})</span>}
+                        </span>
+                      )
+                    })}
+                  </div>
+                )}
+
+                {/* Teacher notes */}
+                {session.generalNotes && (
+                  <div className="p-4 rounded-xl bg-white border-l-4 border-[#4F46E5] ring-1 ring-[#C7C4D8]/10">
+                    <h4 className="text-[10px] font-bold text-[#3525CD] uppercase tracking-widest mb-2">
+                      Teacher Notes
+                    </h4>
+                    <p className="text-sm text-[#1A1B22] whitespace-pre-wrap">{session.generalNotes}</p>
+                  </div>
+                )}
+
+                {/* Level reassessment */}
+                {session.levelReassessmentSkill && session.levelReassessmentLevel && (
+                  <div>
+                    <p className="text-xs font-medium text-zinc-500 mb-0.5">Level reassessment</p>
+                    <p className="text-sm text-[#1A1B22]">
+                      {session.levelReassessmentSkill}: {session.levelReassessmentLevel}
+                    </p>
+                  </div>
+                )}
+
+                {/* Linked lesson */}
+                {session.linkedLessonId && (
+                  <Link
+                    to={`/lessons/${session.linkedLessonId}`}
+                    className="inline-flex items-center gap-1.5 text-xs text-[#3525CD] hover:text-[#4F46E5] font-medium"
+                    data-testid="linked-lesson-link"
+                  >
+                    <ExternalLink className="h-3 w-3" />
+                    View linked lesson
+                  </Link>
                 )}
               </div>
 
-              {/* Snippet -- actualContent, hidden when expanded */}
-              {!expanded && session.actualContent && (
-                <p className="text-xs text-zinc-500 line-clamp-1">
-                  {session.actualContent}
-                </p>
-              )}
+              {/* Right: homework + next session plan (only rendered when needed) */}
+              {hasRightColumn && (
+                <div className="space-y-5">
+                  {/* Homework card */}
+                  {(showHwIcon || session.homeworkAssigned) ? (
+                    <div className="bg-[#F4F2FD] p-4 rounded-2xl">
+                      <h4 className="text-[10px] font-bold text-zinc-400 uppercase tracking-widest mb-3">
+                        Homework
+                      </h4>
+                      <div className="space-y-3">
+                        {showHwIcon && (
+                          <div>
+                            <p className="text-[10px] font-bold text-zinc-400 uppercase tracking-tight mb-1">
+                              Previous Homework Status
+                            </p>
+                            <div className="flex items-center gap-1.5" data-testid="hw-status-badge">
+                              <span className={`text-sm font-bold ${hwInfo.color}`}>{hwInfo.icon}</span>
+                              <span className={`text-xs font-bold uppercase tracking-wide ${hwInfo.color}`}>
+                                {hwInfo.label}
+                              </span>
+                            </div>
+                          </div>
+                        )}
+                        {session.homeworkAssigned && (
+                          <div className={showHwIcon ? 'pt-3 border-t border-[#C7C4D8]/20' : ''}>
+                            <p className="text-[10px] font-bold text-zinc-400 uppercase tracking-tight mb-1">
+                              Homework Assigned
+                            </p>
+                            <p className="text-sm font-semibold text-[#1A1B22]">{session.homeworkAssigned}</p>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  ) : null}
 
-              {/* Next session topics preview */}
-              {!expanded && session.nextSessionTopics && (
-                <p className="text-xs text-amber-700 line-clamp-1" data-testid="next-session-topics-preview">
-                  <span className="font-medium">Next:</span>{' '}
-                  {session.nextSessionTopics}
-                </p>
-              )}
-
-              {/* Topic chips (collapsed) */}
-              {!expanded && topicTags.length > 0 && (
-                <div className="flex flex-wrap gap-1 mt-1">
-                  {topicTags.slice(0, 4).map((tag, i) => (
-                    <span
-                      key={`${tag.tag}-${i}`}
-                      className={`px-2 py-0.5 rounded-full text-[9px] font-bold ${tagCategoryClass(tag.category)}`}
+                  {/* Next session plan */}
+                  {session.nextSessionTopics && (
+                    <div
+                      className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3"
+                      data-testid="next-session-topics-section"
                     >
-                      {tag.tag}
-                    </span>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* Right: duration + mic + chevron */}
-          <div className="flex items-center gap-2 shrink-0">
-            {(session.duration != null || isCancelled) && (
-              <span className="text-xs text-zinc-400 font-medium" data-testid="duration-badge">
-                {isCancelled ? '0' : session.duration} min
-              </span>
-            )}
-            {session.hasVoiceNote && (
-              <span className="text-zinc-400" data-testid="voice-note-icon">
-                <Mic className="h-4 w-4" />
-              </span>
-            )}
-            {expanded ? (
-              <ChevronUp className="h-4 w-4 text-zinc-400" />
-            ) : (
-              <ChevronDown className="h-4 w-4 text-zinc-400" />
-            )}
-          </div>
-        </div>
-      </button>
-
-      {/* Expanded detail */}
-      {expanded && (
-        <div
-          className="border-t border-[#C7C4D8]/10 p-5 bg-[#FBFAFF]"
-          data-testid="session-entry-detail"
-        >
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {/* Left: narrative + tags + notes + planned */}
-            <div className="md:col-span-2 space-y-5">
-              {session.actualContent && (
-                <div>
-                  <h4 className="text-[10px] font-bold text-zinc-400 uppercase tracking-widest mb-2">
-                    Session Narrative
-                  </h4>
-                  <p className="text-sm leading-relaxed text-[#464455] italic whitespace-pre-wrap">
-                    &ldquo;{session.actualContent}&rdquo;
-                  </p>
-                </div>
-              )}
-
-              {/* Planned content (only if different from actual) */}
-              {session.plannedContent && session.plannedContent !== session.actualContent && (
-                <div>
-                  <h4 className="text-[10px] font-bold text-zinc-400 uppercase tracking-widest mb-2">
-                    What was planned
-                  </h4>
-                  <p className="text-sm text-[#1A1B22] whitespace-pre-wrap">{session.plannedContent}</p>
-                </div>
-              )}
-
-              {/* Topic tags */}
-              {topicTags.length > 0 && (
-                <div className="flex flex-wrap gap-1.5">
-                  {topicTags.map((tag, i) => {
-                    const catLabel = tag.category
-                      ? (TAG_CATEGORY_LABELS[tag.category] ?? tag.category)
-                      : null
-                    return (
-                      <span
-                        key={`${tag.tag}-${i}`}
-                        className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-[10px] font-bold ${tagCategoryClass(tag.category)}`}
-                        data-testid="topic-tag-chip"
+                      <p className="text-[10px] font-bold text-amber-700 uppercase tracking-widest mb-2 flex items-center gap-1.5">
+                        <CalendarDays className="h-3 w-3" />
+                        Planned for next class
+                      </p>
+                      <p className="text-sm text-amber-900 whitespace-pre-wrap">{session.nextSessionTopics}</p>
+                      <button
+                        className="mt-3 inline-flex items-center gap-1.5 text-xs font-semibold text-amber-700 hover:text-amber-900 transition-colors"
+                        onClick={() => onStartNextSession(session)}
+                        data-testid="start-next-session-button"
                       >
-                        {tag.tag}
-                        {catLabel && <span className="opacity-60">({catLabel})</span>}
-                      </span>
-                    )
-                  })}
-                </div>
-              )}
-
-              {/* Teacher notes */}
-              {session.generalNotes && (
-                <div className="p-4 rounded-xl bg-white border-l-4 border-[#4F46E5] ring-1 ring-[#C7C4D8]/10">
-                  <h4 className="text-[10px] font-bold text-[#3525CD] uppercase tracking-widest mb-2">
-                    Teacher Notes
-                  </h4>
-                  <p className="text-sm text-[#1A1B22] whitespace-pre-wrap">{session.generalNotes}</p>
-                </div>
-              )}
-
-              {/* Level reassessment */}
-              {session.levelReassessmentSkill && session.levelReassessmentLevel && (
-                <div>
-                  <p className="text-xs font-medium text-zinc-500 mb-0.5">Level reassessment</p>
-                  <p className="text-sm text-[#1A1B22]">
-                    {session.levelReassessmentSkill}: {session.levelReassessmentLevel}
-                  </p>
-                </div>
-              )}
-
-              {/* Linked lesson */}
-              {session.linkedLessonId && (
-                <Link
-                  to={`/lessons/${session.linkedLessonId}`}
-                  className="inline-flex items-center gap-1.5 text-xs text-[#3525CD] hover:text-[#4F46E5] font-medium"
-                  data-testid="linked-lesson-link"
-                >
-                  <ExternalLink className="h-3 w-3" />
-                  View linked lesson
-                </Link>
-              )}
-            </div>
-
-            {/* Right: homework + next session plan */}
-            <div className="space-y-5">
-              {/* Homework card */}
-              {(hwStatus && hwStatus !== 'NotApplicable') || session.homeworkAssigned ? (
-                <div className="bg-[#F4F2FD] p-4 rounded-2xl">
-                  <h4 className="text-[10px] font-bold text-zinc-400 uppercase tracking-widest mb-3">
-                    Homework
-                  </h4>
-                  <div className="space-y-3">
-                    {hwStatus && hwStatus !== 'NotApplicable' && (
-                      <div>
-                        <p className="text-[10px] font-bold text-zinc-400 uppercase tracking-tight mb-1">
-                          Previous Homework Status
-                        </p>
-                        <div className="flex items-center gap-1.5" data-testid="hw-status-badge">
-                          <span className={`text-sm font-bold ${hwInfo.color}`}>{hwInfo.icon}</span>
-                          <span className={`text-xs font-bold uppercase tracking-wide ${hwInfo.color}`}>
-                            {hwInfo.label}
-                          </span>
-                        </div>
-                      </div>
-                    )}
-                    {session.homeworkAssigned && (
-                      <div className={hwStatus && hwStatus !== 'NotApplicable' ? 'pt-3 border-t border-[#C7C4D8]/20' : ''}>
-                        <p className="text-[10px] font-bold text-zinc-400 uppercase tracking-tight mb-1">
-                          Homework Assigned
-                        </p>
-                        <p className="text-sm font-semibold text-[#1A1B22]">{session.homeworkAssigned}</p>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              ) : null}
-
-              {/* Next session plan */}
-              {session.nextSessionTopics && (
-                <div
-                  className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3"
-                  data-testid="next-session-topics-section"
-                >
-                  <p className="text-[10px] font-bold text-amber-700 uppercase tracking-widest mb-2 flex items-center gap-1.5">
-                    <CalendarDays className="h-3 w-3" />
-                    Planned for next class
-                  </p>
-                  <p className="text-sm text-amber-900 whitespace-pre-wrap">{session.nextSessionTopics}</p>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {/* Actions row */}
-          <div className="flex flex-wrap justify-end gap-2 mt-5 pt-4 border-t border-[#C7C4D8]/10">
-            {session.nextSessionTopics && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => onStartNextSession(session)}
-                data-testid="start-next-session-button"
-                className="text-[#3525CD] border-[#4F46E5]/30 hover:bg-[#E2DFFF] hover:text-[#3525CD]"
-              >
-                <PlayCircle className="h-3.5 w-3.5 mr-1" />
-                Start next session
-              </Button>
-            )}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onEdit(session)}
-              data-testid="edit-session-button"
-            >
-              <Pencil className="h-3.5 w-3.5 mr-1" />
-              Edit
-            </Button>
-            <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-              <AlertDialogTrigger
-                render={
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="text-red-600 border-red-200 hover:bg-red-50 hover:text-red-700"
-                    disabled={isDeleting}
-                    data-testid="delete-session-button"
-                  >
-                    <Trash2 className="h-3.5 w-3.5 mr-1" />
-                    Delete
-                  </Button>
-                }
-              />
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Delete session log?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    This session record will be removed. This action cannot be undone.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  {deleteError && (
-                    <p className="text-xs text-red-600 w-full text-center mb-1" data-testid="delete-session-error">
-                      {deleteError}
-                    </p>
+                        <PlayCircle className="h-3.5 w-3.5" />
+                        Start next session
+                      </button>
+                    </div>
                   )}
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction
-                    onClick={() => softDelete()}
-                    disabled={isDeleting}
-                    className="bg-red-600 hover:bg-red-700 text-white"
-                    data-testid="confirm-delete-session"
-                  >
-                    {isDeleting ? 'Deleting...' : 'Delete'}
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+
+      {/* Delete confirmation dialog - at root level, not inside footer */}
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete session log?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This session record will be removed. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            {deleteError && (
+              <p className="text-xs text-red-600 w-full text-center mb-1" data-testid="delete-session-error">
+                {deleteError}
+              </p>
+            )}
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => softDelete()}
+              disabled={isDeleting}
+              className="bg-red-600 hover:bg-red-700 text-white"
+              data-testid="confirm-delete-session"
+            >
+              {isDeleting ? 'Deleting...' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   )
 }
 

--- a/frontend/src/components/session/SessionHistoryTab.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.tsx
@@ -114,11 +114,8 @@ function SessionEntry({
   const isDraft = session.statusName === 'Draft'
   const showHwIcon = Boolean(hwStatus && hwStatus !== 'NotApplicable')
 
-  // Right column is empty when there's no homework and no next plan
-  const hasRightColumn =
-    Boolean(session.homeworkAssigned) ||
-    Boolean(session.nextSessionTopics) ||
-    showHwIcon
+  // Right column is only needed when there's actual homework content or a next plan
+  const hasRightColumn = Boolean(session.homeworkAssigned) || Boolean(session.nextSessionTopics)
 
   const cardClass = isCancelled
     ? 'bg-[#F4F2FD]/50 opacity-60 grayscale'
@@ -459,7 +456,7 @@ function SessionEntry({
       </div>
 
       {/* Delete confirmation dialog - at root level, not inside footer */}
-      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+      <AlertDialog open={deleteOpen} onOpenChange={(open) => { setDeleteOpen(open); if (!open) setDeleteError(null) }}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Delete session log?</AlertDialogTitle>

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -6,6 +6,13 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 
 *Cleared 2026-04-08 during Adaptive Replanning sprint close. All entries deleted (low/info severity, all already deferred with sound reasoning) or batched into #603-#609.*
 
+## #722 — 2026-04-14
+
+| Reviewer | Severity | Note |
+|---|---|---|
+| architecture-reviewer | minor | `formatMonth`/`formatDay` in `SessionHistoryTab.tsx` duplicate shared util logic in `formatDate.ts`. Deferred as #737. |
+| architecture-reviewer | minor | `sessionTitle()` in `SessionHistoryTab.tsx` parallels `getDisplayTitle()` in `StudentOverviewTab.tsx`. Both fall back to date string when no title. Deferred as #737. |
+
 ## #672 — 2026-04-12
 
 | Reviewer | Severity | Note |

--- a/plan/langteach-beta/t722-sessions-tab-polish/task722-sessions-tab-polish.md
+++ b/plan/langteach-beta/t722-sessions-tab-polish/task722-sessions-tab-polish.md
@@ -1,0 +1,50 @@
+# Task 722: Student Detail Sessions Tab Visual Polish
+
+## Issue
+#722 - polish: Student Detail Sessions tab visual polish and interaction fixes
+
+## Files Changed
+- `frontend/src/components/session/SessionHistoryTab.tsx` (main)
+- `frontend/src/components/session/SessionHistoryTab.test.tsx` (updated tests)
+
+## Acceptance Criteria Mapping
+
+### AC1: Action button restructuring
+- Edit and Delete move into a Popover-based kebab menu (MoreHorizontal icon) in the collapsed row header, right-aligned next to the chevron
+- Delete is visually demoted (red text) inside the menu, separated by a divider
+- "Start next session" moves inside the amber "Planned for Next Class" card as a ghost-style button
+- Three-button footer bar removed entirely
+
+### AC2: Collapsed row improvements
+- Homework status icon added in right side of collapsed row (same area as duration/mic/chevron)
+- Uses `hwInfo.icon` and `hwInfo.color` from `HOMEWORK_STATUS_INFO`, shown when `hwStatus !== null && hwStatus !== 'NotApplicable'`
+- Narrative preview: when `!session.title`, use `line-clamp-2` and slightly more prominent text (`text-zinc-600` instead of `text-zinc-500`)
+
+### AC3: Expanded card layout
+- Full-width narrative: when `!session.homeworkAssigned && !session.nextSessionTopics && !(hwStatus && hwStatus !== 'NotApplicable')`, use single-column layout (`md:col-span-3` on narrative column, or remove right column)
+- Previous homework status: already implemented in existing expanded view - no change needed (code at lines 342-354 already shows it with separate label and icon)
+
+## Implementation Notes
+
+### Kebab Menu
+- Uses existing `Popover`/`PopoverContent`/`PopoverTrigger` from `@/components/ui/popover` (no new dependencies)
+- Controlled via `kebabOpen`/`setKebabOpen` state so it can be programmatically closed when an action is taken
+- Header restructured: flex row with expand `<button>` (flex-1) + separate `<div>` for kebab
+- No invalid HTML (no buttons nested inside buttons)
+
+### AlertDialog
+- `AlertDialogTrigger` wrapper is removed entirely (it was the Delete button in the old footer)
+- `AlertDialog` is moved to the ROOT of `SessionEntry` return (not inside the footer which is being deleted)
+- Controlled purely via `open={deleteOpen} onOpenChange={setDeleteOpen}` on `AlertDialog` root
+- Delete button in kebab: `setKebabOpen(false); setDeleteOpen(true)`
+
+### Full-width layout (AC3)
+- Condition: `!session.homeworkAssigned && !session.nextSessionTopics && !(hwStatus && hwStatus !== 'NotApplicable')`
+- Implementation: conditionally render the right column at all (not just `col-span-3`), so the left column uses the full grid width naturally via `md:col-span-2` becoming the only column
+
+### Test Changes
+- Tests for edit/delete: no longer need to expand first; instead open kebab (`session-kebab-trigger`), then interact
+- New tests: hw status icon in collapsed row, full-width layout condition, start-next-session in amber card
+
+## No Backend Changes Needed
+All data fields are already present in the `SessionLog` type.


### PR DESCRIPTION
Closes #722

## Summary

- Move Edit/Delete into a Popover-based kebab menu (three-dots icon) in the collapsed row header. Delete is red, separated by a divider.
- Move "Start next session" button inside the amber "Planned for Next Class" card where it's contextually connected. Remove the three-button footer bar entirely.
- Add homework status icon (✓/✗/◑) in collapsed rows so teachers can scan compliance without expanding each card.
- Make narrative snippet more prominent (2 lines) when no explicit title exists.
- Use full-width single-column layout when no homework or next plan exists (removes empty right column).

## Test plan

- [x] 54 unit tests in `SessionHistoryTab.test.tsx` - all passing
- [x] Build (npm build, lint, dotnet) - PASS
- [x] qa-verify - PASS
- [x] architecture-reviewer - PASS WITH NOTES (deferred #737: extract date helpers / sessionTitle to shared utils)
- [x] review-ui - PASS WITH NOTES (e2e visual spec updated to open kebab before clicking edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added homework status icon to session entries, displaying previous lesson homework status.

* **UI Improvements**
  * Reorganized session entry controls: edit and delete actions now accessible through a kebab menu.
  * Enhanced layout rendering for session history details to better accommodate homework and next-session information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->