### PR TITLE
feat(t730): Dashboard polish - hero CTA, roster signals, followup urgency, empty agenda

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
@@ -439,4 +439,126 @@ public class DashboardServiceTests : IDisposable
         result.Upcoming.Should().HaveCount(1);
         result.Upcoming[0].StudentId.Should().Be(_studentId);
     }
+
+    // GetAsync new fields: LastSessionTopicTags, LastSessionHomework, LastSessionFollowups
+
+    [Fact]
+    public async Task GetAsync_FutureSessionWithPastSession_PopulatesLastSessionTopicTags()
+    {
+        var past = DateTime.UtcNow.AddDays(-7);
+        var future = DateTime.UtcNow.AddDays(1);
+        var pastSession = MakeSession(_studentId, past);
+        pastSession.TopicTags = "[\"Subjuntivo\",\"Concesivas\"]";
+        _db.SessionLogs.Add(pastSession);
+        _db.SessionLogs.Add(MakeSession(_studentId, future));
+        _db.SaveChanges();
+
+        var result = await _sut.GetAsync(_teacherId);
+
+        result.NextSession!.LastSessionTopicTags.Should().Equal("Subjuntivo", "Concesivas");
+    }
+
+    [Fact]
+    public async Task GetAsync_FutureSessionWithPastSession_PopulatesLastSessionHomework()
+    {
+        var past = DateTime.UtcNow.AddDays(-7);
+        var future = DateTime.UtcNow.AddDays(1);
+        var pastSession = MakeSession(_studentId, past);
+        pastSession.HomeworkAssigned = "Redacción mi ciudad ideal";
+        _db.SessionLogs.Add(pastSession);
+        _db.SessionLogs.Add(MakeSession(_studentId, future));
+        _db.SaveChanges();
+
+        var result = await _sut.GetAsync(_teacherId);
+
+        result.NextSession!.LastSessionHomework.Should().Be("Redacción mi ciudad ideal");
+    }
+
+    [Fact]
+    public async Task GetAsync_FutureSessionWithPastSession_PopulatesPendingFollowupsFromPastSession()
+    {
+        var past = DateTime.UtcNow.AddDays(-7);
+        var future = DateTime.UtcNow.AddDays(1);
+        var pastSession = MakeSession(_studentId, past);
+        _db.SessionLogs.Add(pastSession);
+        _db.SessionLogs.Add(MakeSession(_studentId, future));
+        _db.TeacherFollowups.Add(new TeacherFollowup
+        {
+            Id = Guid.NewGuid(),
+            TeacherId = _teacherId,
+            Text = "Prometí ejercicios de por/para",
+            Status = "pending",
+            SourceSessionLogId = pastSession.Id,
+            CreatedAt = DateTime.UtcNow,
+        });
+        _db.TeacherFollowups.Add(new TeacherFollowup
+        {
+            Id = Guid.NewGuid(),
+            TeacherId = _teacherId,
+            Text = "Already done promise",
+            Status = "done",
+            SourceSessionLogId = pastSession.Id,
+            CreatedAt = DateTime.UtcNow,
+        });
+        _db.SaveChanges();
+
+        var result = await _sut.GetAsync(_teacherId);
+
+        result.NextSession!.LastSessionFollowups.Should().ContainSingle().Which.Should().Be("Prometí ejercicios de por/para");
+    }
+
+    [Fact]
+    public async Task GetAsync_NoLastSession_LastSessionFieldsAreEmpty()
+    {
+        var future = DateTime.UtcNow.AddDays(1);
+        _db.SessionLogs.Add(MakeSession(_studentId, future));
+        _db.SaveChanges();
+
+        var result = await _sut.GetAsync(_teacherId);
+
+        result.NextSession!.LastSessionTopicTags.Should().BeEmpty();
+        result.NextSession.LastSessionHomework.Should().BeNull();
+        result.NextSession.LastSessionFollowups.Should().BeEmpty();
+    }
+
+    // GetAsync new field: UpcomingThisWeek
+
+    [Fact]
+    public async Task GetAsync_SessionsThisWeek_ReturnedInUpcomingThisWeek()
+    {
+        var tomorrow = DateTime.UtcNow.Date.AddDays(1).AddHours(10);
+        var inFiveDays = DateTime.UtcNow.Date.AddDays(5).AddHours(10);
+        _db.SessionLogs.Add(MakeSession(_studentId, tomorrow));
+        _db.SessionLogs.Add(MakeSession(_studentId, inFiveDays));
+        _db.SaveChanges();
+
+        var result = await _sut.GetAsync(_teacherId);
+
+        result.UpcomingThisWeek.Should().HaveCount(2);
+        result.UpcomingThisWeek[0].SessionDate.Should().BeCloseTo(tomorrow, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task GetAsync_SessionBeyond7Days_ExcludedFromUpcomingThisWeek()
+    {
+        var inTenDays = DateTime.UtcNow.Date.AddDays(10).AddHours(10);
+        _db.SessionLogs.Add(MakeSession(_studentId, inTenDays));
+        _db.SaveChanges();
+
+        var result = await _sut.GetAsync(_teacherId);
+
+        result.UpcomingThisWeek.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAsync_CancelledSessionThisWeek_ExcludedFromUpcomingThisWeek()
+    {
+        var tomorrow = DateTime.UtcNow.Date.AddDays(1).AddHours(10);
+        _db.SessionLogs.Add(MakeSession(_studentId, tomorrow, isCancelled: true));
+        _db.SaveChanges();
+
+        var result = await _sut.GetAsync(_teacherId);
+
+        result.UpcomingThisWeek.Should().BeEmpty();
+    }
 }

--- a/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
@@ -448,7 +448,7 @@ public class DashboardServiceTests : IDisposable
         var past = DateTime.UtcNow.AddDays(-7);
         var future = DateTime.UtcNow.AddDays(1);
         var pastSession = MakeSession(_studentId, past);
-        pastSession.TopicTags = "[\"Subjuntivo\",\"Concesivas\"]";
+        pastSession.TopicTags = "[{\"Tag\":\"Subjuntivo\",\"Category\":null},{\"Tag\":\"Concesivas\",\"Category\":null}]";
         _db.SessionLogs.Add(pastSession);
         _db.SessionLogs.Add(MakeSession(_studentId, future));
         _db.SaveChanges();

--- a/backend/LangTeach.Api/DTOs/DashboardDtos.cs
+++ b/backend/LangTeach.Api/DTOs/DashboardDtos.cs
@@ -29,7 +29,19 @@ public record NextSessionDto(
     string? LastSessionNotes,
     DateTime? LastSessionDate,
     string? HomeworkAssigned,
-    string? PreviousHomeworkStatus
+    string? PreviousHomeworkStatus,
+    List<string> LastSessionTopicTags,
+    string? LastSessionHomework,
+    List<string> LastSessionFollowups
+);
+
+public record UpcomingSessionDto(
+    Guid SessionLogId,
+    Guid StudentId,
+    string StudentName,
+    string StudentCefrLevel,
+    DateTime SessionDate,
+    string? PlannedContent
 );
 
 public record TodaySessionDto(
@@ -60,5 +72,6 @@ public record DashboardDto(
     NextSessionDto? NextSession,
     List<TodaySessionDto> TodaySessions,
     List<ActiveStudentDto> ActiveStudents,
-    List<TeacherFollowupDto> PendingFollowups
+    List<TeacherFollowupDto> PendingFollowups,
+    List<UpcomingSessionDto> UpcomingThisWeek
 );

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using LangTeach.Api.Data;
 using LangTeach.Api.Data.Models;
 using LangTeach.Api.DTOs;
@@ -28,8 +29,9 @@ public class DashboardService : IDashboardService
         var todaySessions = await GetTodaySessionsAsync(teacherId, today, cancellationToken);
         var activeStudents = await GetActiveStudentsAsync(teacherId, now, cancellationToken);
         var pendingFollowups = await _followupService.GetPendingAsync(teacherId, cancellationToken);
+        var upcomingThisWeek = await GetUpcomingThisWeekAsync(teacherId, today, cancellationToken);
 
-        return new DashboardDto(nextSession, todaySessions, activeStudents, pendingFollowups);
+        return new DashboardDto(nextSession, todaySessions, activeStudents, pendingFollowups, upcomingThisWeek);
     }
 
     private async Task<NextSessionDto?> GetNextSessionAsync(Guid teacherId, DateTime now, CancellationToken cancellationToken)
@@ -56,6 +58,17 @@ public class DashboardService : IDashboardService
             .OrderByDescending(sl => sl.SessionDate)
             .FirstOrDefaultAsync(cancellationToken);
 
+        var lastSessionTopicTags = lastPast is not null
+            ? JsonSerializer.Deserialize<List<string>>(lastPast.TopicTags) ?? []
+            : [];
+
+        var lastSessionFollowups = lastPast is not null
+            ? await _db.TeacherFollowups
+                .Where(f => f.SourceSessionLogId == lastPast.Id && f.Status != "done")
+                .Select(f => f.Text)
+                .ToListAsync(cancellationToken)
+            : [];
+
         return new NextSessionDto(
             SessionLogId: next.Id,
             StudentId: next.StudentId,
@@ -66,7 +79,10 @@ public class DashboardService : IDashboardService
             LastSessionNotes: lastPast?.GeneralNotes,
             LastSessionDate: lastPast?.SessionDate,
             HomeworkAssigned: next.HomeworkAssigned,
-            PreviousHomeworkStatus: next.PreviousHomeworkStatus.ToString()
+            PreviousHomeworkStatus: next.PreviousHomeworkStatus.ToString(),
+            LastSessionTopicTags: lastSessionTopicTags,
+            LastSessionHomework: lastPast?.HomeworkAssigned,
+            LastSessionFollowups: lastSessionFollowups
         );
     }
 
@@ -89,6 +105,32 @@ public class DashboardService : IDashboardService
             SessionDate: sl.SessionDate!.Value,
             PlannedContent: sl.PlannedContent,
             Status: sl.Status.ToString()
+        )).ToList();
+    }
+
+    private async Task<List<UpcomingSessionDto>> GetUpcomingThisWeekAsync(Guid teacherId, DateTime today, CancellationToken cancellationToken)
+    {
+        var endOfWeek = today.AddDays(7);
+
+        var sessions = await _db.SessionLogs
+            .Where(sl => sl.TeacherId == teacherId
+                      && !sl.IsDeleted
+                      && !sl.IsCancelled
+                      && sl.SessionDate.HasValue
+                      && sl.SessionDate.Value.Date > today
+                      && sl.SessionDate.Value.Date <= endOfWeek)
+            .Include(sl => sl.Student)
+            .OrderBy(sl => sl.SessionDate)
+            .Take(5)
+            .ToListAsync(cancellationToken);
+
+        return sessions.Select(sl => new UpcomingSessionDto(
+            SessionLogId: sl.Id,
+            StudentId: sl.StudentId,
+            StudentName: sl.Student.Name,
+            StudentCefrLevel: sl.Student.CefrLevel,
+            SessionDate: sl.SessionDate!.Value,
+            PlannedContent: sl.PlannedContent
         )).ToList();
     }
 

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -58,10 +58,19 @@ public class DashboardService : IDashboardService
             .OrderByDescending(sl => sl.SessionDate)
             .FirstOrDefaultAsync(cancellationToken);
 
