### PR TITLE
fix(t768): search debounce + load more row click bleed on student roster

### DIFF
--- a/frontend/src/pages/Students.tsx
+++ b/frontend/src/pages/Students.tsx
@@ -198,13 +198,25 @@ export default function Students() {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const searchQuery = searchParams.get('q') ?? ''
   const cefrFilter = searchParams.get('level') ?? 'All'
   const sortBy = (searchParams.get('sort') as SortOption) ?? 'lastSession'
   const visibleCount = Number(searchParams.get('count') ?? PAGE_SIZE)
 
+  const [localSearch, setLocalSearch] = useState(() => searchParams.get('q') ?? '')
   const [sortOpen, setSortOpen] = useState(false)
   const sortRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearchParams(prev => {
+        const next = new URLSearchParams(prev)
+        if (localSearch) { next.set('q', localSearch) } else { next.delete('q') }
+        next.delete('count')
+        return next
+      }, { replace: true })
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [localSearch, setSearchParams])
 
   useEffect(() => {
     if (!sortOpen) return
@@ -250,7 +262,7 @@ export default function Students() {
   const allStudents = studentsData?.items ?? []
 
   const filteredStudents = allStudents.filter(s => {
-    const matchesSearch = s.name.toLowerCase().includes(searchQuery.toLowerCase())
+    const matchesSearch = s.name.toLowerCase().includes(localSearch.toLowerCase())
     const matchesCefr = cefrFilter === 'All' || s.cefrLevel === cefrFilter
     return matchesSearch && matchesCefr
   })
@@ -262,9 +274,9 @@ export default function Students() {
 
   function buildSubtitle(): string {
     const total = allStudents.length
-    if (searchQuery) {
+    if (localSearch) {
       const count = filteredStudents.length
-      return `Showing ${count} result${count === 1 ? '' : 's'} for '${searchQuery}'`
+      return `Showing ${count} result${count === 1 ? '' : 's'} for '${localSearch}'`
     }
     if (cefrFilter !== 'All') {
       const count = allStudents.filter(s => s.cefrLevel === cefrFilter).length
@@ -342,8 +354,8 @@ export default function Students() {
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-zinc-400 pointer-events-none" />
             <Input
               placeholder="Search students..."
-              value={searchQuery}
-              onChange={e => updateParam({ q: e.target.value, count: null })}
+              value={localSearch}
+              onChange={e => setLocalSearch(e.target.value)}
               className="pl-8 h-8 text-sm bg-white border-zinc-200 focus-visible:ring-indigo-500"
             />
           </div>
@@ -542,21 +554,21 @@ export default function Students() {
 
           {/* Pagination footer */}
           {sortedStudents.length > 0 && (
-            <div className="px-4 py-3 flex items-center border-t border-zinc-50 relative">
+            <div className="px-4 py-3 grid grid-cols-[1fr_auto_1fr] items-center border-t border-zinc-50">
               <span className="text-xs text-zinc-400">
                 Showing {Math.min(visibleCount, sortedStudents.length)} of {sortedStudents.length} student{sortedStudents.length === 1 ? '' : 's'}
               </span>
-              {visibleCount < sortedStudents.length && (
+              {visibleCount < sortedStudents.length ? (
                 <Button
                   variant="ghost"
                   size="sm"
                   onClick={() => updateParam({ count: String(visibleCount + PAGE_SIZE) })}
                   data-testid="load-more"
-                  className="absolute left-1/2 -translate-x-1/2"
                 >
                   Load more
                 </Button>
-              )}
+              ) : <span />}
+              <span />
             </div>
           )}
         </div>

--- a/frontend/src/pages/Students.tsx
+++ b/frontend/src/pages/Students.tsx
@@ -202,11 +202,23 @@ export default function Students() {
   const sortBy = (searchParams.get('sort') as SortOption) ?? 'lastSession'
   const visibleCount = Number(searchParams.get('count') ?? PAGE_SIZE)
 
-  const [localSearch, setLocalSearch] = useState(() => searchParams.get('q') ?? '')
+  const qFromUrl = searchParams.get('q') ?? ''
+  const [localSearch, setLocalSearch] = useState(() => qFromUrl)
   const [sortOpen, setSortOpen] = useState(false)
   const sortRef = useRef<HTMLDivElement>(null)
+  const didInitSearchRef = useRef(false)
 
+  // Sync input when URL changes via back/forward navigation
   useEffect(() => {
+    setLocalSearch(qFromUrl)
+  }, [qFromUrl])
+
+  // Debounce URL write; skip on mount to avoid wiping ?count from a shared URL
+  useEffect(() => {
+    if (!didInitSearchRef.current) {
+      didInitSearchRef.current = true
+      return
+    }
     const timer = setTimeout(() => {
       setSearchParams(prev => {
         const next = new URLSearchParams(prev)

--- a/plan/langteach-beta/task768-student-roster-polish/task768-student-roster-polish.md
+++ b/plan/langteach-beta/task768-student-roster-polish/task768-student-roster-polish.md
@@ -1,0 +1,37 @@
+# Task 768: Student roster polish
+
+Issue: https://github.com/Robert-Freire/langTeachSaaS/issues/768
+Branch: worktree-task-t768-student-roster-polish
+
+## Acceptance Criteria
+
+1. Search input: fix keystroke loss under real-time URL sync
+2. Row click zone: constrain onClick to row height (Load More no longer captured by row handler)
+3. CEFR badge padding: px-1.5 to px-2 (already px-2 in current code, confirmed no change needed)
+
+## Analysis
+
+### AC1: Search keystroke loss
+Current: `value={searchQuery}` where `searchQuery = searchParams.get('q')`. Every keystroke calls
+`updateParam` which calls `setSearchParams`, triggering a re-render that can steal focus.
+
+Fix:
+- Add `const [localSearch, setLocalSearch] = useState(() => searchParams.get('q') ?? '')`
+- Add `useEffect` that debounces URL sync 300ms after `localSearch` changes
+- Input binds to `localSearch`, onChange calls `setLocalSearch`
+- Filter logic and subtitle read from `localSearch` (immediate, no debounce)
+
+### AC2: Row click bleed
+Current: Load More button uses `absolute left-1/2 -translate-x-1/2` inside a `relative` footer div.
+This can cause overlap with the rows above in certain scroll/layout states.
+
+Fix: Replace absolute positioning with CSS grid layout in the footer:
+`grid-cols-[1fr_auto_1fr]` places count text in col 1, Load More in col 2 (centered), spacer in col 3.
+Eliminates absolute positioning entirely.
+
+### AC3: CEFR badge padding
+CefrBadge.tsx already has `px-2 py-0.5`. No change required.
+
+## Files Changed
+
+- `frontend/src/pages/Students.tsx` - search debounce + footer grid layout


### PR DESCRIPTION
## Summary

- **Search keystroke loss fixed**: input now buffers in `localSearch` state; URL sync debounced 300ms via `useEffect`+`setSearchParams`. Filter and subtitle read from local state instantly — URL is shareability only.
- **Load More row click bleed fixed**: replaced `absolute left-1/2 -translate-x-1/2` button with CSS grid centering (`grid-cols-[1fr_auto_1fr]`), removing the absolute positioning that caused the click zone overlap.
- **CEFR badge padding**: already at `px-2 py-0.5` in the codebase — no change needed.

Closes #768

## Test plan

- [ ] All 33 unit tests pass (`Students.test.tsx`)
- [ ] TypeScript + ESLint clean
- [ ] qa-verify: PASS
- [ ] architecture-reviewer: PASS
- [ ] review-ui: PASS (search, rows, badges render correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized search input responsiveness and behavior for smoother user experience.

* **Style**
  * Updated pagination footer layout; adjusted button visibility when all items are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->