### PR TITLE
feat(t781): log session left panel context + metadata bar polish

### DIFF
--- a/frontend/src/pages/LogSession.test.tsx
+++ b/frontend/src/pages/LogSession.test.tsx
@@ -621,6 +621,118 @@ describe('LogSession — back arrow behavior', () => {
   })
 })
 
+describe('LogSession — left panel context + metadata polish', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(studentsApi.getStudent).mockResolvedValue(SAMPLE_STUDENT)
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([])
+    vi.mocked(sessionLogsApi.createSession).mockResolvedValue({
+      ...SAMPLE_SESSION,
+      id: 'new-session',
+    })
+    vi.mocked(sessionLogsApi.updateSession).mockResolvedValue({
+      ...SAMPLE_SESSION,
+      id: 'new-session',
+    })
+    vi.mocked(followupsApi.getFollowups).mockResolvedValue([])
+    vi.mocked(lessonsApi.getLessons).mockResolvedValue({ items: [], totalCount: 0, page: 1, pageSize: 100 })
+  })
+
+  it('shows "First session" empty state when no prior sessions in create mode', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([])
+    renderLogSession()
+    await screen.findByTestId('first-session-empty')
+    expect(screen.getByText('First session!')).toBeInTheDocument()
+  })
+
+  it('shows last session card with duration when prior sessions exist', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SAMPLE_SESSION, actualContent: 'Covered ser vs estar', duration: 45 },
+    ])
+    renderLogSession()
+    await screen.findByTestId('log-session-left-panel')
+    expect(screen.getByText('45 min')).toBeInTheDocument()
+    expect(screen.getByText(/Covered ser vs estar/)).toBeInTheDocument()
+  })
+
+  it('shows skill level overrides when available', async () => {
+    vi.mocked(studentsApi.getStudent).mockResolvedValue({
+      ...SAMPLE_STUDENT,
+      skillLevelOverrides: { Speaking: 'B1', Writing: 'A2' },
+    })
+    renderLogSession()
+    await screen.findByTestId('skill-levels-row')
+    expect(screen.getByTestId('skill-levels-row')).toHaveTextContent('Speaking B1')
+    expect(screen.getByTestId('skill-levels-row')).toHaveTextContent('Writing A2')
+  })
+
+  it('hides skill level row when no overrides', async () => {
+    renderLogSession()
+    await screen.findByTestId('session-number')
+    expect(screen.queryByTestId('skill-levels-row')).not.toBeInTheDocument()
+  })
+
+  it('shows working memory card when teachingNotes available', async () => {
+    vi.mocked(studentsApi.getStudent).mockResolvedValue({
+      ...SAMPLE_STUDENT,
+      teachingNotes: 'Prefers visual examples. Struggles with subjunctive.',
+    })
+    renderLogSession()
+    await screen.findByTestId('working-memory-card')
+    expect(screen.getByText(/Prefers visual examples/)).toBeInTheDocument()
+  })
+
+  it('hides working memory card when teachingNotes is null', async () => {
+    renderLogSession()
+    await screen.findByTestId('log-session-left-panel')
+    expect(screen.queryByTestId('working-memory-card')).not.toBeInTheDocument()
+  })
+
+  it('shows expand toggle for long difficulty descriptions', async () => {
+    const longDesc = 'A'.repeat(100)
+    vi.mocked(studentsApi.getStudent).mockResolvedValue({
+      ...SAMPLE_STUDENT,
+      difficulties: [{
+        id: 'd1', description: longDesc, competency: 'Grammar',
+        subcategory: 'Verbs', severity: 'high', trend: 'stable', status: 'Active',
+      }],
+    })
+    renderLogSession()
+    await screen.findByTestId('difficulty-item')
+    expect(screen.getByTestId('difficulty-expand-toggle')).toBeInTheDocument()
+    expect(screen.getByTestId('difficulty-expand-toggle')).toHaveTextContent('more')
+  })
+
+  it('does not show expand toggle for short difficulty descriptions', async () => {
+    vi.mocked(studentsApi.getStudent).mockResolvedValue({
+      ...SAMPLE_STUDENT,
+      difficulties: [{
+        id: 'd2', description: 'Short text', competency: 'Grammar',
+        subcategory: 'Articles', severity: 'low', trend: 'stable', status: 'Active',
+      }],
+    })
+    renderLogSession()
+    await screen.findByTestId('difficulty-item')
+    expect(screen.queryByTestId('difficulty-expand-toggle')).not.toBeInTheDocument()
+  })
+
+  it('renders time input defaulting to current time', async () => {
+    renderLogSession()
+    await screen.findByTestId('session-time')
+    const timeInput = screen.getByTestId('session-time') as HTMLInputElement
+    expect(timeInput.value).toMatch(/^\d{2}:\d{2}$/)
+  })
+
+  it('metadata bar has 2x2 grid layout with date, time, duration, and status', async () => {
+    renderLogSession()
+    await screen.findByTestId('session-date')
+    expect(screen.getByTestId('session-date')).toBeInTheDocument()
+    expect(screen.getByTestId('session-time')).toBeInTheDocument()
+    expect(screen.getByTestId('duration-select')).toBeInTheDocument()
+    expect(screen.getByTestId('cancelled-toggle')).toBeInTheDocument()
+  })
+})
+
 describe('LogSession — Ctrl+Enter shortcut', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/frontend/src/pages/LogSession.test.tsx
+++ b/frontend/src/pages/LogSession.test.tsx
@@ -486,6 +486,38 @@ describe('LogSession — edit mode', () => {
     expect(screen.getByTestId('actual-content')).toHaveValue('Covered irregular preterite')
   })
 
+  it('pre-fills time from sessionDate in edit mode', async () => {
+    vi.mocked(sessionLogsApi.getSession).mockResolvedValue({
+      ...EDIT_SESSION,
+      sessionDate: '2026-04-01T14:30:00Z',
+    })
+    renderEditSession()
+    await screen.findByTestId('session-time')
+    expect((screen.getByTestId('session-time') as HTMLInputElement).value).toBe('14:30')
+  })
+
+  it('includes time in autosave payload when Done is clicked in edit mode', async () => {
+    vi.mocked(sessionLogsApi.getSession).mockResolvedValue({
+      ...EDIT_SESSION,
+      sessionDate: '2026-04-01T09:00:00Z',
+    })
+    renderEditSession()
+    await screen.findByTestId('actual-content')
+    fireEvent.change(screen.getByTestId('actual-content'), { target: { value: 'Updated' } })
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('done-btn'))
+    })
+    await waitFor(() => {
+      expect(sessionLogsApi.updateSession).toHaveBeenCalledWith(
+        STUDENT_ID,
+        SESSION_ID,
+        expect.objectContaining({
+          sessionDate: expect.stringContaining('T09:00'),
+        }),
+      )
+    })
+  })
+
   it('does not clobber actual content with plannedForToday in edit mode', async () => {
     vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
       { ...EDIT_SESSION, id: 'other-session', nextSessionTopics: 'Should not appear' },

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -52,6 +52,11 @@ function todayISO(): string {
   return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
 }
 
+function nowTimeHHMM(): string {
+  const now = new Date()
+  return `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`
+}
+
 function getInitials(name: string): string {
   return name.split(' ').map(w => w[0]).filter(Boolean).slice(0, 2).join('').toUpperCase()
 }
@@ -75,7 +80,7 @@ function isSuggestedDifficulty(value: unknown): value is SuggestedDifficulty {
 function PanelSection({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="space-y-2">
-      <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400">{label}</p>
+      <p className="text-[0.6875rem] font-medium uppercase tracking-[0.05em] text-zinc-400">{label}</p>
       {children}
     </div>
   )
@@ -127,6 +132,7 @@ export default function LogSession() {
 
   // Form state
   const [sessionDate, setSessionDate] = useState(todayISO())
+  const [sessionTime, setSessionTime] = useState(nowTimeHHMM())
   const [durationChoice, setDurationChoice] = useState('60')
   const [durationOther, setDurationOther] = useState('')
   const [isCancelled, setIsCancelled] = useState(false)
@@ -148,12 +154,19 @@ export default function LogSession() {
   const [checkedTodoIds, setCheckedTodoIds] = useState<Set<string>>(new Set())
   const [checkedFollowupIds, setCheckedFollowupIds] = useState<Set<string>>(new Set())
   const [mentionedDifficultyKeys, setMentionedDifficultyKeys] = useState<Set<string>>(new Set())
+  const [workingMemoryExpanded, setWorkingMemoryExpanded] = useState(false)
+  const [expandedDifficulties, setExpandedDifficulties] = useState<Set<string>>(new Set())
 
   // Quick-add lists (applied on Done)
   const [newTodoText, setNewTodoText] = useState('')
   const [newTodos, setNewTodos] = useState<string[]>([])
   const [newFollowupText, setNewFollowupText] = useState('')
   const [newFollowups, setNewFollowups] = useState<string[]>([])
+
+  // Scroll gradient
+  const [showScrollGradient, setShowScrollGradient] = useState(false)
+  const scrollSentinelRef = useRef<HTMLDivElement>(null)
+  const asideRef = useRef<HTMLDivElement>(null)
 
   // Done state
   const [isDone, setIsDone] = useState(false)
@@ -228,7 +241,9 @@ export default function LogSession() {
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (!editSession || didInitEdit) return
-    setSessionDate(editSession.sessionDate?.split('T')[0] ?? todayISO())
+    const [datePart, timePart] = (editSession.sessionDate ?? '').split('T')
+    setSessionDate(datePart || todayISO())
+    setSessionTime(timePart?.slice(0, 5) || nowTimeHHMM())
     setActualContent(editSession.actualContent ?? '')
     setHomeworkAssigned(editSession.homeworkAssigned ?? '')
     setPrevHomeworkStatus(editSession.previousHomeworkStatusName ?? null)
@@ -271,7 +286,7 @@ export default function LogSession() {
       .map(d => ({ Competency: d.competency, Subcategory: d.subcategory }))
 
     getFormDataRef.current = (): CreateSessionLogRequest => ({
-      sessionDate: sessionDate || null,
+      sessionDate: sessionDate ? `${sessionDate}T${sessionTime || '00:00'}:00` : null,
       actualContent: isCancelled ? null : (actualContent || null),
       plannedContent: plannedForToday || null,
       homeworkAssigned: isCancelled ? null : (homeworkAssigned || null),
@@ -290,7 +305,7 @@ export default function LogSession() {
       ...(voiceNoteId ? { voiceNoteId } : {}),
     })
   }, [
-    sessionDate, durationChoice, durationOther, isCancelled, prevHomeworkStatus,
+    sessionDate, sessionTime, durationChoice, durationOther, isCancelled, prevHomeworkStatus,
     actualContent, homeworkAssigned, nextSessionTopics, generalNotes, topicTags,
     reassessmentEnabled, reassessmentLevel, selectedLessonId, voiceNoteId,
     mentionedDifficultyKeys, activeDifficulties, plannedForToday, suggestedDifficulties,
@@ -446,6 +461,19 @@ export default function LogSession() {
     return () => document.removeEventListener('keydown', onKeyDown)
   }) // intentionally no deps: reads doneBusy/handleDone from closure each render
 
+  // Scroll gradient: observe sentinel at bottom of left panel
+  useEffect(() => {
+    const sentinel = scrollSentinelRef.current
+    const aside = asideRef.current
+    if (!sentinel || !aside) return
+    const observer = new IntersectionObserver(
+      ([entry]) => setShowScrollGradient(!entry.isIntersecting),
+      { root: aside, threshold: 0 },
+    )
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [])
+
   // Must be before early returns to satisfy Rules of Hooks
   const tagSuggestions = useMemo(
     () => suggestTopicTags(actualContent, topicTags),
@@ -494,7 +522,8 @@ export default function LogSession() {
     <div className="flex h-full min-h-0" data-testid="log-session-page">
       {/* ─── Left panel: Student Context ──────────────────────────────── */}
       <aside
-        className="w-[35%] shrink-0 overflow-y-auto px-6 py-8 space-y-6"
+        ref={asideRef}
+        className="relative w-[35%] shrink-0 overflow-y-auto px-6 py-8 space-y-6"
         style={{ background: '#F4F2FD' }}
         data-testid="log-session-left-panel"
       >
@@ -521,6 +550,16 @@ export default function LogSession() {
               <Skeleton className="h-3 w-20 mt-1" />
             ) : (
               <p className="text-xs text-zinc-400 mt-0.5" data-testid="session-number">Session #{sessionNumber}</p>
+            )}
+            {Object.keys(student.skillLevelOverrides).length > 0 && (
+              <p className="text-xs text-zinc-400 mt-1" data-testid="skill-levels-row">
+                {Object.entries(student.skillLevelOverrides).map(([skill, level], i) => (
+                  <span key={skill}>
+                    {i > 0 && <span className="mx-1 text-zinc-300">|</span>}
+                    {skill} {level}
+                  </span>
+                ))}
+              </p>
             )}
           </div>
         </div>
@@ -612,10 +651,15 @@ export default function LogSession() {
         )}
 
         {/* Last Session */}
-        {prevSession && (
+        {prevSession ? (
           <PanelSection label={`Last Session (#${sessions.filter(s => !s.isCancelled).length})`}>
             <div className="rounded-lg bg-white px-3 py-2.5 space-y-1" style={{ boxShadow: '0 1px 4px rgba(26,27,34,0.06)' }}>
-              <p className="text-xs text-zinc-400">{formatDate(prevSession.sessionDate)}</p>
+              <div className="flex items-center justify-between">
+                <p className="text-xs text-zinc-400">{formatDate(prevSession.sessionDate)}</p>
+                {prevSession.duration && (
+                  <p className="text-xs text-zinc-400">{prevSession.duration} min</p>
+                )}
+              </div>
               {prevSession.actualContent && (
                 <p className="text-sm text-[#1A1B22] line-clamp-3 leading-snug">
                   {prevSession.actualContent}
@@ -625,6 +669,42 @@ export default function LogSession() {
                 <p className="text-xs text-zinc-500">
                   <span className="font-medium">HW:</span> {prevSession.homeworkAssigned}
                 </p>
+              )}
+            </div>
+          </PanelSection>
+        ) : !isEditMode && !sessionsLoading ? (
+          <PanelSection label="Last Session">
+            <div
+              className="rounded-lg bg-white px-3 py-2.5 text-center"
+              style={{ boxShadow: '0 1px 4px rgba(26,27,34,0.06)' }}
+              data-testid="first-session-empty"
+            >
+              <p className="text-sm font-medium text-indigo-600">First session!</p>
+              <p className="text-xs text-zinc-400 mt-0.5">Great start with this student.</p>
+            </div>
+          </PanelSection>
+        ) : null}
+
+        {/* Working Memory (teacher notes) */}
+        {student.teachingNotes && (
+          <PanelSection label="Working Memory">
+            <div
+              className="rounded-lg bg-white px-3 py-2.5"
+              style={{ boxShadow: '0 1px 4px rgba(26,27,34,0.06)' }}
+              data-testid="working-memory-card"
+            >
+              <p className={`text-sm text-zinc-600 leading-snug whitespace-pre-wrap ${!workingMemoryExpanded ? 'line-clamp-4' : ''}`}>
+                {student.teachingNotes}
+              </p>
+              {student.teachingNotes.length > 200 && (
+                <button
+                  type="button"
+                  onClick={() => setWorkingMemoryExpanded(v => !v)}
+                  className="text-xs text-indigo-500 hover:text-indigo-700 mt-1"
+                  data-testid="working-memory-toggle"
+                >
+                  {workingMemoryExpanded ? 'Show less' : 'Show more'}
+                </button>
               )}
             </div>
           </PanelSection>
@@ -653,7 +733,21 @@ export default function LogSession() {
                       onChange={() => toggleDifficulty(key)}
                       className="mt-0.5 h-4 w-4 rounded border-zinc-300 text-indigo-600 shrink-0"
                     />
-                    <span className="text-sm text-[#1A1B22] leading-snug">{d.description}</span>
+                    <span className="text-sm text-[#1A1B22] leading-snug">
+                      <span className={d.description.length > 80 && !expandedDifficulties.has(key) ? 'line-clamp-2' : ''}>
+                        {d.description}
+                      </span>
+                      {d.description.length > 80 && (
+                        <button
+                          type="button"
+                          onClick={(e) => { e.preventDefault(); setExpandedDifficulties(prev => { const next = new Set(prev); if (next.has(key)) next.delete(key); else next.add(key); return next }) }}
+                          className="text-xs text-indigo-500 hover:text-indigo-700 ml-1"
+                          data-testid="difficulty-expand-toggle"
+                        >
+                          {expandedDifficulties.has(key) ? 'less' : 'more'}
+                        </button>
+                      )}
+                    </span>
                   </label>
                 )
               })}
@@ -694,6 +788,19 @@ export default function LogSession() {
               ))}
             </div>
           </PanelSection>
+        )}
+
+        {/* Scroll sentinel */}
+        <div ref={scrollSentinelRef} className="h-px shrink-0" aria-hidden />
+
+        {/* Scroll gradient overlay */}
+        {showScrollGradient && (
+          <div
+            className="pointer-events-none absolute bottom-0 left-0 right-0 h-8"
+            style={{ background: 'linear-gradient(to top, #F4F2FD, transparent)' }}
+            data-testid="scroll-gradient"
+            aria-hidden
+          />
         )}
       </aside>
 
@@ -779,61 +886,78 @@ export default function LogSession() {
             </div>
           )}
 
-          {/* ── Compact metadata bar: Date / Duration / Cancelled ── */}
-          <div className="flex items-center gap-4 flex-wrap rounded-xl px-4 py-3" style={{ background: '#F4F2FD' }}>
-            <div className="flex items-center gap-2">
-              <Label htmlFor="session-date" className="text-xs font-semibold text-zinc-500 shrink-0">Date</Label>
+          {/* ── Compact metadata bar: 2x2 grid ── */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 rounded-xl px-4 py-3" style={{ background: '#F4F2FD' }}>
+            {/* Date */}
+            <div className="space-y-1">
+              <Label htmlFor="session-date" className="text-xs font-medium text-zinc-400 uppercase tracking-wide">Date</Label>
               <Input
                 id="session-date"
                 type="date"
                 value={sessionDate}
                 onChange={e => { setSessionDate(e.target.value); markChangedAndSchedule() }}
-                className="text-sm bg-white h-7 px-2 py-0 w-36"
+                className="text-sm bg-zinc-100 border-none h-8 px-2.5 focus:ring-2 focus:ring-indigo-500/20"
                 data-testid="session-date"
               />
             </div>
 
-            <div className="flex items-center gap-2">
-              <Label htmlFor="duration" className="text-xs font-semibold text-zinc-500 shrink-0">Duration</Label>
-              <Select value={durationChoice} onValueChange={(v) => { const val = v ?? durationChoice; setDurationChoice(val); markChangedAndSaveNow({ duration: val === 'other' ? null : parseInt(val, 10) }) }}>
-                <SelectTrigger id="duration" className="text-sm bg-white h-7 px-2 py-0 w-28" data-testid="duration-select">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {DURATION_OPTIONS.map(o => (
-                    <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+            {/* Time */}
+            <div className="space-y-1">
+              <Label htmlFor="session-time" className="text-xs font-medium text-zinc-400 uppercase tracking-wide">Time</Label>
+              <Input
+                id="session-time"
+                type="time"
+                value={sessionTime}
+                onChange={e => { setSessionTime(e.target.value); markChangedAndSchedule() }}
+                className="text-sm bg-zinc-100 border-none h-8 px-2.5 focus:ring-2 focus:ring-indigo-500/20"
+                data-testid="session-time"
+              />
             </div>
 
-            {durationChoice === 'other' && (
+            {/* Duration */}
+            <div className="space-y-1">
+              <Label htmlFor="duration" className="text-xs font-medium text-zinc-400 uppercase tracking-wide">Duration</Label>
               <div className="flex items-center gap-2">
-                <Label htmlFor="duration-other" className="text-xs font-semibold text-zinc-500 shrink-0">Min</Label>
-                <Input
-                  id="duration-other"
-                  type="number"
-                  min="1"
-                  value={durationOther}
-                  onChange={e => { setDurationOther(e.target.value); markChangedAndSchedule() }}
-                  placeholder="e.g. 75"
-                  className="text-sm bg-white h-7 px-2 py-0 w-20"
-                  data-testid="duration-other"
+                <Select value={durationChoice} onValueChange={(v) => { const val = v ?? durationChoice; setDurationChoice(val); markChangedAndSaveNow({ duration: val === 'other' ? null : parseInt(val, 10) }) }}>
+                  <SelectTrigger id="duration" className="text-sm bg-zinc-100 border-none h-8 px-2.5 focus:ring-2 focus:ring-indigo-500/20 flex-1" data-testid="duration-select">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {DURATION_OPTIONS.map(o => (
+                      <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {durationChoice === 'other' && (
+                  <Input
+                    id="duration-other"
+                    type="number"
+                    min="1"
+                    value={durationOther}
+                    onChange={e => { setDurationOther(e.target.value); markChangedAndSchedule() }}
+                    placeholder="min"
+                    className="text-sm bg-zinc-100 border-none h-8 px-2.5 w-20 focus:ring-2 focus:ring-indigo-500/20"
+                    data-testid="duration-other"
+                  />
+                )}
+              </div>
+            </div>
+
+            {/* Cancelled */}
+            <div className="space-y-1">
+              <Label htmlFor="cancelled-toggle" className="text-xs font-medium text-zinc-400 uppercase tracking-wide">Status</Label>
+              <div className="flex items-center gap-2 h-8">
+                <Label htmlFor="cancelled-toggle" className="text-sm text-zinc-600 cursor-pointer select-none">
+                  Cancelled
+                </Label>
+                <ToggleSwitch
+                  id="cancelled-toggle"
+                  checked={isCancelled}
+                  onChange={(v) => { setIsCancelled(v); markChangedAndSaveNow({ isCancelled: v }) }}
+                  label="Cancelled"
+                  data-testid="cancelled-toggle"
                 />
               </div>
-            )}
-
-            <div className="flex items-center gap-2 ml-auto">
-              <Label htmlFor="cancelled-toggle" className="text-sm text-zinc-600 cursor-pointer select-none">
-                Cancelled
-              </Label>
-              <ToggleSwitch
-                id="cancelled-toggle"
-                checked={isCancelled}
-                onChange={(v) => { setIsCancelled(v); markChangedAndSaveNow({ isCancelled: v }) }}
-                label="Cancelled"
-                data-testid="cancelled-toggle"
-              />
             </div>
           </div>
 
@@ -855,7 +979,7 @@ export default function LogSession() {
               {/* Previous Homework Status */}
               {showPrevHomework && (
                 <div className="space-y-1.5">
-                  <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400">
+                  <p className="text-[0.6875rem] font-medium uppercase tracking-[0.05em] text-zinc-400">
                     Previous Homework
                   </p>
                   <div className="flex gap-2 flex-wrap" data-testid="prev-homework-status">
@@ -909,7 +1033,7 @@ export default function LogSession() {
 
               {/* Topics Covered */}
               <div className="space-y-1" data-testid="topics-covered-section">
-                <Label className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400">Topics Covered</Label>
+                <Label className="text-[0.6875rem] font-medium uppercase tracking-[0.05em] text-zinc-400">Topics Covered</Label>
                 {tagSuggestions.length > 0 && (
                   <div className="flex flex-wrap items-center gap-1.5" data-testid="topic-tag-suggestions">
                     <span className="text-[0.6875rem] text-zinc-400 font-medium shrink-0">Suggested:</span>
@@ -939,7 +1063,7 @@ export default function LogSession() {
 
               {/* Homework Assigned */}
               <div className="space-y-1">
-                <Label htmlFor="homework-assigned" className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400">
+                <Label htmlFor="homework-assigned" className="text-[0.6875rem] font-medium uppercase tracking-[0.05em] text-zinc-400">
                   Homework Assigned
                 </Label>
                 <Input
@@ -954,7 +1078,7 @@ export default function LogSession() {
 
               {/* Next Session Plan */}
               <div className="space-y-1">
-                <Label htmlFor="next-session-topics" className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400">
+                <Label htmlFor="next-session-topics" className="text-[0.6875rem] font-medium uppercase tracking-[0.05em] text-zinc-400">
                   Next Session Plan
                 </Label>
                 <Textarea
@@ -972,7 +1096,7 @@ export default function LogSession() {
               <div className="grid grid-cols-2 gap-4">
                 {/* Teaching Todos quick-add */}
                 <div className="space-y-2 rounded-xl p-4" style={{ background: '#F0EFFF' }}>
-                  <p className="text-xs font-semibold uppercase tracking-wider text-indigo-600">New Teaching Todos</p>
+                  <p className="text-xs font-medium uppercase tracking-wider text-indigo-600">New Teaching Todos</p>
                   {newTodos.map((text, idx) => (
                     <div key={idx} className="flex items-center gap-2" data-testid="new-todo-item">
                       <span className="flex-1 text-sm text-[#1A1B22]">{text}</span>
@@ -1003,7 +1127,7 @@ export default function LogSession() {
 
                 {/* Followups quick-add */}
                 <div className="space-y-2 rounded-xl p-4" style={{ background: '#FFFBEB' }}>
-                  <p className="text-xs font-semibold uppercase tracking-wider text-amber-600">New Followups</p>
+                  <p className="text-xs font-medium uppercase tracking-wider text-amber-600">New Followups</p>
                   {newFollowups.map((text, idx) => (
                     <div key={idx} className="flex items-center gap-2" data-testid="new-followup-item">
                       <span className="flex-1 text-sm text-[#1A1B22]">{text}</span>
@@ -1048,7 +1172,7 @@ export default function LogSession() {
                 <div className="space-y-6">
                   {/* Today's Context */}
                   <div className="space-y-1">
-                    <Label htmlFor="general-notes" className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400">
+                    <Label htmlFor="general-notes" className="text-[0.6875rem] font-medium uppercase tracking-[0.05em] text-zinc-400">
                       Today's Context
                     </Label>
                     <Textarea
@@ -1065,7 +1189,7 @@ export default function LogSession() {
                   {/* Link to Lesson Plan */}
                   {studentLessons.length > 0 && (
                     <div className="space-y-1">
-                      <Label htmlFor="linked-lesson" className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400">
+                      <Label htmlFor="linked-lesson" className="text-[0.6875rem] font-medium uppercase tracking-[0.05em] text-zinc-400">
                         Link to Lesson Plan (optional)
                       </Label>
                       <Select
@@ -1127,7 +1251,7 @@ export default function LogSession() {
 
               {/* Topics Covered */}
               <div className="space-y-1 pt-4">
-                <Label className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400">Topics Covered</Label>
+                <Label className="text-[0.6875rem] font-medium uppercase tracking-[0.05em] text-zinc-400">Topics Covered</Label>
                 <TopicTagsInput
                   value={topicTags}
                   onChange={(tags) => { setTopicTags(tags); markChangedAndSaveNow({ topicTags: tags.length > 0 ? serializeTopicTags(tags) : null }) }}
@@ -1136,7 +1260,7 @@ export default function LogSession() {
 
               {/* Today's Context */}
               <div className="space-y-1 pt-2">
-                <Label htmlFor="general-notes" className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400">
+                <Label htmlFor="general-notes" className="text-[0.6875rem] font-medium uppercase tracking-[0.05em] text-zinc-400">
                   Notes
                 </Label>
                 <Textarea

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -896,7 +896,7 @@ export default function LogSession() {
                 type="date"
                 value={sessionDate}
                 onChange={e => { setSessionDate(e.target.value); markChangedAndSchedule() }}
-                className="text-sm bg-zinc-100 border-none h-8 px-2.5 focus:ring-2 focus:ring-indigo-500/20"
+                className="text-sm bg-zinc-100 border-none h-8 px-2.5 focus-visible:border-none focus-visible:ring-2 focus-visible:ring-indigo-500/20"
                 data-testid="session-date"
               />
             </div>
@@ -909,7 +909,7 @@ export default function LogSession() {
                 type="time"
                 value={sessionTime}
                 onChange={e => { setSessionTime(e.target.value); markChangedAndSchedule() }}
-                className="text-sm bg-zinc-100 border-none h-8 px-2.5 focus:ring-2 focus:ring-indigo-500/20"
+                className="text-sm bg-zinc-100 border-none h-8 px-2.5 focus-visible:border-none focus-visible:ring-2 focus-visible:ring-indigo-500/20"
                 data-testid="session-time"
               />
             </div>
@@ -919,7 +919,7 @@ export default function LogSession() {
               <Label htmlFor="duration" className="text-xs font-medium text-zinc-400 uppercase tracking-wide">Duration</Label>
               <div className="flex items-center gap-2">
                 <Select value={durationChoice} onValueChange={(v) => { const val = v ?? durationChoice; setDurationChoice(val); markChangedAndSaveNow({ duration: val === 'other' ? null : parseInt(val, 10) }) }}>
-                  <SelectTrigger id="duration" className="text-sm bg-zinc-100 border-none h-8 px-2.5 focus:ring-2 focus:ring-indigo-500/20 flex-1" data-testid="duration-select">
+                  <SelectTrigger id="duration" className="text-sm bg-zinc-100 border-none h-8 px-2.5 focus-visible:border-none focus-visible:ring-2 focus-visible:ring-indigo-500/20 flex-1" data-testid="duration-select">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -462,6 +462,7 @@ export default function LogSession() {
   }) // intentionally no deps: reads doneBusy/handleDone from closure each render
 
   // Scroll gradient: observe sentinel at bottom of left panel
+  // Depends on loading state so the observer attaches after early-return skeleton is replaced by the real DOM
   useEffect(() => {
     const sentinel = scrollSentinelRef.current
     const aside = asideRef.current
@@ -472,7 +473,7 @@ export default function LogSession() {
     )
     observer.observe(sentinel)
     return () => observer.disconnect()
-  }, [])
+  }, [studentLoading, editSessionLoading])
 
   // Must be before early returns to satisfy Rules of Hooks
   const tagSuggestions = useMemo(

--- a/plan/langteach-beta/task781-log-session-panel-polish.md
+++ b/plan/langteach-beta/task781-log-session-panel-polish.md
@@ -1,0 +1,120 @@
+# Task 781: Log Session left panel context + metadata bar polish and session time field
+
+**Issue:** #781
+**Branch:** `task/t781-log-session-panel-polish` (from `sprint/ui-redesign-student-polish`)
+
+## Summary
+
+Two groups of polish for LogSession.tsx: left panel context improvements (Part A) and metadata bar visual/functional fixes (Part B).
+
+## DTO Field Verification
+
+- **Skill levels:** `student.skillLevelOverrides` is `Record<string, string>` (e.g. `{ Speaking: "B1", Writing: "A2" }`)
+- **Teacher notes / Working Memory:** `student.teachingNotes` is `string | null`
+- **Session date:** `sessionDate` is `string | null` (ISO DateTime, e.g. "2026-04-17T14:30:00")
+- **No `surface-0`/`surface-1` CSS tokens exist.** Use `bg-zinc-100` for tonal fills, matching existing codebase patterns.
+
+## Implementation Plan
+
+### Part A: Left Panel Context
+
+#### A1. Last Session card: show data in create mode + correct edit mode behavior
+
+**Current state:** Line 614-631. The card only shows when `prevSession` exists. In create mode `prevSession = nonCancelledSessions[0]`, which is correct (most recent session). In edit mode it shows the session before the edited one (also correct, lines 200-208).
+
+**Gap:** When a student has zero prior sessions (create mode), nothing shows. The issue asks for a "First session" encouraging empty state.
+
+**Changes:**
+- After the existing `{prevSession && ...}` block (line 614), add an else branch:
+  - If `!prevSession && !isEditMode && !sessionsLoading`, render a "First session" empty state card with encouraging text.
+- Also add `duration` display to the existing Last Session card (when available).
+- Add first ~100 chars of `actualContent` as narrative summary (already done via `line-clamp-3` on line 620).
+
+#### A2. Scroll gradient indicator
+
+**Changes:**
+- Add a sentinel `<div>` at the bottom of the `<aside>` scroll container.
+- Use `IntersectionObserver` via `useEffect` + `useRef` to track whether the sentinel is visible.
+- When sentinel is NOT visible (content overflows and not scrolled to bottom), render an 8px gradient overlay at the bottom of the aside: `bg-gradient-to-t from-[#F4F2FD]` (matching the aside background).
+- When sentinel IS visible, hide the gradient.
+
+#### A3. Skill level summary row
+
+**Changes:**
+- Below the student name/CEFR badge area (after line 523), add a compact skill levels row.
+- Only render if `Object.keys(student.skillLevelOverrides).length > 0`.
+- Format: `Speaking B1 | Writing A2 | ...` using `text-xs text-zinc-400`.
+
+#### A4. Teacher's Working Memory card
+
+**Changes:**
+- After the Last Session card section, add a "Working Memory" card.
+- Only render if `student.teachingNotes` is truthy and non-empty.
+- Style: `rounded-lg bg-white px-3 py-2.5`, `text-sm text-zinc-600`.
+- Max 4 lines with `line-clamp-4` by default. Add "Show more" link that removes the clamp.
+- Use `useState` for the expanded state.
+
+#### A5. Difficulty text truncation
+
+**Changes:**
+- On the difficulty description spans (line 656), apply `line-clamp-2` when text length > 80.
+- Add a small "more" text button that toggles the clamp off.
+- Track expanded state per difficulty using a `Set<string>` state.
+
+### Part B: Metadata Bar Polish
+
+#### B6. Remove borders from inputs
+
+**Changes:**
+- On Date input (line 791): change `className` from `"text-sm bg-white h-7 px-2 py-0 w-36"` to `"text-sm bg-zinc-100 border-none h-7 px-2 py-0 w-36 focus:ring-2 focus:ring-indigo-500/20"`.
+- On Duration select trigger (line 799): same border-none + bg-zinc-100 + focus ring treatment.
+- On Duration "other" input (line 818): same treatment.
+- Apply to any other bordered inputs in the metadata bar.
+
+#### B7. Section headers visually lighter
+
+**Changes:**
+- The right panel section labels currently use `text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400` (PanelSection style). These are already quite subtle.
+- The issue specifically targets h3/section headers: "Session Details", "Narrative", "Topic Tags", etc. In the current code these are the `Label` elements. Check if any use `font-semibold text-lg`. The main heading uses `text-2xl font-bold` (line 845). The section labels appear fine already with the uppercase mini-label style.
+- If there are any `h3` elements or larger section headers, change to `font-medium text-base text-zinc-600`.
+
+#### B8. Session time field
+
+**Changes:**
+- Add `sessionTime` state, initialized from current time (`HH:MM`) for new sessions.
+- In edit mode, parse time from `editSession.sessionDate` (the ISO DateTime string already contains the time portion).
+- Add a `<input type="time">` next to the date field.
+- Restructure metadata bar from flex to `grid grid-cols-2 gap-3`:
+  - Row 1: Date + Time
+  - Row 2: Duration + Cancelled
+- Labels: `text-xs font-medium text-zinc-400 uppercase tracking-wide`.
+- Combine date + time into `sessionDate` for autosave: `${sessionDate}T${sessionTime}:00`.
+- Update `getFormDataRef.current` to include time in sessionDate.
+- Update the edit mode init (line 231) to also extract time from the ISO string.
+
+### Mobile Considerations
+
+- The left panel already collapses on mobile (hidden via responsive classes, not visible in current code but assumed from existing behavior).
+- Metadata grid: add `sm:grid-cols-2 grid-cols-1` for single-column stacking on mobile.
+
+### Test Updates
+
+- Update `LogSession.test.tsx` for:
+  - First session empty state
+  - Skill levels display
+  - Working memory card visibility
+  - Time field presence and default value
+  - Difficulty text expansion
+  - Scroll gradient (may be hard to test, defer if IntersectionObserver mocking is complex)
+
+## Files Modified
+
+- `frontend/src/pages/LogSession.tsx` (primary)
+- `frontend/src/pages/LogSession.test.tsx` (tests)
+
+## Out of Scope
+
+- Audio recorder placement (#780)
+- Navigation or autosave behavior (#778)
+- Backend schema changes
+- Student detail screen changes


### PR DESCRIPTION
## Summary

Closes #781. Two groups of polish for the Log Session screen:

**Part A (left panel context):**
- First-session empty state ("First session!") when no prior sessions exist
- Skill level summary row (`skillLevelOverrides`) below student name
- Working Memory card showing `teachingNotes` with line-clamp + expand
- Scroll gradient (IntersectionObserver) when left panel overflows
- Difficulty description truncation with inline "more" toggle (>80 chars)
- Duration display in Last Session card

**Part B (metadata bar):**
- Restructured to 2x2 grid (Date+Time / Duration+Cancelled)
- Session time field with current-time default and edit-mode pre-fill
- Tonal fill inputs (`bg-zinc-100 border-none`) replacing bordered style
- Softer section headers (`font-medium` replacing `font-bold`)

## Test plan

- [x] 50 unit tests pass (12 new tests added)
- [x] All 1281 frontend tests pass
- [x] TypeScript compiles clean
- [x] ESLint: 0 errors (1 pre-existing warning)
- [ ] Verify first-session empty state with a student that has no sessions
- [ ] Verify skill levels row appears for students with `skillLevelOverrides`
- [ ] Verify working memory card appears for students with `teachingNotes`
- [ ] Verify time field defaults to current time (create) and pre-fills (edit)
- [ ] Verify metadata grid stacks on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session time input to the logging interface
  * Introduced working memory (teacher notes) panel with expand/collapse functionality
  * Added truncation controls for long difficulty descriptions
  * Skill level overrides now display in session details
  * Improved metadata layout with responsive grid

* **Tests**
  * Added test coverage for session time input, empty states, and UI controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->