### PR TITLE
refactor(tests): migrate useStudentAutosave tests from vi.mock to MSW

### DIFF
--- a/frontend/src/hooks/useStudentAutosave.test.ts
+++ b/frontend/src/hooks/useStudentAutosave.test.ts
@@ -1,13 +1,23 @@
 import { renderHook, act } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-
-const mockUpdateStudent = vi.fn()
-vi.mock('../api/students', () => ({
-  updateStudent: (...args: unknown[]) => mockUpdateStudent(...args),
-}))
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from 'vitest'
+import { setupServer } from 'msw/node'
+import { http, HttpResponse } from 'msw'
 
 import { useStudentAutosave } from './useStudentAutosave'
 import type { StudentFormData } from '../api/students'
+
+const STUDENT_URL = 'http://localhost:5000/api/students/stu-1'
+
+const server = setupServer(
+  http.put(STUDENT_URL, () => HttpResponse.json({ id: 'stu-1' })),
+)
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  server.resetHandlers()
+  vi.useRealTimers()
+})
+afterAll(() => server.close())
 
 const BASE_FORM_DATA: StudentFormData = {
   name: 'Ana',
@@ -27,12 +37,6 @@ function makeGetFormDataRef(data: StudentFormData | null = BASE_FORM_DATA) {
 describe('useStudentAutosave', () => {
   beforeEach(() => {
     vi.useFakeTimers()
-    vi.clearAllMocks()
-    mockUpdateStudent.mockResolvedValue({ id: 'stu-1' })
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('starts with idle status', () => {
@@ -42,56 +46,98 @@ describe('useStudentAutosave', () => {
   })
 
   it('does not save when studentId is undefined', async () => {
+    let callCount = 0
+    server.use(
+      http.put(STUDENT_URL, () => {
+        callCount++
+        return HttpResponse.json({ id: 'stu-1' })
+      }),
+    )
     const ref = makeGetFormDataRef()
     const { result } = renderHook(() => useStudentAutosave(undefined, ref))
     act(() => { result.current.saveNow() })
     await vi.runAllTimersAsync()
-    expect(mockUpdateStudent).not.toHaveBeenCalled()
+    expect(callCount).toBe(0)
   })
 
   it('does not save when getFormData returns null (required fields missing)', async () => {
+    let callCount = 0
+    server.use(
+      http.put(STUDENT_URL, () => {
+        callCount++
+        return HttpResponse.json({ id: 'stu-1' })
+      }),
+    )
     const ref = makeGetFormDataRef(null)
     const { result } = renderHook(() => useStudentAutosave('stu-1', ref))
     act(() => { result.current.saveNow() })
     await vi.runAllTimersAsync()
-    expect(mockUpdateStudent).not.toHaveBeenCalled()
+    expect(callCount).toBe(0)
   })
 
   it('saveNow calls updateStudent immediately with form data', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.put(STUDENT_URL, async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json({ id: 'stu-1' })
+      }),
+    )
     const ref = makeGetFormDataRef()
     const { result } = renderHook(() => useStudentAutosave('stu-1', ref))
     act(() => { result.current.saveNow() })
     await vi.runAllTimersAsync()
-    expect(mockUpdateStudent).toHaveBeenCalledWith('stu-1', BASE_FORM_DATA)
+    expect(capturedBody).toEqual(BASE_FORM_DATA)
   })
 
   it('saveNow merges override on top of form data', async () => {
+    let capturedBody: unknown
+    server.use(
+      http.put(STUDENT_URL, async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json({ id: 'stu-1' })
+      }),
+    )
     const ref = makeGetFormDataRef()
     const { result } = renderHook(() => useStudentAutosave('stu-1', ref))
     act(() => { result.current.saveNow({ isActive: false }) })
     await vi.runAllTimersAsync()
-    expect(mockUpdateStudent).toHaveBeenCalledWith('stu-1', { ...BASE_FORM_DATA, isActive: false })
+    expect(capturedBody).toEqual({ ...BASE_FORM_DATA, isActive: false })
   })
 
   it('scheduleTextSave fires after 400ms debounce', async () => {
+    let callCount = 0
+    server.use(
+      http.put(STUDENT_URL, () => {
+        callCount++
+        return HttpResponse.json({ id: 'stu-1' })
+      }),
+    )
     const ref = makeGetFormDataRef()
     const { result } = renderHook(() => useStudentAutosave('stu-1', ref))
     act(() => { result.current.scheduleTextSave() })
-    expect(mockUpdateStudent).not.toHaveBeenCalled()
+    expect(callCount).toBe(0)
     await act(async () => { await vi.advanceTimersByTimeAsync(400) })
-    expect(mockUpdateStudent).toHaveBeenCalledOnce()
+    expect(callCount).toBe(1)
   })
 
   it('scheduleTextSave resets timer on multiple calls', async () => {
+    let callCount = 0
+    server.use(
+      http.put(STUDENT_URL, () => {
+        callCount++
+        return HttpResponse.json({ id: 'stu-1' })
+      }),
+    )
     const ref = makeGetFormDataRef()
     const { result } = renderHook(() => useStudentAutosave('stu-1', ref))
     act(() => { result.current.scheduleTextSave() })
     await act(async () => { await vi.advanceTimersByTimeAsync(200) })
     act(() => { result.current.scheduleTextSave() })
     await act(async () => { await vi.advanceTimersByTimeAsync(200) })
-    expect(mockUpdateStudent).not.toHaveBeenCalled()
+    expect(callCount).toBe(0)
     await act(async () => { await vi.advanceTimersByTimeAsync(200) })
-    expect(mockUpdateStudent).toHaveBeenCalledOnce()
+    expect(callCount).toBe(1)
   })
 
   it('transitions status idle -> saving -> saved -> idle', async () => {
@@ -99,7 +145,7 @@ describe('useStudentAutosave', () => {
     const { result } = renderHook(() => useStudentAutosave('stu-1', ref))
     act(() => { result.current.saveNow() })
     expect(result.current.status).toBe('saving')
-    // Resolve the updateStudent promise but don't advance idle timer yet
+    // Resolve the network request but don't advance idle timer yet
     await act(async () => { await vi.advanceTimersByTimeAsync(0) })
     expect(result.current.status).toBe('saved')
     // Advance idle timer
@@ -108,7 +154,9 @@ describe('useStudentAutosave', () => {
   })
 
   it('sets error status when updateStudent rejects', async () => {
-    mockUpdateStudent.mockRejectedValue(new Error('Network error'))
+    server.use(
+      http.put(STUDENT_URL, () => new HttpResponse(null, { status: 500 })),
+    )
     const ref = makeGetFormDataRef()
     const { result } = renderHook(() => useStudentAutosave('stu-1', ref))
     act(() => { result.current.saveNow() })
@@ -117,7 +165,13 @@ describe('useStudentAutosave', () => {
   })
 
   it('retries after error (up to 3 times)', async () => {
-    mockUpdateStudent.mockRejectedValue(new Error('Network error'))
+    let callCount = 0
+    server.use(
+      http.put(STUDENT_URL, () => {
+        callCount++
+        return new HttpResponse(null, { status: 500 })
+      }),
+    )
     const ref = makeGetFormDataRef()
     const { result } = renderHook(() => useStudentAutosave('stu-1', ref))
     act(() => { result.current.saveNow() })
@@ -125,7 +179,7 @@ describe('useStudentAutosave', () => {
     for (let i = 0; i < 3; i++) {
       await act(async () => { await vi.runAllTimersAsync() })
     }
-    expect(mockUpdateStudent).toHaveBeenCalledTimes(4)
+    expect(callCount).toBe(4)
     expect(result.current.status).toBe('error')
   })
 })

--- a/frontend/src/hooks/useStudentAutosave.test.ts
+++ b/frontend/src/hooks/useStudentAutosave.test.ts
@@ -13,10 +13,7 @@ const server = setupServer(
 )
 
 beforeAll(() => server.listen())
-afterEach(() => {
-  server.resetHandlers()
-  vi.useRealTimers()
-})
+afterEach(() => server.resetHandlers())
 afterAll(() => server.close())
 
 const BASE_FORM_DATA: StudentFormData = {
@@ -37,6 +34,10 @@ function makeGetFormDataRef(data: StudentFormData | null = BASE_FORM_DATA) {
 describe('useStudentAutosave', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('starts with idle status', () => {

--- a/plan/langteach-beta/task741-autosave-msw.md
+++ b/plan/langteach-beta/task741-autosave-msw.md
@@ -1,0 +1,57 @@
+# Task 741 — Migrate useStudentAutosave tests from vi.mock to MSW
+
+## Issue
+#741 — refactor: migrate useStudentAutosave tests from vi.mock to MSW
+
+## Goal
+Replace `vi.mock('../api/students')` with an MSW `setupServer` that intercepts `PUT /api/students/:id` at the network layer, aligning with the project convention used in `useGenerate.test.ts`.
+
+## Acceptance Criteria
+- All 10 existing tests continue to pass
+- No `vi.mock` of the students API module
+- MSW `setupServer` / `http.put` / `HttpResponse` used for network interception
+- `vi.useFakeTimers()` still works (MSW intercepts fetch, not timers)
+- Error scenario tested via MSW `http.put` returning a 500 response
+
+## Approach
+
+### Setup
+```ts
+import { setupServer } from 'msw/node'
+import { http, HttpResponse } from 'msw'
+
+const STUDENT_URL = 'http://localhost:5000/api/students/stu-1'
+
+const server = setupServer(
+  http.put(STUDENT_URL, () => HttpResponse.json({ id: 'stu-1' }))
+)
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+```
+
+### beforeEach
+- Keep `vi.useFakeTimers()` (controls debounce/retry timers)
+- Remove `vi.clearAllMocks()` and `mockUpdateStudent.mockResolvedValue`
+
+### Error test
+Override handler per-test:
+```ts
+server.use(
+  http.put(STUDENT_URL, () => new HttpResponse(null, { status: 500 }))
+)
+```
+
+### Argument assertions
+Replace `expect(mockUpdateStudent).toHaveBeenCalledWith(...)` with a captured-request approach:
+- Store `lastRequest` body in the handler closure, assert after timer flush
+
+### Call count assertions
+Track a `callCount` counter incremented in the MSW handler instead of `mockUpdateStudent.mock.calls.length`.
+
+## Files Changed
+- `frontend/src/hooks/useStudentAutosave.test.ts` (rewrite tests only, no production code changes)
+
+## No e2e changes needed
+This is a pure test refactor; no user-visible behavior changes.


### PR DESCRIPTION
## Summary

- Replaces `vi.mock('../api/students')` + `mockUpdateStudent` with MSW `setupServer`/`http.put`/`HttpResponse`, intercepting at the network layer
- All 10 existing tests continue to pass
- Timer teardown scoped inside `describe` block to match `useGenerate.test.ts` convention

Closes #741

## Test plan

- [x] All 10 unit tests pass (`npx vitest run src/hooks/useStudentAutosave.test.ts`)
- [x] Full frontend test suite passes (1206 tests)
- [x] No production code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)