### PR TITLE
refactor(t760): delete dead hooks/autosaveConstants.ts

### DIFF
--- a/frontend/src/hooks/autosaveConstants.ts
+++ b/frontend/src/hooks/autosaveConstants.ts
@@ -1,6 +1,0 @@
-export type SaveStatus = 'idle' | 'saving' | 'saved' | 'retrying' | 'error'
-
-export const DEBOUNCE_MS = 400
-export const IDLE_RESET_MS = 2000
-export const RETRY_DELAY_MS = 3000
-export const MAX_RETRIES = 3


### PR DESCRIPTION
Closes #760

## Summary
- Deletes `frontend/src/hooks/autosaveConstants.ts` — identical duplicate of `frontend/src/lib/autosaveConstants.ts`
- Both hooks already import from `lib/autosaveConstants.ts` (since t746); the `hooks/` copy was unreferenced dead code
- No behavioral change

## Test plan
- [x] `npm run build` passes
- [x] All 1226 unit tests pass (`npm run test -- --run`)
- [x] Grep confirms zero imports reference `hooks/autosaveConstants`

🤖 Generated with [Claude Code](https://claude.com/claude-code)