### PR TITLE
polish: Sidebar Settings separation and generation counter cleanup

### DIFF
--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
@@ -87,28 +87,27 @@ describe('AppShell', () => {
 
   it('Settings link is outside the main nav element', () => {
     renderShell()
-    const aside = document.querySelector('aside')
-    const nav = aside?.querySelector('nav')
-    const settingsInNav = nav?.querySelector('a[href="/settings"]')
-    expect(settingsInNav).toBeNull()
-    // Settings is still in the aside, just outside nav
-    const settingsInAside = aside?.querySelector('a[href="/settings"]')
-    expect(settingsInAside).toBeInTheDocument()
+    // Settings must not be inside the <nav> (main nav group)
+    const nav = screen.getByRole('navigation')
+    expect(within(nav).queryByRole('link', { name: /^settings$/i })).not.toBeInTheDocument()
+    // Settings must still render as a link in the overall sidebar
+    const settingsLinks = screen.getAllByRole('link', { name: /^settings$/i })
+    expect(settingsLinks.length).toBeGreaterThanOrEqual(1)
   })
 
   it('does not show generation counter in sidebar', () => {
     renderShell()
-    expect(document.querySelector('aside')?.textContent).not.toMatch(/generations/)
+    expect(screen.queryByText(/generations/)).not.toBeInTheDocument()
   })
 
   it('logout button is inside the teacher profile card and calls logout', async () => {
     const user = userEvent.setup()
     renderShell()
-    const card = document.querySelector('[data-testid="teacher-profile-card"]')
+    const card = screen.getAllByTestId('teacher-profile-card')[0]
     expect(card).toBeInTheDocument()
-    const logoutBtn = card?.querySelector('button[aria-label="Log out"]')
+    const logoutBtn = within(card).getByRole('button', { name: /log out/i })
     expect(logoutBtn).toBeInTheDocument()
-    await user.click(logoutBtn as Element)
+    await user.click(logoutBtn)
     expect(mockLogout).toHaveBeenCalledWith({ logoutParams: { returnTo: window.location.origin } })
   })
 

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -78,11 +78,38 @@ describe('AppShell', () => {
     expect(allDashboardLinks.length).toBeGreaterThanOrEqual(2)
   })
 
-  it('renders nav items in correct order: Dashboard, Students, Sessions, Courses, Lessons, Settings', () => {
+  it('renders nav items in correct order: Dashboard, Students, Sessions, Courses, Lessons, then Settings separated at bottom', () => {
     renderShell()
     const links = document.querySelector('aside')?.querySelectorAll('a')
     const labels = Array.from(links ?? []).map(a => a.textContent?.trim())
     expect(labels).toEqual(['Dashboard', 'Students', 'Sessions', 'Courses', 'Lessons', 'Settings'])
+  })
+
+  it('Settings link is outside the main nav element', () => {
+    renderShell()
+    const aside = document.querySelector('aside')
+    const nav = aside?.querySelector('nav')
+    const settingsInNav = nav?.querySelector('a[href="/settings"]')
+    expect(settingsInNav).toBeNull()
+    // Settings is still in the aside, just outside nav
+    const settingsInAside = aside?.querySelector('a[href="/settings"]')
+    expect(settingsInAside).toBeInTheDocument()
+  })
+
+  it('does not show generation counter in sidebar', () => {
+    renderShell()
+    expect(document.querySelector('aside')?.textContent).not.toMatch(/generations/)
+  })
+
+  it('logout button is inside the teacher profile card and calls logout', async () => {
+    const user = userEvent.setup()
+    renderShell()
+    const card = document.querySelector('[data-testid="teacher-profile-card"]')
+    expect(card).toBeInTheDocument()
+    const logoutBtn = card?.querySelector('button[aria-label="Log out"]')
+    expect(logoutBtn).toBeInTheDocument()
+    await user.click(logoutBtn as Element)
+    expect(mockLogout).toHaveBeenCalledWith({ logoutParams: { returnTo: window.location.origin } })
   })
 
   it('renders Sessions nav item linking to /sessions', () => {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -7,16 +7,32 @@ import { cn } from '@/lib/utils'
 import LangTeachLogo from '@/components/LangTeachLogo'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
-import { UsageIndicator } from '@/components/UsageIndicator'
 
-const navItems = [
+const mainNavItems = [
   { to: '/', label: 'Dashboard', icon: LayoutDashboard },
   { to: '/students', label: 'Students', icon: Users },
   { to: '/sessions', label: 'Sessions', icon: CalendarDays },
   { to: '/courses', label: 'Courses', icon: GraduationCap },
   { to: '/lessons', label: 'Lessons', icon: BookOpen },
-  { to: '/settings', label: 'Settings', icon: Settings },
 ]
+
+function SettingsLink({ location }: { location: ReturnType<typeof useLocation> }) {
+  const active = location.pathname === '/settings'
+  return (
+    <Link
+      to="/settings"
+      className={cn(
+        'flex items-center gap-3 py-2.5 pl-4 pr-3 text-base font-medium font-inter transition-colors',
+        active
+          ? 'bg-white border-l-[3px] border-l-indigo-600 text-indigo-700 rounded-r-md'
+          : 'text-zinc-500 hover:bg-[#E6E0F8] hover:text-zinc-900 rounded-md border-l-[3px] border-l-transparent'
+      )}
+    >
+      <Settings className={cn('h-5 w-5 shrink-0', active ? 'text-indigo-600' : 'text-zinc-400')} />
+      Settings
+    </Link>
+  )
+}
 
 function SidebarContent({ user, initials, logout, location }: {
   user: ReturnType<typeof useAuth0>['user']
@@ -37,9 +53,9 @@ function SidebarContent({ user, initials, logout, location }: {
         </p>
       </div>
 
-      {/* Nav */}
+      {/* Main nav */}
       <nav className="flex-1 overflow-y-auto px-3 space-y-0.5">
-        {navItems.map(({ to, label, icon: Icon }) => {
+        {mainNavItems.map(({ to, label, icon: Icon }) => {
           const active = location.pathname === to || (to !== '/' && location.pathname.startsWith(to))
           return (
             <Link
@@ -59,26 +75,29 @@ function SidebarContent({ user, initials, logout, location }: {
         })}
       </nav>
 
-      {/* Usage + User card + Logout */}
-      <div className="px-3 py-4 mt-2 space-y-3">
-        <UsageIndicator />
-        <div className="bg-white rounded-xl p-3 flex items-center gap-3">
+      {/* Bottom: Settings (visually separated) + teacher profile with tucked logout */}
+      <div className="px-3 py-4 space-y-3">
+        <div className="border-t border-zinc-200/60 pt-3">
+          <SettingsLink location={location} />
+        </div>
+        <div className="bg-white rounded-xl p-3 flex items-center gap-3" data-testid="teacher-profile-card">
           <Avatar className="h-9 w-9 shrink-0">
             <AvatarImage src={user?.picture} alt={user?.name} />
             <AvatarFallback className="bg-indigo-600 text-white text-xs font-semibold">{initials}</AvatarFallback>
           </Avatar>
-          <div className="flex flex-col overflow-hidden min-w-0">
+          <div className="flex flex-col overflow-hidden min-w-0 flex-1">
             <span className="text-sm font-bold text-zinc-900 truncate font-inter">{user?.name ?? user?.email}</span>
             <span className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter">Teacher</span>
           </div>
+          <button
+            onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}
+            aria-label="Log out"
+            title="Log out"
+            className="text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 transition-colors p-1.5 rounded-lg shrink-0"
+          >
+            <LogOut className="h-4 w-4" />
+          </button>
         </div>
-        <button
-          onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}
-          className="flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-zinc-400 hover:bg-[#E6E0F8] hover:text-zinc-700 transition-colors font-inter"
-        >
-          <LogOut className="h-5 w-5 shrink-0" />
-          Log out
-        </button>
       </div>
     </>
   )

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, type ElementType } from 'react'
 import { Link, Outlet, useLocation } from 'react-router-dom'
 import { useAuth0 } from '@auth0/auth0-react'
 import { LayoutDashboard, Users, CalendarDays, BookOpen, GraduationCap, Settings, LogOut, Menu } from 'lucide-react'
@@ -16,11 +16,16 @@ const mainNavItems = [
   { to: '/lessons', label: 'Lessons', icon: BookOpen },
 ]
 
-function SettingsLink({ location }: { location: ReturnType<typeof useLocation> }) {
-  const active = location.pathname === '/settings'
+function NavLink({ to, label, icon: Icon, location }: {
+  to: string
+  label: string
+  icon: ElementType
+  location: ReturnType<typeof useLocation>
+}) {
+  const active = location.pathname === to || (to !== '/' && location.pathname.startsWith(to))
   return (
     <Link
-      to="/settings"
+      to={to}
       className={cn(
         'flex items-center gap-3 py-2.5 pl-4 pr-3 text-base font-medium font-inter transition-colors',
         active
@@ -28,8 +33,8 @@ function SettingsLink({ location }: { location: ReturnType<typeof useLocation> }
           : 'text-zinc-500 hover:bg-[#E6E0F8] hover:text-zinc-900 rounded-md border-l-[3px] border-l-transparent'
       )}
     >
-      <Settings className={cn('h-5 w-5 shrink-0', active ? 'text-indigo-600' : 'text-zinc-400')} />
-      Settings
+      <Icon className={cn('h-5 w-5 shrink-0', active ? 'text-indigo-600' : 'text-zinc-400')} />
+      {label}
     </Link>
   )
 }
@@ -55,30 +60,15 @@ function SidebarContent({ user, initials, logout, location }: {
 
       {/* Main nav */}
       <nav className="flex-1 overflow-y-auto px-3 space-y-0.5">
-        {mainNavItems.map(({ to, label, icon: Icon }) => {
-          const active = location.pathname === to || (to !== '/' && location.pathname.startsWith(to))
-          return (
-            <Link
-              key={to}
-              to={to}
-              className={cn(
-                'flex items-center gap-3 py-2.5 pl-4 pr-3 text-base font-medium font-inter transition-colors',
-                active
-                  ? 'bg-white border-l-[3px] border-l-indigo-600 text-indigo-700 rounded-r-md'
-                  : 'text-zinc-500 hover:bg-[#E6E0F8] hover:text-zinc-900 rounded-md border-l-[3px] border-l-transparent'
-              )}
-            >
-              <Icon className={cn('h-5 w-5 shrink-0', active ? 'text-indigo-600' : 'text-zinc-400')} />
-              {label}
-            </Link>
-          )
-        })}
+        {mainNavItems.map(({ to, label, icon }) => (
+          <NavLink key={to} to={to} label={label} icon={icon} location={location} />
+        ))}
       </nav>
 
       {/* Bottom: Settings (visually separated) + teacher profile with tucked logout */}
       <div className="px-3 py-4 space-y-3">
         <div className="border-t border-zinc-200/60 pt-3">
-          <SettingsLink location={location} />
+          <NavLink to="/settings" label="Settings" icon={Settings} location={location} />
         </div>
         <div className="bg-white rounded-xl p-3 flex items-center gap-3" data-testid="teacher-profile-card">
           <Avatar className="h-9 w-9 shrink-0">

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -22,7 +22,7 @@ function NavLink({ to, label, icon: Icon, location }: {
   icon: ElementType
   location: ReturnType<typeof useLocation>
 }) {
-  const active = location.pathname === to || (to !== '/' && location.pathname.startsWith(to))
+  const active = location.pathname === to || (to !== '/' && location.pathname.startsWith(`${to}/`))
   return (
     <Link
       to={to}

--- a/plan/langteach-beta/task731-sidebar-polish.md
+++ b/plan/langteach-beta/task731-sidebar-polish.md
@@ -1,0 +1,33 @@
+# Task 731: Sidebar Settings separation and generation counter cleanup
+
+## Issue
+GitHub #731 - P2:should, area:frontend, qa:ready
+
+## Acceptance Criteria
+1. Settings separated from main nav (pinned at bottom with visual border-t separator)
+2. Generation counter ("X / Y generations") removed from sidebar
+3. Log out tucked into teacher profile card as an icon button
+
+## Files to change
+- `frontend/src/components/AppShell.tsx` - main implementation
+- `frontend/src/components/AppShell.test.tsx` - update/add tests
+
+## Implementation Plan
+
+### AppShell.tsx
+- Split `navItems` into `mainNavItems` (Dashboard, Students, Sessions, Courses, Lessons) - Settings removed
+- Remove `<UsageIndicator />` render and import
+- Add Settings link in a new bottom section with `border-t border-zinc-200/60 pt-3` separator above the profile card
+- Replace standalone logout button with an icon-only `LogOut` button tucked inside the profile card (right side, `aria-label="Log out"`)
+
+### AppShell.test.tsx
+- Existing tests should still pass (Settings link is still a `<a>` in the aside, DOM order preserved)
+- Add: "generation counter not shown in sidebar"
+- Add: "Settings link is not inside the main nav element"
+- Add: "logout button is inside profile card and calls logout"
+
+## Out of scope
+- Contextual sidebar CTAs
+- Brand name changes
+- Vertical spacing between nav items
+- Changes to UsageIndicator component logic (display only, remove from sidebar)


### PR DESCRIPTION
## Summary
- Settings link moved out of the main nav into a visually separated bottom section (border-t divider), matching the Notion/Linear/Figma pattern of pinning low-frequency items away from primary navigation
- Generation counter ("X / Y generations") removed from sidebar display; the UsageIndicator component and its data logic are untouched, available for Settings page use
- Log out demoted to an icon-only button tucked inside the teacher profile card, reducing visual weight of a rare action

Closes #731

## Test plan
- [x] Unit: 13/13 AppShell tests pass, including 3 new tests covering each AC
- [x] QA verify: PASS
- [x] Architecture review: PASS (after fixing NavLink deduplication and RTL test queries)
- [x] UI review: PASS (all 3 visual requirements confirmed in screenshots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Moved Settings link to the bottom of the sidebar with visual separation for improved navigation hierarchy.

* **Bug Fixes**
  * Removed unnecessary generations counter display from sidebar.

* **Refactor**
  * Relocated logout functionality from full-width bottom button to a compact icon-only button on the teacher profile card.

* **Tests**
  * Enhanced test coverage for sidebar navigation and logout interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->