### PR TITLE
feat(t780): log session audio recorder placement + form interaction polish

### DIFF
--- a/e2e/tests/session-log-form-quality.spec.ts
+++ b/e2e/tests/session-log-form-quality.spec.ts
@@ -83,3 +83,37 @@ test('log session form quality: topics covered visible without secondary, sugges
     await context.close()
   }
 })
+
+test('audio recorder visible on log session page without toggling secondary', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    const studentName = `Audio Visible Test ${Date.now()}`
+    const createRes = await page.request.post(`${API_BASE}/api/students`, {
+      headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
+      data: {
+        name: studentName,
+        learningLanguage: 'Spanish',
+        cefrLevel: 'B1',
+        interests: [],
+        learningGoals: [],
+        weaknesses: [],
+        difficulties: [],
+      },
+    })
+    expect(createRes.ok()).toBeTruthy()
+    const student = await createRes.json()
+
+    await page.goto(`/students/${student.id}/log-session`)
+    await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: NAV_TIMEOUT })
+
+    // Voice recorder section visible without any toggle interaction
+    await expect(page.getByTestId('voice-recorder-section')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
+
+    // Toggle button shows descriptor text
+    await expect(page.getByTestId('toggle-secondary')).toContainText('Show homework, cultural notes, error patterns...')
+  } finally {
+    await context.close()
+  }
+})

--- a/e2e/tests/visual/session-edit.visual.spec.ts
+++ b/e2e/tests/visual/session-edit.visual.spec.ts
@@ -30,7 +30,10 @@ test.beforeAll(async ({ browser }) => {
   const sessions: Array<{ id: string; sessionDate: string }> = await sessionsRes.json()
   if (!sessions.length) throw new Error('Diego Seed has no sessions. Run start-visual-stack.sh first.')
   // Sort descending by date, take most recent
-  sessions.sort((a, b) => b.sessionDate.localeCompare(a.sessionDate))
+  sessions.sort((a, b) => {
+    const byDate = b.sessionDate.localeCompare(a.sessionDate)
+    return byDate !== 0 ? byDate : a.id.localeCompare(b.id)
+  })
   sessionId = sessions[0].id
 
   await page.close()

--- a/e2e/tests/visual/session-edit.visual.spec.ts
+++ b/e2e/tests/visual/session-edit.visual.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test'
+import { createMockAuthContext } from '../../helpers/auth-helper'
+import { setupMockTeacher } from '../../helpers/mock-teacher-helper'
+import { NAV_TIMEOUT, UI_TIMEOUT } from '../../helpers/timeouts'
+import * as fs from 'fs'
+
+const API_BASE = process.env.VITE_API_BASE_URL ?? 'http://localhost:5178'
+const AUTH_HEADER = { Authorization: 'Bearer test-token' }
+
+// Diego Seed has 2 session logs -- use most recent for edit mode
+let sessionId = ''
+let studentId = ''
+
+test.beforeAll(async ({ browser }) => {
+  const ctx = await createMockAuthContext(browser)
+  const page = await ctx.newPage()
+  await setupMockTeacher(page)
+
+  const res = await page.request.get(`${API_BASE}/api/students`, { headers: AUTH_HEADER })
+  expect(res.ok()).toBeTruthy()
+  const body = await res.json()
+  const students: Array<{ name?: string; id: string }> = Array.isArray(body) ? body : (body.items ?? body.data ?? [])
+
+  const diego = students.find((s) => s.name === 'Diego Seed')
+  if (!diego) throw new Error('No Diego Seed student found. Run start-visual-stack.sh first.')
+  studentId = diego.id
+
+  const sessionsRes = await page.request.get(`${API_BASE}/api/students/${studentId}/sessions`, { headers: AUTH_HEADER })
+  expect(sessionsRes.ok()).toBeTruthy()
+  const sessions: Array<{ id: string; sessionDate: string }> = await sessionsRes.json()
+  if (!sessions.length) throw new Error('Diego Seed has no sessions. Run start-visual-stack.sh first.')
+  // Sort descending by date, take most recent
+  sessions.sort((a, b) => b.sessionDate.localeCompare(a.sessionDate))
+  sessionId = sessions[0].id
+
+  await page.close()
+  await ctx.close()
+})
+
+test('@visual edit session page', async ({ browser }) => {
+  fs.mkdirSync('screenshots', { recursive: true })
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  const consoleErrors: string[] = []
+  page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()) })
+
+  await page.goto(`/students/${studentId}/sessions/${sessionId}/edit`)
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: NAV_TIMEOUT })
+  await expect(page.getByTestId('actual-content')).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.screenshot({ path: 'screenshots/session-edit.png', fullPage: true })
+
+  expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)
+  await context.close()
+})

