### PR TITLE
refactor(t776): extract useBlurSave hook to unify blur-save indicator pattern

### DIFF
--- a/frontend/src/components/session/SessionHistoryTab.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo, useRef, useEffect } from 'react'
+import { useState, useMemo, useRef } from 'react'
+import { useBlurSave } from '../../hooks/useBlurSave'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   ChevronDown,
@@ -78,18 +79,8 @@ function SessionEntry({
   const [narrativeDraft, setNarrativeDraft] = useState(session.actualContent ?? '')
   const [durationDraft, setDurationDraft] = useState(session.duration?.toString() ?? '')
   const [nextPlanDraft, setNextPlanDraft] = useState(session.nextSessionTopics ?? '')
-  const [savedVisible, setSavedVisible] = useState(false)
-  const [fieldError, setFieldError] = useState<string | null>(null)
-  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const { savedVisible, fieldError, onSaveSuccess, onSaveError } = useBlurSave()
   const isRevertingRef = useRef(false)
-
-  useEffect(() => {
-    return () => {
-      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
-      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
-    }
-  }, [])
 
   const { mutate: softDelete, isPending: isDeleting } = useMutation({
     mutationFn: () => deleteSession(studentId, session.id),
@@ -118,9 +109,7 @@ function SessionEntry({
       } else {
         const n = Number(value)
         if (!Number.isFinite(n) || n < 0) {
-          setFieldError('Invalid duration')
-          if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
-          errorTimerRef.current = setTimeout(() => setFieldError(null), 3000)
+          onSaveError('Invalid duration')
           return
         }
         patch[field] = n
@@ -131,15 +120,10 @@ function SessionEntry({
     try {
       await patchSessionField(studentId, session, patch as Parameters<typeof patchSessionField>[2])
       queryClient.invalidateQueries({ queryKey: ['sessions', studentId] })
-      setSavedVisible(true)
-      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
-      savedTimerRef.current = setTimeout(() => setSavedVisible(false), 1500)
-      setFieldError(null)
+      onSaveSuccess()
     } catch (err) {
       logger.error('SessionHistoryTab', 'inline field save failed', err)
-      setFieldError('Failed to save')
-      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
-      errorTimerRef.current = setTimeout(() => setFieldError(null), 3000)
+      onSaveError('Failed to save')
     }
   }
 

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
+import { useBlurSave } from '../../hooks/useBlurSave'
 import { Pencil, X, Plus, Check, GraduationCap, ChevronDown } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import type { Student } from '@/api/students'
@@ -244,10 +245,7 @@ function MotivationHero({
 }) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(student.reasonForStudying ?? '')
-  const [savedVisible, setSavedVisible] = useState(false)
-  const [saveError, setSaveError] = useState<string | null>(null)
-  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const { savedVisible, fieldError: saveError, onSaveSuccess, onSaveError } = useBlurSave()
   const lastSavedRef = useRef(student.reasonForStudying ?? '')
   const isRevertingRef = useRef(false)
 
@@ -255,14 +253,6 @@ function MotivationHero({
   useEffect(() => {
     if (!editing) lastSavedRef.current = student.reasonForStudying ?? ''
   }, [student.reasonForStudying, editing])
-
-  // Clear timers on unmount to avoid setState on unmounted component
-  useEffect(() => {
-    return () => {
-      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
-      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
-    }
-  }, [])
 
   async function handleBlur() {
     if (!onSave || isRevertingRef.current) {
@@ -273,15 +263,10 @@ function MotivationHero({
     try {
       await onSave(value)
       lastSavedRef.current = value
-      setSavedVisible(true)
-      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
-      savedTimerRef.current = setTimeout(() => setSavedVisible(false), 1500)
-      setSaveError(null)
+      onSaveSuccess()
       setEditing(false)
     } catch {
-      setSaveError('Failed to save')
-      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
-      errorTimerRef.current = setTimeout(() => setSaveError(null), 3000)
+      onSaveError('Failed to save')
     }
   }
 
@@ -417,18 +402,8 @@ function InterestsSection({
 }) {
   const [chips, setChips] = useState<string[]>(student.interests)
   const [inputValue, setInputValue] = useState('')
-  const [savedVisible, setSavedVisible] = useState(false)
-  const [saveError, setSaveError] = useState<string | null>(null)
+  const { savedVisible, fieldError: saveError, onSaveSuccess, onSaveError } = useBlurSave()
   const inputRef = useRef<HTMLInputElement>(null)
-  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  useEffect(() => {
-    return () => {
-      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
-      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
-    }
-  }, [])
 
   async function commitAdd(value: string) {
     const trimmed = value.trim()
@@ -438,15 +413,10 @@ function InterestsSection({
     setInputValue('')
     try {
       await onSave(next)
-      setSavedVisible(true)
-      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
-      savedTimerRef.current = setTimeout(() => setSavedVisible(false), 1500)
-      setSaveError(null)
+      onSaveSuccess()
     } catch {
       setChips(chips) // revert
-      setSaveError('Failed to save')
-      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
-      errorTimerRef.current = setTimeout(() => setSaveError(null), 3000)
+      onSaveError('Failed to save')
     }
   }
 
@@ -456,15 +426,10 @@ function InterestsSection({
     setChips(next)
     try {
       await onSave(next)
-      setSavedVisible(true)
-      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
-      savedTimerRef.current = setTimeout(() => setSavedVisible(false), 1500)
-      setSaveError(null)
+      onSaveSuccess()
     } catch {
       setChips(chips) // revert
-      setSaveError('Failed to save')
-      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
-      errorTimerRef.current = setTimeout(() => setSaveError(null), 3000)
+      onSaveError('Failed to save')
     }
   }
 

--- a/frontend/src/hooks/useBlurSave.test.ts
+++ b/frontend/src/hooks/useBlurSave.test.ts
@@ -1,0 +1,71 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useBlurSave } from './useBlurSave'
+import { SAVED_VISIBLE_DURATION_MS, ERROR_VISIBLE_DURATION_MS } from '../lib/autosaveConstants'
+
+describe('useBlurSave', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('savedVisible auto-hides after SAVED_VISIBLE_DURATION_MS', () => {
+    const { result } = renderHook(() => useBlurSave())
+
+    expect(result.current.savedVisible).toBe(false)
+
+    act(() => { result.current.onSaveSuccess() })
+    expect(result.current.savedVisible).toBe(true)
+
+    act(() => { vi.advanceTimersByTime(SAVED_VISIBLE_DURATION_MS) })
+    expect(result.current.savedVisible).toBe(false)
+  })
+
+  it('fieldError auto-clears after ERROR_VISIBLE_DURATION_MS', () => {
+    const { result } = renderHook(() => useBlurSave())
+
+    expect(result.current.fieldError).toBeNull()
+
+    act(() => { result.current.onSaveError('Failed to save') })
+    expect(result.current.fieldError).toBe('Failed to save')
+
+    act(() => { vi.advanceTimersByTime(ERROR_VISIBLE_DURATION_MS) })
+    expect(result.current.fieldError).toBeNull()
+  })
+
+  it('onSaveSuccess clears existing fieldError', () => {
+    const { result } = renderHook(() => useBlurSave())
+
+    act(() => { result.current.onSaveError('Failed to save') })
+    expect(result.current.fieldError).toBe('Failed to save')
+
+    act(() => { result.current.onSaveSuccess() })
+    expect(result.current.fieldError).toBeNull()
+    expect(result.current.savedVisible).toBe(true)
+  })
+
+  it('clearError clears fieldError immediately', () => {
+    const { result } = renderHook(() => useBlurSave())
+
+    act(() => { result.current.onSaveError('Invalid value') })
+    expect(result.current.fieldError).toBe('Invalid value')
+
+    act(() => { result.current.clearError() })
+    expect(result.current.fieldError).toBeNull()
+  })
+
+  it('timers are cleaned up on unmount (no setState after unmount)', () => {
+    const { result, unmount } = renderHook(() => useBlurSave())
+
+    act(() => { result.current.onSaveSuccess() })
+    expect(result.current.savedVisible).toBe(true)
+
+    unmount()
+
+    // Advancing time after unmount should not throw
+    expect(() => act(() => { vi.advanceTimersByTime(SAVED_VISIBLE_DURATION_MS) })).not.toThrow()
+  })
+})

--- a/frontend/src/hooks/useBlurSave.ts
+++ b/frontend/src/hooks/useBlurSave.ts
@@ -1,0 +1,37 @@
+import { useState, useRef, useEffect } from 'react'
+import { SAVED_VISIBLE_DURATION_MS, ERROR_VISIBLE_DURATION_MS } from '../lib/autosaveConstants'
+
+export function useBlurSave() {
+  const [savedVisible, setSavedVisible] = useState(false)
+  const [fieldError, setFieldError] = useState<string | null>(null)
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+    }
+  }, [])
+
+  function onSaveSuccess() {
+    setSavedVisible(true)
+    if (savedTimerRef.current) clearTimeout(savedTimerRef.current)
+    savedTimerRef.current = setTimeout(() => setSavedVisible(false), SAVED_VISIBLE_DURATION_MS)
+    setFieldError(null)
+    if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+  }
+
+  function onSaveError(message: string) {
+    setFieldError(message)
+    if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+    errorTimerRef.current = setTimeout(() => setFieldError(null), ERROR_VISIBLE_DURATION_MS)
+  }
+
+  function clearError() {
+    setFieldError(null)
+    if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+  }
+
+  return { savedVisible, fieldError, onSaveSuccess, onSaveError, clearError }
+}

--- a/frontend/src/lib/autosaveConstants.ts
+++ b/frontend/src/lib/autosaveConstants.ts
@@ -4,3 +4,6 @@ export const DEBOUNCE_MS = 400
 export const IDLE_RESET_MS = 2000
 export const RETRY_DELAY_MS = 3000
 export const MAX_RETRIES = 3
+
+export const SAVED_VISIBLE_DURATION_MS = 1500
+export const ERROR_VISIBLE_DURATION_MS = 3000

--- a/plan/langteach-beta/task776-blur-save-hook.md
+++ b/plan/langteach-beta/task776-blur-save-hook.md
@@ -1,0 +1,73 @@
+# Task 776 — Extract useBlurSave hook
+
+## Goal
+
+Extract duplicated blur-save indicator state from `SessionHistoryTab` and `StudentProfileTab` into a shared `useBlurSave` hook.
+
+## Context
+
+Both files hand-roll the same pattern inline:
+- `savedVisible` + `savedTimerRef` (auto-hide after 1500ms)
+- `fieldError` + `errorTimerRef` (auto-clear after 3000ms)
+- Cleanup effect on unmount
+
+The issue names the constants as `SAVED_VISIBLE_DURATION_MS` and `ERROR_VISIBLE_DURATION_MS` but these don't exist in `autosaveConstants.ts` yet — they must be added.
+
+## Files Changed
+
+1. `frontend/src/lib/autosaveConstants.ts` — add `SAVED_VISIBLE_DURATION_MS = 1500`, `ERROR_VISIBLE_DURATION_MS = 3000`
+2. `frontend/src/hooks/useBlurSave.ts` — new hook
+3. `frontend/src/components/session/SessionHistoryTab.tsx` — use hook in `SessionEntry`
+4. `frontend/src/components/student/StudentProfileTab.tsx` — use hook in `ReasonSection` and `InterestsSection`
+5. `frontend/src/hooks/useBlurSave.test.ts` — unit tests
+
+## Hook API
+
+```ts
+export function useBlurSave(): {
+  savedVisible: boolean
+  fieldError: string | null
+  onSaveSuccess: () => void
+  onSaveError: (message: string) => void
+  clearError: () => void
+}
+```
+
+- `onSaveSuccess()`: sets `savedVisible=true`, auto-hides after `SAVED_VISIBLE_DURATION_MS`, clears `fieldError`
+- `onSaveError(message)`: sets `fieldError=message`, auto-clears after `ERROR_VISIBLE_DURATION_MS`
+- `clearError()`: clears `fieldError` immediately (for validation before API call)
+- Cleanup: clears both timers on unmount
+
+## Refactor Notes
+
+### SessionHistoryTab (SessionEntry)
+
+`fieldError` is used for both validation errors (before API call) and API errors. The `clearError` export handles the validation path; `onSaveError` handles the API path.
+
+Replace:
+- `useState(false)` savedVisible + `useState(null)` fieldError + two `useRef` timers + cleanup `useEffect`
+- All timer management calls in `handleFieldBlur`
+
+Keep:
+- `isRevertingRef` (not related to save indicators)
+- `deleteOpen`/`deleteError` (delete flow, not blur-save)
+
+### StudentProfileTab
+
+Two components need the hook independently: `ReasonSection` and `InterestsSection`. Both use `saveError` (not `fieldError`) as the variable name — rename to `fieldError` from the hook destructure.
+
+## Tests
+
+`useBlurSave.test.ts` covers:
+1. `savedVisible` starts false, becomes true after `onSaveSuccess`, auto-hides after `SAVED_VISIBLE_DURATION_MS`
+2. `fieldError` starts null, becomes message after `onSaveError`, auto-clears after `ERROR_VISIBLE_DURATION_MS`
+3. `onSaveSuccess` clears any existing `fieldError`
+4. Timers cleaned up on unmount (no setState after unmount)
+
+## Acceptance Criteria
+
+- [ ] `useBlurSave` at `frontend/src/hooks/useBlurSave.ts`
+- [ ] `SessionHistoryTab` — no hand-rolled savedVisible/savedTimerRef/fieldError/errorTimerRef
+- [ ] `StudentProfileTab` — same inline state removed from both ReasonSection and InterestsSection
+- [ ] `useBlurSave.test.ts` — 4 tests pass
+- [ ] Existing tab tests still pass


### PR DESCRIPTION
Closes #776

## Summary
- Extracts `useBlurSave` hook at `frontend/src/hooks/useBlurSave.ts` encapsulating `savedVisible`/`fieldError` state + auto-hide/auto-clear timers
- Adds `SAVED_VISIBLE_DURATION_MS` (1500) and `ERROR_VISIBLE_DURATION_MS` (3000) to `autosaveConstants.ts`
- Refactors `SessionHistoryTab` (`SessionEntry`) and `StudentProfileTab` (`ReasonSection`, `InterestsSection`) to use the hook — all hand-rolled timer refs removed
- 5 unit tests covering success/error/clearError/unmount cleanup paths

## Test plan
- [ ] `useBlurSave.test.ts` — 5 tests pass
- [ ] `SessionHistoryTab.test.tsx` + `StudentProfileTab.test.tsx` — 129 tests pass
- [ ] Full vitest suite — 1288 tests pass
- [ ] TypeScript build clean
- [ ] UI review PASS (no visual regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced consistency and reliability of save feedback across components through improved state management architecture. Standardized notification timings for a more predictable user experience.

* **Tests**
  * Added comprehensive test coverage for save success and error notification behavior, including auto-hide functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->