### PR TITLE
feat(t771): student detail interaction standard — autosave, inline session edit, profile polish

### DIFF
--- a/e2e/tests/student-detail.spec.ts
+++ b/e2e/tests/student-detail.spec.ts
@@ -344,8 +344,8 @@ test('student profile tab: motivation Escape reverts value', async ({ browser })
 
     // After escape, edit mode exits and original quote is visible
     await expect(page.getByTestId('reason-quote')).toBeVisible({ timeout: UI_TIMEOUT })
-    // SavedIndicator should NOT appear
-    await expect(page.getByTestId('saved-indicator')).not.toBeVisible()
+    // SavedIndicator should NOT appear — use toHaveCount(0) to avoid race with deferred mount
+    await expect(page.getByTestId('saved-indicator')).toHaveCount(0)
   } finally {
     await context.close()
   }

--- a/e2e/tests/student-detail.spec.ts
+++ b/e2e/tests/student-detail.spec.ts
@@ -295,3 +295,204 @@ test('student detail profile tab: inline-add focus area difficulty', async ({ br
     await context.close()
   }
 })
+
+// ----- t771: interaction standard -----
+
+test('student profile tab: motivation autosave on blur', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  try {
+    await page.goto('/students')
+    await expect(page.locator('h1')).toHaveText('Students', { timeout: NAV_TIMEOUT })
+    await page.getByText('Ana Seed').first().click()
+    await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
+
+    await page.getByTestId('tab-profile').click()
+    await expect(page.getByTestId('student-profile-tab')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await page.getByTestId('reason-edit-trigger').click()
+    const textarea = page.getByTestId('reason-textarea')
+    await expect(textarea).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await textarea.fill('Autosave e2e test reason')
+    await textarea.blur()
+
+    await expect(page.getByTestId('saved-indicator')).toBeVisible({ timeout: UI_TIMEOUT })
+  } finally {
+    await context.close()
+  }
+})
+
+test('student profile tab: motivation Escape reverts value', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  try {
+    await page.goto('/students')
+    await expect(page.locator('h1')).toHaveText('Students', { timeout: NAV_TIMEOUT })
+    await page.getByText('Ana Seed').first().click()
+    await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
+
+    await page.getByTestId('tab-profile').click()
+    await expect(page.getByTestId('student-profile-tab')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await page.getByTestId('reason-edit-trigger').click()
+    const textarea = page.getByTestId('reason-textarea')
+    await expect(textarea).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await textarea.fill('Should not be saved')
+    await textarea.press('Escape')
+
+    // After escape, edit mode exits and original quote is visible
+    await expect(page.getByTestId('reason-quote')).toBeVisible({ timeout: UI_TIMEOUT })
+    // SavedIndicator should NOT appear
+    await expect(page.getByTestId('saved-indicator')).not.toBeVisible()
+  } finally {
+    await context.close()
+  }
+})
+
+test('student profile tab: interests chip input always visible', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  try {
+    await page.goto('/students')
+    await expect(page.locator('h1')).toHaveText('Students', { timeout: NAV_TIMEOUT })
+    await page.getByText('Ana Seed').first().click()
+    await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
+
+    await page.getByTestId('tab-profile').click()
+    await expect(page.getByTestId('student-profile-tab')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await expect(page.getByTestId('interests-input')).toBeVisible({ timeout: UI_TIMEOUT })
+  } finally {
+    await context.close()
+  }
+})
+
+test('student profile tab: add interest chip via Enter', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  try {
+    const studentName = `Interests E2E ${Date.now()}`
+    await page.goto('/students/new')
+    await expect(page.locator('h1')).toHaveText('Add Student', { timeout: NAV_TIMEOUT })
+    await page.getByTestId('student-name').fill(studentName)
+    await page.getByTestId('student-language').click()
+    await page.getByRole('option', { name: 'Spanish' }).click()
+    await page.getByTestId('student-cefr').click()
+    await page.getByRole('option', { name: 'A1' }).click()
+    await page.getByTestId('student-native-language').click()
+    await page.getByRole('option', { name: 'English' }).click()
+    await page.keyboard.press('Escape')
+    await page.getByRole('button', { name: 'Save Student' }).click()
+    await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
+
+    await page.getByTestId('tab-profile').click()
+    await expect(page.getByTestId('student-profile-tab')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    const input = page.getByTestId('interests-input')
+    await expect(input).toBeVisible({ timeout: UI_TIMEOUT })
+    await input.fill('reading')
+    await input.press('Enter')
+
+    await expect(page.getByTestId('interest-tag').filter({ hasText: 'reading' })).toBeVisible({ timeout: UI_TIMEOUT })
+    await expect(page.getByTestId('saved-indicator')).toBeVisible({ timeout: UI_TIMEOUT })
+  } finally {
+    await context.close()
+  }
+})
+
+test('student profile tab: TWM always visible without show-all', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  try {
+    const studentName = `TWM Visibility ${Date.now()}`
+    await page.goto('/students/new')
+    await expect(page.locator('h1')).toHaveText('Add Student', { timeout: NAV_TIMEOUT })
+    await page.getByTestId('student-name').fill(studentName)
+    await page.getByTestId('student-language').click()
+    await page.getByRole('option', { name: 'Spanish' }).click()
+    await page.getByTestId('student-cefr').click()
+    await page.getByRole('option', { name: 'A1' }).click()
+    await page.getByTestId('student-native-language').click()
+    await page.getByRole('option', { name: 'English' }).click()
+    await page.keyboard.press('Escape')
+    await page.getByRole('button', { name: 'Save Student' }).click()
+    await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
+
+    await page.getByTestId('tab-profile').click()
+    await expect(page.getByTestId('student-profile-tab')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await expect(page.getByTestId('profile-about')).toBeVisible({ timeout: UI_TIMEOUT })
+  } finally {
+    await context.close()
+  }
+})
+
+test('sessions tab: no kebab menu on session rows', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  try {
+    await page.goto('/students')
+    await expect(page.locator('h1')).toHaveText('Students', { timeout: NAV_TIMEOUT })
+    await page.getByText('Diego Seed').first().click()
+    await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
+
+    await page.getByTestId('tab-sessions').click()
+    await expect(page.getByTestId('session-history-list')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await expect(page.getByTestId('session-kebab-trigger')).not.toBeVisible()
+  } finally {
+    await context.close()
+  }
+})
+
+test('sessions tab: expand row shows editable title and narrative inputs', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  try {
+    await page.goto('/students')
+    await expect(page.locator('h1')).toHaveText('Students', { timeout: NAV_TIMEOUT })
+    await page.getByText('Diego Seed').first().click()
+    await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
+
+    await page.getByTestId('tab-sessions').click()
+    await expect(page.getByTestId('session-history-list')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await page.getByTestId('session-entry-toggle').first().click()
+    await expect(page.getByTestId('session-entry-detail').first()).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await expect(page.getByTestId('session-title-input').first()).toBeVisible({ timeout: UI_TIMEOUT })
+    await expect(page.getByTestId('session-narrative-input').first()).toBeVisible({ timeout: UI_TIMEOUT })
+    await expect(page.getByTestId('session-duration-input').first()).toBeVisible({ timeout: UI_TIMEOUT })
+  } finally {
+    await context.close()
+  }
+})
+
+test('sessions tab: expanded row has delete button that opens confirmation dialog', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  try {
+    await page.goto('/students')
+    await expect(page.locator('h1')).toHaveText('Students', { timeout: NAV_TIMEOUT })
+    await page.getByText('Diego Seed').first().click()
+    await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
+
+    await page.getByTestId('tab-sessions').click()
+    await expect(page.getByTestId('session-history-list')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await page.getByTestId('session-entry-toggle').first().click()
+    await expect(page.getByTestId('session-entry-detail').first()).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await expect(page.getByTestId('delete-session-btn').first()).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await page.getByTestId('delete-session-btn').first().click()
+    await expect(page.getByText('Delete this session?')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    await page.getByRole('button', { name: 'Cancel' }).click()
+    await expect(page.getByText('Delete this session?')).not.toBeVisible()
+  } finally {
+    await context.close()
+  }
+})

--- a/e2e/tests/visual/student-detail.visual.spec.ts
+++ b/e2e/tests/visual/student-detail.visual.spec.ts
@@ -84,3 +84,41 @@ test('@visual student detail sessions tab - with sessions', async ({ browser }) 
   expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)
   await context.close()
 })
+
+test('@visual student detail profile tab - right sidebar visible', async ({ browser }) => {
+  fs.mkdirSync('screenshots', { recursive: true })
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  const consoleErrors: string[] = []
+  page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()) })
+
+  await page.goto(`/students/${studentWithSessionsId}`)
+  await expect(page.getByTestId('student-detail-name')).toBeVisible({ timeout: NAV_TIMEOUT })
+  await page.getByTestId('tab-profile').click()
+  await expect(page.getByTestId('student-profile-tab')).toBeVisible({ timeout: UI_TIMEOUT })
+  await expect(page.getByTestId('profile-about')).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.screenshot({ path: 'screenshots/student-detail-profile-tab.png', fullPage: true })
+
+  expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)
+  await context.close()
+})
+
+test('@visual student detail sessions tab - expanded row with editable fields', async ({ browser }) => {
+  fs.mkdirSync('screenshots', { recursive: true })
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  const consoleErrors: string[] = []
+  page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()) })
+
+  await page.goto(`/students/${studentWithSessionsId}`)
+  await expect(page.getByTestId('student-detail-name')).toBeVisible({ timeout: NAV_TIMEOUT })
+  await page.getByTestId('tab-sessions').click()
+  await expect(page.getByTestId('session-history-list')).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.getByTestId('session-entry-toggle').first().click()
+  await expect(page.getByTestId('session-entry-detail').first()).toBeVisible({ timeout: UI_TIMEOUT })
+  await expect(page.getByTestId('session-title-input').first()).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.screenshot({ path: 'screenshots/student-detail-session-expanded.png', fullPage: true })
+
+  expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)
+  await context.close()
+})

--- a/frontend/src/api/sessionLogs.ts
+++ b/frontend/src/api/sessionLogs.ts
@@ -154,6 +154,10 @@ export async function updateSession(
   return res.data
 }
 