--- a/frontend/src/pages/LogSession.test.tsx
+++ b/frontend/src/pages/LogSession.test.tsx
@@ -392,7 +392,7 @@ describe('LogSession', () => {
     await screen.findByTestId('actual-content')
     expect(screen.getByTestId('audio-recorder')).toBeDefined()
     // audio recorder should be visible without toggling secondary
-    expect(screen.queryByTestId('voice-recorder-section')).toBeInTheDocument()
+    expect(screen.getByTestId('voice-recorder-section')).toBeDefined()
   })
 
   it('toggle button shows descriptor text when closed and changes on open', async () => {

--- a/frontend/src/pages/LogSession.test.tsx
+++ b/frontend/src/pages/LogSession.test.tsx
@@ -387,6 +387,24 @@ describe('LogSession', () => {
     expect(screen.getByTestId('topic-tags-input')).toBeDefined()
   })
 
+  it('shows audio recorder without opening secondary section', async () => {
+    renderLogSession()
+    await screen.findByTestId('actual-content')
+    expect(screen.getByTestId('audio-recorder')).toBeDefined()
+    // audio recorder should be visible without toggling secondary
+    expect(screen.queryByTestId('voice-recorder-section')).toBeInTheDocument()
+  })
+
+  it('toggle button shows descriptor text when closed and changes on open', async () => {
+    renderLogSession()
+    const toggle = await screen.findByTestId('toggle-secondary')
+    expect(toggle).toHaveTextContent('Show homework, cultural notes, error patterns...')
+    fireEvent.click(toggle)
+    await waitFor(() => {
+      expect(screen.getByTestId('toggle-secondary')).toHaveTextContent('Hide additional sections')
+    })
+  })
+
   it('shows suggestion chips when narrative contains a known keyword', async () => {
     renderLogSession()
     await screen.findByTestId('actual-content')

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -2,8 +2,8 @@ import { useState, useRef, useEffect, useMemo } from 'react'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
-  ArrowLeft, Plus, X, ChevronDown, ChevronUp,
-  Loader2, CheckCircle, RefreshCw, Mic,
+  ArrowLeft, Plus, X, ChevronDown,
+  Loader2, CheckCircle, RefreshCw,
 } from 'lucide-react'
 import { getStudent, appendTeachingTodo, updateTeachingTodo } from '@/api/students'
 import {
@@ -583,7 +583,8 @@ export default function LogSession() {
 
         {/* Pending Followups */}
         {pendingFollowups.length > 0 && (
-          <PanelSection label="Pending Followups">
+          <PanelSection label="Open followups from previous sessions">
+            <p className="text-xs text-zinc-400 -mt-1">Check items you addressed in this session</p>
             <div className="space-y-1.5">
               {pendingFollowups.map(f => (
                 <label
@@ -595,10 +596,10 @@ export default function LogSession() {
                     type="checkbox"
                     checked={checkedFollowupIds.has(f.id)}
                     onChange={() => toggleFollowup(f.id)}
-                    className="mt-0.5 h-4 w-4 rounded border-amber-300 text-amber-500 shrink-0"
+                    className="mt-0.5 h-4 w-4 rounded border-amber-300 text-indigo-600 shrink-0"
                     data-testid="followup-checkbox"
                   />
-                  <span className={`text-sm leading-snug ${checkedFollowupIds.has(f.id) ? 'line-through text-zinc-400' : 'text-[#1A1B22]'}`}>
+                  <span className={`text-sm leading-snug transition-all duration-150 ${checkedFollowupIds.has(f.id) ? 'line-through text-zinc-400 opacity-60' : 'text-[#1A1B22]'}`}>
                     {f.text}
                     {f.dueDate && (
                       <span className="ml-1.5 text-xs text-amber-600">{formatDate(f.dueDate)}</span>
@@ -896,6 +897,16 @@ export default function LogSession() {
                 />
               </div>
 
+              {/* Voice Note */}
+              <div className="mt-3" data-testid="voice-recorder-section">
+                <AudioRecorder
+                  onVoiceNote={(note) => {
+                    setVoiceNoteId(note.id)
+                    markChangedAndSaveNow({ voiceNoteId: note.id })
+                  }}
+                />
+              </div>
+
               {/* Topics Covered */}
               <div className="space-y-1" data-testid="topics-covered-section">
                 <Label className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400">Topics Covered</Label>
@@ -911,7 +922,7 @@ export default function LogSession() {
                           setTopicTags(next)
                           markChangedAndSaveNow({ topicTags: serializeTopicTags(next) })
                         }}
-                        className="inline-flex items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-xs text-indigo-700 hover:bg-indigo-100 transition-colors"
+                        className="inline-flex items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-3 py-1.5 min-h-[36px] text-sm font-medium text-indigo-700 hover:bg-indigo-100 transition-colors"
                         data-testid={`tag-suggestion-${suggestion}`}
                       >
                         <Plus className="h-3 w-3" />
@@ -1029,31 +1040,12 @@ export default function LogSession() {
                 className="flex items-center gap-1.5 text-sm text-zinc-500 hover:text-indigo-600 transition-colors"
                 data-testid="toggle-secondary"
               >
-                {secondaryOpen ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-                {secondaryOpen ? 'Hide extra sections' : 'Show extra sections'}
+                <ChevronDown className={`h-4 w-4 transition-transform duration-200 ${secondaryOpen ? 'rotate-180' : ''}`} />
+                {secondaryOpen ? 'Hide additional sections' : 'Show homework, cultural notes, error patterns...'}
               </button>
 
               {secondaryOpen && (
                 <div className="space-y-6">
-                  {/* Voice Note - horizontal bar */}
-                  <div className="flex items-center gap-4 rounded-xl px-4 py-3 bg-white" style={{ boxShadow: '0 1px 4px rgba(26,27,34,0.06)' }}>
-                    <div className="flex items-center gap-2 text-zinc-600">
-                      <Mic className="h-4 w-4 text-indigo-500" />
-                      <div>
-                        <p className="text-sm font-medium text-[#1A1B22]">Voice Note</p>
-                        <p className="text-xs text-zinc-400">Capture thoughts via voice</p>
-                      </div>
-                    </div>
-                    <div className="ml-auto">
-                      <AudioRecorder
-                        onVoiceNote={(note) => {
-                          setVoiceNoteId(note.id)
-                          markChangedAndSaveNow({ voiceNoteId: note.id })
-                        }}
-                      />
-                    </div>
-                  </div>
-
                   {/* Today's Context */}
                   <div className="space-y-1">
                     <Label htmlFor="general-notes" className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400">

--- a/plan/langteach-beta/task780-log-session-form-polish.md
+++ b/plan/langteach-beta/task780-log-session-form-polish.md
@@ -1,0 +1,111 @@
+# Task 780: Log Session Audio Recorder Placement + Form Interaction Polish
+
+**Issue:** #780  
+**Branch:** worktree-task-t780-log-session-form-polish  
+**Sprint:** sprint/ui-redesign-student-polish
+
+---
+
+## Problem
+
+Two sets of changes to `LogSession.tsx`:
+1. `AudioRecorder` is hidden behind the "Show extra sections" toggle — it should be visible by default.
+2. Several form interaction details need polish (chip sizing, followup feedback, toggle text, followup label).
+
+---
+
+## Current State Analysis
+
+After PRs #775 and #778 merged, the LogSession layout is:
+- Todos + Followups cards are already OUTSIDE the secondaryOpen block (B.3 is already done)
+- AudioRecorder is inside the `secondaryOpen` block (lines 1038-1055), wrapped in a card with "Voice Note" header
+- secondaryOpen block contains: AudioRecorder, Today's Context, Link to Lesson Plan, Level Reassessment
+- Topic suggestion chips use `px-2 py-0.5 text-xs` (too small)
+- Previous followups in left panel already have `line-through text-zinc-400` but need `opacity-60 transition-all duration-150` and indigo checkbox
+
+---
+
+## Changes Required
+
+### Part A — AudioRecorder placement
+
+**File:** `frontend/src/pages/LogSession.tsx`
+
+1. Remove the entire "Voice Note" card block from `{secondaryOpen && (...)}` (the `<div className="flex items-center gap-4 rounded-xl...">` wrapper with Mic icon, title, and `<AudioRecorder>`).
+2. Place `<AudioRecorder>` directly after the textarea's parent `<div className="space-y-1">` (around line 897), before the Topics Covered section. Use `<div className="mt-3">` wrapper only. Keep the same `onVoiceNote` prop.
+
+### Part B — Form interaction polish
+
+**File:** `frontend/src/pages/LogSession.tsx`
+
+#### B.1 — Topic suggestion chips (lines ~903-920)
+
+Change each suggestion button:
+- Padding: `px-2 py-0.5 text-xs` → `px-3 py-1.5 min-h-[36px] text-sm font-medium`
+- Unselected: `bg-indigo-50 text-indigo-700 border border-indigo-200 hover:bg-indigo-100` (currently same, just add border)
+- Selected: keep as-is (already looks fine)
+
+These are the suggestion buttons (the `+suggestion` chips), not the added-tag chips in TopicTagsInput.
+
+#### B.2 — Followup strikethrough (left panel, lines ~594-608)
+
+- Checkbox: change `text-amber-500` → `text-indigo-600`
+- Text span: add `opacity-60 transition-all duration-150` to the checked className
+
+#### B.4 — Toggle text (lines ~1026-1034)
+
+Replace the two-icon (ChevronUp/ChevronDown) pattern with a single `ChevronDown` that rotates 180deg when open. Update text:
+- Closed: "Show homework, cultural notes, error patterns..."
+- Open: "Hide additional sections"
+
+#### B.5 — Previous followups label (left panel, line ~586)
+
+- Change `label="Pending Followups"` to `label="Open followups from previous sessions"`
+- Add subtitle as first child inside PanelSection (before the `<div className="space-y-1.5">` wrapper):
+  ```jsx
+  <p className="text-xs text-zinc-400 -mt-1">Check items you addressed in this session</p>
+  ```
+
+---
+
+## Acceptance Criteria Coverage
+
+| AC | Implementation |
+|----|----------------|
+| Audio recorder visible immediately (create + edit) | Part A — moved out of toggle |
+| Recording and transcription still work | Props unchanged (onVoiceNote, etc.) |
+| Toggle still works for remaining secondary fields | secondaryOpen block kept, AudioRecorder removed from it |
+| Topic chips have adequate padding (36px min height) | B.1 |
+| Chips tappable on mobile | B.1 padding |
+| Checking followup shows strikethrough + dimmed | B.2 (already line-through, adding opacity-60) |
+| Unchecking reverses visual change | B.2 (conditional class) |
+| Todos + Followups visible without toggle | Already done in #778 |
+| Toggle text shows descriptor text | B.4 |
+| Toggle text changes when open | B.4 |
+| Previous followups label + subtitle | B.5 |
+| Works in create and edit modes | AudioRecorder is inside `!isCancelled` block, both modes handled |
+
+---
+
+## Test Plan
+
+### Unit tests (`frontend/src/pages/LogSession.test.tsx`)
+
+1. **AudioRecorder initial visibility**: Assert `screen.getByTestId('audio-recorder')` is present on initial render without clicking `toggle-secondary`. Existing mock uses `data-testid="audio-recorder"`.
+2. **Toggle text closed state**: Assert button with `data-testid="toggle-secondary"` has text containing "Show homework, cultural notes, error patterns...".
+3. **Toggle text open state**: After clicking `toggle-secondary`, assert the button text contains "Hide additional sections".
+
+### E2E test (Playwright)
+
+Add a test in the log session test file verifying the AudioRecorder is visible on the Log Session page on initial render, without any toggle interaction. Use an existing student fixture that has prior sessions.
+
+### No changes needed
+- TopicTagsInput unit tests (component unchanged)
+- Existing toggle-secondary tests that only check presence (not text)
+
+---
+
+## Files Changed
+
+- `frontend/src/pages/LogSession.tsx` — all changes
+- `frontend/src/pages/LogSession.test.tsx` — test updates

--- a/plan/ui-review-backlog.md
+++ b/plan/ui-review-backlog.md
@@ -54,3 +54,5 @@ Non-blocking findings from review-ui runs. Periodically review this file and bat
 |----------|--------|---------|
 | Low | Dashboard / Hero card | Mock teacher has no scheduled sessions, so Start Session CTA, adaptive urgency badge, structured Last Session Briefing (4 bullets), and warm homework card cannot be visually verified. Needs a future session seeded for the mock teacher. All code paths tested via unit tests. |
 | Low | Dashboard / Pending Followups | Mock teacher has no pending followups, so OVERDUE/OLD/TODAY badge designs and colored priority dots are unverified visually. Unit tests verify all badge variants. |
+| Low | Log Session / Toggle text | Toggle button text ('Show homework, cultural notes, error patterns...' / 'Hide additional sections') is below the fold in the visual spec screenshot. Verified by unit tests (38 pass) and e2e. |
+| Low | Log Session / Followup label | 'Open followups from previous sessions' label + subtitle not visually verified (Diego Seed has no open followups seeded). Verified by code review. |


### PR DESCRIPTION
Closes #780

## Summary
- Move `AudioRecorder` out of the secondary toggle — visible by default below the narrative textarea in both create and edit modes
- Topic suggestion chips: `px-3 py-1.5 min-h-[36px] text-sm font-medium` for better touch targets
- Followup checkbox: indigo accent; checked text adds `opacity-60 transition-all duration-150`
- Toggle text: "Show homework, cultural notes, error patterns..." / "Hide additional sections" with rotating chevron
- "Pending Followups" label renamed to "Open followups from previous sessions" with subtitle

## Test plan
- [ ] 38 unit tests pass (LogSession.test.tsx)
- [ ] New unit tests: AudioRecorder visible without toggle, toggle text in both states
- [ ] New e2e test: `voice-recorder-section` visible on log session page without toggle interaction; toggle text check
- [ ] New visual spec: `session-edit.visual.spec.ts` for edit mode route
- [ ] Screenshots confirm AudioRecorder placement in create + edit mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Voice recorder now displays on the main session logging page without additional toggles.
  * Redesigned "Open Followups" panel with updated labels and improved styling for followup items.
  * Enhanced secondary toggle button with clearer action descriptions and improved animations.

* **Tests**
  * Added test coverage for voice recorder visibility and session edit page functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->