-        var lastSessionTopicTags = lastPast is not null
-            ? (JsonSerializer.Deserialize<List<TopicTagEntry>>(lastPast.TopicTags) ?? [])
-                .Select(t => t.Tag).ToList()
-            : [];
+        List<string> lastSessionTopicTags = [];
+        if (lastPast is not null)
+        {
+            try
+            {
+                lastSessionTopicTags = (JsonSerializer.Deserialize<List<TopicTagEntry>>(lastPast.TopicTags) ?? [])
+                    .Select(t => t.Tag).ToList();
+            }
+            catch (JsonException)
+            {
+                _logger.LogWarning("Failed to deserialize TopicTags for session {SessionId}", lastPast.Id);
+            }
+        }
 
         var lastSessionFollowups = lastPast is not null
             ? await _db.TeacherFollowups

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -59,7 +59,8 @@ public class DashboardService : IDashboardService
             .FirstOrDefaultAsync(cancellationToken);
 
         var lastSessionTopicTags = lastPast is not null
-            ? JsonSerializer.Deserialize<List<string>>(lastPast.TopicTags) ?? []
+            ? (JsonSerializer.Deserialize<List<TopicTagEntry>>(lastPast.TopicTags) ?? [])
+                .Select(t => t.Tag).ToList()
             : [];
 
         var lastSessionFollowups = lastPast is not null
@@ -239,4 +240,6 @@ public class DashboardService : IDashboardService
             );
         }).ToList();
     }
+
+    private sealed record TopicTagEntry(string Tag, string? Category);
 }

--- a/e2e/tests/dashboard.spec.ts
+++ b/e2e/tests/dashboard.spec.ts
@@ -34,6 +34,51 @@ test('dashboard renders with seeded data', async ({ browser }) => {
   }
 })
 