+function parseJsonArray<T>(json: string): T[] {
+  try { return JSON.parse(json) as T[] } catch { return [] }
+}
+
 export async function patchSessionField(
   studentId: string,
   session: SessionLog,
@@ -175,6 +179,9 @@ export async function patchSessionField(
     status: session.statusName,
     duration: session.duration,
     title: session.title,
+    // Preserve AI-generated fields so the PUT does not silently clear them
+    mentionedDifficultyPairs: parseJsonArray(session.mentionedDifficultyPairs),
+    suggestedDifficulties: parseJsonArray(session.suggestedDifficulties),
     ...patch,
   }
   return updateSession(studentId, session.id, payload)

--- a/frontend/src/api/sessionLogs.ts
+++ b/frontend/src/api/sessionLogs.ts
@@ -76,6 +76,7 @@ export interface CreateSessionLogRequest {
   mentionedDifficultyPairs?: { Competency: string; Subcategory: string }[]
   suggestedDifficulties?: SuggestedDifficulty[]
   duration?: number | null
+  title?: string | null
   voiceNoteId?: string
   voiceNoteTranscription?: string
   rawExtractionJson?: string
@@ -151,6 +152,32 @@ export async function updateSession(
     data,
   )
   return res.data
+}
+
+export async function patchSessionField(
+  studentId: string,
+  session: SessionLog,
+  patch: Partial<Pick<UpdateSessionLogRequest, 'title' | 'actualContent' | 'duration' | 'nextSessionTopics'>>,
+): Promise<SessionLog> {
+  const payload: UpdateSessionLogRequest = {
+    sessionDate: session.sessionDate,
+    plannedContent: session.plannedContent,
+    actualContent: session.actualContent,
+    homeworkAssigned: session.homeworkAssigned,
+    previousHomeworkStatus: session.previousHomeworkStatusName || 'NotApplicable',
+    nextSessionTopics: session.nextSessionTopics,
+    generalNotes: session.generalNotes,
+    levelReassessmentSkill: session.levelReassessmentSkill,
+    levelReassessmentLevel: session.levelReassessmentLevel,
+    linkedLessonId: session.linkedLessonId,
+    topicTags: session.topicTags,
+    isCancelled: session.isCancelled,
+    status: session.statusName,
+    duration: session.duration,
+    title: session.title,
+    ...patch,
+  }
+  return updateSession(studentId, session.id, payload)
 }
 
 export async function deleteSession(studentId: string, sessionId: string): Promise<void> {

--- a/frontend/src/components/session/SessionHistoryTab.test.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.test.tsx
@@ -15,6 +15,7 @@ vi.mock('react-router-dom', async (importOriginal) => {
 vi.mock('../../api/sessionLogs', () => ({
   listSessions: vi.fn(),
   deleteSession: vi.fn(),
+  patchSessionField: vi.fn(),
   updateSession: vi.fn(),
   createSession: vi.fn(),
   serializeTopicTags: vi.fn((tags) => JSON.stringify(tags)),
@@ -133,8 +134,9 @@ describe('SessionHistoryTab', () => {
     await screen.findByTestId('session-entry')
     fireEvent.click(screen.getByTestId('session-entry-toggle'))
     expect(screen.getByTestId('session-entry-detail')).toBeInTheDocument()
-    // actualContent appears exactly once (in the narrative section, not also in collapsed row)
-    expect(screen.getAllByText(/Covered basics and exercises/)).toHaveLength(1)
+    // collapsed snippet <p> gone; actualContent now appears in the editable narrative textarea
+    expect(screen.queryByText(/Covered basics and exercises/, { selector: 'p' })).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue(/Covered basics and exercises/)).toBeInTheDocument()
     // plannedContent appears in the detail (since it differs from actualContent)
     expect(screen.getByText(/Preterito indefinido intro/)).toBeInTheDocument()
   })
@@ -187,39 +189,19 @@ describe('SessionHistoryTab', () => {
     expect(chips[1]).toHaveTextContent('viajes')
   })
 
-  it('shows kebab menu trigger in collapsed row', async () => {
+  it('does not show kebab trigger in the collapsed row', async () => {
     vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
     wrapper()
     await screen.findByTestId('session-entry')
-    expect(screen.getByTestId('session-kebab-trigger')).toBeInTheDocument()
+    expect(screen.queryByTestId('session-kebab-trigger')).not.toBeInTheDocument()
   })
 
-  it('shows delete button in kebab menu', async () => {
+  it('shows delete button in expanded row', async () => {
     vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
     wrapper()
     await screen.findByTestId('session-entry')
-    fireEvent.click(screen.getByTestId('session-kebab-trigger'))
-    expect(await screen.findByTestId('delete-session-button')).toBeInTheDocument()
-  })
-
-  it('shows edit button in kebab menu', async () => {
-    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
-    wrapper()
-    await screen.findByTestId('session-entry')
-    fireEvent.click(screen.getByTestId('session-kebab-trigger'))
-    expect(await screen.findByTestId('edit-session-button')).toBeInTheDocument()
-  })
-
-  it('clicking edit button navigates to the edit session route', async () => {
-    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
-    wrapper()
-    await screen.findByTestId('session-entry')
-    fireEvent.click(screen.getByTestId('session-kebab-trigger'))
-    const editBtn = await screen.findByTestId('edit-session-button')
-    fireEvent.click(editBtn)
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(`/students/student-1/sessions/${SESSION_BASE.id}/edit`)
-    })
+    fireEvent.click(screen.getByTestId('session-entry-toggle'))
+    expect(await screen.findByTestId('delete-session-btn')).toBeInTheDocument()
   })
 
   it('does not call deleteSession when delete button is clicked without confirming', async () => {
@@ -227,8 +209,8 @@ describe('SessionHistoryTab', () => {
     vi.mocked(sessionLogsApi.deleteSession).mockResolvedValue(undefined)
     wrapper()
     await screen.findByTestId('session-entry')
-    fireEvent.click(screen.getByTestId('session-kebab-trigger'))
-    const deleteBtn = await screen.findByTestId('delete-session-button')
+    fireEvent.click(screen.getByTestId('session-entry-toggle'))
+    const deleteBtn = await screen.findByTestId('delete-session-btn')
     fireEvent.click(deleteBtn)
     // Dialog opens but we cancel
     const cancelBtn = await screen.findByRole('button', { name: /cancel/i })
@@ -241,8 +223,8 @@ describe('SessionHistoryTab', () => {
     vi.mocked(sessionLogsApi.deleteSession).mockResolvedValue(undefined)
     wrapper()
     await screen.findByTestId('session-entry')
-    fireEvent.click(screen.getByTestId('session-kebab-trigger'))
-    const deleteBtn = await screen.findByTestId('delete-session-button')
+    fireEvent.click(screen.getByTestId('session-entry-toggle'))
+    const deleteBtn = await screen.findByTestId('delete-session-btn')
     fireEvent.click(deleteBtn)
     const confirmBtn = await screen.findByTestId('confirm-delete-session')
     fireEvent.click(confirmBtn)
@@ -365,35 +347,33 @@ describe('SessionHistoryTab', () => {
     expect(screen.queryByTestId('next-session-topics-preview')).not.toBeInTheDocument()
   })
 
-  it('shows next session topics section with amber styling in expanded state', async () => {
+  it('shows next plan textarea with amber heading and value in expanded state', async () => {
     vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
     wrapper()
     await screen.findByTestId('session-entry')
     fireEvent.click(screen.getByTestId('session-entry-toggle'))
-    const section = screen.getByTestId('next-session-topics-section')
-    expect(section).toBeInTheDocument()
-    expect(section).toHaveTextContent('Planned for next class')
-    expect(section).toHaveTextContent('Review irregular verbs')
+    expect(screen.getByText('Planned for next class')).toBeInTheDocument()
+    const textarea = screen.getByTestId('session-next-plan-input')
+    expect(textarea).toBeInTheDocument()
+    expect(textarea).toHaveValue('Review irregular verbs')
   })
 
-  it('does not show next session topics section when nextSessionTopics is null', async () => {
+  it('does not show start-next-session-button when nextSessionTopics is null', async () => {
     vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
       { ...SESSION_BASE, nextSessionTopics: null },
     ])
     wrapper()
     await screen.findByTestId('session-entry')
     fireEvent.click(screen.getByTestId('session-entry-toggle'))
-    expect(screen.queryByTestId('next-session-topics-section')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('start-next-session-button')).not.toBeInTheDocument()
   })
 
-  it('shows "Start next session" button inside the amber card when nextSessionTopics is non-empty', async () => {
+  it('shows "Start next session" button when nextSessionTopics is non-empty', async () => {
     vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
     wrapper()
     await screen.findByTestId('session-entry')
     fireEvent.click(screen.getByTestId('session-entry-toggle'))
-    const section = screen.getByTestId('next-session-topics-section')
-    const button = section.querySelector('[data-testid="start-next-session-button"]')
-    expect(button).not.toBeNull()
+    expect(screen.getByTestId('start-next-session-button')).toBeInTheDocument()
   })
 
   it('does not show "Start next session" button when nextSessionTopics is null', async () => {

--- a/frontend/src/components/session/SessionHistoryTab.test.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.test.tsx
@@ -233,6 +233,39 @@ describe('SessionHistoryTab', () => {
     })
   })
 
+  it('blurring session title calls patchSessionField and shows saved indicator', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
+    vi.mocked(sessionLogsApi.patchSessionField).mockResolvedValue({ ...SESSION_BASE, title: 'New Title' })
+    wrapper()
+    await screen.findByTestId('session-entry')
+    fireEvent.click(screen.getByTestId('session-entry-toggle'))
+    const titleInput = screen.getByTestId('session-title-input')
+    fireEvent.change(titleInput, { target: { value: 'New Title' } })
+    fireEvent.blur(titleInput)
+    await waitFor(() => {
+      expect(sessionLogsApi.patchSessionField).toHaveBeenCalledWith(
+        'student-1',
+        expect.objectContaining({ id: 'session-1' }),
+        { title: 'New Title' },
+      )
+    })
+    expect(await screen.findByTestId('saved-indicator')).toBeInTheDocument()
+  })
+
+  it('Escape on session narrative reverts value and does not call patchSessionField', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
+    wrapper()
+    await screen.findByTestId('session-entry')
+    fireEvent.click(screen.getByTestId('session-entry-toggle'))
+    const narrativeInput = screen.getByTestId('session-narrative-input')
+    fireEvent.change(narrativeInput, { target: { value: 'Edited content' } })
+    fireEvent.keyDown(narrativeInput, { key: 'Escape' })
+    await waitFor(() => {
+      expect(sessionLogsApi.patchSessionField).not.toHaveBeenCalled()
+    })
+    expect(screen.getByDisplayValue('Covered basics and exercises')).toBeInTheDocument()
+  })
+
   it('shows separate action item and note counts when both are set', async () => {
     vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([SESSION_BASE])
     wrapper()

--- a/frontend/src/components/session/SessionHistoryTab.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef } from 'react'
+import { useState, useMemo, useRef, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   ChevronDown,
@@ -84,6 +84,13 @@ function SessionEntry({
   const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isRevertingRef = useRef(false)
 
+  useEffect(() => {
+    return () => {
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+    }
+  }, [])
+
   const { mutate: softDelete, isPending: isDeleting } = useMutation({
     mutationFn: () => deleteSession(studentId, session.id),
     onSuccess: () => {
@@ -106,7 +113,18 @@ function SessionEntry({
     if (value === savedValue) return
     const patch: Record<string, string | number | null> = {}
     if (field === 'duration') {
-      patch[field] = value === '' ? null : Number(value)
+      if (value === '') {
+        patch[field] = null
+      } else {
+        const n = Number(value)
+        if (!Number.isFinite(n) || n < 0) {
+          setFieldError('Invalid duration')
+          if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+          errorTimerRef.current = setTimeout(() => setFieldError(null), 3000)
+          return
+        }
+        patch[field] = n
+      }
     } else {
       patch[field] = value || null
     }

--- a/frontend/src/components/session/SessionHistoryTab.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.tsx
@@ -1,21 +1,19 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   ChevronDown,
   ChevronUp,
   Trash2,
-  Pencil,
   ExternalLink,
   PlayCircle,
   Search,
   Mic,
   CalendarDays,
   Filter,
-  MoreHorizontal,
 } from 'lucide-react'
 import { logger } from '../../lib/logger'
 import { Link, useNavigate } from 'react-router-dom'
-import { listSessions, deleteSession, parseTopicTags, type SessionLog } from '../../api/sessionLogs'
+import { listSessions, deleteSession, patchSessionField, parseTopicTags, type SessionLog } from '../../api/sessionLogs'
 import { formatMonth, formatDay } from '../../utils/formatDate'
 import { getSessionTitle } from '../../lib/sessionUtils'
 import { HOMEWORK_STATUS_INFO } from '../../utils/homeworkStatusStyles'
@@ -23,6 +21,7 @@ import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { SavedIndicator } from '@/components/ui/SavedIndicator'
 import {
   AlertDialog,
   AlertDialogContent,
@@ -63,19 +62,27 @@ const HW_STATUS_FALLBACK = { icon: '—', color: 'text-zinc-400', label: 'N/A' }
 function SessionEntry({
   session,
   studentId,
-  onEdit,
   onStartNextSession,
 }: {
   session: SessionLog
   studentId: string
-  onEdit: (session: SessionLog) => void
   onStartNextSession: () => void
 }) {
   const [expanded, setExpanded] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
-  const [kebabOpen, setKebabOpen] = useState(false)
   const queryClient = useQueryClient()
+
+  // Inline edit state — initialized from session prop
+  const [titleDraft, setTitleDraft] = useState(session.title ?? '')
+  const [narrativeDraft, setNarrativeDraft] = useState(session.actualContent ?? '')
+  const [durationDraft, setDurationDraft] = useState(session.duration?.toString() ?? '')
+  const [nextPlanDraft, setNextPlanDraft] = useState(session.nextSessionTopics ?? '')
+  const [savedVisible, setSavedVisible] = useState(false)
+  const [fieldError, setFieldError] = useState<string | null>(null)
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const isRevertingRef = useRef(false)
 
   const { mutate: softDelete, isPending: isDeleting } = useMutation({
     mutationFn: () => deleteSession(studentId, session.id),
@@ -89,6 +96,34 @@ function SessionEntry({
       setDeleteError('Failed to delete session. Please try again.')
     },
   })
+
+  async function handleFieldBlur(
+    field: 'title' | 'actualContent' | 'duration' | 'nextSessionTopics',
+    value: string,
+    savedValue: string,
+  ) {
+    if (isRevertingRef.current) { isRevertingRef.current = false; return }
+    if (value === savedValue) return
+    const patch: Record<string, string | number | null> = {}
+    if (field === 'duration') {
+      patch[field] = value === '' ? null : Number(value)
+    } else {
+      patch[field] = value || null
+    }
+    try {
+      await patchSessionField(studentId, session, patch as Parameters<typeof patchSessionField>[2])
+      queryClient.invalidateQueries({ queryKey: ['sessions', studentId] })
+      setSavedVisible(true)
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
+      savedTimerRef.current = setTimeout(() => setSavedVisible(false), 1500)
+      setFieldError(null)
+    } catch (err) {
+      logger.error('SessionHistoryTab', 'inline field save failed', err)
+      setFieldError('Failed to save')
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+      errorTimerRef.current = setTimeout(() => setFieldError(null), 3000)
+    }
+  }
 
   const topicTags = parseTopicTags(session.topicTags)
   const hasActionItem = Boolean(session.nextSessionTopics)
@@ -112,208 +147,208 @@ function SessionEntry({
         className={`rounded-2xl ring-1 ring-[#C7C4D8]/10 overflow-hidden transition-all ${cardClass}`}
         data-testid="session-entry"
       >
-        {/* Header row: expand button + kebab menu */}
-        <div className="flex items-stretch">
-          {/* Main expand button */}
-          <button
-            onClick={() => setExpanded((v) => !v)}
-            className="flex-1 min-w-0 text-left p-4 hover:bg-[#F4F2FD]/40 transition-colors"
-            aria-expanded={expanded}
-            data-testid="session-entry-toggle"
-          >
-            <div className="flex items-center gap-3">
-              {/* Left: date badge + title + snippet */}
-              <div className="flex items-start gap-3 min-w-0 flex-1">
-                {/* Date badge */}
-                <div
-                  className={`flex flex-col items-center justify-center shrink-0 rounded-xl w-12 h-12 ${
-                    isCancelled ? 'bg-zinc-200 text-zinc-500' : 'bg-[#E2DFFF] text-[#3525CD]'
-                  }`}
-                >
-                  <span className="text-[8px] font-bold uppercase leading-none">{formatMonth(session.sessionDate)}</span>
-                  <span className="text-lg font-extrabold leading-tight">{formatDay(session.sessionDate)}</span>
-                </div>
-
-                {/* Title + content */}
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2 flex-wrap mb-0.5">
-                    <h3
-                      className={`font-bold text-sm text-[#1A1B22] ${isCancelled ? 'line-through text-zinc-500' : ''}`}
-                    >
-                      {getSessionTitle(session)}
-                    </h3>
-                    {isCancelled && (
-                      <span
-                        className="px-2 py-0.5 rounded bg-zinc-200 text-zinc-600 text-[9px] font-bold uppercase"
-                        data-testid="cancelled-badge"
-                      >
-                        Cancelled
-                      </span>
-                    )}
-                    {isDraft && !isCancelled && (
-                      <span
-                        className="px-2 py-0.5 rounded bg-amber-100 text-amber-700 text-[9px] font-bold uppercase"
-                        data-testid="draft-badge"
-                      >
-                        Pending review
-                      </span>
-                    )}
-                    {!isCancelled && !isDraft && (
-                      <span className="px-2 py-0.5 rounded bg-emerald-50 text-emerald-600 text-[9px] font-bold uppercase">
-                        Completed
-                      </span>
-                    )}
-                    {hasActionItem && (
-                      <span className="inline-flex items-center gap-1 text-xs text-amber-600" data-testid="action-item-count">
-                        <span className="bg-amber-400 rounded-full w-1.5 h-1.5 shrink-0" />
-                        1 action item
-                        {expanded ? (
-                          <ChevronUp className="h-3 w-3 shrink-0" />
-                        ) : (
-                          <ChevronDown className="h-3 w-3 shrink-0" />
-                        )}
-                      </span>
-                    )}
-                    {hasNote && (
-                      <span className="inline-flex items-center gap-1 text-xs text-zinc-400" data-testid="general-note-count">
-                        <span className="bg-zinc-300 rounded-full w-1.5 h-1.5 shrink-0" />
-                        1 note
-                        {expanded ? (
-                          <ChevronUp className="h-3 w-3 shrink-0" />
-                        ) : (
-                          <ChevronDown className="h-3 w-3 shrink-0" />
-                        )}
-                      </span>
-                    )}
-                  </div>
-
-                  {/* Snippet -- actualContent, slightly more prominent when no title */}
-                  {!expanded && session.actualContent && (
-                    <p className={`line-clamp-${session.title ? '1' : '2'} ${session.title ? 'text-xs text-zinc-500' : 'text-xs text-zinc-600'}`}>
-                      {session.actualContent}
-                    </p>
-                  )}
-
-                  {/* Next session topics preview */}
-                  {!expanded && session.nextSessionTopics && (
-                    <p className="text-xs text-amber-700 line-clamp-1" data-testid="next-session-topics-preview">
-                      <span className="font-medium">Next:</span>{' '}
-                      {session.nextSessionTopics}
-                    </p>
-                  )}
-
-                  {/* Topic chips (collapsed) */}
-                  {!expanded && topicTags.length > 0 && (
-                    <div className="flex flex-wrap gap-1 mt-1">
-                      {topicTags.slice(0, 4).map((tag, i) => (
-                        <span
-                          key={`${tag.tag}-${i}`}
-                          className={`px-2 py-0.5 rounded-full text-[9px] font-bold ${tagCategoryClass(tag.category)}`}
-                        >
-                          {tag.tag}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                </div>
+        {/* Header row: expand button only (no kebab) */}
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="w-full text-left p-4 hover:bg-[#F4F2FD]/40 transition-colors"
+          aria-expanded={expanded}
+          data-testid="session-entry-toggle"
+        >
+          <div className="flex items-center gap-3">
+            {/* Left: date badge + title + snippet */}
+            <div className="flex items-start gap-3 min-w-0 flex-1">
+              {/* Date badge */}
+              <div
+                className={`flex flex-col items-center justify-center shrink-0 rounded-xl w-12 h-12 ${
+                  isCancelled ? 'bg-zinc-200 text-zinc-500' : 'bg-[#E2DFFF] text-[#3525CD]'
+                }`}
+              >
+                <span className="text-[8px] font-bold uppercase leading-none">{formatMonth(session.sessionDate)}</span>
+                <span className="text-lg font-extrabold leading-tight">{formatDay(session.sessionDate)}</span>
               </div>
 
-              {/* Right: hw status icon + duration + mic + chevron */}
-              <div className="flex items-center gap-2 shrink-0">
-                {/* Homework status icon */}
-                {showHwIcon && (
-                  <span
-                    className={`text-sm font-bold leading-none ${hwInfo.color}`}
-                    title={hwInfo.label}
-                    data-testid="hw-status-icon"
+              {/* Title + content */}
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 flex-wrap mb-0.5">
+                  <h3
+                    className={`font-bold text-sm text-[#1A1B22] ${isCancelled ? 'line-through text-zinc-500' : ''}`}
                   >
-                    {hwInfo.icon}
-                  </span>
+                    {getSessionTitle(session)}
+                  </h3>
+                  {isCancelled && (
+                    <span
+                      className="px-2 py-0.5 rounded bg-zinc-200 text-zinc-600 text-[9px] font-bold uppercase"
+                      data-testid="cancelled-badge"
+                    >
+                      Cancelled
+                    </span>
+                  )}
+                  {isDraft && !isCancelled && (
+                    <span
+                      className="px-2 py-0.5 rounded bg-amber-100 text-amber-700 text-[9px] font-bold uppercase"
+                      data-testid="draft-badge"
+                    >
+                      Pending review
+                    </span>
+                  )}
+                  {!isCancelled && !isDraft && (
+                    <span className="px-2 py-0.5 rounded bg-emerald-50 text-emerald-600 text-[9px] font-bold uppercase">
+                      Completed
+                    </span>
+                  )}
+                  {hasActionItem && (
+                    <span className="inline-flex items-center gap-1 text-xs text-amber-600" data-testid="action-item-count">
+                      <span className="bg-amber-400 rounded-full w-1.5 h-1.5 shrink-0" />
+                      1 action item
+                      {expanded ? (
+                        <ChevronUp className="h-3 w-3 shrink-0" />
+                      ) : (
+                        <ChevronDown className="h-3 w-3 shrink-0" />
+                      )}
+                    </span>
+                  )}
+                  {hasNote && (
+                    <span className="inline-flex items-center gap-1 text-xs text-zinc-400" data-testid="general-note-count">
+                      <span className="bg-zinc-300 rounded-full w-1.5 h-1.5 shrink-0" />
+                      1 note
+                      {expanded ? (
+                        <ChevronUp className="h-3 w-3 shrink-0" />
+                      ) : (
+                        <ChevronDown className="h-3 w-3 shrink-0" />
+                      )}
+                    </span>
+                  )}
+                </div>
+
+                {/* Snippet -- actualContent, slightly more prominent when no title */}
+                {!expanded && session.actualContent && (
+                  <p className={`line-clamp-${session.title ? '1' : '2'} ${session.title ? 'text-xs text-zinc-500' : 'text-xs text-zinc-600'}`}>
+                    {session.actualContent}
+                  </p>
                 )}
-                {(session.duration != null || isCancelled) && (
-                  <span className="text-xs text-zinc-400 font-medium" data-testid="duration-badge">
-                    {isCancelled ? '0' : session.duration} min
-                  </span>
+
+                {/* Next session topics preview */}
+                {!expanded && session.nextSessionTopics && (
+                  <p className="text-xs text-amber-700 line-clamp-1" data-testid="next-session-topics-preview">
+                    <span className="font-medium">Next:</span>{' '}
+                    {session.nextSessionTopics}
+                  </p>
                 )}
-                {session.hasVoiceNote && (
-                  <span className="text-zinc-400" data-testid="voice-note-icon">
-                    <Mic className="h-4 w-4" />
-                  </span>
-                )}
-                {expanded ? (
-                  <ChevronUp className="h-4 w-4 text-zinc-400" />
-                ) : (
-                  <ChevronDown className="h-4 w-4 text-zinc-400" />
+
+                {/* Topic chips (collapsed) */}
+                {!expanded && topicTags.length > 0 && (
+                  <div className="flex flex-wrap gap-1 mt-1">
+                    {topicTags.slice(0, 4).map((tag, i) => (
+                      <span
+                        key={`${tag.tag}-${i}`}
+                        className={`px-2 py-0.5 rounded-full text-[9px] font-bold ${tagCategoryClass(tag.category)}`}
+                      >
+                        {tag.tag}
+                      </span>
+                    ))}
+                  </div>
                 )}
               </div>
             </div>
-          </button>
 
-          {/* Kebab menu - outside the expand button */}
-          <div className="flex items-center px-2 shrink-0">
-            <Popover open={kebabOpen} onOpenChange={setKebabOpen}>
-              <PopoverTrigger
-                render={
-                  <button
-                    className="p-1.5 rounded-lg hover:bg-[#F4F2FD] text-zinc-400 hover:text-zinc-600 transition-colors"
-                    aria-label="Session options"
-                    data-testid="session-kebab-trigger"
-                  >
-                    <MoreHorizontal className="h-4 w-4" />
-                  </button>
-                }
-              />
-              <PopoverContent className="w-44 p-1" align="end" side="bottom">
-                <button
-                  className="w-full flex items-center gap-2 px-3 py-2 text-sm rounded-lg hover:bg-[#F4F2FD] text-[#1A1B22] transition-colors"
-                  onClick={() => {
-                    setKebabOpen(false)
-                    onEdit(session)
-                  }}
-                  data-testid="edit-session-button"
+            {/* Right: hw status icon + duration + mic + chevron */}
+            <div className="flex items-center gap-2 shrink-0">
+              {/* Homework status icon */}
+              {showHwIcon && (
+                <span
+                  className={`text-sm font-bold leading-none ${hwInfo.color}`}
+                  title={hwInfo.label}
+                  data-testid="hw-status-icon"
                 >
-                  <Pencil className="h-3.5 w-3.5" />
-                  Edit
-                </button>
-                <div className="h-px bg-[#C7C4D8]/20 my-1" />
-                <button
-                  className="w-full flex items-center gap-2 px-3 py-2 text-sm rounded-lg hover:bg-red-50 text-red-600 transition-colors"
-                  onClick={() => {
-                    setKebabOpen(false)
-                    setDeleteOpen(true)
-                  }}
-                  disabled={isDeleting}
-                  data-testid="delete-session-button"
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                  Delete
-                </button>
-              </PopoverContent>
-            </Popover>
+                  {hwInfo.icon}
+                </span>
+              )}
+              {(session.duration != null || isCancelled) && (
+                <span className="text-xs text-zinc-400 font-medium" data-testid="duration-badge">
+                  {isCancelled ? '0' : session.duration} min
+                </span>
+              )}
+              {session.hasVoiceNote && (
+                <span className="text-zinc-400" data-testid="voice-note-icon">
+                  <Mic className="h-4 w-4" />
+                </span>
+              )}
+              {expanded ? (
+                <ChevronUp className="h-4 w-4 text-zinc-400" />
+              ) : (
+                <ChevronDown className="h-4 w-4 text-zinc-400" />
+              )}
+            </div>
           </div>
-        </div>
+        </button>
 
         {/* Expanded detail */}
         {expanded && (
           <div
             className="border-t border-[#C7C4D8]/10 p-5 bg-[#FBFAFF]"
             data-testid="session-entry-detail"
+            onClick={(e) => e.stopPropagation()}
           >
-            <div className={`grid grid-cols-1 gap-6 ${hasRightColumn ? 'md:grid-cols-3' : ''}`}>
-              {/* Left/full: narrative + tags + notes */}
-              <div className={`${hasRightColumn ? 'md:col-span-2' : ''} space-y-5`}>
-                {session.actualContent && (
-                  <div>
-                    <h4 className="text-[10px] font-bold text-zinc-400 uppercase tracking-widest mb-2">
-                      Session Narrative
-                    </h4>
-                    <p className="text-sm leading-relaxed text-[#464455] italic whitespace-pre-wrap">
-                      &ldquo;{session.actualContent}&rdquo;
-                    </p>
-                  </div>
+            {/* Editable header row: title + saved indicator */}
+            <div className="flex items-center justify-between gap-3 mb-4">
+              <input
+                type="text"
+                value={titleDraft}
+                onChange={(e) => setTitleDraft(e.target.value)}
+                onBlur={() => void handleFieldBlur('title', titleDraft, session.title ?? '')}
+                onKeyDown={(e) => { if (e.key === 'Escape') { isRevertingRef.current = true; setTitleDraft(session.title ?? ''); e.currentTarget.blur() } }}
+                placeholder="Session title..."
+                className="flex-1 text-sm font-bold text-[#1A1B22] bg-transparent border-b border-transparent hover:border-zinc-200 focus:border-indigo-300 focus:outline-none px-1 py-0.5 transition-colors"
+                data-testid="session-title-input"
+              />
+              <div className="flex items-center gap-2 shrink-0">
+                {fieldError && (
+                  <span className="text-xs text-red-500" data-testid="session-field-error">{fieldError}</span>
                 )}
+                <SavedIndicator visible={savedVisible} />
+              </div>
+            </div>
 
-                {/* Planned content (only if different from actual) */}
+            <div className={`grid grid-cols-1 gap-6 ${hasRightColumn ? 'md:grid-cols-3' : ''}`}>
+              {/* Left/full: narrative + duration + tags + notes */}
+              <div className={`${hasRightColumn ? 'md:col-span-2' : ''} space-y-5`}>
+                {/* Editable narrative */}
+                <div>
+                  <h4 className="text-[10px] font-bold text-zinc-400 uppercase tracking-widest mb-2">
+                    Session Narrative
+                  </h4>
+                  <textarea
+                    value={narrativeDraft}
+                    onChange={(e) => setNarrativeDraft(e.target.value)}
+                    onBlur={() => void handleFieldBlur('actualContent', narrativeDraft, session.actualContent ?? '')}
+                    onKeyDown={(e) => { if (e.key === 'Escape') { isRevertingRef.current = true; setNarrativeDraft(session.actualContent ?? ''); e.currentTarget.blur() } }}
+                    placeholder="What happened in this session..."
+                    rows={3}
+                    className="w-full text-sm leading-relaxed text-[#464455] italic bg-white border border-zinc-200 rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-1 focus:ring-indigo-300 placeholder:text-zinc-300 placeholder:not-italic"
+                    data-testid="session-narrative-input"
+                  />
+                </div>
+
+                {/* Editable duration */}
+                <div className="flex items-center gap-2">
+                  <h4 className="text-[10px] font-bold text-zinc-400 uppercase tracking-widest shrink-0">
+                    Duration
+                  </h4>
+                  <input
+                    type="number"
+                    min="0"
+                    value={durationDraft}
+                    onChange={(e) => setDurationDraft(e.target.value)}
+                    onBlur={() => void handleFieldBlur('duration', durationDraft, session.duration?.toString() ?? '')}
+                    onKeyDown={(e) => { if (e.key === 'Escape') { isRevertingRef.current = true; setDurationDraft(session.duration?.toString() ?? ''); e.currentTarget.blur() } }}
+                    placeholder="60"
+                    className="w-16 text-sm text-[#1A1B22] bg-white border border-zinc-200 rounded px-2 py-0.5 focus:outline-none focus:ring-1 focus:ring-indigo-300"
+                    data-testid="session-duration-input"
+                  />
+                  <span className="text-xs text-zinc-400">min</span>
+                </div>
+
+                {/* Planned content (read-only, only if different from actual) */}
                 {session.plannedContent && session.plannedContent !== session.actualContent && (
                   <div>
                     <h4 className="text-[10px] font-bold text-zinc-400 uppercase tracking-widest mb-2">
@@ -344,7 +379,7 @@ function SessionEntry({
                   </div>
                 )}
 
-                {/* Teacher notes */}
+                {/* Teacher notes (read-only) */}
                 {session.generalNotes && (
                   <div className="p-4 rounded-xl bg-white border-l-4 border-[#4F46E5] ring-1 ring-[#C7C4D8]/10">
                     <h4 className="text-[10px] font-bold text-[#3525CD] uppercase tracking-widest mb-2">
@@ -377,7 +412,7 @@ function SessionEntry({
                 )}
               </div>
 
-              {/* Right: homework + next session plan (only rendered when needed) */}
+              {/* Right: homework + next session plan */}
               {hasRightColumn && (
                 <div className="space-y-5">
                   {/* Homework card */}
@@ -412,41 +447,60 @@ function SessionEntry({
                     </div>
                   ) : null}
 
-                  {/* Next session plan */}
-                  {session.nextSessionTopics && (
-                    <div
-                      className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3"
-                      data-testid="next-session-topics-section"
-                    >
-                      <p className="text-[10px] font-bold text-amber-700 uppercase tracking-widest mb-2 flex items-center gap-1.5">
-                        <CalendarDays className="h-3 w-3" />
-                        Planned for next class
-                      </p>
-                      <p className="text-sm text-amber-900 whitespace-pre-wrap">{session.nextSessionTopics}</p>
+                  {/* Next class plan (editable) */}
+                  <div>
+                    <p className="text-[10px] font-bold text-amber-700 uppercase tracking-widest mb-2 flex items-center gap-1.5">
+                      <CalendarDays className="h-3 w-3" />
+                      Planned for next class
+                    </p>
+                    <textarea
+                      value={nextPlanDraft}
+                      onChange={(e) => setNextPlanDraft(e.target.value)}
+                      onBlur={() => void handleFieldBlur('nextSessionTopics', nextPlanDraft, session.nextSessionTopics ?? '')}
+                      onKeyDown={(e) => { if (e.key === 'Escape') { isRevertingRef.current = true; setNextPlanDraft(session.nextSessionTopics ?? ''); e.currentTarget.blur() } }}
+                      placeholder="What to cover next time..."
+                      rows={3}
+                      className="w-full text-sm text-amber-900 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-1 focus:ring-amber-300 placeholder:text-amber-300"
+                      data-testid="session-next-plan-input"
+                    />
+                    {session.nextSessionTopics && (
                       <button
-                        className="mt-3 inline-flex items-center gap-1.5 text-xs font-semibold text-amber-700 hover:text-amber-900 transition-colors"
+                        className="mt-2 inline-flex items-center gap-1.5 text-xs font-semibold text-amber-700 hover:text-amber-900 transition-colors"
                         onClick={() => onStartNextSession()}
                         data-testid="start-next-session-button"
                       >
                         <PlayCircle className="h-3.5 w-3.5" />
                         Start next session
                       </button>
-                    </div>
-                  )}
+                    )}
+                  </div>
                 </div>
               )}
+            </div>
+
+            {/* Delete session button at bottom of expanded row */}
+            <div className="mt-6 pt-4 border-t border-[#C7C4D8]/10">
+              <button
+                type="button"
+                onClick={() => setDeleteOpen(true)}
+                className="inline-flex items-center gap-1.5 text-sm text-red-600 hover:text-red-700 transition-colors px-2 py-1 rounded hover:bg-red-50"
+                data-testid="delete-session-btn"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                Delete session
+              </button>
             </div>
           </div>
         )}
       </div>
 
-      {/* Delete confirmation dialog - at root level, not inside footer */}
+      {/* Delete confirmation dialog */}
       <AlertDialog open={deleteOpen} onOpenChange={(open) => { setDeleteOpen(open); if (!open) setDeleteError(null) }}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete session log?</AlertDialogTitle>
+            <AlertDialogTitle>Delete this session?</AlertDialogTitle>
             <AlertDialogDescription>
-              This session record will be removed. This action cannot be undone.
+              This cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -479,10 +533,6 @@ export function SessionHistoryTab({ studentId }: SessionHistoryTabProps) {
   const [dateFrom, setDateFrom] = useState<string>('')
   const [dateTo, setDateTo] = useState<string>('')
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
-
-  function handleEdit(session: SessionLog) {
-    navigate(`/students/${studentId}/sessions/${session.id}/edit`)
-  }
 
   function handleStartNextSession() {
     navigate(`/students/${studentId}/log-session`)
@@ -789,7 +839,6 @@ export function SessionHistoryTab({ studentId }: SessionHistoryTabProps) {
               key={session.id}
               session={session}
               studentId={studentId}
-              onEdit={handleEdit}
               onStartNextSession={handleStartNextSession}
             />
           ))}

--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -167,34 +167,58 @@ describe('StudentProfileTab', () => {
       expect(screen.queryByTestId('reason-edit-btn')).not.toBeInTheDocument()
     })
 
-    it('switches to edit mode on pencil click', async () => {
+    it('switches to edit mode on trigger click', async () => {
       const onSave = vi.fn().mockResolvedValue(undefined)
       renderProfile(FULL_STUDENT, { onSaveReason: onSave })
-      fireEvent.click(screen.getByTestId('reason-edit-btn'))
+      fireEvent.click(screen.getByTestId('reason-edit-trigger'))
       expect(screen.getByTestId('reason-textarea')).toBeInTheDocument()
     })
 
-    it('calls onSaveReasonForStudying on save', async () => {
+    it('calls onSaveReasonForStudying on blur with trimmed value', async () => {
       const onSave = vi.fn().mockResolvedValue(undefined)
       renderProfile(FULL_STUDENT, { onSaveReason: onSave })
-      fireEvent.click(screen.getByTestId('reason-edit-btn'))
+      fireEvent.click(screen.getByTestId('reason-edit-trigger'))
       const textarea = screen.getByTestId('reason-textarea')
-      fireEvent.change(textarea, { target: { value: 'New reason' } })
-      fireEvent.click(screen.getByTestId('reason-save-btn'))
+      fireEvent.change(textarea, { target: { value: '  New reason  ' } })
+      fireEvent.blur(textarea)
       await waitFor(() => expect(onSave).toHaveBeenCalledWith('New reason'))
     })
 
-    it('cancels edit and restores original value', () => {
+    it('Escape exits edit mode and does not call onSave', async () => {
       const onSave = vi.fn().mockResolvedValue(undefined)
       renderProfile(FULL_STUDENT, { onSaveReason: onSave })
-      fireEvent.click(screen.getByTestId('reason-edit-btn'))
-      fireEvent.change(screen.getByTestId('reason-textarea'), { target: { value: 'Changed' } })
-      fireEvent.click(screen.getByTestId('reason-cancel-btn'))
+      fireEvent.click(screen.getByTestId('reason-edit-trigger'))
+      const textarea = screen.getByTestId('reason-textarea')
+      fireEvent.change(textarea, { target: { value: 'Changed' } })
+      fireEvent.keyDown(textarea, { key: 'Escape' })
+      // Edit mode exits: textarea gone, original quote restored
+      expect(screen.queryByTestId('reason-textarea')).not.toBeInTheDocument()
       expect(screen.getByTestId('reason-quote')).toHaveTextContent('Vive en Barcelona')
+      expect(onSave).not.toHaveBeenCalled()
+    })
+
+    it('shows SavedIndicator after successful save', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      renderProfile(FULL_STUDENT, { onSaveReason: onSave })
+      fireEvent.click(screen.getByTestId('reason-edit-trigger'))
+      const textarea = screen.getByTestId('reason-textarea')
+      fireEvent.change(textarea, { target: { value: 'New reason' } })
+      fireEvent.blur(textarea)
+      await waitFor(() => expect(screen.getByTestId('saved-indicator')).toBeInTheDocument())
+    })
+
+    it('shows error message when onSave rejects', async () => {
+      const onSave = vi.fn().mockRejectedValue(new Error('network'))
+      renderProfile(FULL_STUDENT, { onSaveReason: onSave })
+      fireEvent.click(screen.getByTestId('reason-edit-trigger'))
+      const textarea = screen.getByTestId('reason-textarea')
+      fireEvent.change(textarea, { target: { value: 'New reason' } })
+      fireEvent.blur(textarea)
+      await waitFor(() => expect(screen.getByTestId('reason-save-error')).toBeInTheDocument())
     })
   })
 
-  describe('Working Memory sidebar (right col top)', () => {
+  describe('Working Memory sidebar (right col top, always visible)', () => {
     it('shows identity fields when populated', () => {
       renderProfile(FULL_STUDENT)
       expect(screen.getByText('Rome, Italy')).toBeInTheDocument()
@@ -204,53 +228,62 @@ describe('StudentProfileTab', () => {
       expect(screen.getByText('Film student')).toBeInTheDocument()
     })
 
-    it('is hidden when no identity data (empty state collapse)', () => {
+    it('is always visible even when no identity data (unconditional render)', () => {
       renderProfile(EMPTY_STUDENT)
-      // section is not rendered when empty by default
-      expect(screen.queryByTestId('profile-about')).not.toBeInTheDocument()
-    })
-
-    it('shows empty state when revealed via show-all toggle', () => {
-      renderProfile(EMPTY_STUDENT)
-      const toggle = screen.getByTestId('show-empty-sections-btn')
-      fireEvent.click(toggle)
+      // TWM right sidebar is now always rendered, no need to click show-all
       expect(screen.getByTestId('profile-about')).toBeInTheDocument()
       expect(screen.getByText('No identity details added yet')).toBeInTheDocument()
     })
   })
 
-  describe('Interests section (right column)', () => {
-    it('renders interest tags', () => {
+  describe('Interests section (right column, always-editable)', () => {
+    it('renders interest chips', () => {
       renderProfile(FULL_STUDENT)
       const section = screen.getByTestId('profile-interests')
       expect(section).toBeInTheDocument()
       const tags = screen.getAllByTestId('interest-tag')
-      expect(tags.some((t) => t.textContent === 'cinema')).toBe(true)
+      expect(tags.some((t) => t.textContent?.includes('cinema'))).toBe(true)
     })
 
-    it('shows empty state when no interests', () => {
-      renderProfile(EMPTY_STUDENT)
-      expect(screen.getByText('No interests added yet')).toBeInTheDocument()
-    })
-
-    it('shows edit/add buttons when onSaveInterests provided', () => {
+    it('chip input is always visible without any interaction', () => {
       renderProfile(FULL_STUDENT, { onSaveInterests: vi.fn().mockResolvedValue(undefined) })
-      expect(screen.getByTestId('interests-edit-btn')).toBeInTheDocument()
-      expect(screen.getByTestId('interests-add-btn')).toBeInTheDocument()
-    })
-
-    it('enters edit mode and shows input', () => {
-      renderProfile(FULL_STUDENT, { onSaveInterests: vi.fn().mockResolvedValue(undefined) })
-      fireEvent.click(screen.getByTestId('interests-edit-btn'))
       expect(screen.getByTestId('interests-input')).toBeInTheDocument()
     })
 
-    it('calls onSaveInterests on save', async () => {
+    it('Enter key adds chip and calls onSave', async () => {
       const onSave = vi.fn().mockResolvedValue(undefined)
       renderProfile(FULL_STUDENT, { onSaveInterests: onSave })
-      fireEvent.click(screen.getByTestId('interests-edit-btn'))
-      fireEvent.click(screen.getByTestId('interests-save-btn'))
-      await waitFor(() => expect(onSave).toHaveBeenCalled())
+      const input = screen.getByTestId('interests-input')
+      fireEvent.change(input, { target: { value: 'gaming' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+      await waitFor(() => expect(onSave).toHaveBeenCalledWith(['cinema', 'cooking', 'gaming']))
+    })
+
+    it('comma key adds chip and calls onSave', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      renderProfile(FULL_STUDENT, { onSaveInterests: onSave })
+      const input = screen.getByTestId('interests-input')
+      fireEvent.change(input, { target: { value: 'gaming' } })
+      fireEvent.keyDown(input, { key: ',' })
+      await waitFor(() => expect(onSave).toHaveBeenCalledWith(['cinema', 'cooking', 'gaming']))
+    })
+
+    it('clicking × removes chip and calls onSave', async () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      renderProfile(FULL_STUDENT, { onSaveInterests: onSave })
+      const removeBtn = screen.getByTestId('interest-remove-cinema')
+      fireEvent.click(removeBtn)
+      await waitFor(() => expect(onSave).toHaveBeenCalledWith(['cooking']))
+    })
+
+    it('does not call onSave on each keystroke', () => {
+      const onSave = vi.fn().mockResolvedValue(undefined)
+      renderProfile(FULL_STUDENT, { onSaveInterests: onSave })
+      const input = screen.getByTestId('interests-input')
+      fireEvent.change(input, { target: { value: 'c' } })
+      fireEvent.change(input, { target: { value: 'co' } })
+      fireEvent.change(input, { target: { value: 'coo' } })
+      expect(onSave).not.toHaveBeenCalled()
     })
   })
 
@@ -597,22 +630,28 @@ describe('StudentProfileTab', () => {
   })
 
   describe('Empty state progressive disclosure', () => {
-    it('shows "show all sections" toggle when some sections are empty', () => {
+    it('shows "show all sections" toggle when left column dark TWM is empty', () => {
       renderProfile(EMPTY_STUDENT)
+      // EMPTY_STUDENT has no notes, so left column dark TWM is collapsed
       expect(screen.getByTestId('show-empty-sections-btn')).toBeInTheDocument()
     })
 
     it('does not show the toggle when all sections have data', () => {
       renderProfile(FULL_STUDENT)
-      // FULL_STUDENT has profession/birthYear/notes, so no sections collapsed
+      // FULL_STUDENT has notes, so left column dark TWM is visible
       expect(screen.queryByTestId('show-empty-sections-btn')).not.toBeInTheDocument()
     })
 
-    it('reveals hidden sections after clicking show-all', () => {
+    it('right sidebar TWM (profile-about) is always visible, not controlled by show-all', () => {
       renderProfile(EMPTY_STUDENT)
-      expect(screen.queryByTestId('profile-about')).not.toBeInTheDocument()
-      fireEvent.click(screen.getByTestId('show-empty-sections-btn'))
+      // TWM right sidebar is unconditionally rendered
       expect(screen.getByTestId('profile-about')).toBeInTheDocument()
+    })
+
+    it('reveals left column dark TWM after clicking show-all', () => {
+      renderProfile(EMPTY_STUDENT)
+      expect(screen.queryByTestId('profile-teachers-working-memory')).not.toBeInTheDocument()
+      fireEvent.click(screen.getByTestId('show-empty-sections-btn'))
       expect(screen.getByTestId('profile-teachers-working-memory')).toBeInTheDocument()
     })
 

--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -572,6 +572,11 @@ describe('StudentProfileTab', () => {
       expect(screen.getByTestId('teaching-todos-list')).toBeInTheDocument()
       expect(screen.getByText('Enviar ejercicios de por/para')).toBeInTheDocument()
     })
+
+    it('displays section heading as "Ideas para Clases"', () => {
+      renderProfile(FULL_STUDENT)
+      expect(screen.getByText('Ideas para Clases')).toBeInTheDocument()
+    })
   })
 
   describe('Pending Followups section', () => {

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -374,16 +374,19 @@ function MotivationHero({
 
             {/* Interest chips pulled into banner */}
             {student.interests.length > 0 && (
-              <div className="flex flex-wrap gap-1.5 lg:max-w-[180px]" data-testid="hero-interests">
-                {student.interests.map((interest) => (
-                  <span
-                    key={interest}
-                    className="inline-block bg-indigo-100 text-indigo-700 text-xs font-semibold rounded-full px-3 py-1"
-                    data-testid="hero-interest-tag"
-                  >
-                    {interest}
-                  </span>
-                ))}
+              <div className="flex flex-col gap-1.5 lg:max-w-[180px]" data-testid="hero-interests">
+                <p className="text-[0.6rem] font-bold uppercase tracking-widest text-indigo-500 opacity-70">Interests</p>
+                <div className="flex flex-wrap gap-1.5">
+                  {student.interests.map((interest) => (
+                    <span
+                      key={interest}
+                      className="inline-block bg-indigo-100 text-indigo-700 text-xs font-semibold rounded-full px-3 py-1"
+                      data-testid="hero-interest-tag"
+                    >
+                      {interest}
+                    </span>
+                  ))}
+                </div>
               </div>
             )}
           </div>

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -251,10 +251,18 @@ function MotivationHero({
   const lastSavedRef = useRef(student.reasonForStudying ?? '')
   const isRevertingRef = useRef(false)
 
-  // Keep lastSavedRef in sync with server state (no setState -- draft is set from prop when entering edit)
+  // Keep lastSavedRef in sync with server state when not editing; draft is set from prop on edit enter
   useEffect(() => {
-    lastSavedRef.current = student.reasonForStudying ?? ''
-  }, [student.reasonForStudying])
+    if (!editing) lastSavedRef.current = student.reasonForStudying ?? ''
+  }, [student.reasonForStudying, editing])
+
+  // Clear timers on unmount to avoid setState on unmounted component
+  useEffect(() => {
+    return () => {
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+    }
+  }, [])
 
   async function handleBlur() {
     if (!onSave || isRevertingRef.current) {
@@ -325,10 +333,10 @@ function MotivationHero({
               {student.reasonForStudying ? (
                 <div
                   className="flex items-start gap-2 cursor-pointer"
-                  onClick={() => { setDraft(student.reasonForStudying ?? ''); setEditing(true) }}
+                  onClick={() => { const v = student.reasonForStudying ?? ''; setDraft(v); lastSavedRef.current = v; setEditing(true) }}
                   role="button"
                   tabIndex={0}
-                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { setDraft(student.reasonForStudying ?? ''); setEditing(true) } }}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { const v = student.reasonForStudying ?? ''; setDraft(v); lastSavedRef.current = v; setEditing(true) } }}
                   data-testid="reason-edit-trigger"
                 >
                   <p
@@ -350,10 +358,10 @@ function MotivationHero({
               ) : (
                 <div
                   className="flex items-center gap-2 cursor-pointer"
-                  onClick={() => { setDraft(student.reasonForStudying ?? ''); setEditing(true) }}
+                  onClick={() => { const v = student.reasonForStudying ?? ''; setDraft(v); lastSavedRef.current = v; setEditing(true) }}
                   role="button"
                   tabIndex={0}
-                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { setDraft(student.reasonForStudying ?? ''); setEditing(true) } }}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { const v = student.reasonForStudying ?? ''; setDraft(v); lastSavedRef.current = v; setEditing(true) } }}
                   data-testid="reason-edit-trigger"
                 >
                   <p className="font-manrope text-lg italic text-zinc-400 flex-1" data-testid="reason-quote">
@@ -414,6 +422,13 @@ function InterestsSection({
   const inputRef = useRef<HTMLInputElement>(null)
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+    }
+  }, [])
 
   async function commitAdd(value: string) {
     const trimmed = value.trim()

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -1,7 +1,6 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { Pencil, X, Plus, Check, GraduationCap, ChevronDown } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import type { Student } from '@/api/students'
 import type { TeacherFollowup } from '@/api/followups'
 import { parseNotes } from './studentNoteUtils'
@@ -11,6 +10,7 @@ import { getObjectiveUrgency } from '@/lib/objectiveUrgency'
 import { SectionHeader } from './SectionHeader'
 import { CefrBadge } from '@/components/dashboard/CefrBadge'
 import { langCode } from './langUtils'
+import { SavedIndicator } from '@/components/ui/SavedIndicator'
 
 const SKILL_ORDER = ['Reading', 'Writing', 'Speaking', 'Listening']
 
@@ -233,6 +233,7 @@ function InlineAddDifficulty({
 
 // ------------------------------------------------------------------
 // Motivation Hero (banner with Manrope quote + interest chips inside)
+// Autosave on blur. No Save/Cancel buttons.
 // ------------------------------------------------------------------
 function MotivationHero({
   student,
@@ -243,26 +244,45 @@ function MotivationHero({
 }) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(student.reasonForStudying ?? '')
-  const [saving, setSaving] = useState(false)
+  const [savedVisible, setSavedVisible] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lastSavedRef = useRef(student.reasonForStudying ?? '')
+  const isRevertingRef = useRef(false)
 
-  async function handleSave() {
-    if (!onSave) return
+  // Keep lastSavedRef in sync with server state (no setState -- draft is set from prop when entering edit)
+  useEffect(() => {
+    lastSavedRef.current = student.reasonForStudying ?? ''
+  }, [student.reasonForStudying])
+
+  async function handleBlur() {
+    if (!onSave || isRevertingRef.current) {
+      isRevertingRef.current = false
+      return
+    }
     const value = draft.trim()
-    setSaving(true)
     try {
       await onSave(value)
-      setDraft(value)
+      lastSavedRef.current = value
+      setSavedVisible(true)
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
+      savedTimerRef.current = setTimeout(() => setSavedVisible(false), 1500)
+      setSaveError(null)
       setEditing(false)
     } catch {
-      // keep editor open
-    } finally {
-      setSaving(false)
+      setSaveError('Failed to save')
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+      errorTimerRef.current = setTimeout(() => setSaveError(null), 3000)
     }
   }
 
-  function handleCancel() {
-    setDraft(student.reasonForStudying ?? '')
-    setEditing(false)
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Escape') {
+      isRevertingRef.current = true
+      setDraft(lastSavedRef.current)
+      setEditing(false)
+    }
   }
 
   return (
@@ -274,51 +294,43 @@ function MotivationHero({
       <div className="absolute top-0 right-0 w-40 h-40 bg-indigo-100/50 rounded-full -mr-20 -mt-20 pointer-events-none" />
 
       <div className="relative z-10">
-        <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-indigo-600 mb-3 opacity-70">
-          The Why / Motivation
-        </p>
+        <div className="flex items-center justify-between mb-3">
+          <p className="text-[0.6875rem] font-bold uppercase tracking-widest text-indigo-600 opacity-70">
+            The Why / Motivation
+          </p>
+          <div className="flex items-center gap-2">
+            {saveError && (
+              <span className="text-xs text-red-500" data-testid="reason-save-error">{saveError}</span>
+            )}
+            <SavedIndicator visible={savedVisible} />
+          </div>
+        </div>
 
         {editing ? (
-          <div className="space-y-2">
-            <textarea
-              value={draft}
-              onChange={(e) => setDraft(e.target.value)}
-              className="w-full font-manrope text-xl italic text-[#1A1B22] bg-white border border-indigo-300 rounded-xl px-4 py-3 resize-none focus:outline-none focus:ring-2 focus:ring-indigo-300"
-              rows={3}
-              maxLength={512}
-              placeholder="Why is this student learning?"
-              autoFocus
-              data-testid="reason-textarea"
-            />
-            <div className="flex gap-2">
-              <Button
-                type="button"
-                size="sm"
-                onClick={handleSave}
-                disabled={saving}
-                className="bg-indigo-600 hover:bg-indigo-700 text-white h-7 px-3 text-xs"
-                data-testid="reason-save-btn"
-              >
-                <Check className="h-3 w-3 mr-1" />
-                {saving ? 'Saving...' : 'Save'}
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                onClick={handleCancel}
-                className="h-7 px-3 text-xs text-zinc-500"
-                data-testid="reason-cancel-btn"
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={handleBlur}
+            onKeyDown={handleKeyDown}
+            className="w-full font-manrope text-xl italic text-[#1A1B22] bg-white border border-indigo-300 rounded-xl px-4 py-3 resize-none focus:outline-none focus:ring-2 focus:ring-indigo-300"
+            rows={3}
+            maxLength={512}
+            placeholder="Why is this student learning?"
+            autoFocus
+            data-testid="reason-textarea"
+          />
         ) : (
           <div className="flex flex-col lg:flex-row lg:items-start gap-4">
             <div className="flex-1 min-w-0">
               {student.reasonForStudying ? (
-                <div className="flex items-start gap-2">
+                <div
+                  className="flex items-start gap-2 cursor-pointer"
+                  onClick={() => { setDraft(student.reasonForStudying ?? ''); setEditing(true) }}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { setDraft(student.reasonForStudying ?? ''); setEditing(true) } }}
+                  data-testid="reason-edit-trigger"
+                >
                   <p
                     className="font-manrope text-2xl font-extrabold text-primary italic leading-snug flex-1"
                     data-testid="reason-quote"
@@ -326,32 +338,35 @@ function MotivationHero({
                     &ldquo;{student.reasonForStudying}&rdquo;
                   </p>
                   {onSave && (
-                    <button
-                      type="button"
-                      onClick={() => setEditing(true)}
-                      className="opacity-0 group-hover:opacity-100 transition-opacity p-1 text-zinc-400 hover:text-indigo-600 rounded shrink-0 mt-1"
-                      aria-label="Edit reason for studying"
+                    <span
+                      className="opacity-0 group-hover:opacity-100 transition-opacity p-1 text-zinc-400 shrink-0 mt-1"
+                      aria-hidden="true"
                       data-testid="reason-edit-btn"
                     >
-                      <Pencil className="h-4 w-4" />
-                    </button>
+                      <Pencil className="h-3 w-3" />
+                    </span>
                   )}
                 </div>
               ) : (
-                <div className="flex items-center gap-2">
+                <div
+                  className="flex items-center gap-2 cursor-pointer"
+                  onClick={() => { setDraft(student.reasonForStudying ?? ''); setEditing(true) }}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { setDraft(student.reasonForStudying ?? ''); setEditing(true) } }}
+                  data-testid="reason-edit-trigger"
+                >
                   <p className="font-manrope text-lg italic text-zinc-400 flex-1" data-testid="reason-quote">
                     Why is this student learning {student.learningLanguage}?
                   </p>
                   {onSave && (
-                    <button
-                      type="button"
-                      onClick={() => setEditing(true)}
-                      className="opacity-0 group-hover:opacity-100 transition-opacity p-1 text-zinc-400 hover:text-indigo-600 rounded shrink-0"
-                      aria-label="Edit reason for studying"
+                    <span
+                      className="opacity-0 group-hover:opacity-100 transition-opacity p-1 text-zinc-400 shrink-0"
+                      aria-hidden="true"
                       data-testid="reason-edit-btn"
                     >
-                      <Pencil className="h-4 w-4" />
-                    </button>
+                      <Pencil className="h-3 w-3" />
+                    </span>
                   )}
                 </div>
               )}
@@ -379,7 +394,8 @@ function MotivationHero({
 }
 
 // ------------------------------------------------------------------
-// Interests section (right column, editable)
+// Interests section (right column, always-editable chip input)
+// Saves immediately on add (Enter/comma) or remove (×). No edit mode.
 // ------------------------------------------------------------------
 function InterestsSection({
   student,
@@ -388,157 +404,110 @@ function InterestsSection({
   student: Student
   onSave?: (value: string[]) => Promise<void>
 }) {
-  const [editing, setEditing] = useState(false)
-  const [draft, setDraft] = useState<string[]>(student.interests)
+  const [chips, setChips] = useState<string[]>(student.interests)
   const [inputValue, setInputValue] = useState('')
-  const [saving, setSaving] = useState(false)
+  const [savedVisible, setSavedVisible] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  function handleAddInterest(value: string) {
+  async function commitAdd(value: string) {
     const trimmed = value.trim()
-    if (trimmed && !draft.includes(trimmed)) {
-      setDraft((prev) => [...prev, trimmed])
-    }
+    if (!trimmed || chips.includes(trimmed) || !onSave) return
+    const next = [...chips, trimmed]
+    setChips(next)
     setInputValue('')
+    try {
+      await onSave(next)
+      setSavedVisible(true)
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
+      savedTimerRef.current = setTimeout(() => setSavedVisible(false), 1500)
+      setSaveError(null)
+    } catch {
+      setChips(chips) // revert
+      setSaveError('Failed to save')
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+      errorTimerRef.current = setTimeout(() => setSaveError(null), 3000)
+    }
+  }
+
+  async function commitRemove(item: string) {
+    if (!onSave) return
+    const next = chips.filter((c) => c !== item)
+    setChips(next)
+    try {
+      await onSave(next)
+      setSavedVisible(true)
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
+      savedTimerRef.current = setTimeout(() => setSavedVisible(false), 1500)
+      setSaveError(null)
+    } catch {
+      setChips(chips) // revert
+      setSaveError('Failed to save')
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+      errorTimerRef.current = setTimeout(() => setSaveError(null), 3000)
+    }
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === 'Enter' || e.key === ',') {
       e.preventDefault()
-      handleAddInterest(inputValue)
+      void commitAdd(inputValue)
     }
-    if (e.key === 'Backspace' && inputValue === '' && draft.length > 0) {
-      setDraft((prev) => prev.slice(0, -1))
+    if (e.key === 'Backspace' && inputValue === '' && chips.length > 0) {
+      void commitRemove(chips[chips.length - 1])
     }
-  }
-
-  function handleRemove(item: string) {
-    setDraft((prev) => prev.filter((i) => i !== item))
-  }
-
-  async function handleSave() {
-    if (!onSave) return
-    const trimmed = inputValue.trim()
-    const finalList = trimmed && !draft.includes(trimmed) ? [...draft, trimmed] : draft
-    setSaving(true)
-    try {
-      await onSave(finalList)
-      setDraft(finalList)
-      setEditing(false)
-      setInputValue('')
-    } catch {
-      // keep open
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  function handleCancel() {
-    setDraft(student.interests)
-    setInputValue('')
-    setEditing(false)
   }
 
   return (
     <section data-testid="profile-interests">
       <div className="flex items-center justify-between mb-3">
         <SectionHeader>Interests</SectionHeader>
-        {onSave && !editing && (
-          <div className="flex gap-1">
-            <button
-              type="button"
-              onClick={() => { setEditing(true); setTimeout(() => inputRef.current?.focus(), 50) }}
-              className="p-1 text-zinc-400 hover:text-indigo-600 rounded transition-colors"
-              aria-label="Edit interests"
-              data-testid="interests-edit-btn"
-            >
-              <Pencil className="h-3.5 w-3.5" />
-            </button>
-            <button
-              type="button"
-              onClick={() => { setEditing(true); setTimeout(() => inputRef.current?.focus(), 50) }}
-              className="p-1 text-zinc-400 hover:text-indigo-600 rounded transition-colors"
-              aria-label="Add interest"
-              data-testid="interests-add-btn"
-            >
-              <Plus className="h-3.5 w-3.5" />
-            </button>
-          </div>
-        )}
+        <div className="flex items-center gap-2">
+          {saveError && (
+            <span className="text-xs text-red-500" data-testid="interests-save-error">{saveError}</span>
+          )}
+          <SavedIndicator visible={savedVisible} />
+        </div>
       </div>
 
-      {editing ? (
-        <div className="space-y-2">
-          <div
-            className="flex flex-wrap gap-1.5 min-h-9 w-full rounded-md border border-indigo-300 bg-white px-3 py-2 cursor-text"
-            onClick={() => inputRef.current?.focus()}
+      <div
+        className="flex flex-wrap gap-1.5 min-h-9 w-full rounded-md border border-zinc-200 bg-white px-3 py-2 cursor-text focus-within:border-indigo-300 transition-colors"
+        onClick={() => inputRef.current?.focus()}
+      >
+        {chips.map((interest) => (
+          <span
+            key={interest}
+            className="inline-flex items-center gap-1 bg-indigo-50 text-indigo-700 text-xs font-medium rounded px-2 py-0.5"
+            data-testid="interest-tag"
           >
-            {draft.map((interest) => (
-              <span
-                key={interest}
-                className="inline-flex items-center gap-1 bg-indigo-50 text-indigo-700 text-xs font-medium rounded px-2 py-0.5"
+            {interest}
+            {onSave && (
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); void commitRemove(interest) }}
+                className="text-indigo-400 hover:text-indigo-700"
+                aria-label={`Remove ${interest}`}
+                data-testid={`interest-remove-${interest}`}
               >
-                {interest}
-                <button
-                  type="button"
-                  onClick={(e) => { e.stopPropagation(); handleRemove(interest) }}
-                  className="text-indigo-400 hover:text-indigo-700"
-                  aria-label={`Remove ${interest}`}
-                >
-                  <X className="h-3 w-3" />
-                </button>
-              </span>
-            ))}
-            <input
-              ref={inputRef}
-              value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              onKeyDown={handleKeyDown}
-              onBlur={() => { if (inputValue.trim()) handleAddInterest(inputValue) }}
-              placeholder={draft.length === 0 ? 'Type and press Enter' : ''}
-              className="flex-1 min-w-16 outline-none text-sm bg-transparent placeholder:text-zinc-400"
-              data-testid="interests-input"
-            />
-          </div>
-          <div className="flex gap-2">
-            <Button
-              type="button"
-              size="sm"
-              onClick={handleSave}
-              disabled={saving}
-              className="bg-indigo-600 hover:bg-indigo-700 text-white h-7 px-3 text-xs"
-              data-testid="interests-save-btn"
-            >
-              <Check className="h-3 w-3 mr-1" />
-              {saving ? 'Saving...' : 'Save'}
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant="ghost"
-              onClick={handleCancel}
-              className="h-7 px-3 text-xs text-zinc-500"
-              data-testid="interests-cancel-btn"
-            >
-              Cancel
-            </Button>
-          </div>
-        </div>
-      ) : student.interests.length > 0 ? (
-        <div className="flex flex-wrap gap-1.5">
-          {student.interests.map((interest) => (
-            <span
-              key={interest}
-              className="inline-block bg-indigo-50 text-indigo-700 text-xs font-medium rounded-full px-2.5 py-1"
-              data-testid="interest-tag"
-            >
-              {interest}
-            </span>
-          ))}
-        </div>
-      ) : (
-        <EmptyState text="No interests added yet" />
-      )}
+                <X className="h-3 w-3" />
+              </button>
+            )}
+          </span>
+        ))}
+        {onSave && (
+          <input
+            ref={inputRef}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={chips.length === 0 ? 'Add interest...' : ''}
+            className="flex-1 min-w-16 outline-none text-sm bg-transparent placeholder:text-zinc-400"
+            data-testid="interests-input"
+          />
+        )}
+      </div>
     </section>
   )
 }
@@ -589,7 +558,8 @@ export function StudentProfileTab({
   const location = [student.cityOfResidence, student.countryOfResidence].filter(Boolean).join(', ')
   const origin = [student.cityOfOrigin, student.countryOfOrigin].filter(Boolean).join(', ')
 
-  const anySectionCollapsed = (!hasAbout || !hasWorkingMemory) && !showEmptySections
+  // TWM right sidebar is always visible; only left column dark card can be collapsed
+  const anySectionCollapsed = !hasWorkingMemory && !showEmptySections
 
   return (
     <div
@@ -904,29 +874,27 @@ export function StudentProfileTab({
             ============================================================ */}
         <div className="lg:col-span-4 space-y-6">
 
-          {/* 1. Working Memory sidebar (Profession, Born+age, Origin, Residence) */}
-          {(hasAbout || showEmptySections) && (
-            <section
-              className="bg-white rounded-xl p-5"
-              style={{ boxShadow: '0 2px 12px rgba(26,27,34,0.06)' }}
-              data-testid="profile-about"
-            >
-              <SectionHeader>Teacher&apos;s Working Memory</SectionHeader>
-              {hasAbout ? (
-                <div>
-                  {student.profession && <FieldValue label="Profession" value={student.profession} />}
-                  {student.birthYear != null && (() => {
-                    const age = new Date().getFullYear() - student.birthYear!
-                    return <FieldValue label="Born" value={`${student.birthYear} (${age})`} />
-                  })()}
-                  {origin && <FieldValue label="Origin" value={origin} />}
-                  {location && <FieldValue label="Residence" value={location} />}
-                </div>
-              ) : (
-                <EmptyState text="No identity details added yet" />
-              )}
-            </section>
-          )}
+          {/* 1. Teacher's Working Memory (always visible, unconditional) */}
+          <section
+            className="bg-white rounded-xl p-5"
+            style={{ boxShadow: '0 2px 12px rgba(26,27,34,0.06)' }}
+            data-testid="profile-about"
+          >
+            <SectionHeader>Teacher&apos;s Working Memory</SectionHeader>
+            {hasAbout ? (
+              <div>
+                {student.profession && <FieldValue label="Profession" value={student.profession} />}
+                {student.birthYear != null && (() => {
+                  const age = new Date().getFullYear() - student.birthYear!
+                  return <FieldValue label="Born" value={`${student.birthYear} (${age})`} />
+                })()}
+                {origin && <FieldValue label="Origin" value={origin} />}
+                {location && <FieldValue label="Residence" value={location} />}
+              </div>
+            ) : (
+              <EmptyState text="No identity details added yet" />
+            )}
+          </section>
 
           {/* 2. Language Ecosystem */}
           <section data-testid="profile-language-ecosystem">
@@ -1005,9 +973,9 @@ export function StudentProfileTab({
             </div>
           </section>
 
-          {/* 5. Teaching Todos */}
+          {/* 5. Ideas para Clases */}
           <section data-testid="profile-teaching-todos">
-            <SectionHeader>Teaching Todos</SectionHeader>
+            <SectionHeader>Ideas para Clases</SectionHeader>
             <TeachingTodosCard
               todos={student.teachingTodos}
               studentId={student.id}

--- a/frontend/src/components/ui/SavedIndicator.test.tsx
+++ b/frontend/src/components/ui/SavedIndicator.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { SavedIndicator } from './SavedIndicator'
+
+describe('SavedIndicator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders nothing when visible is false', () => {
+    render(<SavedIndicator visible={false} />)
+    expect(screen.queryByTestId('saved-indicator')).not.toBeInTheDocument()
+  })
+
+  it('shows Check icon and "Saved" text when visible is true', () => {
+    render(<SavedIndicator visible={true} />)
+    // Advance past the deferred setTimeout(0) that sets shown state
+    act(() => { vi.advanceTimersByTime(0) })
+    expect(screen.getByTestId('saved-indicator')).toBeInTheDocument()
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+  })
+
+  it('auto-hides after hold + fade duration', () => {
+    render(<SavedIndicator visible={true} />)
+    act(() => { vi.advanceTimersByTime(0) })  // trigger show
+    expect(screen.getByTestId('saved-indicator')).toBeInTheDocument()
+    // Advance past hold (1000ms) + fade (300ms)
+    act(() => { vi.advanceTimersByTime(1400) })
+    expect(screen.queryByTestId('saved-indicator')).not.toBeInTheDocument()
+  })
+
+  it('resets immediately when visible goes back to false', () => {
+    const { rerender } = render(<SavedIndicator visible={true} />)
+    act(() => { vi.advanceTimersByTime(0) })  // trigger show
+    expect(screen.getByTestId('saved-indicator')).toBeInTheDocument()
+    rerender(<SavedIndicator visible={false} />)
+    act(() => { vi.advanceTimersByTime(0) })  // trigger hide
+    expect(screen.queryByTestId('saved-indicator')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ui/SavedIndicator.tsx
+++ b/frontend/src/components/ui/SavedIndicator.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from 'react'
+import { Check } from 'lucide-react'
+
+interface SavedIndicatorProps {
+  visible: boolean
+}
+
+export function SavedIndicator({ visible }: SavedIndicatorProps) {
+  const [shown, setShown] = useState(false)
+  const [fading, setFading] = useState(false)
+  const showTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const fadeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (showTimer.current) clearTimeout(showTimer.current)
+    if (hideTimer.current) clearTimeout(hideTimer.current)
+    if (fadeTimer.current) clearTimeout(fadeTimer.current)
+
+    if (visible) {
+      // Defer setState to avoid synchronous setState in effect body
+      showTimer.current = setTimeout(() => {
+        setShown(true)
+        setFading(false)
+        hideTimer.current = setTimeout(() => {
+          setFading(true)
+          fadeTimer.current = setTimeout(() => setShown(false), 300)
+        }, 1000)
+      }, 0)
+    } else {
+      showTimer.current = setTimeout(() => {
+        setShown(false)
+        setFading(false)
+      }, 0)
+    }
+
+    return () => {
+      if (showTimer.current) clearTimeout(showTimer.current)
+      if (hideTimer.current) clearTimeout(hideTimer.current)
+      if (fadeTimer.current) clearTimeout(fadeTimer.current)
+    }
+  }, [visible])
+
+  if (!shown) return null
+
+  return (
+    <span
+      className="flex items-center gap-1 text-xs text-zinc-400"
+      style={{
+        opacity: fading ? 0 : 1,
+        transition: fading ? 'opacity 300ms ease-out' : 'opacity 200ms ease-out',
+      }}
+      data-testid="saved-indicator"
+    >
+      <Check className="h-3 w-3" />
+      Saved
+    </span>
+  )
+}

--- a/frontend/src/pages/StudentDetail.test.tsx
+++ b/frontend/src/pages/StudentDetail.test.tsx
@@ -525,7 +525,8 @@ describe('StudentDetail - Profile tab sections', () => {
     await openProfileTab()
     // identity sidebar is collapsed (no data) — show-empty-sections toggle is visible instead
     await screen.findByTestId('show-empty-sections-btn')
-    expect(screen.queryByTestId('profile-about')).not.toBeInTheDocument()
+    // profile-about (Teacher's Working Memory) is always visible regardless of identity data
+    expect(screen.getByTestId('profile-about')).toBeInTheDocument()
     // these sections are always shown (inside Pedagogical Diagnostic card)
     expect(screen.getByText('No learning goals set')).toBeInTheDocument()
     expect(screen.getByText('No objectives set')).toBeInTheDocument()

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -419,7 +419,7 @@ export default function StudentDetail() {
           <div className="flex items-center gap-2 shrink-0">
             <Link
               to={`/students/${student.id}/edit`}
-              className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium bg-[#E8E7F1] text-[#3525CD] hover:bg-[#DDD9F5] transition-colors"
+              className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium bg-indigo-50 text-indigo-600 hover:bg-indigo-100 transition-colors"
               data-testid="edit-profile-link"
             >
               <Pencil className="h-3.5 w-3.5" />

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -97,3 +97,4 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 |---|---|---|
 | architecture-reviewer | minor | `getInitials` is defined privately in Students.tsx, StudentDetail.tsx, and LogSession.tsx — three copies of the same two-word-initials helper. Should be extracted to `src/utils/initials.ts` in a cleanup pass. |
 | architecture-reviewer | minor | `formatRelativeDate` in Students.tsx reimplements day-relative logic already in `src/utils/formatDate.ts:relativeTime`. The time-of-day extension is new, but base logic should build on the shared util in a future refactor. |
+| t771 / architecture-reviewer | minor | SessionHistoryTab and StudentProfileTab hand-roll saved-timer + error-timer state instead of reusing useSessionAutosave/useStudentAutosave hooks. Hooks use debounce scheduling; blur-save pattern would need a new hook variant. Defer to cleanup. |

--- a/plan/langteach-beta/task771-student-detail-interaction-standard/task771-student-detail-interaction-standard.md
+++ b/plan/langteach-beta/task771-student-detail-interaction-standard/task771-student-detail-interaction-standard.md
@@ -1,0 +1,280 @@
+# Task 771 — Student Detail: Interaction Standard
+
+**Issue:** #771  
+**Branch:** worktree-task-t771-student-detail-interaction-standard  
+**Sprint:** sprint/ui-redesign-student-polish
+
+---
+
+## Objective
+
+Implement the interaction standard (autosave, inline session edit, profile polish) across the student detail screen. Seven discrete changes to two files plus one new component.
+
+---
+
+## Code Audit Findings
+
+### Files to change
+
+| File | Change |
+|------|--------|
+| `frontend/src/components/ui/SavedIndicator.tsx` | CREATE new component |
+| `frontend/src/components/student/StudentProfileTab.tsx` | Motivation autosave, Interests always-edit, TWM position, label rename |
+| `frontend/src/pages/StudentDetail.tsx` | Edit Student button styling |
+| `frontend/src/components/session/SessionHistoryTab.tsx` | Remove kebab, inline editable fields, delete in expanded state |
+| `frontend/src/api/sessionLogs.ts` | Add `title` to `CreateSessionLogRequest` (missing field) |
+| `e2e/tests/student-detail.spec.ts` | New e2e tests for motivation autosave, interests, session inline edit |
+| `e2e/tests/visual/student-detail.visual.spec.ts` | Add profile tab screenshot + expanded session screenshot |
+
+### Infrastructure findings
+
+1. **`title` missing from frontend request type**: `CreateSessionLogRequest` does not include `title`, but the backend `UpdateSessionLogDto` does accept `Title`. Must add `title?: string | null` to the frontend type before inline session title editing can work.
+
+2. **No PATCH endpoint for sessions**: Backend only has PUT at `api/students/{studentId}/sessions/{sessionId}` requiring the full payload. The inline session edit will call `updateSession` (PUT) with the full payload, merging the changed field into the current session state. This matches how `saveReasonForStudying` works for students. The intent (save the field) is achieved without corrupting data.
+
+3. **`previousHomeworkStatus` is required in `UpdateSessionLogRequest`**: The frontend `SessionLog` type exposes `previousHomeworkStatusName` (string) and `previousHomeworkStatus` (number). When building a PUT payload from a session, use `previousHomeworkStatusName` for the `previousHomeworkStatus` field in the request.
+
+---
+
+## Implementation Steps
+
+### Step 1 — `SavedIndicator` component
+
+**File:** `frontend/src/components/ui/SavedIndicator.tsx`
+
+```tsx
+// Props: visible: boolean
+// Renders: Lucide Check (h-3 w-3) + "Saved" text
+// Classes: text-xs text-zinc-400 flex items-center gap-1
+// Animation: fade in 200ms ease-out on visible=true, hold 1000ms, fade out 300ms
+// useEffect + setTimeout for auto-hide; reset immediately when visible goes false externally
+```
+
+Use CSS transitions with opacity and `pointer-events-none` when hidden. The parent passes `visible` and the component manages its own hide timer internally via `useEffect`.
+
+---
+
+### Step 2 — Motivation banner autosave
+
+**File:** `frontend/src/components/student/StudentProfileTab.tsx`, `MotivationHero` component (lines 237-379)
+
+**Changes to `MotivationHero`:**
+- Remove `saving` state and the Save + Cancel buttons entirely.
+- Add `savedVisible` state (boolean) for `SavedIndicator`.
+- Add `saveError` state (string | null) for error display.
+- On `onBlur` of the textarea: call `onSave(draft.trim())`. If success: set `savedVisible = true` (auto-hides via component). If error: show `text-xs text-red-500` "Failed to save" inline in banner header (top right area), auto-hide after 3s.
+- Pencil icon is already present on hover (`opacity-0 group-hover:opacity-100`). Keep it.
+- On textarea render: add `onKeyDown` for `Escape` key: revert `draft` to `student.reasonForStudying ?? ''` and `inputRef.current?.blur()` (no save).
+- Add `savedVisible` and `saveError` rendering in banner header top-right.
+- No debounce — fires on blur only.
+
+---
+
+### Step 3 — Interests section always-editable
+
+**File:** `frontend/src/components/student/StudentProfileTab.tsx`, `InterestsSection` component (lines 384-544)
+
+**Redesign `InterestsSection`:**
+- Remove `editing` state, `editing ? ...` conditional rendering, Save button, Cancel button, pencil icon, and plus icon from the header.
+- Always render the chip input below the existing chips.
+- Local `chips` state initialized from `student.interests` (sync when student prop changes via `useEffect`).
+- `savedVisible` state (boolean) for `SavedIndicator` in section header.
+- `saveError` state (string | null).
+- **Add chip:** type + Enter or comma. Append to `chips`. Call `onSave(updatedChips)`. On success: show `SavedIndicator`. On error: revert chip, show error.
+- **Remove chip:** click ×. Remove from `chips`. Call `onSave(updatedChips)`. On success: show `SavedIndicator`. On error: re-add chip, show error.
+- Do NOT save on every keystroke — only on Enter/comma (add) or × (remove).
+- Placeholder: "Add interest..."
+- Input is always visible at the bottom of the chip list.
+
+---
+
+### Step 4 — TWM unconditional in right sidebar
+
+**File:** `frontend/src/components/student/StudentProfileTab.tsx`, right column section (lines 902-1026)
+
+**Current problem:** TWM (`profile-about` section) is conditionally rendered behind `(hasAbout || showEmptySections)`. The `showEmptySections` state is also controlled by the "Show all sections" toggle in the left column (via the `anySectionCollapsed` guard).
+
+**Changes:**
+- Move the TWM section (currently at position 1 in right column, lines 907-929) to render **unconditionally** at the top of the right column, outside any condition.
+- `showEmptySections` and "Show all sections" button must only control left column sections. To achieve this: the TWM section in the right sidebar must NOT be gated on `showEmptySections`.
+- Right sidebar order (top to bottom): Teacher's Working Memory (unconditional) → Language Ecosystem → Interests → Commercial → Ideas para Clases → Pending Followups.
+- The `hasAbout` and `hasWorkingMemory` booleans can remain for internal logic within the TWM card, but the card itself renders regardless.
+- The left column Teacher's Working Memory section (dark card, lines 835-899) is already gated on `(hasWorkingMemory || showEmptySections)` — that is correct and unchanged.
+
+---
+
+### Step 5 — Rename "Teaching Todos" to "IDEAS PARA CLASES"
+
+**File:** `frontend/src/components/student/StudentProfileTab.tsx`
+
+Line 1010: Change `<SectionHeader>Teaching Todos</SectionHeader>` to `<SectionHeader>Ideas para Clases</SectionHeader>`.
+
+The `data-testid="profile-teaching-todos"` attribute stays as-is.
+
+---
+
+### Step 6 — Edit Student button Secondary variant
+
+**File:** `frontend/src/pages/StudentDetail.tsx` (lines 422-427)
+
+The Edit Student link currently uses `className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium bg-[#E8E7F1] text-[#3525CD] hover:bg-[#DDD9F5] transition-colors"`. This already uses a light indigo background and indigo text. Looking at the design-system Section 5 Secondary: `bg-indigo-50`, `text-indigo-600`, no border.
+
+Update to match Secondary variant exactly:
+- `bg-indigo-50` (instead of `#E8E7F1`)
+- `text-indigo-600` (instead of `#3525CD`)
+- `hover:bg-indigo-100`
+- No border, same height and padding as Log Session button.
+
+---
+
+### Step 7 — Sessions tab: remove kebab, inline editable fields, delete in expanded state
+
+**File:** `frontend/src/components/session/SessionHistoryTab.tsx`
+
+**7a. Add `patchSession` helper to `sessionLogs.ts`:**
+
+Rather than duplicating the full payload build everywhere, add a helper in `sessionLogs.ts`:
+
+```typescript
+export async function patchSessionField(
+  studentId: string,
+  session: SessionLog,
+  patch: Partial<Pick<CreateSessionLogRequest, 'title' | 'actualContent' | 'duration' | 'nextSessionTopics'>>,
+): Promise<SessionLog> {
+  const payload: UpdateSessionLogRequest = {
+    sessionDate: session.sessionDate,
+    plannedContent: session.plannedContent,
+    actualContent: session.actualContent,
+    homeworkAssigned: session.homeworkAssigned,
+    previousHomeworkStatus: session.previousHomeworkStatusName,
+    nextSessionTopics: session.nextSessionTopics,
+    generalNotes: session.generalNotes,
+    levelReassessmentSkill: session.levelReassessmentSkill,
+    levelReassessmentLevel: session.levelReassessmentLevel,
+    linkedLessonId: session.linkedLessonId,
+    topicTags: session.topicTags,
+    isCancelled: session.isCancelled,
+    status: session.statusName,
+    duration: session.duration,
+    title: session.title,
+    ...patch,
+  }
+  return updateSession(studentId, session.id, payload)
+}
+```
+
+**7b. Remove kebab from `SessionEntry`:**
+- Remove the kebab `<div>` (lines 252-293) entirely.
+- Remove `kebabOpen` state, `Popover`, `PopoverTrigger`, `PopoverContent`, `onEdit` prop reference.
+- Remove `MoreHorizontal` import.
+- Remove `onEdit` from `SessionEntry` props and from `SessionHistoryTab`'s call site.
+- Remove `handleEdit` function from `SessionHistoryTab` (line 483-485). Also remove navigation import if only used for that.
+
+**7c. Inline editable fields in expanded state:**
+
+When `expanded = true`, replace static text with editable inputs for:
+
+| Field display | Element | API field in patch |
+|---|---|---|
+| Title (`getSessionTitle(session)` in header) | `<input type="text">` | `title` |
+| Session Narrative (`session.actualContent`) | `<textarea>` auto-resize | `actualContent` |
+| Duration (number + "min") | `<input type="number" min="0">` + "min" label | `duration` |
+| Next class plan (`session.nextSessionTopics`) | `<textarea>` auto-resize | `nextSessionTopics` |
+
+Each field:
+- Tracked in local state initialized from `session` prop values (title: `session.title ?? ''`, narrative: `session.actualContent ?? ''`, etc.)
+- On `onBlur`: if value changed, call `patchSessionField(studentId, session, { [field]: value })`. Show `SavedIndicator` in row header on success, `text-xs text-red-500` "Failed to save" auto-hide 3s on error.
+- `Escape` key: revert to saved value, blur (no save).
+- `savedVisible` state and `saveError` state in `SessionEntry`.
+
+The title input replaces the `<h3>` in the collapsed header too - wait, no. The issue says the title input appears "when a row is expanded." In collapsed state, the title still renders as `<h3>`. In expanded state, the title in the collapsed header area becomes an `<input>`. Actually re-reading: "When a row is expanded, the following fields become editable inputs instead of static text." So when expanded, the `<h3>` in the header becomes an input. Simplest approach: keep the `<h3>` logic for collapsed, add the `<input>` for title in the expanded area (not in the header row), similar to the other fields.
+
+Actually the issue says "Session title | `<span>` heading text | `<input type="text">` | `title`" - I'll put the title input at the top of the expanded detail section.
+
+**7d. Delete in expanded state:**
+
+In the expanded detail section, add at the bottom:
+- A ghost button with `Trash2` icon + "Delete session" text, `text-red-600`, styled as ghost.
+- On click: open the existing `AlertDialog`. This replaces the kebab Delete action.
+- Keep existing `AlertDialog` logic intact.
+
+---
+
+### Step 8 — Add `title` to `CreateSessionLogRequest`
+
+**File:** `frontend/src/api/sessionLogs.ts`
+
+Add `title?: string | null` to `CreateSessionLogRequest`.
+
+---
+
+### Step 9 — Unit tests
+
+**Files:**
+- `frontend/src/components/ui/SavedIndicator.test.tsx` (new)
+- `frontend/src/components/student/StudentProfileTab.test.tsx` (existing, add cases)
+
+**SavedIndicator tests:**
+- Renders nothing (opacity-0 / pointer-events-none) when `visible=false`.
+- Shows check icon and "Saved" text when `visible=true`.
+- Auto-hides after ~1500ms (use fake timers).
+
+**MotivationHero tests (in StudentProfileTab.test.tsx):**
+- Blur on textarea calls `onSave` with trimmed value.
+- Escape key reverts textarea value and does NOT call `onSave`.
+- `SavedIndicator` appears after successful save (mock `onSave` resolving).
+- Error message appears when `onSave` rejects.
+
+**InterestsSection tests (in StudentProfileTab.test.tsx):**
+- Chip input is always visible without any user interaction.
+- Enter key adds chip and calls `onSave` with updated array.
+- Comma key adds chip and calls `onSave`.
+- × on chip removes it and calls `onSave`.
+- Does NOT call `onSave` on each keystroke.
+
+---
+
+### Step 10 — E2E tests
+
+**File:** `e2e/tests/student-detail.spec.ts` — add tests:
+
+1. **Motivation autosave:** navigate to Ana Seed (has `reasonForStudying`), go to Profile tab, click motivation text to open textarea, change value, blur (tab away), verify `SavedIndicator` appears. Also verify Escape reverts without saving: fill a unique value, press Escape, verify the textarea shows the original value (not the typed value) by checking the DOM, not `page.request`.
+
+2. **Interests always-edit:** go to Profile tab for Ana Seed, verify interests chip input is always visible (no edit button needed), type an interest + Enter, verify chip appears. Click × on a chip, verify it disappears.
+
+3. **TWM always visible:** navigate to a student without notes AND without clicking "Show all sections", verify `profile-about` section is visible immediately.
+
+4. **Session inline edit:** navigate to Diego Seed, go to Sessions tab, click a session row to expand it, verify title input and narrative textarea are visible. Change title, blur, verify `SavedIndicator` appears. Verify Escape reverts.
+
+5. **Session delete in expanded state:** expand a session row, verify "Delete session" button is visible (no kebab needed). Click it, verify confirm dialog appears. Cancel - verify dialog closes. (Do not actually delete in this test to avoid seeder side-effects.)
+
+6. **No kebab:** expand a session row, verify `data-testid="session-kebab-trigger"` does NOT exist.
+
+**File:** `e2e/tests/visual/student-detail.visual.spec.ts` — add tests:
+
+1. Profile tab screenshot with right sidebar visible (TWM showing).
+2. Sessions tab with an expanded session row (editable fields visible).
+
+Use `Diego Seed` for session tests (already has sessions in seeder).
+
+---
+
+## Acceptance Criteria Checklist
+
+All ACs from issue #771 covered by the implementation above.
+
+Key notes:
+- The `SavedIndicator` holds its own hide timer internally.
+- `onSave` props in `StudentProfileTab` already exist (`onSaveReasonForStudying`, `onSaveInterests`) and are wired in `StudentDetail.tsx`.
+- For session fields, use `patchSessionField` helper for clean payload building.
+- The `previousHomeworkStatus` mapping: use `session.previousHomeworkStatusName` (e.g. "NotApplicable", "Done", etc.). Guard with fallback: `session.previousHomeworkStatusName || 'NotApplicable'` since the field is required in the request type.
+
+---
+
+## Out of Scope
+
+- Overview tab changes
+- Edit Student screen (`/students/:id/edit`)
+- Sessions tab search bar, filters, TOTAL HOURS stat card
+- Underlying data model or API contracts (only `title` field added to request type)
+- Edit Student full-page form autosave


### PR DESCRIPTION
Closes #771

## Summary

- **SavedIndicator** component: Check icon + "Saved" text, auto-fades after 1s, deferred setState to satisfy react-hooks/set-state-in-effect rule
- **patchSessionField** helper in `sessionLogs.ts`: builds full PUT payload from existing session + patch fields (no PATCH endpoint exists)
- **MotivationHero**: click-to-edit, blur-to-autosave, Escape-to-revert (isRevertingRef pattern), no Save/Cancel buttons
- **InterestsSection**: always-editable chip input, immediate save on add (Enter/comma) or remove (x), no edit mode toggle
- **SessionHistoryTab**: inline editable title/narrative/duration/next-plan with blur-save and Escape-revert; delete button at bottom of expanded row; kebab menu removed
- **Teacher's Working Memory sidebar**: always visible on profile tab (unconditional render); section heading renamed to "Ideas para Clases"
- **Edit Student button**: updated to secondary indigo style (bg-indigo-50 text-indigo-600, no border)
- **Motivation banner**: Interests chips shown with "INTERESTS" label for visual grouping

## Test plan

- [ ] Unit tests: 1249 passing (SavedIndicator, SessionHistoryTab, StudentProfileTab, StudentDetail all updated)
- [ ] Lint: clean (fixed react-hooks/set-state-in-effect in 3 locations)
- [ ] E2E: 8 new interaction tests (motivation autosave/escape, interests add/remove, sessions inline edit, delete, TWM always visible, no kebab)
- [ ] Visual E2E: 2 new @visual tests (profile tab with sidebar, sessions tab expanded row)
- [ ] UI review: PASS (interests label added after initial NEEDS WORK)
- [ ] Architecture review: PASS WITH NOTES (hand-rolled save timers — deferred as #776)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inline editing for session titles, narratives, and duration with auto-save feedback.
  * Always-visible interests input with keyboard shortcuts (Enter/comma to add).
  * Auto-save motivation field with Escape key to revert changes.

* **Improvements**
  * Added visual "Saved" indicator for field updates.
  * Profile-about section now permanently visible.

* **Tests**
  * Added comprehensive E2E and visual regression tests for student detail pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->