### PR TITLE
polish(t764): dashboard label polish — natural language, relative dates, status chips

### DIFF
--- a/frontend/src/components/dashboard/PendingFollowups.test.tsx
+++ b/frontend/src/components/dashboard/PendingFollowups.test.tsx
@@ -60,15 +60,21 @@ describe('PendingFollowups', () => {
     expect(screen.getByTestId('followup-age-f1')).toHaveTextContent('TODAY')
   })
 
-  it('shows OVERDUE badge for followup more than 3 days old', () => {
+  it('shows DAYS OVERDUE badge for followup more than 3 days old', () => {
     const old = new Date(Date.now() - 7 * 86400000).toISOString()
     render(<PendingFollowups followups={[makeFollowup({ id: 'f1', createdAt: old })]} />)
-    expect(screen.getByTestId('followup-age-f1')).toHaveTextContent('OVERDUE')
+    expect(screen.getByTestId('followup-age-f1')).toHaveTextContent('DAYS OVERDUE')
   })
 
-  it('shows OLD badge for followup 1-3 days old', () => {
+  it('shows YESTERDAY badge for followup 1 day old', () => {
+    const yesterday = new Date(Date.now() - 1 * 86400000).toISOString()
+    render(<PendingFollowups followups={[makeFollowup({ id: 'f1', createdAt: yesterday })]} />)
+    expect(screen.getByTestId('followup-age-f1')).toHaveTextContent('YESTERDAY')
+  })
+
+  it('shows DAYS AGO badge for followup 2-3 days old', () => {
     const twoDaysAgo = new Date(Date.now() - 2 * 86400000).toISOString()
     render(<PendingFollowups followups={[makeFollowup({ id: 'f1', createdAt: twoDaysAgo })]} />)
-    expect(screen.getByTestId('followup-age-f1')).toHaveTextContent('OLD')
+    expect(screen.getByTestId('followup-age-f1')).toHaveTextContent('DAYS AGO')
   })
 })

--- a/frontend/src/components/dashboard/PendingFollowups.tsx
+++ b/frontend/src/components/dashboard/PendingFollowups.tsx
@@ -19,13 +19,18 @@ function ageBadge(createdAt: string): AgeBadgeInfo {
     dotColor: 'bg-emerald-500',
     badgeClassName: 'bg-emerald-100 text-emerald-700',
   }
+  if (days === 1) return {
+    label: 'YESTERDAY',
+    dotColor: 'bg-amber-400',
+    badgeClassName: 'bg-amber-100 text-amber-700',
+  }
   if (days <= 3) return {
-    label: `${days}D OLD`,
+    label: `${days} DAYS AGO`,
     dotColor: 'bg-amber-400',
     badgeClassName: 'bg-amber-100 text-amber-700',
   }
   return {
-    label: `${days}D OVERDUE`,
+    label: `${days} DAYS OVERDUE`,
     dotColor: 'bg-red-500',
     badgeClassName: 'bg-red-100 text-red-700',
   }

--- a/frontend/src/components/dashboard/StudentRoster.test.tsx
+++ b/frontend/src/components/dashboard/StudentRoster.test.tsx
@@ -102,9 +102,45 @@ describe('StudentRoster', () => {
         <StudentRoster students={[makeStudent({ nativeLanguages: [] })]} />
       </MemoryRouter>,
     )
-    // Multiple dashes may appear (Last, Next also show — for nulls in this case)
     const cells = screen.getAllByText('—')
     expect(cells.length).toBeGreaterThan(0)
+  })
+
+  it('shows paired last/next dates with arrow when both exist', () => {
+    render(
+      <MemoryRouter>
+        <StudentRoster students={[makeStudent({
+          lastSessionDate: new Date(Date.now() - 3 * 86400000).toISOString(),
+          nextSessionDate: new Date(Date.now() + 5 * 86400000).toISOString(),
+        })]} />
+      </MemoryRouter>,
+    )
+    const row = screen.getByTestId('zone3-student-row')
+    expect(row.textContent).toMatch(/→/)
+    // The → appears in the data cell, not just the nav link
+    const cells = row.querySelectorAll('td')
+    const lastNextCell = Array.from(cells).find(td => td.textContent?.includes('→'))
+    expect(lastNextCell).toBeTruthy()
+  })
+
+  it('shows only last date when no next session', () => {
+    render(
+      <MemoryRouter>
+        <StudentRoster students={[makeStudent({ nextSessionDate: null })]} />
+      </MemoryRouter>,
+    )
+    const row = screen.getByTestId('zone3-student-row')
+    // The data row itself should not contain →
+    expect(row.textContent).not.toMatch(/→/)
+  })
+
+  it('shows relative Today for last session today', () => {
+    render(
+      <MemoryRouter>
+        <StudentRoster students={[makeStudent({ lastSessionDate: new Date().toISOString(), nextSessionDate: null })]} />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('Today')).toBeInTheDocument()
   })
 
   it('shows Review pending signal when student has pending todos', () => {

--- a/frontend/src/components/dashboard/StudentRoster.tsx
+++ b/frontend/src/components/dashboard/StudentRoster.tsx
@@ -58,9 +58,17 @@ function sortStudents(students: ActiveStudent[], sortBy: SortOption): ActiveStud
   }
 }
 
-function formatDate(dateStr: string | null): string {
+function formatRelativeDate(dateStr: string | null): string {
   if (!dateStr) return '—'
-  return new Date(dateStr).toLocaleDateString([], { month: 'short', day: 'numeric' })
+  const date = new Date(dateStr)
+  const now = new Date()
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const dateStart = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+  const diffDays = Math.round((dateStart.getTime() - todayStart.getTime()) / 86400000)
+  if (diffDays === 0) return 'Today'
+  if (diffDays === -1) return 'Yesterday'
+  if (diffDays < 0 && diffDays >= -29) return `${Math.abs(diffDays)}d ago`
+  return date.toLocaleDateString([], { month: 'short', day: 'numeric' })
 }
 
 const SORT_OPTIONS: { value: SortOption; label: string }[] = [
@@ -157,9 +165,8 @@ export function StudentRoster({ students }: StudentRosterProps) {
                 <th className="px-6 py-2 text-left text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400">Name</th>
                 <th className="px-3 py-2 text-left text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400">Level</th>
                 <th className="px-3 py-2 text-left text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hidden sm:table-cell">L1</th>
-                <th className="px-3 py-2 text-left text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hidden sm:table-cell">Last</th>
-                <th className="px-3 py-2 text-left text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hidden sm:table-cell">Next</th>
-                <th className="px-3 py-2 text-left text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hidden md:table-cell">Signal</th>
+                <th className="px-3 py-2 text-left text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hidden sm:table-cell">Last / Next</th>
+                <th className="px-3 py-2 text-left text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hidden md:table-cell">Activity Signal</th>
               </tr>
             </thead>
             <tbody>
@@ -188,10 +195,9 @@ export function StudentRoster({ students }: StudentRosterProps) {
                       {l1 ?? '—'}
                     </td>
                     <td className="px-3 py-2.5 text-zinc-500 hidden sm:table-cell">
-                      {formatDate(student.lastSessionDate)}
-                    </td>
-                    <td className="px-3 py-2.5 text-zinc-500 hidden sm:table-cell">
-                      {formatDate(student.nextSessionDate)}
+                      {student.nextSessionDate
+                        ? `${formatRelativeDate(student.lastSessionDate)} → ${formatRelativeDate(student.nextSessionDate)}`
+                        : formatRelativeDate(student.lastSessionDate)}
                     </td>
                     <td className="px-3 py-2.5 hidden md:table-cell">
                       {signal && (

--- a/frontend/src/components/dashboard/TodayAgenda.test.tsx
+++ b/frontend/src/components/dashboard/TodayAgenda.test.tsx
@@ -63,7 +63,7 @@ describe('TodayAgenda', () => {
     expect(screen.getByText('Carmen')).toBeInTheDocument()
   })
 
-  it('highlights the next session', () => {
+  it('highlights the next session and shows NEXT SESSION chip', () => {
     const session = makeSession({ sessionLogId: 'sl-next' })
     render(
       <MemoryRouter>
@@ -72,6 +72,33 @@ describe('TodayAgenda', () => {
     )
     const link = screen.getByRole('link', { name: /Ana/ })
     expect(link.className).toContain('border-l-indigo-600')
+    expect(screen.getByText('NEXT SESSION')).toBeInTheDocument()
+  })
+
+  it('shows DONE chip for past session', () => {
+    const pastSession = makeSession({
+      sessionLogId: 'sl-past',
+      sessionDate: new Date(Date.now() - 2 * 3600000).toISOString(),
+    })
+    render(
+      <MemoryRouter>
+        <TodayAgenda sessions={[pastSession]} nextSessionId={null} upcomingThisWeek={[]} />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('DONE')).toBeInTheDocument()
+  })
+
+  it('shows SCHEDULED chip for future session today', () => {
+    const futureSession = makeSession({
+      sessionLogId: 'sl-future',
+      sessionDate: new Date(Date.now() + 2 * 3600000).toISOString(),
+    })
+    render(
+      <MemoryRouter>
+        <TodayAgenda sessions={[futureSession]} nextSessionId={null} upcomingThisWeek={[]} />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText('SCHEDULED')).toBeInTheDocument()
   })
 
   it('renders zone2-today-agenda testid', () => {

--- a/frontend/src/components/dashboard/TodayAgenda.tsx
+++ b/frontend/src/components/dashboard/TodayAgenda.tsx
@@ -1,3 +1,4 @@
+import type React from 'react'
 import { Link } from 'react-router-dom'
 import { CefrBadge } from './CefrBadge'
 import type { TodaySession, UpcomingSession } from '@/api/dashboard'
@@ -64,6 +65,30 @@ export function TodayAgenda({ sessions, nextSessionId, upcomingThisWeek }: Today
     )
   }
 
+  const now = new Date()
+
+  function sessionStatusChip(session: TodaySession, isNext: boolean): React.ReactNode {
+    if (isNext) {
+      return (
+        <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[0.6875rem] font-bold font-inter uppercase tracking-[0.05em] shrink-0 bg-indigo-100 text-indigo-700">
+          NEXT SESSION
+        </span>
+      )
+    }
+    if (new Date(session.sessionDate) < now) {
+      return (
+        <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[0.6875rem] font-bold font-inter uppercase tracking-[0.05em] shrink-0 bg-zinc-100 text-zinc-400">
+          DONE
+        </span>
+      )
+    }
+    return (
+      <span className="inline-flex items-center rounded-full px-2 py-0.5 text-[0.6875rem] font-bold font-inter uppercase tracking-[0.05em] shrink-0 bg-zinc-100 text-zinc-500">
+        SCHEDULED
+      </span>
+    )
+  }
+
   return (
     <div className="rounded-2xl bg-white p-5 shadow-[0_12px_40px_rgba(26,27,34,0.06)] ring-1 ring-[#C7C4D8]/20" data-testid="zone2-today-agenda">
       <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22] mb-4">Today's Agenda</h3>
@@ -92,6 +117,7 @@ export function TodayAgenda({ sessions, nextSessionId, upcomingThisWeek }: Today
                   {session.plannedContent}
                 </span>
               )}
+              {sessionStatusChip(session, isNext)}
             </Link>
           )
         })}

--- a/plan/langteach-beta/dashboard-polish-labels/task764-dashboard-polish-labels.md
+++ b/plan/langteach-beta/dashboard-polish-labels/task764-dashboard-polish-labels.md
@@ -1,0 +1,107 @@
+# Task 764 — Dashboard: followup labels, relative roster dates, LAST/NEXT column merge, agenda status chips
+
+## Issue
+Robert-Freire/langTeachSaaS#764
+
+## Goal
+Fix five display gaps in the dashboard found during Stitch side-by-side review. All changes are pure frontend display formatting — no backend changes needed.
+
+## Status Values (verified from backend)
+`SessionLogStatus` enum serializes to: `"Confirmed"` (default) or `"Draft"`.
+The status chip logic must use session time (past/future) rather than the status field, since "completed" is not a real value.
+
+---
+
+## Changes
+
+### 1. PendingFollowups.tsx — Natural-language age labels
+
+Update `ageBadge()` function:
+
+| days | label (old) | label (new) | color |
+|------|-------------|-------------|-------|
+| 0 | TODAY | TODAY | green (no change) |
+| 1 | 1D OLD | YESTERDAY | amber |
+| 2-3 | Xd OLD | X DAYS AGO | amber |
+| 4+ | Xd OVERDUE | X DAYS OVERDUE | red |
+
+### 2. StudentRoster.tsx — Three sub-changes
+
+**a) Relative date formatting**
+
+Replace `formatDate()` with a new `formatRelativeDate()`:
+- null → "—" (preserving existing null handling)
+- today → "Today"
+- yesterday → "Yesterday"
+- 2-29 days ago → "Xd ago"
+- 30+ days ago → absolute "Apr 13" (existing format)
+- future dates → absolute "Apr 17" (for next session)
+
+Both Last and Next sub-values in the merged cell use this formatter.
+
+Note: existing test "shows dash for missing native language" (StudentRoster.test.tsx:106) checks `getAllByText('—').length > 0` — this still passes after the merge because the test student has non-null lastSessionDate and nextSessionDate, so the only dash is from L1. No change needed to that test.
+
+**b) Merge NEXT into LAST column as "LAST / NEXT"**
+
+- Remove `<th>Next</th>` column header.
+- Rename LAST th text to "LAST / NEXT".
+- In the data cell: when `nextSessionDate` exists, render `"{lastDate} → {nextDate}"` (using relative format for both); when no `nextSessionDate`, render just the last session date as before.
+- The Next Session sort option stays (still useful for ordering even without a dedicated column).
+
+**c) Rename signal column header**
+
+- `"Signal"` → `"ACTIVITY SIGNAL"`
+
+### 3. TodayAgenda.tsx — Row status chips
+
+Add a status chip (right-aligned) to each session row in the today list.
+
+Status chip logic (evaluated in order):
+1. `session.sessionLogId === nextSessionId` → chip: "NEXT SESSION" (indigo: `bg-indigo-100 text-indigo-700`)
+   - Also retain the existing `border-l-[3px] border-l-indigo-600 bg-[#ECEAFD]` styling on the row.
+2. `new Date(session.sessionDate) < now` → chip: "DONE" (`bg-zinc-100 text-zinc-400`)
+3. Otherwise (future sessions today) → chip: "SCHEDULED" (`bg-zinc-100 text-zinc-500`)
+
+Chip placement: append as the last element in the flex row, after the optional `plannedContent` span. Since the row is `flex items-center gap-3`, the chip will be right-most. The `plannedContent` span already has `truncate max-w-[120px]` so there is no layout collision.
+
+Chip style class: `inline-flex items-center rounded-full px-2 py-0.5 text-[0.6875rem] font-bold font-inter uppercase tracking-[0.05em] shrink-0`
+
+---
+
+## Tests to update / add
+
+### PendingFollowups.test.tsx
+- Update "shows OLD badge for followup 1-3 days old" → now checks for `"DAYS AGO"` (not `"OLD"`)
+- Update "shows OVERDUE badge for followup more than 3 days old" → checks for `"DAYS OVERDUE"` (still passes but now includes "DAYS")
+- Add: 1-day-old shows "YESTERDAY"
+
+### StudentRoster.test.tsx
+- Update existing tests that check for "Next" column header text (now "LAST / NEXT")
+- Update tests that look for "Signal" → "ACTIVITY SIGNAL"
+- Add: relative date test (last session today shows "Today")
+- Add: paired column shows "→" when nextSessionDate exists
+- Add: only last date shown when no next session
+
+### TodayAgenda.test.tsx
+- Update "highlights the next session" test to also check for "NEXT SESSION" chip text
+- Add: past session shows "DONE" chip
+- Add: future session today shows "SCHEDULED" chip
+
+---
+
+## Files to change
+- `frontend/src/components/dashboard/PendingFollowups.tsx`
+- `frontend/src/components/dashboard/StudentRoster.tsx`
+- `frontend/src/components/dashboard/TodayAgenda.tsx`
+- `frontend/src/components/dashboard/PendingFollowups.test.tsx`
+- `frontend/src/components/dashboard/StudentRoster.test.tsx`
+- `frontend/src/components/dashboard/TodayAgenda.test.tsx`
+
+No backend changes. No e2e visual spec changes needed (no string assertions in dashboard.visual.spec.ts).
+
+---
+
+## Out of scope
+- Hero card student identity subtitle
+- Calendar View link
+- Signal badge logic


### PR DESCRIPTION
## Summary

- **PendingFollowups**: Age labels now use natural language ("YESTERDAY", "2 DAYS AGO", "7 DAYS OVERDUE") instead of developer shorthand ("1D OLD", "7D OVERDUE")
- **StudentRoster**: Relative date formatting ("Today", "Yesterday", "4d ago"), LAST and NEXT columns merged into a single "LAST / NEXT" column with `→` separator, "SIGNAL" header renamed to "ACTIVITY SIGNAL"
- **TodayAgenda**: Status chips added to each session row ("NEXT SESSION" in indigo, "DONE" in zinc, "SCHEDULED" in zinc)

## Test plan

- [ ] Dashboard loads without errors
- [ ] Pending followups show natural-language age labels
- [ ] Student roster shows relative dates and paired LAST / NEXT column
- [ ] Today's agenda session rows show status chips
- [ ] All 1232 unit tests pass (`npx vitest run` in `frontend/`)

Closes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session status indicators (NEXT SESSION, DONE, SCHEDULED) to the agenda view for quick status identification
  * Implemented improved date formatting with more intuitive relative time labels (Today, Yesterday, Days Ago, Days Overdue) across the dashboard

* **Improvements**
  * Consolidated student roster by merging Last/Next session dates into a single unified column
  * Enhanced age badge and activity signal labeling for better clarity and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->