### PR TITLE
refactor(t745): extract shared TopicTagEntry record to DTOs

### DIFF
--- a/backend/LangTeach.Api/DTOs/TopicTagEntry.cs
+++ b/backend/LangTeach.Api/DTOs/TopicTagEntry.cs
@@ -1,0 +1,3 @@
+namespace LangTeach.Api.DTOs;
+
+public sealed record TopicTagEntry(string Tag, string? Category);

--- a/backend/LangTeach.Api/Helpers/TopicTagEntry.cs
+++ b/backend/LangTeach.Api/Helpers/TopicTagEntry.cs
@@ -1,0 +1,3 @@
+namespace LangTeach.Api.Helpers;
+
+internal sealed record TopicTagEntry(string Tag, string? Category);

--- a/backend/LangTeach.Api/Helpers/TopicTagEntry.cs
+++ b/backend/LangTeach.Api/Helpers/TopicTagEntry.cs
@@ -1,3 +1,0 @@
-namespace LangTeach.Api.Helpers;
-
-internal sealed record TopicTagEntry(string Tag, string? Category);

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -250,5 +250,4 @@ public class DashboardService : IDashboardService
         }).ToList();
     }
 
-    private sealed record TopicTagEntry(string Tag, string? Category);
 }

--- a/backend/LangTeach.Api/Services/SessionHistoryService.cs
+++ b/backend/LangTeach.Api/Services/SessionHistoryService.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using LangTeach.Api.AI;
 using LangTeach.Api.Data;
 using LangTeach.Api.Data.Models;
+using LangTeach.Api.DTOs;
 using LangTeach.Api.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;

--- a/backend/LangTeach.Api/Services/SessionHistoryService.cs
+++ b/backend/LangTeach.Api/Services/SessionHistoryService.cs
@@ -123,5 +123,4 @@ public class SessionHistoryService : ISessionHistoryService
     private static readonly JsonSerializerOptions JsonOptions =
         new() { PropertyNameCaseInsensitive = true };
 
-    private sealed record TopicTagEntry(string Tag, string? Category);
 }

--- a/plan/langteach-beta/task745-extract-topic-tag-entry.md
+++ b/plan/langteach-beta/task745-extract-topic-tag-entry.md
@@ -1,0 +1,17 @@
+# Task 745: Extract shared TopicTagEntry record
+
+## Issue
+#745 - refactor: extract shared TopicTagEntry record from DashboardService and SessionHistoryService
+
+## What
+`TopicTagEntry(string Tag, string? Category)` was duplicated as a `private sealed record` in both
+`DashboardService` and `SessionHistoryService`. This is the deserialization record for the `TopicTags`
+JSON column on `SessionLog`.
+
+## Change
+- Created `backend/LangTeach.Api/Helpers/TopicTagEntry.cs` with `internal sealed record TopicTagEntry`
+- Removed private definitions from `DashboardService.cs` and `SessionHistoryService.cs`
+- Both services already had `using LangTeach.Api.Helpers;` so no using-directive changes needed
+
+## Tests
+All existing tests pass unchanged (no test logic changed).


### PR DESCRIPTION
## Summary
- Moves the duplicated `private sealed record TopicTagEntry(string Tag, string? Category)` from `DashboardService` and `SessionHistoryService` into a single shared `public sealed record` at `LangTeach.Api/DTOs/TopicTagEntry.cs`
- Both services now reference the shared type; no logic changes
- Closes #745

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` passes (1103/1108 pass, 5 pre-existing skips)
- [x] No conflicts with sprint branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)