### PR TITLE
feat(t724): Progress tab visual fixes and data clarity

### DIFF
--- a/e2e/tests/student-detail.spec.ts
+++ b/e2e/tests/student-detail.spec.ts
@@ -240,6 +240,30 @@ test('student detail profile tab: inline-add short-term objective', async ({ bro
   }
 })
 
+test('student detail progress tab: renders without errors', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    await page.goto('/students')
+    await expect(page.locator('h1')).toHaveText('Students', { timeout: NAV_TIMEOUT })
+
+    const anaSeed = page.getByText('Ana Seed').first()
+    await expect(anaSeed).toBeVisible({ timeout: UI_TIMEOUT })
+    await anaSeed.click()
+
+    await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
+    await expect(page.getByTestId('student-overview-tab')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await page.getByTestId('tab-progress').click()
+    await expect(page.getByTestId('progress-tab-content')).toBeVisible({ timeout: UI_TIMEOUT })
+    await expect(page.getByTestId('skill-imbalance-section')).toBeVisible({ timeout: UI_TIMEOUT })
+    await expect(page.getByTestId('pacing-section')).toBeVisible({ timeout: UI_TIMEOUT })
+  } finally {
+    await context.close()
+  }
+})
+
 test('student detail profile tab: inline-add focus area difficulty', async ({ browser }) => {
   const context = await createMockAuthContext(browser)
   const page = await context.newPage()

--- a/frontend/src/components/student/ProgressDashboard.test.tsx
+++ b/frontend/src/components/student/ProgressDashboard.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, it, expect } from 'vitest'
 import { ProgressDashboard } from './ProgressDashboard'
 import type { Student } from '@/api/students'
@@ -295,6 +296,42 @@ describe('ProgressDashboard', () => {
     renderProgress(student, sessions)
     expect(screen.getByTestId('pacing-behind-badge')).toBeInTheDocument()
     expect(screen.getByTestId('pacing-behind-badge')).toHaveTextContent('Behind')
+  })
+
+  it('shows full description text in difficulty tooltip on hover', async () => {
+    const user = userEvent.setup()
+    const longDescription = 'Very long difficulty description that gets truncated in the UI but shown in full on hover'
+    const student = {
+      ...baseStudent,
+      difficulties: [
+        {
+          id: 'd-tooltip',
+          description: longDescription,
+          competency: 'Grammar',
+          subcategory: 'Complex clauses',
+          severity: 'high',
+          trend: 'stable',
+          status: 'Active',
+        },
+      ],
+    }
+    renderProgress(student)
+    // Tooltip trigger wraps the description — hover to open
+    const truncatedText = screen.getByText(longDescription)
+    await user.hover(truncatedText)
+    // Tooltip popup should now be visible with full description
+    const tooltip = await screen.findByTestId('difficulty-tooltip-d-tooltip')
+    expect(tooltip).toHaveTextContent(longDescription)
+  })
+
+  it('all skill bars use a single consistent fill color (no two-tone artifact)', () => {
+    renderProgress()
+    // Each skill bar should have exactly one fill div with a background-color class
+    // The artifact div from before was an unstyled empty div; after fix, only the fill div remains
+    const readingBar = screen.getByTestId('skill-bar-reading')
+    // The fill bar should have exactly one bg-* color class (primary blue for above baseline)
+    expect(readingBar.className).toContain('bg-[#3525CD]')
+    expect(readingBar.className).not.toContain('bg-[#F4F2FD]') // track color should not bleed into fill
   })
 
   it('does not show Behind badge when student has adequate session frequency', () => {

--- a/frontend/src/components/student/ProgressDashboard.test.tsx
+++ b/frontend/src/components/student/ProgressDashboard.test.tsx
@@ -90,11 +90,36 @@ describe('ProgressDashboard', () => {
   })
 
   it('applies primary color to skills at or above baseline', () => {
-    renderProgress() // baseline B1, Reading=B2 (above), Speaking=B1 (at), Writing=A2 (below)
+    renderProgress() // baseline B1, Reading=B2 (above), Speaking=B1 (at), Writing=A2 (below, gap=1)
     const readingBar = screen.getByTestId('skill-bar-reading')
     expect(readingBar.className).toContain('bg-[#3525CD]')
     const writingBar = screen.getByTestId('skill-bar-writing')
     expect(writingBar.className).toContain('bg-[#C3C0FF]')
+  })
+
+  it('applies amber color and Gap badge when skill is 2+ levels below baseline', () => {
+    // baseline B1 (3), Listening=A1 (1) => gap=2, Writing=A2 (2) => gap=1 (no amber)
+    const student = {
+      ...baseStudent,
+      cefrLevel: 'B1',
+      skillLevelOverrides: { Reading: 'B2', Speaking: 'B1', Listening: 'A1', Writing: 'A2' },
+    }
+    renderProgress(student)
+    const listeningBar = screen.getByTestId('skill-bar-listening')
+    expect(listeningBar.className).toContain('bg-amber-400')
+    expect(screen.getByTestId('skill-gap-badge-listening')).toBeInTheDocument()
+    // Writing has gap=1, should NOT be amber
+    const writingBar = screen.getByTestId('skill-bar-writing')
+    expect(writingBar.className).not.toContain('bg-amber-400')
+    expect(screen.queryByTestId('skill-gap-badge-writing')).not.toBeInTheDocument()
+  })
+
+  it('renders baseline marker for each skill', () => {
+    renderProgress()
+    expect(screen.getByTestId('baseline-marker-reading')).toBeInTheDocument()
+    expect(screen.getByTestId('baseline-marker-writing')).toBeInTheDocument()
+    expect(screen.getByTestId('baseline-marker-speaking')).toBeInTheDocument()
+    expect(screen.getByTestId('baseline-marker-listening')).toBeInTheDocument()
   })
 
   it('shows legend label with BASELINE not TARGET', () => {
@@ -147,7 +172,7 @@ describe('ProgressDashboard', () => {
     expect(screen.getByTestId('cancellation-rate')).toHaveTextContent('0%')
   })
 
-  it('shows covered difficulty with Covered badge', () => {
+  it('shows covered difficulty with Covered badge and competency label', () => {
     const student = {
       ...baseStudent,
       difficulties: [
@@ -166,9 +191,11 @@ describe('ProgressDashboard', () => {
     expect(screen.getByTestId('difficulties-section')).toBeInTheDocument()
     expect(screen.getByText('Por vs Para')).toBeInTheDocument()
     expect(screen.getByText('Covered')).toBeInTheDocument()
+    // Competency label should render
+    expect(screen.getByText('Grammar')).toBeInTheDocument()
   })
 
-  it('shows active difficulty with Working badge when recently mentioned', () => {
+  it('shows active difficulty with Working badge and time-since when recently mentioned', () => {
     const recentDate = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString()
     const student = {
       ...baseStudent,
@@ -193,6 +220,35 @@ describe('ProgressDashboard', () => {
     ]
     renderProgress(student, sessions)
     expect(screen.getByText('Working')).toBeInTheDocument()
+    // Should show time-since badge (5 days ago => "5d")
+    expect(screen.getByTestId('difficulty-time-since-d1')).toHaveTextContent('5d')
+  })
+
+  it('shows time-since in weeks for old mentions', () => {
+    const oldDate = new Date(Date.now() - 35 * 24 * 60 * 60 * 1000).toISOString() // 5 weeks ago
+    const student = {
+      ...baseStudent,
+      difficulties: [
+        {
+          id: 'd1',
+          description: 'Ser vs Estar',
+          competency: 'Grammar',
+          subcategory: 'Verb types',
+          severity: 'high',
+          trend: 'stable',
+          status: 'Active',
+        },
+      ],
+    }
+    const sessions = [
+      {
+        ...baseSession,
+        sessionDate: oldDate,
+        mentionedDifficultyPairs: JSON.stringify([{ Competency: 'Grammar', Subcategory: 'Verb types' }]),
+      },
+    ]
+    renderProgress(student, sessions)
+    expect(screen.getByTestId('difficulty-time-since-d1')).toHaveTextContent('5w')
   })
 
   it('shows active difficulty with Stale badge when not recently mentioned', () => {

--- a/frontend/src/components/student/ProgressDashboard.test.tsx
+++ b/frontend/src/components/student/ProgressDashboard.test.tsx
@@ -216,7 +216,7 @@ describe('ProgressDashboard', () => {
       {
         ...baseSession,
         sessionDate: recentDate,
-        mentionedDifficultyPairs: JSON.stringify([{ Competency: 'Grammar', Subcategory: 'Subjunctive' }]),
+        mentionedDifficultyPairs: JSON.stringify([{ competency: 'Grammar', subcategory: 'Subjunctive' }]),
       },
     ]
     renderProgress(student, sessions)
@@ -245,7 +245,7 @@ describe('ProgressDashboard', () => {
       {
         ...baseSession,
         sessionDate: oldDate,
-        mentionedDifficultyPairs: JSON.stringify([{ Competency: 'Grammar', Subcategory: 'Verb types' }]),
+        mentionedDifficultyPairs: JSON.stringify([{ competency: 'Grammar', subcategory: 'Verb types' }]),
       },
     ]
     renderProgress(student, sessions)

--- a/frontend/src/components/student/ProgressDashboard.tsx
+++ b/frontend/src/components/student/ProgressDashboard.tsx
@@ -91,10 +91,10 @@ function computeRecentMentions(sessions: SessionLog[]): Set<string> {
     .forEach((s) => {
       try {
         const pairs = JSON.parse(s.mentionedDifficultyPairs || '[]') as {
-          Competency: string
-          Subcategory: string
+          competency: string
+          subcategory: string
         }[]
-        pairs.forEach((p) => mentions.add(`${p.Competency}|${p.Subcategory}`))
+        pairs.forEach((p) => mentions.add(`${p.competency}|${p.subcategory}`))
       } catch {
         /* empty */
       }
@@ -110,11 +110,11 @@ function computeLastMentionDates(sessions: SessionLog[]): Map<string, Date> {
       const sessionDate = new Date(s.sessionDate!)
       try {
         const pairs = JSON.parse(s.mentionedDifficultyPairs || '[]') as {
-          Competency: string
-          Subcategory: string
+          competency: string
+          subcategory: string
         }[]
         pairs.forEach((p) => {
-          const key = `${p.Competency}|${p.Subcategory}`
+          const key = `${p.competency}|${p.subcategory}`
           const existing = lastMentioned.get(key)
           if (!existing || sessionDate > existing) {
             lastMentioned.set(key, sessionDate)

--- a/frontend/src/components/student/ProgressDashboard.tsx
+++ b/frontend/src/components/student/ProgressDashboard.tsx
@@ -23,9 +23,20 @@ function isAboveOrAtBaseline(skillLevel: string, baselineLevel: string): boolean
   return (CEFR_ORDER[skillLevel] ?? 0) >= (CEFR_ORDER[baselineLevel] ?? 0)
 }
 
+function isGapTwoOrMore(skillLevel: string, baselineLevel: string): boolean {
+  return (CEFR_ORDER[baselineLevel] ?? 0) - (CEFR_ORDER[skillLevel] ?? 0) >= 2
+}
+
 function formatStartDate(dateStr: string): string {
   const d = new Date(dateStr)
   return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
+}
+
+function formatTimeSince(date: Date): string {
+  const diffMs = Date.now() - date.getTime()
+  const days = Math.floor(diffMs / (24 * 60 * 60 * 1000))
+  if (days < 7) return `${days}d`
+  return `${Math.floor(days / 7)}w`
 }
 
 interface PacingStats {
@@ -91,6 +102,31 @@ function computeRecentMentions(sessions: SessionLog[]): Set<string> {
   return mentions
 }
 
+function computeLastMentionDates(sessions: SessionLog[]): Map<string, Date> {
+  const lastMentioned = new Map<string, Date>()
+  sessions
+    .filter((s) => !s.isCancelled && s.statusName === 'Confirmed' && s.sessionDate)
+    .forEach((s) => {
+      const sessionDate = new Date(s.sessionDate!)
+      try {
+        const pairs = JSON.parse(s.mentionedDifficultyPairs || '[]') as {
+          Competency: string
+          Subcategory: string
+        }[]
+        pairs.forEach((p) => {
+          const key = `${p.Competency}|${p.Subcategory}`
+          const existing = lastMentioned.get(key)
+          if (!existing || sessionDate > existing) {
+            lastMentioned.set(key, sessionDate)
+          }
+        })
+      } catch {
+        /* empty */
+      }
+    })
+  return lastMentioned
+}
+
 export function ProgressDashboard({ student, sessions }: Props) {
   const baselineNum = CEFR_ORDER[student.cefrLevel] ?? 3
   const baselinePercent = (baselineNum / 6) * 100
@@ -103,6 +139,7 @@ export function ProgressDashboard({ student, sessions }: Props) {
 
   // Difficulty classification
   const recentMentions = useMemo(() => computeRecentMentions(sessions), [sessions])
+  const lastMentionDates = useMemo(() => computeLastMentionDates(sessions), [sessions])
   const difficulties = student.difficulties ?? []
 
   const coveredDifficulties = difficulties.filter((d) => d.status === 'Covered')
@@ -156,27 +193,34 @@ export function ProgressDashboard({ student, sessions }: Props) {
                 if (!level) return null
                 const width = cefrBarWidth(level)
                 const above = isAboveOrAtBaseline(level, student.cefrLevel)
+                const hasGap = isGapTwoOrMore(level, student.cefrLevel)
+                const barColor = hasGap ? 'bg-amber-400' : above ? 'bg-[#3525CD]' : 'bg-[#C3C0FF]'
                 return (
                   <div key={skill} className="relative">
                     <div className="flex justify-between items-center mb-2">
                       <span className="text-sm font-semibold text-[#1A1B22]">{skill}</span>
-                      <CefrBadge level={level} />
+                      <div className="flex items-center gap-2">
+                        {hasGap && (
+                          <span
+                            className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[0.5625rem] font-bold text-amber-700"
+                            data-testid={`skill-gap-badge-${skill.toLowerCase()}`}
+                          >
+                            Gap
+                          </span>
+                        )}
+                        <CefrBadge level={level} />
+                      </div>
                     </div>
                     <div className="relative h-3 w-full bg-[#F4F2FD] rounded-full overflow-visible">
-                      {/* Baseline reference line */}
+                      {/* Baseline reference marker — positioned outside clip context */}
                       <div
-                        className="absolute top-0 h-full w-0.5 bg-zinc-400/50 z-10"
-                        style={{ left: `${baselinePercent}%` }}
+                        className="absolute z-10 w-0.5 bg-[#C7C4D8]"
+                        style={{ left: `${baselinePercent}%`, top: '-2px', bottom: '-2px' }}
                         aria-label={`Baseline ${student.cefrLevel}`}
+                        data-testid={`baseline-marker-${skill.toLowerCase()}`}
                       />
                       <div
-                        className="h-full rounded-full overflow-hidden"
-                        style={{ width: `${baselinePercent}%` }}
-                      />
-                      <div
-                        className={`absolute top-0 left-0 h-full rounded-full transition-all duration-300 ${
-                          above ? 'bg-[#3525CD]' : 'bg-[#C3C0FF]'
-                        }`}
+                        className={`absolute top-0 left-0 h-full rounded-full transition-all duration-300 ${barColor}`}
                         style={{ width: `${width}%` }}
                         data-testid={`skill-bar-${skill.toLowerCase()}`}
                       />
@@ -196,13 +240,13 @@ export function ProgressDashboard({ student, sessions }: Props) {
         </div>
 
         {/* Right column — 4 cols */}
-        <div className="lg:col-span-4 space-y-4">
+        <div className="lg:col-span-4 space-y-5">
           {/* Pacing Analytics */}
-          <div className="bg-[#F4F2FD] rounded-2xl p-6" data-testid="pacing-section">
+          <div className="bg-[#F4F2FD] rounded-2xl p-7" data-testid="pacing-section">
             <h3 className="text-xs font-bold uppercase tracking-widest text-zinc-500 mb-6">
               Pacing Analytics
             </h3>
-            <div className="space-y-5">
+            <div className="space-y-6">
               <div>
                 <p className="text-3xl font-black text-[#3525CD] mb-1">
                   {completedSessions.length}
@@ -287,7 +331,7 @@ export function ProgressDashboard({ student, sessions }: Props) {
           {/* Difficulties Summary */}
           {difficulties.length > 0 && (
             <div
-              className="bg-white rounded-2xl p-6"
+              className="bg-white rounded-2xl p-7"
               style={{ boxShadow: '0 1px 3px rgba(26,27,34,0.08)', border: '1px solid rgba(199,196,216,0.15)' }}
               data-testid="difficulties-section"
             >
@@ -303,30 +347,64 @@ export function ProgressDashboard({ student, sessions }: Props) {
                     const isStale = d.status !== 'Covered' &&
                       !recentMentions.has(`${d.competency}|${d.subcategory}`)
                     const isCovered = d.status === 'Covered'
+                    const lastMentionDate = lastMentionDates.get(`${d.competency}|${d.subcategory}`)
+                    const timeSince = lastMentionDate ? formatTimeSince(lastMentionDate) : null
 
                     return (
                       <div
                         key={d.id}
                         className="flex items-center justify-between py-2 border-b border-zinc-50 last:border-0"
                       >
-                        <span className="text-xs font-bold text-[#1A1B22] truncate mr-2 max-w-[140px]">
-                          {d.description}
-                        </span>
-                        {isWorking && (
-                          <span className="px-2 py-0.5 rounded-full text-[0.5625rem] font-bold bg-[#E2DFFF] text-[#3323CC] shrink-0">
-                            Working
-                          </span>
-                        )}
-                        {isStale && (
-                          <span className="px-2 py-0.5 rounded-full text-[0.5625rem] font-bold bg-amber-100 text-amber-700 shrink-0">
-                            Stale
-                          </span>
-                        )}
-                        {isCovered && (
-                          <span className="px-2 py-0.5 rounded-full text-[0.5625rem] font-bold bg-green-100 text-green-700 shrink-0">
-                            Covered
-                          </span>
-                        )}
+                        <TooltipPrimitive.Root>
+                          <TooltipPrimitive.Trigger
+                            render={
+                              <div className="flex flex-col gap-0.5 mr-2 min-w-0 cursor-default" />
+                            }
+                          >
+                            <span className="text-xs font-bold text-[#1A1B22] truncate max-w-[140px] block">
+                              {d.description}
+                            </span>
+                            <span className="text-[0.5625rem] font-bold uppercase text-zinc-400 block">
+                              {d.competency}
+                            </span>
+                          </TooltipPrimitive.Trigger>
+                          <TooltipPrimitive.Portal>
+                            <TooltipPrimitive.Positioner side="top" sideOffset={4} className="isolate z-50">
+                              <TooltipPrimitive.Popup
+                                className="z-50 max-w-xs rounded-lg bg-white px-3 py-2 text-xs leading-relaxed text-zinc-700"
+                                style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.10)' }}
+                                data-testid={`difficulty-tooltip-${d.id}`}
+                              >
+                                {d.description}
+                              </TooltipPrimitive.Popup>
+                            </TooltipPrimitive.Positioner>
+                          </TooltipPrimitive.Portal>
+                        </TooltipPrimitive.Root>
+                        <div className="flex items-center gap-1 shrink-0">
+                          {timeSince && (
+                            <span
+                              className="text-[0.5625rem] text-zinc-400"
+                              data-testid={`difficulty-time-since-${d.id}`}
+                            >
+                              {timeSince}
+                            </span>
+                          )}
+                          {isWorking && (
+                            <span className="px-2 py-0.5 rounded-full text-[0.5625rem] font-bold bg-[#E2DFFF] text-[#3323CC]">
+                              Working
+                            </span>
+                          )}
+                          {isStale && (
+                            <span className="px-2 py-0.5 rounded-full text-[0.5625rem] font-bold bg-amber-100 text-amber-700">
+                              Stale
+                            </span>
+                          )}
+                          {isCovered && (
+                            <span className="px-2 py-0.5 rounded-full text-[0.5625rem] font-bold bg-green-100 text-green-700">
+                              Covered
+                            </span>
+                          )}
+                        </div>
                       </div>
                     )
                   })}

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -6,6 +6,13 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 
 *Cleared 2026-04-08 during Adaptive Replanning sprint close. All entries deleted (low/info severity, all already deferred with sound reasoning) or batched into #603-#609.*
 
+## #724 — 2026-04-14
+
+| Reviewer | Severity | Note |
+|---|---|---|
+| architecture-reviewer | minor | `formatTimeSince` in `ProgressDashboard.tsx` duplicates day/week bucketing logic from `relativeTime()` in `formatDate.ts`. Formats differ (`"5d"` vs `"5 days ago"`) so they serve different purposes, but if a third compact-time callsite appears, extract to `formatDate.ts` as `formatTimeSinceCompact`. |
+| architecture-reviewer | minor | `CEFR_ORDER` (as Record) is redeclared in `ProgressDashboard.tsx` and `StudentOverviewTab.tsx` also has a private CEFR array. Both are pre-existing; worth extracting to a shared `cefrUtils.ts` if a third file needs it. |
+
 ## #672 — 2026-04-12
 
 | Reviewer | Severity | Note |

--- a/plan/langteach-beta/task724-progress-tab-polish.md
+++ b/plan/langteach-beta/task724-progress-tab-polish.md
@@ -1,0 +1,101 @@
+# Task 724 — Progress Tab Visual Fixes and Data Clarity
+
+## Issue
+[#724 polish: Student Detail Progress tab visual fixes and data clarity](https://github.com/Robert-Freire/langTeachSaaS/issues/724)
+
+## Scope
+
+All changes are in `frontend/src/components/student/ProgressDashboard.tsx` and its test file `ProgressDashboard.test.tsx`.
+
+## Changes
+
+### 1. Difficulty text truncation + tooltip (HIGH)
+
+**Current:** `<span className="text-xs font-bold text-[#1A1B22] truncate mr-2 max-w-[140px]">{d.description}</span>`
+
+**Fix:** Wrap in `TooltipPrimitive.Root/Trigger/Popup` (already imported) showing `d.description` on hover. Keep the truncated span as the trigger child.
+
+### 2. Competency label on difficulty entries (HIGH)
+
+**Current:** Only `d.description` renders.
+
+**Fix:** Add a small competency badge above/below the description within the same list item. Use a muted label style (e.g. `text-[0.5625rem] font-bold uppercase text-zinc-400`).
+
+### 3. Time-since-last-mention on difficulty badges (HIGH)
+
+**Approach:** Compute per-difficulty the most recent session date where that difficulty's `competency|subcategory` pair appeared in `mentionedDifficultyPairs`. Format the elapsed time as `"Nd"` (days) or `"Nw"` (weeks, if >= 7 days). Show next to the status badge.
+
+**New helper:** `computeLastMentionDates(sessions): Map<string, Date>` — module-level function (like `computeRecentMentions`), parses `mentionedDifficultyPairs` across all confirmed sessions, returns map of `` `${p.Competency}|${p.Subcategory}` `` -> most recent session date. Keys must use capital C/S (`p.Competency`, `p.Subcategory`) to match the JSON field names in `mentionedDifficultyPairs`, consistent with `computeRecentMentions` at line 82.
+
+Display: `<span className="text-[0.5625rem] text-zinc-400 shrink-0">{timeSince}</span>` adjacent to the badge.
+
+### 4. Baseline/target marker on skill bars (HIGH)
+
+**Current:** There is already a `div` rendering the baseline line (line 167-171 of ProgressDashboard.tsx):
+```tsx
+<div
+  className="absolute top-0 h-full w-0.5 bg-zinc-400/50 z-10"
+  style={{ left: `${baselinePercent}%` }}
+/>
+```
+
+**Current state:** The baseline marker div already exists at lines 167-171 with `aria-label`. The track at line 165 has `overflow-visible`, so clipping is NOT the issue. The artifact div (lines 172-175, change 6) renders a partial-width `overflow-hidden` div that visually overlaps the marker on some bars.
+
+**Fix:** After removing the artifact div (change 6), visually verify the marker. If it's still not visible (likely due to z-index or color being too subtle), change `bg-zinc-400/50` to `bg-[#C7C4D8]` and ensure `z-10` is set. Extend the marker slightly above/below the bar using `top: -2px; bottom: -2px; height: auto` (remove `h-full`, use absolute `inset-y-[-2px]`).
+
+### 5. 2+ level gap visual warning (HIGH)
+
+**Logic:** For each skill, compute `gap = CEFR_ORDER[student.cefrLevel] - CEFR_ORDER[level]`. If `gap >= 2`, apply an amber accent.
+
+**Current:** Below-baseline uses `bg-[#C3C0FF]` (light purple). For gap >= 2: use `bg-amber-400` bar tint + add a small amber badge `"! Gap"` next to the CEFR badge.
+
+### 6. Fix Listening bar two-tone (HIGH)
+
+**Root cause:** The current bar structure renders a background div (`bg-[#F4F2FD]` track) plus a fill div that sits absolute on top. However there's also a second `div` at line 173-175:
+```tsx
+<div
+  className="h-full rounded-full overflow-hidden"
+  style={{ width: `${baselinePercent}%` }}
+/>
+```
+This empty div with `overflow-hidden` creates a visual artifact on some bars depending on bar width vs baseline. **Remove this empty div entirely** — it serves no purpose (it was a leftover from a draft).
+
+### 7. Right column breathing room (MEDIUM)
+
+**Fix:** Change Pacing Analytics from `p-6` to `p-7` and add `space-y-6` (from `space-y-5`). Change Difficulties Summary from `p-6` to `p-7`. Change the gap between them from `space-y-4` to `space-y-5` on the right column container.
+
+### 8. Remove Pacing Analytics dot chart decoration (LOW)
+
+There is no decorative dot chart visible in the current code — this may have been in a prior design. No action needed unless it appears during UI review.
+
+### Layout note for change 2
+
+The difficulty row uses `flex items-center justify-between`. To add a competency label, wrap description + competency in a `flex-col` sub-container (left side) and keep the badge on the right:
+```tsx
+<div className="flex flex-col gap-0.5 mr-2 min-w-0">
+  <span className="text-xs font-bold text-[#1A1B22] truncate max-w-[140px]">{d.description}</span>
+  <span className="text-[0.5625rem] font-bold uppercase text-zinc-400">{d.competency}</span>
+</div>
+```
+
+## Test Plan
+
+Add/update tests in `ProgressDashboard.test.tsx`:
+- Tooltip on difficulty description (check tooltip content is in DOM)
+- Competency label renders for each difficulty
+- Time-since-last-mention renders for difficulties that were recently or not-recently mentioned
+- Baseline marker is present in DOM (`aria-label="Baseline B1"`)
+- 2+ level gap: amber class applied when gap >= 2
+- The empty artifact div is not present (indirect: bar renders without two-tone class)
+- 2+ level gap: amber bar class applied when gap >= 2 (use fixture: student B1 with Listening A1 = gap 2, Writing A2 = gap 1; only Listening should be amber)
+
+### E2E test (Playwright)
+
+Add a Playwright test in the existing student detail spec. Navigate to the Progress tab for Ana (who has skill overrides). Assert:
+- Skill Imbalance section is visible
+- At least one skill bar is present
+- Difficulties summary is visible (if Ana has difficulties in seeder)
+
+## Files Changed
+- `frontend/src/components/student/ProgressDashboard.tsx`
+- `frontend/src/components/student/ProgressDashboard.test.tsx`

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -3,6 +3,7 @@
 Out-of-scope observations logged by agents during implementation. Each row is something an agent noticed but did not fix because it was outside the current task's scope. These get batched into future GitHub issues by the PM.
 
 | Source issue | Date | Severity | Observation |
+| #724 | 2026-04-14 | info | CodeRabbit #739 flagged dual-casing risk in mentionedDifficultyPairs. Dismissed: SerializePairs uses CamelCaseOptions so both API and seeder produce lowercase keys. No mixed-casing rows exist. |
 | #724 | 2026-04-14 | medium | No seeded student has SkillLevelOverrides set; Skill Imbalance Analysis always shows empty state in visual review. Consider adding skill overrides to Ana Visual or Ana Seed for visual QA coverage. |
 | #721 | 2026-04-14 | low | Ana Seed has no SkillLevelOverrides in seeder so horizontal Skill Assessment badges on Profile tab cannot be visually verified. Consider adding skill overrides to Ana Seed seeder entry. |
 | #721 | 2026-04-14 | low | Ana Seed has PersonalNotes but no TeachingNotes in seeder; Teacher's Working Memory dark section only shows Sensitivities subsection. Consider adding TeachingNotes to Ana Seed for fuller visual verification. |

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -3,6 +3,7 @@
 Out-of-scope observations logged by agents during implementation. Each row is something an agent noticed but did not fix because it was outside the current task's scope. These get batched into future GitHub issues by the PM.
 
 | Source issue | Date | Severity | Observation |
+| #724 | 2026-04-14 | medium | No seeded student has SkillLevelOverrides set; Skill Imbalance Analysis always shows empty state in visual review. Consider adding skill overrides to Ana Visual or Ana Seed for visual QA coverage. |
 | #721 | 2026-04-14 | low | Ana Seed has no SkillLevelOverrides in seeder so horizontal Skill Assessment badges on Profile tab cannot be visually verified. Consider adding skill overrides to Ana Seed seeder entry. |
 | #721 | 2026-04-14 | low | Ana Seed has PersonalNotes but no TeachingNotes in seeder; Teacher's Working Memory dark section only shows Sensitivities subsection. Consider adding TeachingNotes to Ana Seed for fuller visual verification. |
 | #674 | 2026-04-12 | low | review-ui agent could not find `log-session-button` testid on student detail page in create mode. Pre-existing selector mismatch, unrelated to this PR. Should be investigated and fixed in a future task. |


### PR DESCRIPTION
Closes #724

## Summary

- **Difficulty tooltips**: Full description text shown on hover; truncated with ellipsis as default
- **Competency labels**: `GRAMMAR` / `VOCABULARY` etc. rendered below each difficulty description
- **Time-since badges**: `"7d"` / `"3w"` shown next to Working/Stale/Covered badge using session history
- **Baseline marker**: Visible `#C7C4D8` tick line at CEFR target level on each skill bar
- **Gap warning**: Amber bar + `Gap` badge when skill is 2+ CEFR levels below student general level
- **Two-tone fix**: Removed empty artifact div causing inconsistent fill on Listening bar
- **Right column breathing room**: Padding increased from `p-6` to `p-7` in both right-column panels
- **Bug fix**: `mentionedDifficultyPairs` JSON uses lowercase keys; code was incorrectly using PascalCase, causing Working badge and time-since to never render

## Test plan

- [ ] 23 unit tests pass (`ProgressDashboard.test.tsx`)
- [ ] New e2e test: "student detail progress tab: renders without errors" (Ana Seed)
- [ ] UI review PASS with Ana Visual: Working badge, time-since badge ("1w"), competency labels, and description truncation all verified in screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced visual gap indicators for skills falling 2+ levels behind baseline
  * Added time-since labels showing when difficulties were last mentioned
  * Enhanced difficulty descriptions with hoverable tooltips
  * Improved vertical spacing in Progress Dashboard

* **Tests**
  * Added end-to-end test for student profile navigation and Progress tab
  * Extended Progress Dashboard component test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->