### PR TITLE
fix(t773): sidebar clips under section nav + Notes/Commercial nav lands on Difficulties

### DIFF
--- a/e2e/tests/students.spec.ts
+++ b/e2e/tests/students.spec.ts
@@ -1145,3 +1145,36 @@ test('partial difficulty row shows inline validation error and blocks save', asy
 
   await context.close()
 })
+
+test('Notes section nav link scrolls to Notes fields', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  const studentName = `NotesNavTest_${Date.now()}`
+
+  // Create a student
+  await page.goto('/students/new')
+  await page.getByTestId('student-name').fill(studentName)
+  await page.getByTestId('student-language').click()
+  await page.getByRole('option', { name: 'Spanish' }).click()
+  await page.getByTestId('student-cefr').click()
+  await page.getByRole('option', { name: 'B1' }).click()
+  await page.getByRole('button', { name: 'Save Student' }).click()
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
+
+  // Navigate to edit
+  await page.getByTestId('edit-profile-link').click()
+  await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: UI_TIMEOUT })
+
+  // Click Notes nav link and verify notes fields scroll into view
+  await page.getByTestId('section-nav-section-notes').click()
+  await expect(page.getByTestId('student-personal-notes')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
+  await expect(page.getByTestId('student-teaching-notes')).toBeVisible()
+
+  // Cleanup
+  await page.getByTestId('delete-student-btn').click()
+  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
+  await page.getByTestId('confirm-delete').click()
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
+
+  await context.close()
+})

--- a/e2e/tests/students.spec.ts
+++ b/e2e/tests/students.spec.ts
@@ -1165,10 +1165,10 @@ test('Notes section nav link scrolls to Notes fields', async ({ browser }) => {
   await page.getByTestId('edit-profile-link').click()
   await expect(page.locator('h1')).toHaveText('Edit Student', { timeout: UI_TIMEOUT })
 
-  // Click Notes nav link and verify notes fields scroll into view
+  // Click Notes nav link and verify notes fields scroll into the viewport
   await page.getByTestId('section-nav-section-notes').click()
-  await expect(page.getByTestId('student-personal-notes')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
-  await expect(page.getByTestId('student-teaching-notes')).toBeVisible()
+  await expect(page.getByTestId('student-personal-notes')).toBeInViewport({ timeout: FEEDBACK_TIMEOUT })
+  await expect(page.getByTestId('student-teaching-notes')).toBeInViewport()
 
   // Cleanup
   await page.getByTestId('delete-student-btn').click()

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -605,7 +605,7 @@ export default function StudentForm() {
       <div className={isEdit ? 'grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_280px] gap-6 items-start' : 'max-w-2xl space-y-6'}>
         <div className="space-y-6">
 
-          <form id="student-form" onSubmit={handleSubmit} className="space-y-6">
+          <form id="student-form" onSubmit={handleSubmit} className={`space-y-6${isEdit ? ' pb-[600px]' : ''}`}>
 
             {/* ── SECTION: Basic Info + Proficiency (2-column on desktop) ── */}
             <div id="section-basic" className="grid grid-cols-1 lg:grid-cols-[7fr_5fr] gap-6 items-start">
@@ -1412,7 +1412,7 @@ export default function StudentForm() {
         </div>
 
         {isEdit && id && (
-          <div className="space-y-4 lg:sticky lg:top-6" data-testid="form-sidebar">
+          <div className="space-y-4 lg:sticky lg:top-[76px]" data-testid="form-sidebar">
             <div
               className="bg-white rounded-2xl p-4"
               style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}

--- a/plan/langteach-beta/task773-edit-student-nav-bugs/task773-edit-student-nav-bugs.md
+++ b/plan/langteach-beta/task773-edit-student-nav-bugs/task773-edit-student-nav-bugs.md
@@ -1,0 +1,32 @@
+# Task 773: fix(edit-student): sidebar clips under section nav + Notes/Commercial nav lands on Difficulties
+
+## Issue
+https://github.com/Robert-Freire/langTeachSaaS/issues/773
+
+## Root Causes (pre-diagnosed in issue)
+
+**Bug 1 - Sidebar clipping:** Sidebar uses `lg:top-6` (24px) but the sticky section nav is 49px tall (sticks at top-0), so the sidebar slides under it.
+
+**Bug 2 - Notes/Commercial scroll clamping:** `maxScroll = scrollHeight - clientHeight = 2097px`, but `section-notes` starts at 2405px. `scrollTo()` is clamped and the scrollspy detects Difficulties as active.
+
+## Changes
+
+### `frontend/src/pages/StudentForm.tsx`
+
+1. **Line 1415**: `lg:top-6` → `lg:top-[76px]`
+   - 49px (section nav height) + 24px (original gap) + 3px margin = ~76px. Keeps sidebar below section nav.
+
+2. **Line 608**: Add `pb-[600px]` to `<form>` when `isEdit`
+   - Increases total scroll height so Notes and Commercial can be scrolled to and pass the 80px scrollspy threshold.
+
+## Testing
+
+- Unit tests: existing snapshot/DOM tests should still pass (CSS-only changes)
+- E2E: no new test needed; visual confirmation via review-ui
+
+## Acceptance Criteria
+
+- [ ] Sidebar "TEACHING TODOS" header fully visible when scrolled
+- [ ] "Notes" nav link scrolls to and highlights Notes section
+- [ ] "Commercial" nav link scrolls to and highlights Commercial section
+- [ ] All other section nav links still work correctly


### PR DESCRIPTION
## Summary

- `lg:top-6` changed to `lg:top-[76px]` on the sidebar wrapper so it clears the sticky section nav (measured at 49px tall)
- `pb-[600px]` added to the form in edit mode so Notes and Commercial sections can scroll past the 80px scrollspy threshold (maxScroll was 2097px, section-notes starts at 2405px)
- E2e test added: clicking the Notes section nav link makes the notes textareas visible

Closes #773

## Test plan

- [ ] On Edit Student screen, scroll the page and verify sidebar "TEACHING TODOS" header is fully visible (not clipped under section nav)
- [ ] Click "Notes" in section nav - scrolls to and highlights Notes section
- [ ] Click "Commercial" in section nav - scrolls to and highlights Commercial section
- [ ] All other section nav links (Basic Info, Background, Proficiency, Teaching Goals, Difficulties) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added end-to-end test validating the Notes section navigation functionality, verifying that the navigation link properly scrolls to and displays the personal and teaching notes fields on the student record edit page.

* **Bug Fixes**
  * Improved form padding and adjusted sticky sidebar positioning in student edit mode for better layout consistency and overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->