+test('dashboard zone3 roster shows student count and sort control', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    await page.goto('/')
+    await expect(page.locator('h1')).toHaveText('Dashboard', { timeout: NAV_TIMEOUT })
+    await expect(page.getByTestId('zone3-student-roster')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    const rosterRows = page.getByTestId('zone3-student-row')
+    const rowCount = await rosterRows.count()
+    if (rowCount > 0) {
+      // Sort control should be present when students exist
+      await expect(page.getByTestId('roster-sort')).toBeVisible({ timeout: UI_TIMEOUT })
+      // Student count label should be present
+      await expect(page.getByTestId('student-count')).toBeVisible({ timeout: UI_TIMEOUT })
+    }
+  } finally {
+    await context.close()
+  }
+})
+
+test('start session button navigates to log-session when next session is shown', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    await page.goto('/')
+    await expect(page.locator('h1')).toHaveText('Dashboard', { timeout: NAV_TIMEOUT })
+
+    const heroPresent = await page.getByTestId('zone1-next-session').isVisible()
+    if (!heroPresent) {
+      // No next session seeded — skip assertion
+      return
+    }
+
+    const startBtn = page.getByTestId('start-session-btn')
+    await expect(startBtn).toBeVisible({ timeout: UI_TIMEOUT })
+    await startBtn.click()
+    await expect(page).toHaveURL(/\/students\/[0-9a-f-]+\/log-session/, { timeout: UI_TIMEOUT })
+  } finally {
+    await context.close()
+  }
+})
+
 test('clicking student in roster navigates to student detail', async ({ browser }) => {
   const context = await createMockAuthContext(browser)
   const page = await context.newPage()

--- a/frontend/src/api/dashboard.ts
+++ b/frontend/src/api/dashboard.ts
@@ -21,6 +21,18 @@ export interface NextSession {
   lastSessionDate: string | null
   homeworkAssigned: string | null
   previousHomeworkStatus: string | null
+  lastSessionTopicTags: string[]
+  lastSessionHomework: string | null
+  lastSessionFollowups: string[]
+}
+
+export interface UpcomingSession {
+  sessionLogId: string
+  studentId: string
+  studentName: string
+  studentCefrLevel: string
+  sessionDate: string
+  plannedContent: string | null
 }
 
 export interface TodaySession {
@@ -52,6 +64,7 @@ export interface DashboardData {
   todaySessions: TodaySession[]
   activeStudents: ActiveStudent[]
   pendingFollowups: TeacherFollowup[]
+  upcomingThisWeek: UpcomingSession[]
 }
 
 export type { TeacherFollowup }

--- a/frontend/src/components/dashboard/NextSessionHero.test.tsx
+++ b/frontend/src/components/dashboard/NextSessionHero.test.tsx
@@ -16,6 +16,9 @@ function makeSession(overrides: Partial<NextSession> = {}): NextSession {
     lastSessionDate: new Date(Date.now() - 7 * 86400000).toISOString(),
     homeworkAssigned: 'Exercises page 42',
     previousHomeworkStatus: '3',
+    lastSessionTopicTags: ['Subjuntivo', 'Concesivas'],
+    lastSessionHomework: 'Redacción mi ciudad ideal',
+    lastSessionFollowups: ['Prometí ejercicios de por/para'],
     ...overrides,
   }
 }
@@ -59,16 +62,75 @@ describe('NextSessionHero', () => {
     expect(screen.getByText('Subjunctive mood')).toBeInTheDocument()
   })
 
-  it('shows last session notes', () => {
+  it('shows Start session CTA linking to log-session route', () => {
     render(
       <MemoryRouter>
         <NextSessionHero session={makeSession()} />
       </MemoryRouter>,
     )
-    expect(screen.getByText('Struggles with ser/estar')).toBeInTheDocument()
+    const btn = screen.getByTestId('start-session-btn')
+    expect(btn).toBeInTheDocument()
+    expect(btn).toHaveAttribute('href', '/students/student-1/log-session')
   })
 
-  it('shows homework assignment and status', () => {
+  it('shows View profile link', () => {
+    render(
+      <MemoryRouter>
+        <NextSessionHero session={makeSession()} />
+      </MemoryRouter>,
+    )
+    expect(screen.getByRole('link', { name: /View profile/ })).toHaveAttribute('href', '/students/student-1')
+  })
+
+  it('shows green gradient badge for session within 2 hours', () => {
+    render(
+      <MemoryRouter>
+        <NextSessionHero session={makeSession({ sessionDate: new Date(Date.now() + 30 * 60000).toISOString() })} />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/IN \d+ MIN/)).toBeInTheDocument()
+  })
+
+  it('shows neutral TODAY badge for session today but not imminent', () => {
+    render(
+      <MemoryRouter>
+        <NextSessionHero session={makeSession({ sessionDate: new Date(Date.now() + 4 * 3600000).toISOString() })} />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/TODAY/)).toBeInTheDocument()
+  })
+
+  it('shows no badge for session more than 7 days away', () => {
+    render(
+      <MemoryRouter>
+        <NextSessionHero session={makeSession({ sessionDate: new Date(Date.now() + 10 * 86400000).toISOString() })} />
+      </MemoryRouter>,
+    )
+    // No IN badge should appear
+    expect(screen.queryByText(/^IN \d/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/TODAY/)).not.toBeInTheDocument()
+  })
+
+  it('shows structured briefing: topics and promises', () => {
+    render(
+      <MemoryRouter>
+        <NextSessionHero session={makeSession()} />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('Subjuntivo, Concesivas')).toBeInTheDocument()
+    expect(screen.getByText('Prometí ejercicios de por/para')).toBeInTheDocument()
+  })
+
+  it('shows last session homework in briefing', () => {
+    render(
+      <MemoryRouter>
+        <NextSessionHero session={makeSession()} />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('Redacción mi ciudad ideal')).toBeInTheDocument()
+  })
+
+  it('shows homework status card with previousHomeworkStatus', () => {
     render(
       <MemoryRouter>
         <NextSessionHero session={makeSession()} />
@@ -78,21 +140,21 @@ describe('NextSessionHero', () => {
     expect(screen.getByText('Completed')).toBeInTheDocument()
   })
 
-  it('shows link to student profile', () => {
+  it('hides briefing section when all briefing fields are empty', () => {
     render(
       <MemoryRouter>
-        <NextSessionHero session={makeSession()} />
+        <NextSessionHero
+          session={makeSession({
+            lastSessionNotes: null,
+            lastSessionTopicTags: [],
+            lastSessionHomework: null,
+            lastSessionFollowups: [],
+            homeworkAssigned: null,
+          })}
+        />
       </MemoryRouter>,
     )
-    expect(screen.getByRole('link', { name: /View profile/ })).toHaveAttribute('href', '/students/student-1')
-  })
-
-  it('shows countdown badge', () => {
-    render(
-      <MemoryRouter>
-        <NextSessionHero session={makeSession()} />
-      </MemoryRouter>,
-    )
-    expect(screen.getByText(/IN \d+/)).toBeInTheDocument()
+    expect(screen.queryByText('Topics')).not.toBeInTheDocument()
+    expect(screen.queryByText('Promises made')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/dashboard/NextSessionHero.tsx
+++ b/frontend/src/components/dashboard/NextSessionHero.tsx
@@ -6,15 +6,34 @@ interface NextSessionHeroProps {
   session: NextSession | null
 }
 
-function formatCountdown(sessionDate: string): string {
+interface UrgencyBadge {
+  label: string
+  className: string
+  showBadge: boolean
+}
+
+function getUrgencyBadge(sessionDate: string): UrgencyBadge {
   const diff = new Date(sessionDate).getTime() - Date.now()
-  if (diff <= 0) return 'NOW'
+  if (diff <= 0) return { label: 'NOW', className: 'bg-gradient-to-br from-[#3525CD] to-indigo-500 text-white', showBadge: true }
   const mins = Math.round(diff / 60000)
-  if (mins < 60) return `IN ${mins} MIN`
-  const hrs = Math.round(mins / 60)
-  if (hrs < 24) return `IN ${hrs}H`
-  const days = Math.round(hrs / 24)
-  return `IN ${days}D`
+  if (mins <= 120) {
+    // Within 2 hours: green gradient pill
+    const label = mins < 60 ? `IN ${mins} MIN` : `IN ${Math.round(mins / 60)}H`
+    return { label, className: 'bg-gradient-to-br from-[#3525CD] to-indigo-500 text-white', showBadge: true }
+  }
+  const hrs = diff / 3600000
+  if (hrs < 24) {
+    // Today but not imminent: neutral
+    const timeStr = new Date(sessionDate).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    return { label: `TODAY, ${timeStr}`, className: 'bg-zinc-100 text-zinc-600', showBadge: true }
+  }
+  const days = Math.round(diff / 86400000)
+  if (days <= 7) {
+    // Within a week: neutral no-frills
+    return { label: `IN ${days}D`, className: 'bg-zinc-100 text-zinc-500', showBadge: true }
+  }
+  // More than 7 days: no badge
+  return { label: '', className: '', showBadge: false }
 }
 
 function formatSessionTime(sessionDate: string): string {
@@ -56,7 +75,14 @@ export function NextSessionHero({ session }: NextSessionHeroProps) {
     )
   }
 
+  const urgency = getUrgencyBadge(session.sessionDate)
   const hwStatus = homeworkStatusLabel(session.previousHomeworkStatus)
+
+  const hasTopics = session.lastSessionTopicTags.length > 0
+  const hasResponse = !!session.lastSessionNotes
+  const hasLastHomework = !!session.lastSessionHomework
+  const hasPromises = session.lastSessionFollowups.length > 0
+  const hasBriefing = hasTopics || hasResponse || hasLastHomework || hasPromises
 
   return (
     <div
@@ -67,9 +93,11 @@ export function NextSessionHero({ session }: NextSessionHeroProps) {
       <div className="flex items-start justify-between gap-4 mb-5">
         <div>
           <div className="flex items-center gap-3 mb-1">
-            <span className="inline-flex items-center rounded-full bg-gradient-to-br from-[#3525CD] to-indigo-500 px-3 py-1 text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-white font-inter">
-              {formatCountdown(session.sessionDate)}
-            </span>
+            {urgency.showBadge && (
+              <span className={`inline-flex items-center rounded-full px-3 py-1 text-[0.6875rem] font-bold uppercase tracking-[0.05em] font-inter ${urgency.className}`}>
+                {urgency.label}
+              </span>
+            )}
             <span className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter">
               {formatSessionDay(session.sessionDate)} &middot; {formatSessionTime(session.sessionDate)}
             </span>
@@ -80,12 +108,21 @@ export function NextSessionHero({ session }: NextSessionHeroProps) {
         </div>
         <div className="flex flex-col items-end gap-2">
           <CefrBadge level={session.studentCefrLevel} />
-          <Link
-            to={`/students/${session.studentId}`}
-            className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-indigo-600 hover:text-indigo-800 font-inter transition-colors"
-          >
-            View profile
-          </Link>
+          <div className="flex items-center gap-3">
+            <Link
+              to={`/students/${session.studentId}`}
+              className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-indigo-600 hover:text-indigo-800 font-inter transition-colors"
+            >
+              View profile
+            </Link>
+            <Link
+              to={`/students/${session.studentId}/log-session`}
+              className="inline-flex items-center rounded-xl bg-gradient-to-br from-[#3525CD] to-indigo-500 px-3 py-1.5 text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-white font-inter transition-opacity hover:opacity-90"
+              data-testid="start-session-btn"
+            >
+              Start session
+            </Link>
+          </div>
         </div>
       </div>
 
@@ -97,21 +134,47 @@ export function NextSessionHero({ session }: NextSessionHeroProps) {
         </div>
       )}
 
-      {/* Briefing grid */}
-      {(session.lastSessionNotes || session.homeworkAssigned) && (
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 rounded-xl bg-[#F4F2FD] p-4">
-          {session.lastSessionNotes && (
-            <div>
-              <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mb-1">
+      {/* Last session briefing + homework card */}
+      {(hasBriefing || session.homeworkAssigned) && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {/* Structured briefing */}
+          {hasBriefing && (
+            <div className="rounded-xl bg-[#F4F2FD] p-4 space-y-2.5">
+              <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter">
                 Last session{session.lastSessionDate ? ` · ${formatLastSessionDate(session.lastSessionDate)}` : ''}
               </p>
-              <p className="text-sm text-[#1A1B22] font-inter">{session.lastSessionNotes}</p>
+              {hasTopics && (
+                <div>
+                  <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mb-0.5">Topics</p>
+                  <p className="text-sm text-[#1A1B22] font-inter">{session.lastSessionTopicTags.join(', ')}</p>
+                </div>
+              )}
+              {hasResponse && (
+                <div>
+                  <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mb-0.5">How it went</p>
+                  <p className="text-sm text-[#1A1B22] font-inter">{session.lastSessionNotes}</p>
+                </div>
+              )}
+              {hasLastHomework && (
+                <div>
+                  <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mb-0.5">Homework assigned</p>
+                  <p className="text-sm text-[#1A1B22] font-inter">{session.lastSessionHomework}</p>
+                </div>
+              )}
+              {hasPromises && (
+                <div>
+                  <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mb-0.5">Promises made</p>
+                  <p className="text-sm text-[#1A1B22] font-inter">{session.lastSessionFollowups.join(' · ')}</p>
+                </div>
+              )}
             </div>
           )}
+
+          {/* Homework status card */}
           {session.homeworkAssigned && (
-            <div>
-              <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mb-1">
-                Homework &middot; <span className={hwStatus.color}>{hwStatus.label}</span>
+            <div className="rounded-xl bg-amber-50 border border-amber-100 p-4">
+              <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-amber-700 font-inter mb-1">
+                Homework pending &middot; <span className={hwStatus.color}>{hwStatus.label}</span>
               </p>
               <p className="text-sm text-[#1A1B22] font-inter">{session.homeworkAssigned}</p>
             </div>

--- a/frontend/src/components/dashboard/PendingFollowups.test.tsx
+++ b/frontend/src/components/dashboard/PendingFollowups.test.tsx
@@ -54,4 +54,21 @@ describe('PendingFollowups', () => {
     render(<PendingFollowups followups={[makeFollowup({ id: 'f1' })]} />)
     expect(screen.getByTestId('followup-dot-f1')).toBeInTheDocument()
   })
+
+  it('shows TODAY badge for followup created today', () => {
+    render(<PendingFollowups followups={[makeFollowup({ id: 'f1', createdAt: new Date().toISOString() })]} />)
+    expect(screen.getByTestId('followup-age-f1')).toHaveTextContent('TODAY')
+  })
+
+  it('shows OVERDUE badge for followup more than 3 days old', () => {
+    const old = new Date(Date.now() - 7 * 86400000).toISOString()
+    render(<PendingFollowups followups={[makeFollowup({ id: 'f1', createdAt: old })]} />)
+    expect(screen.getByTestId('followup-age-f1')).toHaveTextContent('OVERDUE')
+  })
+
+  it('shows OLD badge for followup 1-3 days old', () => {
+    const twoDaysAgo = new Date(Date.now() - 2 * 86400000).toISOString()
+    render(<PendingFollowups followups={[makeFollowup({ id: 'f1', createdAt: twoDaysAgo })]} />)
+    expect(screen.getByTestId('followup-age-f1')).toHaveTextContent('OLD')
+  })
 })

--- a/frontend/src/components/dashboard/PendingFollowups.tsx
+++ b/frontend/src/components/dashboard/PendingFollowups.tsx
@@ -6,12 +6,29 @@ interface PendingFollowupsProps {
   followups: TeacherFollowup[]
 }
 
-function ageBadge(createdAt: string): { label: string; className: string } {
+interface AgeBadgeInfo {
+  label: string
+  dotColor: string
+  badgeClassName: string
+}
+
+function ageBadge(createdAt: string): AgeBadgeInfo {
   const days = Math.floor(Math.max(0, Date.now() - new Date(createdAt).getTime()) / 86400000)
-  if (days === 0) return { label: 'new', className: 'bg-emerald-100 text-emerald-700' }
-  if (days <= 3) return { label: `${days}d`, className: 'bg-emerald-100 text-emerald-700' }
-  if (days <= 7) return { label: `${days}d`, className: 'bg-amber-100 text-amber-700' }
-  return { label: `${days}d`, className: 'bg-red-100 text-red-700' }
+  if (days === 0) return {
+    label: 'TODAY',
+    dotColor: 'bg-emerald-500',
+    badgeClassName: 'bg-emerald-100 text-emerald-700',
+  }
+  if (days <= 3) return {
+    label: `${days}D OLD`,
+    dotColor: 'bg-amber-400',
+    badgeClassName: 'bg-amber-100 text-amber-700',
+  }
+  return {
+    label: `${days}D OVERDUE`,
+    dotColor: 'bg-red-500',
+    badgeClassName: 'bg-red-100 text-red-700',
+  }
 }
 
 export function PendingFollowups({ followups }: PendingFollowupsProps) {
@@ -50,7 +67,7 @@ export function PendingFollowups({ followups }: PendingFollowupsProps) {
                 <button
                   onClick={() => handleMarkDone(f.id)}
                   aria-label="Mark done"
-                  className="mt-0.5 shrink-0 w-3.5 h-3.5 rounded-full border-2 border-amber-400 bg-amber-100 hover:bg-amber-400 transition-colors"
+                  className={`mt-0.5 shrink-0 w-3.5 h-3.5 rounded-full border-2 ${badge.dotColor} border-transparent hover:opacity-80 transition-opacity`}
                   data-testid={`followup-dot-${f.id}`}
                 />
                 <div className="flex-1 min-w-0">
@@ -61,7 +78,7 @@ export function PendingFollowups({ followups }: PendingFollowupsProps) {
                   )}
                   <p className="text-sm text-[#1A1B22] font-inter">{f.text}</p>
                 </div>
-                <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[0.6875rem] font-bold font-inter shrink-0 ${badge.className}`}>
+                <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[0.6875rem] font-bold font-inter shrink-0 ${badge.badgeClassName}`} data-testid={`followup-age-${f.id}`}>
                   {badge.label}
                 </span>
               </div>

--- a/frontend/src/components/dashboard/StudentRoster.test.tsx
+++ b/frontend/src/components/dashboard/StudentRoster.test.tsx
@@ -142,14 +142,13 @@ describe('StudentRoster', () => {
     expect(screen.getByText(/Inactive \d+d/)).toBeInTheDocument()
   })
 
-  it('renders sort dropdown defaulting to Last Session', () => {
+  it('renders sort dropdown showing Last Session by default', () => {
     render(
       <MemoryRouter>
         <StudentRoster students={[makeStudent()]} />
       </MemoryRouter>,
     )
-    const select = screen.getByTestId('roster-sort') as HTMLSelectElement
-    expect(select.value).toBe('lastSession')
+    expect(screen.getByTestId('roster-sort')).toHaveTextContent('Last Session')
   })
 
   it('sorts by name when Name option selected', () => {
@@ -162,8 +161,8 @@ describe('StudentRoster', () => {
         <StudentRoster students={students} />
       </MemoryRouter>,
     )
-    const select = screen.getByTestId('roster-sort')
-    fireEvent.change(select, { target: { value: 'name' } })
+    fireEvent.click(screen.getByTestId('roster-sort'))
+    fireEvent.click(screen.getByTestId('roster-sort-option-name'))
     const rows = screen.getAllByTestId('zone3-student-row')
     expect(rows[0]).toHaveTextContent('Ana')
     expect(rows[1]).toHaveTextContent('Zara')

--- a/frontend/src/components/dashboard/StudentRoster.test.tsx
+++ b/frontend/src/components/dashboard/StudentRoster.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { StudentRoster } from './StudentRoster'
@@ -69,7 +69,45 @@ describe('StudentRoster', () => {
     expect(screen.getByRole('link', { name: /Add your first student/i })).toBeInTheDocument()
   })
 
-  it('shows pending todo count badge when student has pending todos', () => {
+  it('shows student count', () => {
+    render(
+      <MemoryRouter>
+        <StudentRoster students={[makeStudent(), makeStudent({ studentId: 's2', name: 'Marco Rossi' })]} />
+      </MemoryRouter>,
+    )
+    expect(screen.getByTestId('student-count')).toHaveTextContent('2 active enrollments')
+  })
+
+  it('shows singular enrollment for one student', () => {
+    render(
+      <MemoryRouter>
+        <StudentRoster students={[makeStudent()]} />
+      </MemoryRouter>,
+    )
+    expect(screen.getByTestId('student-count')).toHaveTextContent('1 active enrollment')
+  })
+
+  it('shows L1 native language', () => {
+    render(
+      <MemoryRouter>
+        <StudentRoster students={[makeStudent({ nativeLanguages: ['Spanish'] })]} />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('Spanish')).toBeInTheDocument()
+  })
+
+  it('shows dash for missing native language', () => {
+    render(
+      <MemoryRouter>
+        <StudentRoster students={[makeStudent({ nativeLanguages: [] })]} />
+      </MemoryRouter>,
+    )
+    // Multiple dashes may appear (Last, Next also show — for nulls in this case)
+    const cells = screen.getAllByText('—')
+    expect(cells.length).toBeGreaterThan(0)
+  })
+
+  it('shows Review pending signal when student has pending todos', () => {
     const student = makeStudent({ pendingTodos: [
       { id: 't1', text: 'Todo 1', createdAt: new Date().toISOString(), status: 'pending', sourceSessionLogId: null, coveredInSessionLogId: null },
     ] })
@@ -78,18 +116,56 @@ describe('StudentRoster', () => {
         <StudentRoster students={[student]} />
       </MemoryRouter>,
     )
-    expect(screen.getByText('1')).toBeInTheDocument()
+    expect(screen.getByText('Review pending')).toBeInTheDocument()
   })
 
-  it('limits to 10 students maximum', () => {
-    const students = Array.from({ length: 15 }, (_, i) =>
-      makeStudent({ studentId: `s${i}`, name: `Student ${i}`, nextSessionDate: new Date(Date.now() + i * 86400000).toISOString() }),
+  it('shows Cancelled 2x signal when cancelledSessionsLast30Days >= 2', () => {
+    const student = makeStudent({ cancelledSessionsLast30Days: 2 })
+    render(
+      <MemoryRouter>
+        <StudentRoster students={[student]} />
+      </MemoryRouter>,
     )
+    expect(screen.getByText('Cancelled 2x')).toBeInTheDocument()
+  })
+
+  it('shows Inactive signal when last session >= 14 days ago and no next session', () => {
+    const student = makeStudent({
+      lastSessionDate: new Date(Date.now() - 20 * 86400000).toISOString(),
+      nextSessionDate: null,
+    })
+    render(
+      <MemoryRouter>
+        <StudentRoster students={[student]} />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/Inactive \d+d/)).toBeInTheDocument()
+  })
+
+  it('renders sort dropdown defaulting to Last Session', () => {
+    render(
+      <MemoryRouter>
+        <StudentRoster students={[makeStudent()]} />
+      </MemoryRouter>,
+    )
+    const select = screen.getByTestId('roster-sort') as HTMLSelectElement
+    expect(select.value).toBe('lastSession')
+  })
+
+  it('sorts by name when Name option selected', () => {
+    const students = [
+      makeStudent({ studentId: 's1', name: 'Zara' }),
+      makeStudent({ studentId: 's2', name: 'Ana' }),
+    ]
     render(
       <MemoryRouter>
         <StudentRoster students={students} />
       </MemoryRouter>,
     )
-    expect(screen.getAllByTestId('zone3-student-row')).toHaveLength(10)
+    const select = screen.getByTestId('roster-sort')
+    fireEvent.change(select, { target: { value: 'name' } })
+    const rows = screen.getAllByTestId('zone3-student-row')
+    expect(rows[0]).toHaveTextContent('Ana')
+    expect(rows[1]).toHaveTextContent('Zara')
   })
 })

--- a/frontend/src/components/dashboard/StudentRoster.tsx
+++ b/frontend/src/components/dashboard/StudentRoster.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { Link } from 'react-router-dom'
+import { ChevronsUpDown } from 'lucide-react'
 import { CefrBadge } from './CefrBadge'
 import type { ActiveStudent } from '@/api/dashboard'
 
@@ -70,7 +71,19 @@ const SORT_OPTIONS: { value: SortOption; label: string }[] = [
 
 export function StudentRoster({ students }: StudentRosterProps) {
   const [sortBy, setSortBy] = useState<SortOption>('lastSession')
+  const [sortOpen, setSortOpen] = useState(false)
+  const sortRef = useRef<HTMLDivElement>(null)
 
+  useEffect(() => {
+    if (!sortOpen) return
+    function handleClick(e: MouseEvent) {
+      if (!sortRef.current?.contains(e.target as Node)) setSortOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [sortOpen])
+
+  const currentSortLabel = SORT_OPTIONS.find(o => o.value === sortBy)?.label ?? 'Last Session'
   const sorted = sortStudents(students, sortBy)
 
   return (
@@ -85,19 +98,43 @@ export function StudentRoster({ students }: StudentRosterProps) {
           )}
         </div>
         {students.length > 0 && (
-          <div className="flex items-center gap-2 shrink-0">
-            <span className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter hidden sm:block">Sort</span>
-            <select
-              value={sortBy}
-              onChange={e => setSortBy(e.target.value as SortOption)}
-              className="text-xs font-inter text-[#1A1B22] bg-[#F4F2FD] rounded-lg px-2 py-1.5 border-none outline-none cursor-pointer"
+          <div className="relative shrink-0" ref={sortRef}>
+            <button
               aria-label="Sort students"
+              aria-haspopup="listbox"
+              aria-expanded={sortOpen}
+              onClick={() => setSortOpen(o => !o)}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg bg-[#F4F2FD] hover:bg-[#ECEAFD] transition-colors"
               data-testid="roster-sort"
             >
-              {SORT_OPTIONS.map(opt => (
-                <option key={opt.value} value={opt.value}>{opt.label}</option>
-              ))}
-            </select>
+              <span className="text-zinc-500 hidden sm:inline">Sort:</span>
+              <span className="font-medium text-[#1A1B22]">{currentSortLabel}</span>
+              <ChevronsUpDown className="h-3.5 w-3.5 text-zinc-400" />
+            </button>
+            {sortOpen && (
+              <div
+                role="listbox"
+                className="absolute right-0 top-full mt-1 w-36 bg-white rounded-lg shadow-lg border border-zinc-100 z-10 py-1"
+              >
+                {SORT_OPTIONS.map(opt => (
+                  <button
+                    key={opt.value}
+                    role="option"
+                    aria-selected={sortBy === opt.value}
+                    data-testid={`roster-sort-option-${opt.value}`}
+                    onClick={() => { setSortBy(opt.value); setSortOpen(false) }}
+                    className={[
+                      'w-full text-left px-3 py-1.5 text-xs transition-colors',
+                      sortBy === opt.value
+                        ? 'font-semibold text-[#3525CD] bg-indigo-50'
+                        : 'text-zinc-600 hover:bg-zinc-50',
+                    ].join(' ')}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/components/dashboard/StudentRoster.tsx
+++ b/frontend/src/components/dashboard/StudentRoster.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { CefrBadge } from './CefrBadge'
 import type { ActiveStudent } from '@/api/dashboard'
@@ -6,25 +7,99 @@ interface StudentRosterProps {
   students: ActiveStudent[]
 }
 
+type SortOption = 'lastSession' | 'nextSession' | 'name'
+
+interface RosterSignal {
+  label: string
+  className: string
+  redDot?: boolean
+}
+
+function buildRosterSignal(student: ActiveStudent): RosterSignal | null {
+  if (student.cancelledSessionsLast30Days >= 2) {
+    return { label: 'Cancelled 2x', className: 'bg-[#1A1B22] text-white', redDot: true }
+  }
+  const now = Date.now()
+  const lastSessionMs = student.lastSessionDate ? new Date(student.lastSessionDate).getTime() : null
+  const lastSessionGapDays = lastSessionMs != null
+    ? Math.floor((now - lastSessionMs) / (1000 * 60 * 60 * 24))
+    : null
+  if (lastSessionGapDays != null && lastSessionGapDays >= 14 && !student.nextSessionDate) {
+    return { label: `Inactive ${lastSessionGapDays}d`, className: 'bg-amber-500 text-white' }
+  }
+  if (student.pendingTodos.length > 0) {
+    return { label: 'Review pending', className: 'bg-[#3525CD] text-white' }
+  }
+  return null
+}
+
+function sortStudents(students: ActiveStudent[], sortBy: SortOption): ActiveStudent[] {
+  const sorted = [...students]
+  switch (sortBy) {
+    case 'lastSession':
+      return sorted.sort((a, b) => {
+        if (!a.lastSessionDate && !b.lastSessionDate) return 0
+        if (!a.lastSessionDate) return 1
+        if (!b.lastSessionDate) return -1
+        return new Date(b.lastSessionDate).getTime() - new Date(a.lastSessionDate).getTime()
+      })
+    case 'nextSession':
+      return sorted.sort((a, b) => {
+        if (!a.nextSessionDate && !b.nextSessionDate) return 0
+        if (!a.nextSessionDate) return 1
+        if (!b.nextSessionDate) return -1
+        return new Date(a.nextSessionDate).getTime() - new Date(b.nextSessionDate).getTime()
+      })
+    case 'name':
+      return sorted.sort((a, b) => a.name.localeCompare(b.name))
+    default:
+      return sorted
+  }
+}
+
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return '—'
   return new Date(dateStr).toLocaleDateString([], { month: 'short', day: 'numeric' })
 }
 
+const SORT_OPTIONS: { value: SortOption; label: string }[] = [
+  { value: 'lastSession', label: 'Last Session' },
+  { value: 'nextSession', label: 'Next Session' },
+  { value: 'name', label: 'Name' },
+]
+
 export function StudentRoster({ students }: StudentRosterProps) {
-  const sorted = [...students]
-    .sort((a, b) => {
-      if (!a.nextSessionDate && !b.nextSessionDate) return 0
-      if (!a.nextSessionDate) return 1
-      if (!b.nextSessionDate) return -1
-      return new Date(a.nextSessionDate).getTime() - new Date(b.nextSessionDate).getTime()
-    })
-    .slice(0, 10)
+  const [sortBy, setSortBy] = useState<SortOption>('lastSession')
+
+  const sorted = sortStudents(students, sortBy)
 
   return (
     <div className="rounded-2xl bg-white shadow-[0_12px_40px_rgba(26,27,34,0.06)] ring-1 ring-[#C7C4D8]/20 overflow-hidden" data-testid="zone3-student-roster">
-      <div className="px-6 pt-5 pb-3">
-        <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22]">Students</h3>
+      <div className="px-6 pt-5 pb-3 flex items-start justify-between gap-4">
+        <div>
+          <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22]">Student Roster</h3>
+          {students.length > 0 && (
+            <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mt-0.5" data-testid="student-count">
+              {students.length} active enrollment{students.length !== 1 ? 's' : ''}
+            </p>
+          )}
+        </div>
+        {students.length > 0 && (
+          <div className="flex items-center gap-2 shrink-0">
+            <span className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter hidden sm:block">Sort</span>
+            <select
+              value={sortBy}
+              onChange={e => setSortBy(e.target.value as SortOption)}
+              className="text-xs font-inter text-[#1A1B22] bg-[#F4F2FD] rounded-lg px-2 py-1.5 border-none outline-none cursor-pointer"
+              aria-label="Sort students"
+              data-testid="roster-sort"
+            >
+              {SORT_OPTIONS.map(opt => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+        )}
       </div>
 
       {sorted.length === 0 ? (
@@ -44,44 +119,56 @@ export function StudentRoster({ students }: StudentRosterProps) {
               <tr className="border-none">
                 <th className="px-6 py-2 text-left text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400">Name</th>
                 <th className="px-3 py-2 text-left text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400">Level</th>
+                <th className="px-3 py-2 text-left text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hidden sm:table-cell">L1</th>
                 <th className="px-3 py-2 text-left text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hidden sm:table-cell">Last</th>
                 <th className="px-3 py-2 text-left text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hidden sm:table-cell">Next</th>
-                <th className="px-3 py-2 text-right text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hidden md:table-cell">Pending</th>
+                <th className="px-3 py-2 text-left text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hidden md:table-cell">Signal</th>
               </tr>
             </thead>
             <tbody>
-              {sorted.map(student => (
-                <tr
-                  key={student.studentId}
-                  className="group hover:bg-[#F4F2FD] transition-colors"
-                  data-testid="zone3-student-row"
-                >
-                  <td className="px-6 py-2.5">
-                    <Link
-                      to={`/students/${student.studentId}`}
-                      className="font-medium text-[#1A1B22] group-hover:text-indigo-700 transition-colors"
-                    >
-                      {student.name}
-                    </Link>
-                  </td>
-                  <td className="px-3 py-2.5">
-                    <CefrBadge level={student.cefrLevel} />
-                  </td>
-                  <td className="px-3 py-2.5 text-zinc-500 hidden sm:table-cell">
-                    {formatDate(student.lastSessionDate)}
-                  </td>
-                  <td className="px-3 py-2.5 text-zinc-500 hidden sm:table-cell">
-                    {formatDate(student.nextSessionDate)}
-                  </td>
-                  <td className="px-3 py-2.5 text-right hidden md:table-cell">
-                    {(student.pendingTodos?.length ?? 0) > 0 && (
-                      <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[0.6875rem] font-bold text-amber-700">
-                        {student.pendingTodos.length}
-                      </span>
-                    )}
-                  </td>
-                </tr>
-              ))}
+              {sorted.map(student => {
+                const signal = buildRosterSignal(student)
+                const l1 = student.nativeLanguages[0] ?? null
+
+                return (
+                  <tr
+                    key={student.studentId}
+                    className="group hover:bg-[#F4F2FD] transition-colors"
+                    data-testid="zone3-student-row"
+                  >
+                    <td className="px-6 py-2.5">
+                      <Link
+                        to={`/students/${student.studentId}`}
+                        className="font-medium text-[#1A1B22] group-hover:text-indigo-700 transition-colors"
+                      >
+                        {student.name}
+                      </Link>
+                    </td>
+                    <td className="px-3 py-2.5">
+                      <CefrBadge level={student.cefrLevel} />
+                    </td>
+                    <td className="px-3 py-2.5 text-zinc-500 hidden sm:table-cell">
+                      {l1 ?? '—'}
+                    </td>
+                    <td className="px-3 py-2.5 text-zinc-500 hidden sm:table-cell">
+                      {formatDate(student.lastSessionDate)}
+                    </td>
+                    <td className="px-3 py-2.5 text-zinc-500 hidden sm:table-cell">
+                      {formatDate(student.nextSessionDate)}
+                    </td>
+                    <td className="px-3 py-2.5 hidden md:table-cell">
+                      {signal && (
+                        <span className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[0.6875rem] font-bold font-inter ${signal.className}`}>
+                          {signal.redDot && (
+                            <span className="w-1.5 h-1.5 rounded-full bg-red-500 shrink-0" />
+                          )}
+                          {signal.label}
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
             </tbody>
           </table>
 

--- a/frontend/src/components/dashboard/TodayAgenda.test.tsx
+++ b/frontend/src/components/dashboard/TodayAgenda.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { TodayAgenda } from './TodayAgenda'
-import type { TodaySession } from '@/api/dashboard'
+import type { TodaySession, UpcomingSession } from '@/api/dashboard'
 
 function makeSession(overrides: Partial<TodaySession> = {}): TodaySession {
   return {
@@ -17,35 +17,57 @@ function makeSession(overrides: Partial<TodaySession> = {}): TodaySession {
   }
 }
 
+function makeUpcoming(overrides: Partial<UpcomingSession> = {}): UpcomingSession {
+  return {
+    sessionLogId: 'ul1',
+    studentId: 'student-2',
+    studentName: 'Marco Rossi',
+    studentCefrLevel: 'A2',
+    sessionDate: new Date(Date.now() + 2 * 86400000).toISOString(),
+    plannedContent: null,
+    ...overrides,
+  }
+}
+
 describe('TodayAgenda', () => {
-  it('shows empty state when no sessions', () => {
+  it('shows no sessions this week when both empty', () => {
     render(
       <MemoryRouter>
-        <TodayAgenda sessions={[]} nextSessionId={null} />
+        <TodayAgenda sessions={[]} nextSessionId={null} upcomingThisWeek={[]} />
       </MemoryRouter>,
     )
-    expect(screen.getByText(/No sessions today/)).toBeInTheDocument()
+    expect(screen.getByText(/No sessions this week/)).toBeInTheDocument()
   })
 
-  it('renders session rows', () => {
+  it('shows This Week fallback when today empty but upcoming non-empty', () => {
+    render(
+      <MemoryRouter>
+        <TodayAgenda sessions={[]} nextSessionId={null} upcomingThisWeek={[makeUpcoming()]} />
+      </MemoryRouter>,
+    )
+    expect(screen.getByTestId('this-week-sessions')).toBeInTheDocument()
+    expect(screen.getByText('Marco Rossi')).toBeInTheDocument()
+  })
+
+  it('renders session rows when today has sessions', () => {
     const sessions = [
       makeSession({ sessionLogId: 'sl1', studentName: 'Ana' }),
-      makeSession({ sessionLogId: 'sl2', studentName: 'Marco' }),
+      makeSession({ sessionLogId: 'sl2', studentName: 'Carmen' }),
     ]
     render(
       <MemoryRouter>
-        <TodayAgenda sessions={sessions} nextSessionId={null} />
+        <TodayAgenda sessions={sessions} nextSessionId={null} upcomingThisWeek={[]} />
       </MemoryRouter>,
     )
     expect(screen.getByText('Ana')).toBeInTheDocument()
-    expect(screen.getByText('Marco')).toBeInTheDocument()
+    expect(screen.getByText('Carmen')).toBeInTheDocument()
   })
 
   it('highlights the next session', () => {
     const session = makeSession({ sessionLogId: 'sl-next' })
     render(
       <MemoryRouter>
-        <TodayAgenda sessions={[session]} nextSessionId="sl-next" />
+        <TodayAgenda sessions={[session]} nextSessionId="sl-next" upcomingThisWeek={[]} />
       </MemoryRouter>,
     )
     const link = screen.getByRole('link', { name: /Ana/ })
@@ -55,7 +77,7 @@ describe('TodayAgenda', () => {
   it('renders zone2-today-agenda testid', () => {
     render(
       <MemoryRouter>
-        <TodayAgenda sessions={[]} nextSessionId={null} />
+        <TodayAgenda sessions={[]} nextSessionId={null} upcomingThisWeek={[]} />
       </MemoryRouter>,
     )
     expect(screen.getByTestId('zone2-today-agenda')).toBeInTheDocument()

--- a/frontend/src/components/dashboard/TodayAgenda.tsx
+++ b/frontend/src/components/dashboard/TodayAgenda.tsx
@@ -1,53 +1,101 @@
 import { Link } from 'react-router-dom'
 import { CefrBadge } from './CefrBadge'
-import type { TodaySession } from '@/api/dashboard'
+import type { TodaySession, UpcomingSession } from '@/api/dashboard'
 
 interface TodayAgendaProps {
   sessions: TodaySession[]
   nextSessionId: string | null
+  upcomingThisWeek: UpcomingSession[]
 }
 
 function formatTime(dateStr: string): string {
   return new Date(dateStr).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
 }
 
-export function TodayAgenda({ sessions, nextSessionId }: TodayAgendaProps) {
+function formatUpcomingDate(dateStr: string): string {
+  const d = new Date(dateStr)
+  const today = new Date()
+  const tomorrow = new Date(today)
+  tomorrow.setDate(today.getDate() + 1)
+  if (d.toDateString() === tomorrow.toDateString()) return 'Tomorrow'
+  return d.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' })
+}
+
+export function TodayAgenda({ sessions, nextSessionId, upcomingThisWeek }: TodayAgendaProps) {
+  if (sessions.length === 0) {
+    if (upcomingThisWeek.length === 0) {
+      return (
+        <div className="rounded-2xl bg-white p-5 shadow-[0_12px_40px_rgba(26,27,34,0.06)] ring-1 ring-[#C7C4D8]/20" data-testid="zone2-today-agenda">
+          <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22] mb-2">Today's Agenda</h3>
+          <p className="text-sm text-zinc-400 font-inter py-4 text-center">No sessions this week</p>
+        </div>
+      )
+    }
+
+    return (
+      <div className="rounded-2xl bg-white p-5 shadow-[0_12px_40px_rgba(26,27,34,0.06)] ring-1 ring-[#C7C4D8]/20" data-testid="zone2-today-agenda">
+        <div className="flex items-baseline gap-2 mb-4">
+          <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22]">Today's Agenda</h3>
+          <span className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter">No sessions · This Week</span>
+        </div>
+        <div className="space-y-2" data-testid="this-week-sessions">
+          {upcomingThisWeek.map(session => (
+            <Link
+              key={session.sessionLogId}
+              to={`/students/${session.studentId}`}
+              className="flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-[#F4F2FD]"
+            >
+              <div className="flex flex-col items-start w-24 shrink-0">
+                <span className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter leading-tight">
+                  {formatUpcomingDate(session.sessionDate)}
+                </span>
+                <span className="text-[0.6875rem] text-zinc-400 font-inter leading-tight">
+                  {formatTime(session.sessionDate)}
+                </span>
+              </div>
+              <span className="flex-1 text-sm font-medium text-[#1A1B22] font-inter truncate">
+                {session.studentName}
+              </span>
+              <CefrBadge level={session.studentCefrLevel} />
+            </Link>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="rounded-2xl bg-white p-5 shadow-[0_12px_40px_rgba(26,27,34,0.06)] ring-1 ring-[#C7C4D8]/20" data-testid="zone2-today-agenda">
       <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22] mb-4">Today's Agenda</h3>
 
-      {sessions.length === 0 ? (
-        <p className="text-sm text-zinc-400 font-inter py-4 text-center">No sessions today</p>
-      ) : (
-        <div className="space-y-2">
-          {sessions.map(session => {
-            const isNext = session.sessionLogId === nextSessionId
-            return (
-              <Link
-                key={session.sessionLogId}
-                to={`/students/${session.studentId}`}
-                className={[
-                  'flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-[#F4F2FD]',
-                  isNext ? 'border-l-[3px] border-l-indigo-600 bg-[#ECEAFD]' : '',
-                ].join(' ')}
-              >
-                <span className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter w-12 shrink-0">
-                  {formatTime(session.sessionDate)}
+      <div className="space-y-2">
+        {sessions.map(session => {
+          const isNext = session.sessionLogId === nextSessionId
+          return (
+            <Link
+              key={session.sessionLogId}
+              to={`/students/${session.studentId}`}
+              className={[
+                'flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-[#F4F2FD]',
+                isNext ? 'border-l-[3px] border-l-indigo-600 bg-[#ECEAFD]' : '',
+              ].join(' ')}
+            >
+              <span className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter w-12 shrink-0">
+                {formatTime(session.sessionDate)}
+              </span>
+              <span className="flex-1 text-sm font-medium text-[#1A1B22] font-inter truncate">
+                {session.studentName}
+              </span>
+              <CefrBadge level={session.studentCefrLevel} />
+              {session.plannedContent && (
+                <span className="hidden sm:block text-xs text-zinc-400 font-inter truncate max-w-[120px]">
+                  {session.plannedContent}
                 </span>
-                <span className="flex-1 text-sm font-medium text-[#1A1B22] font-inter truncate">
-                  {session.studentName}
-                </span>
-                <CefrBadge level={session.studentCefrLevel} />
-                {session.plannedContent && (
-                  <span className="hidden sm:block text-xs text-zinc-400 font-inter truncate max-w-[120px]">
-                    {session.plannedContent}
-                  </span>
-                )}
-              </Link>
-            )
-          })}
-        </div>
-      )}
+              )}
+            </Link>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -12,7 +12,7 @@ vi.mock('@/api/dashboard', () => ({
 }))
 
 function makeEmptyDashboard(): DashboardData {
-  return { nextSession: null, todaySessions: [], activeStudents: [], pendingFollowups: [] }
+  return { nextSession: null, todaySessions: [], activeStudents: [], pendingFollowups: [], upcomingThisWeek: [] }
 }
 
 function makeDashboard(overrides: Partial<DashboardData> = {}): DashboardData {
@@ -28,6 +28,9 @@ function makeDashboard(overrides: Partial<DashboardData> = {}): DashboardData {
       lastSessionDate: new Date(Date.now() - 7 * 86400000).toISOString(),
       homeworkAssigned: 'Page 42',
       previousHomeworkStatus: '3',
+      lastSessionTopicTags: [],
+      lastSessionHomework: null,
+      lastSessionFollowups: [],
     },
     todaySessions: [
       {
@@ -58,6 +61,7 @@ function makeDashboard(overrides: Partial<DashboardData> = {}): DashboardData {
       },
     ],
     pendingFollowups: [],
+    upcomingThisWeek: [],
     ...overrides,
   }
 }
@@ -127,9 +131,9 @@ describe('Dashboard', () => {
   })
 
   describe('Zone 2: Today Agenda', () => {
-    it('shows empty state when no today sessions', async () => {
+    it('shows empty state when no today or upcoming sessions', async () => {
       renderDashboard()
-      expect(await screen.findByText(/No sessions today/)).toBeInTheDocument()
+      expect(await screen.findByText(/No sessions this week/)).toBeInTheDocument()
     })
 
     it('shows session rows when sessions exist', async () => {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -56,6 +56,7 @@ export default function Dashboard() {
   const todaySessions = data?.todaySessions ?? []
   const activeStudents = data?.activeStudents ?? []
   const pendingFollowups = data?.pendingFollowups ?? []
+  const upcomingThisWeek = data?.upcomingThisWeek ?? []
 
   return (
     <div className="space-y-5">
@@ -74,6 +75,7 @@ export default function Dashboard() {
         <TodayAgenda
           sessions={todaySessions}
           nextSessionId={nextSession?.sessionLogId ?? null}
+          upcomingThisWeek={upcomingThisWeek}
         />
         <PendingFollowups followups={pendingFollowups} />
       </div>

--- a/frontend/src/pages/Students.test.tsx
+++ b/frontend/src/pages/Students.test.tsx
@@ -19,7 +19,7 @@ vi.mock('../lib/logger', () => ({
   logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
 }))
 
-const emptyDashboard = { nextSession: null, todaySessions: [], activeStudents: [], pendingFollowups: [] }
+const emptyDashboard = { nextSession: null, todaySessions: [], activeStudents: [], pendingFollowups: [], upcomingThisWeek: [] }
 
 // Default createdAt is 30 days ago to avoid triggering the NEW signal badge
 const DEFAULT_CREATED_AT = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
@@ -217,6 +217,7 @@ describe('Students page', () => {
       nextSession: null,
       todaySessions: [],
       pendingFollowups: [],
+      upcomingThisWeek: [],
       activeStudents: [
         makeActiveStudent({
           studentId: 'abc-123',
@@ -260,7 +261,7 @@ describe('Students page', () => {
       ])
     )
     vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
-      nextSession: null, todaySessions: [], pendingFollowups: [],
+      nextSession: null, todaySessions: [], pendingFollowups: [], upcomingThisWeek: [],
       activeStudents: [
         makeActiveStudent({ studentId: 'b', name: 'Bruno', nextSessionDate: later }),
         makeActiveStudent({ studentId: 'a', name: 'Ana', nextSessionDate: soon }),
@@ -286,7 +287,7 @@ describe('Students page', () => {
       ])
     )
     vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
-      nextSession: null, todaySessions: [], pendingFollowups: [],
+      nextSession: null, todaySessions: [], pendingFollowups: [], upcomingThisWeek: [],
       activeStudents: [
         makeActiveStudent({ studentId: 'b', name: 'Bruno', lastSessionDate: older }),
         makeActiveStudent({ studentId: 'a', name: 'Ana', lastSessionDate: recent }),
@@ -340,7 +341,7 @@ describe('Students page', () => {
       ])
     )
     vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
-      nextSession: null, todaySessions: [], pendingFollowups: [],
+      nextSession: null, todaySessions: [], pendingFollowups: [], upcomingThisWeek: [],
       activeStudents: [
         makeActiveStudent({ studentId: 'z', name: 'Zara Smith', lastSessionDate: recent }),
       ],
@@ -366,7 +367,7 @@ describe('Students page', () => {
       makeListResponse([makeStudent({ id: 'abc-123' })])
     )
     vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
-      nextSession: null, todaySessions: [], pendingFollowups: [],
+      nextSession: null, todaySessions: [], pendingFollowups: [], upcomingThisWeek: [],
       activeStudents: [makeActiveStudent({ studentId: 'abc-123', lastSessionDate: lastSession, nextSessionDate: null })],
     })
     wrapper(<Students />)
@@ -379,7 +380,7 @@ describe('Students page', () => {
       makeListResponse([makeStudent({ id: 'abc-123' })])
     )
     vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
-      nextSession: null, todaySessions: [], pendingFollowups: [],
+      nextSession: null, todaySessions: [], pendingFollowups: [], upcomingThisWeek: [],
       activeStudents: [makeActiveStudent({ studentId: 'abc-123', cancelledSessionsLast30Days: 2 })],
     })
     wrapper(<Students />)
@@ -393,7 +394,7 @@ describe('Students page', () => {
       makeListResponse([makeStudent({ id: 'abc-123', createdAt: recentDate })])
     )
     vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
-      nextSession: null, todaySessions: [], pendingFollowups: [],
+      nextSession: null, todaySessions: [], pendingFollowups: [], upcomingThisWeek: [],
       activeStudents: [makeActiveStudent({ studentId: 'abc-123', totalSessions: 1 })],
     })
     wrapper(<Students />)
@@ -406,7 +407,7 @@ describe('Students page', () => {
       makeListResponse([makeStudent({ id: 'abc-123' })])
     )
     vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
-      nextSession: null, todaySessions: [], pendingFollowups: [],
+      nextSession: null, todaySessions: [], pendingFollowups: [], upcomingThisWeek: [],
       activeStudents: [makeActiveStudent({ studentId: 'abc-123', totalSessions: 1 })],
     })
     wrapper(<Students />)
@@ -423,7 +424,7 @@ describe('Students page', () => {
       })])
     )
     vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
-      nextSession: null, todaySessions: [], pendingFollowups: [],
+      nextSession: null, todaySessions: [], pendingFollowups: [], upcomingThisWeek: [],
       activeStudents: [makeActiveStudent({ studentId: 'abc-123' })],
     })
     wrapper(<Students />)
@@ -438,7 +439,7 @@ describe('Students page', () => {
       makeListResponse([makeStudent({ id: 'abc-123' })])
     )
     vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
-      nextSession: null, todaySessions: [], pendingFollowups: [],
+      nextSession: null, todaySessions: [], pendingFollowups: [], upcomingThisWeek: [],
       activeStudents: [makeActiveStudent({ studentId: 'abc-123', lastSessionDate: lastSession, nextSessionDate: nextSession })],
     })
     wrapper(<Students />)
@@ -471,7 +472,7 @@ describe('Students page', () => {
       makeListResponse([makeStudent({ id: 'abc-123' })])
     )
     vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
-      nextSession: null, todaySessions: [], pendingFollowups: [],
+      nextSession: null, todaySessions: [], pendingFollowups: [], upcomingThisWeek: [],
       activeStudents: [makeActiveStudent({ studentId: 'abc-123', nextSessionDate: todayAt2PM.toISOString() })],
     })
     wrapper(<Students />)

--- a/plan/langteach-beta/task730-dashboard-polish.md
+++ b/plan/langteach-beta/task730-dashboard-polish.md
@@ -1,0 +1,240 @@
+# Task 730: Dashboard Polish — Hero Card, Roster Signals, Followup Urgency
+
+**Issue:** #730
+**Sprint branch:** sprint/ui-redesign-student-polish
+**Worktree:** task-t730-dashboard-polish
+
+## Objective
+
+Polish the Dashboard across four zones: hero card (Start CTA + structured briefing + urgency badge), student roster (signals + L1 + sort + count), pending followups (overdue urgency), and empty agenda (This Week view).
+
+## Files Changed
+
+### Backend
+- `backend/LangTeach.Api/DTOs/DashboardDtos.cs` — extend `NextSessionDto` and `DashboardDto`
+- `backend/LangTeach.Api/Services/DashboardService.cs` — populate new fields (only one call site: line 59)
+- `backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs` — update tests
+
+### Frontend
+- `frontend/src/api/dashboard.ts` — add new fields to TS types
+- `frontend/src/pages/Dashboard.tsx` — pass `upcomingThisWeek` prop to TodayAgenda
+- `frontend/src/components/dashboard/NextSessionHero.tsx` — Start CTA, briefing, urgency
+- `frontend/src/components/dashboard/StudentRoster.tsx` — signals, L1, sort, count
+- `frontend/src/components/dashboard/PendingFollowups.tsx` — overdue urgency
+- `frontend/src/components/dashboard/TodayAgenda.tsx` — empty-state This Week view
+- `frontend/src/components/dashboard/NextSessionHero.test.tsx` — update tests
+- `frontend/src/components/dashboard/StudentRoster.test.tsx` — update tests
+- `frontend/src/components/dashboard/PendingFollowups.test.tsx` — update tests
+- `frontend/src/components/dashboard/TodayAgenda.test.tsx` — update tests
+
+## Backend Changes
+
+### 1. `DashboardDtos.cs` — Extend NextSessionDto and DashboardDto
+
+```csharp
+public record NextSessionDto(
+    Guid SessionLogId,
+    Guid StudentId,
+    string StudentName,
+    string StudentCefrLevel,
+    DateTime SessionDate,
+    string? PlannedContent,
+    string? LastSessionNotes,        // GeneralNotes (student response / how it went)
+    DateTime? LastSessionDate,
+    string? HomeworkAssigned,        // KEEP: homework on the upcoming session (pre-planned)
+    string? PreviousHomeworkStatus,
+    List<string> LastSessionTopicTags,    // NEW: TopicTags from lastPast session
+    string? LastSessionHomework,          // NEW: HomeworkAssigned from lastPast session
+    List<string> LastSessionFollowups     // NEW: pending followup text from lastPast session
+);
+
+// NEW: minimal upcoming session DTO for the This Week view
+public record UpcomingSessionDto(
+    Guid SessionLogId,
+    Guid StudentId,
+    string StudentName,
+    string StudentCefrLevel,
+    DateTime SessionDate,
+    string? PlannedContent
+);
+
+public record DashboardDto(
+    NextSessionDto? NextSession,
+    List<TodaySessionDto> TodaySessions,
+    List<ActiveStudentDto> ActiveStudents,
+    List<TeacherFollowupDto> PendingFollowups,
+    List<UpcomingSessionDto> UpcomingThisWeek  // NEW: sessions in next 7 days (excl. today)
+);
+```
+
+### 2. `DashboardService.cs` — Populate new fields
+
+**`GetNextSessionAsync` additions:**
+- After fetching `lastPast`, deserialize `lastPast.TopicTags` using `System.Text.Json`:
+  `JsonSerializer.Deserialize<List<string>>(lastPast.TopicTags) ?? []`
+- Include `lastPast.HomeworkAssigned` as `LastSessionHomework`
+- Query `TeacherFollowup` where `SourceSessionLogId == lastPast.Id && Status != "done"` for `LastSessionFollowups`
+  - `TeacherFollowup.Status` is a plain `string` ("pending" / "done"), NOT an enum. Use string literal comparison.
+  - DbSet confirmed as `_db.TeacherFollowups` (AppDbContext line 27)
+
+**New `GetUpcomingThisWeekAsync` method:**
+```csharp
+private async Task<List<UpcomingSessionDto>> GetUpcomingThisWeekAsync(...)
+```
+- Query sessions where `SessionDate.Value.Date > today` AND `SessionDate.Value.Date <= today.AddDays(7)` (inclusive upper bound — "within next 7 calendar days, not counting today")
+- Not cancelled, not deleted
+- Take first 5, ordered by `SessionDate` ascending
+- Map to `UpcomingSessionDto`
+
+## Frontend Changes
+
+### 1. `frontend/src/api/dashboard.ts`
+
+Add to `NextSession`:
+```ts
+lastSessionTopicTags: string[]
+lastSessionHomework: string | null
+lastSessionFollowups: string[]
+```
+
+Add `UpcomingSession` interface and `upcomingThisWeek: UpcomingSession[]` to `DashboardData`.
+
+### 2. `NextSessionHero.tsx` — Hero card polish
+
+**Urgency badge (adaptive):**
+```
+diff < 0              → 'NOW'           (green)
+diff <= 2 hours       → 'IN X MIN/H'   (green indigo gradient, same as now)
+diff <= 24 hours      → 'TODAY, HH:MM' (neutral zinc, no gradient)
+diff <= 7 days        → 'IN Xd'        (neutral zinc, no gradient, no pill)
+diff > 7 days         → show date only  (no badge, just date text)
+```
+Green gradient pill only for sessions within 2 hours. Neutral/no pill otherwise.
+
+**"Start session" CTA:**
+- Primary gradient button (indigo) next to "View profile" link
+- Navigate to `/students/:id/log-session`
+- Text: "Start session"
+- Use same gradient style as design system primary buttons
+
+**Last Session Briefing block (replace raw notes with structured bullets):**
+Replace the current `lastSessionNotes` text block with 4 structured bullet lines:
+1. **Topics** (from `lastSessionTopicTags`): comma-joined tags, or fall back to first ~80 chars of `lastSessionNotes` if tags empty
+2. **Response** (from `lastSessionNotes`): show as-is, labeled "How it went"
+3. **Homework** (from `lastSessionHomework`): show with warm amber accent
+4. **Promises** (from `lastSessionFollowups`): comma-joined followup texts
+
+Show a bullet only if the data is non-empty. Section is hidden entirely if all 4 are empty.
+
+**Homework Status card:**
+The current homework grid cell becomes a standalone warm-toned mini-card:
+- Background: warm amber tint (`bg-amber-50` or similar warm tone)
+- Separate visual weight from the rest of the briefing
+- Label: "Homework pending" or "Homework · [status]"
+- Show `homeworkAssigned` text (next session pre-planned) alongside `previousHomeworkStatus`
+
+### 3. `StudentRoster.tsx` — Signals, L1, sort, count
+
+**Student count:**
+- Under "Student Roster" heading: `{students.length} active enrollment{plural}`
+- Subtitle style (zinc-400, label-sm)
+
+**Sort control:**
+- Dropdown (same style as Students list sort)
+- Options: "Last Session" (default), "Next Session", "Name"
+- Sorting logic:
+  - Last Session: desc by `lastSessionDate` (null last)
+  - Next Session: asc by `nextSessionDate` (null last)
+  - Name: asc alphabetical
+- Remove hardcoded sort-by-nextSession that currently truncates to 10
+
+**L1 column:**
+- After Level column header "L1"
+- Display first native language from `nativeLanguages[0]` or `—`
+- Hidden on small screens (`hidden sm:table-cell`)
+
+**Activity Signal column:**
+- After L1 (or before Pending)
+- Header "Signal"
+- Build signals from `ActiveStudent` dashboard data:
+  - Inactive Xd: `lastSessionDate` gap >= 14 days AND no `nextSessionDate`
+  - Cancelled 2x: `cancelledSessionsLast30Days >= 2` (red dot)
+  - Review pending: `pendingTodos.length > 0`
+- Use same badge style as Students page (pill, colored bg)
+- Show first signal only (most urgent first: Cancelled > Inactive > Review)
+- Hidden on mobile (`hidden md:table-cell`)
+
+### 4. `PendingFollowups.tsx` — Overdue urgency
+
+Replace the subtle age badge with visual urgency indicators:
+- **Priority dot** (colored circle, larger than current dot): red if overdue (> 3d), amber if recent
+- **Age badge redesign**: Replace "1d" with "X DAYS OVERDUE" for items > 3 days old
+  - Format: "TODAY", "1D OLD", "3D OVERDUE", "7D OVERDUE"
+  - Color: green (0d), amber (1-3d), red (>3d)
+  - The dot next to the item should match this color
+
+### 5. `TodayAgenda.tsx` — Empty state
+
+When `sessions.length === 0`:
+- If `upcomingThisWeek` is non-empty: render a "This Week" mini-view
+  - Section label: "This Week" (instead of "Today")
+  - Show next 3-5 sessions with date + time + student name + CEFR badge
+  - Same row style as today's sessions
+- If both empty: render a brief "No sessions this week" message (not the large white block)
+
+Requires passing `upcomingThisWeek` prop from Dashboard.tsx.
+
+## Tests
+
+### Backend
+- `DashboardServiceTests.cs`: add tests for:
+  - `LastSessionTopicTags` populated from lastPast session
+  - `LastSessionHomework` populated from lastPast session
+  - `LastSessionFollowups` populated (only `Status != "done"` followups with matching `SourceSessionLogId`)
+  - `UpcomingThisWeek` returns sessions in next 7 calendar days (not today)
+
+### Frontend
+- `NextSessionHero.test.tsx`:
+  - Add new fields to `makeSession()` factory (`lastSessionTopicTags`, `lastSessionHomework`, `lastSessionFollowups`)
+  - Test adaptive urgency: session in 30min → green pill, session today in 4h → neutral, session in 3d → no badge
+  - Test Start session link renders and points to `/students/student-1/log-session`
+  - Test briefing bullets: topics, last-session homework, promises render when present
+- `StudentRoster.test.tsx`:
+  - Test sort default (Last Session order)
+  - Test L1 column renders `nativeLanguages[0]`
+  - Test signal badge "Cancelled 2x" for `cancelledSessionsLast30Days >= 2`
+  - Test signal badge "Review pending" for `pendingTodos.length > 0`
+  - Test student count label (`N active enrollment(s)`)
+- `PendingFollowups.test.tsx`:
+  - Test "DAYS OVERDUE" label for items > 3 days old
+  - Test red dot for overdue items
+- `TodayAgenda.test.tsx`:
+  - Test This Week fallback renders when `sessions=[]` and `upcomingThisWeek` has entries
+  - Test "No sessions this week" renders when both empty
+
+### E2E (happy path)
+- New e2e test in `frontend/e2e/` (or existing dashboard test file) covering:
+  - Dashboard loads and hero card shows "Start session" button
+  - Clicking "Start session" navigates to log-session page
+  - (If data available) Activity Signal badge renders in roster
+
+## Acceptance Criteria Mapping
+
+| AC | Implementation |
+|----|----------------|
+| Start session CTA | Primary gradient Link in hero header |
+| Last Session Briefing | 4-bullet block from backend new fields |
+| Homework as distinct warm card | Separate amber-tinted card in hero |
+| Urgency badge adaptive | `formatUrgency()` function with thresholds |
+| Activity Signal column | `buildRosterSignal()` from ActiveStudent data |
+| L1 column | `nativeLanguages[0]` in roster table |
+| Sort control (default Last Session) | Dropdown state in StudentRoster |
+| Student count | Count label under heading |
+| Overdue followup urgency | Redesigned age badge + colored dot |
+| Empty agenda This Week | TodayAgenda with `upcomingThisWeek` prop |
+
+## Notes / Risks
+
+- **TeacherFollowup table name in DbContext**: verify navigation property name before using `_db.TeacherFollowups`
+- **Signal logic duplication**: Dashboard roster signals are a simplified subset of Students.tsx signals (no NEW/ExamPrep since we lack `createdAt`/`shortTermObjectives`). This is acceptable; if a shared component is wanted, defer to a separate issue.
+- **Empty agenda "This Week" view**: requires adding `UpcomingThisWeek` to `DashboardDto`. This is a small extension to the existing endpoint, not a new data source.


### PR DESCRIPTION
Closes #730

## Summary

- **Hero card:** "Start session" primary CTA, adaptive urgency badge (green gradient <2h, neutral today, no badge >7d), structured Last Session Briefing (topics/response/homework/promises as 4 bullets), warm amber homework pending card
- **Student Roster:** Activity Signal column (Cancelled 2x / Inactive Nd / Review pending), L1 native language column, custom sort dropdown defaulting to Last Session, student count label
- **Pending Followups:** Redesigned age badges (TODAY / Xd OLD / Xd OVERDUE) with color-coded priority dots
- **Empty Agenda:** "This Week" fallback view showing next 3-5 sessions when today is empty
- **Backend:** Extended `NextSessionDto` with `LastSessionTopicTags`, `LastSessionHomework`, `LastSessionFollowups`; added `UpcomingThisWeek` to `DashboardDto`

## Test plan

- [ ] `dotnet test` passes (1099 tests, 30 new dashboard service tests)
- [ ] `npm test` passes (1237 tests, new component tests for all changed components)
- [ ] E2E: `dashboard.spec.ts` has 2 new tests (roster count/sort, start session CTA)
- [ ] Visual: hero card with-session state requires mock teacher to have a scheduled session (logged to ui-review-backlog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * View upcoming sessions scheduled for the week on your dashboard
  * See previous session context in next session briefing, including topics, homework, and pending followups
  * Session urgency badges indicate timing ("IN X MIN", "TODAY", etc.)
  * Sort student roster by last session, next session, or name
  * Student status indicators show inactivity, cancellations, and pending items
  * Student roster now displays native language information

* **UI/UX Improvements**
  * Enhanced student roster layout with improved visual hierarchy and status signals

<!-- end of auto-generated comment: release notes by coderabbit.ai -->