### PR TITLE
feat(t766): seed-scenario CLI command and shell wrapper

### DIFF
--- a/backend/LangTeach.Api/Data/ScenarioSeeder.cs
+++ b/backend/LangTeach.Api/Data/ScenarioSeeder.cs
@@ -1,0 +1,510 @@
+using LangTeach.Api.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace LangTeach.Api.Data;
+
+/// <summary>
+/// Idempotent dashboard scenario seeder for dev/review use.
+/// Each call: wipe-then-reseed the 9 scenario students' sessions, followups, and todos.
+/// Does NOT touch DemoSeeder, production seeding paths, or any other students.
+/// </summary>
+public static class ScenarioSeeder
+{
+    private const string ScenarioTag = "[scenario-seed]";
+
+    // All students whose sessions, followups, and todos are managed by this seeder.
+    // Ana Visual, Ana Seed, Marco Seed, Clara Seed, Diego Seed already exist after --visual-seed.
+    // Marco B1, Carmen C1, Nadia B2, Hans B1 are created on first run.
+    private static readonly (string Name, string Cefr, string NativeLang, string LearningLang)[] ScenarioStudentDefs =
+    [
+        ("Ana Visual",  "B2", """["Ukrainian"]""",   "English"),
+        ("Marco B1",    "B1", """["Italian"]""",     "English"),
+        ("Carmen C1",   "C1", """["Spanish"]""",     "English"),
+        ("Nadia B2",    "B2", """["French"]""",      "English"),
+        ("Hans B1",     "B1", """["German"]""",      "English"),
+        ("Ana Seed",    "B1", """["Portuguese"]""",  "English"),
+        ("Marco Seed",  "A2", """["Italian"]""",     "English"),
+        ("Clara Seed",  "A1", """["German"]""",      "Spanish"),
+        ("Diego Seed",  "B2", """["Spanish"]""",     "English"),
+    ];
+
+    public static async Task<bool> SeedScenarioAsync(AppDbContext db, int scenario, string teacherLookup, ILogger logger)
+    {
+        if (scenario < 1 || scenario > 6)
+        {
+            logger.LogError("Invalid scenario {Scenario}. Valid range: 1-6.", scenario);
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(teacherLookup))
+        {
+            logger.LogError("Teacher lookup is required. Pass an Auth0 user ID or email.");
+            return false;
+        }
+        teacherLookup = teacherLookup.Trim();
+
+        var teacher = teacherLookup.StartsWith("auth0|", StringComparison.OrdinalIgnoreCase)
+            ? await db.Teachers.FirstOrDefaultAsync(t => t.Auth0UserId == teacherLookup)
+            : await db.Teachers.FirstOrDefaultAsync(t => t.Email == teacherLookup);
+
+        if (teacher is null)
+        {
+            logger.LogError("No teacher found for '{Lookup}'. Log in at least once before seeding.", teacherLookup);
+            return false;
+        }
+
+        if (!teacher.IsApproved || !teacher.HasCompletedOnboarding)
+        {
+            teacher.IsApproved = true;
+            teacher.HasCompletedOnboarding = true;
+        }
+
+        var now = DateTime.UtcNow;
+        logger.LogInformation("Seeding scenario {Scenario} for teacher {Email}...", scenario, teacher.Email);
+
+        // Step 1: ensure all 9 scenario students exist
+        var students = await EnsureScenarioStudentsAsync(db, teacher.Id, now);
+
+        // Step 2: wipe sessions, followups, todos for the 9 students (full reset)
+        await WipeAsync(db, teacher.Id, students.Select(s => s.Id).ToArray(), now, logger);
+
+        // Step 3: seed data for the requested scenario
+        await SeedAsync(db, teacher.Id, students, scenario, now, logger);
+
+        logger.LogInformation("Scenario {Scenario} seeded successfully.", scenario);
+        return true;
+    }
+
+    // -------------------------------------------------------------------------
+    // Student bootstrap
+    // -------------------------------------------------------------------------
+
+    private static async Task<List<Student>> EnsureScenarioStudentsAsync(AppDbContext db, Guid teacherId, DateTime now)
+    {
+        var result = new List<Student>();
+
+        foreach (var (name, cefr, nativeLang, learningLang) in ScenarioStudentDefs)
+        {
+            var student = await db.Students.FirstOrDefaultAsync(
+                s => s.TeacherId == teacherId && s.Name == name && !s.IsDeleted);
+
+            if (student is null)
+            {
+                student = new Student
+                {
+                    Id               = Guid.NewGuid(),
+                    TeacherId        = teacherId,
+                    Name             = name,
+                    LearningLanguage = learningLang,
+                    CefrLevel        = cefr,
+                    NativeLanguages  = nativeLang,
+                    PersonalNotes    = ScenarioTag,
+                    IsActive         = true,
+                    CreatedAt        = now,
+                    UpdatedAt        = now,
+                };
+                db.Students.Add(student);
+                await db.SaveChangesAsync();
+            }
+
+            result.Add(student);
+        }
+
+        return result;
+    }
+
+    // -------------------------------------------------------------------------
+    // Wipe — runs before every scenario to guarantee idempotency.
+    // Deletes ALL sessions for the 9 students and ALL teacher followups (regardless
+    // of student) so that every scenario starts from a fully clean state. This is
+    // intentional: the tool is a complete DB state switcher for a dev/review teacher.
+    // -------------------------------------------------------------------------
+
+    private static async Task WipeAsync(AppDbContext db, Guid teacherId, Guid[] studentIds, DateTime now, ILogger logger)
+    {
+        var sessions = await db.SessionLogs.Where(sl => studentIds.Contains(sl.StudentId)).ToListAsync();
+        db.SessionLogs.RemoveRange(sessions);
+
+        var followups = await db.TeacherFollowups.Where(f => f.TeacherId == teacherId).ToListAsync();
+        db.TeacherFollowups.RemoveRange(followups);
+
+        var students = await db.Students.Where(s => studentIds.Contains(s.Id)).ToListAsync();
+        foreach (var s in students)
+        {
+            s.TeachingTodos = "[]";
+            s.UpdatedAt     = now;
+        }
+
+        await db.SaveChangesAsync();
+        logger.LogInformation("Wiped {Sessions} sessions and {Followups} followups for scenario students.",
+            sessions.Count, followups.Count);
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario dispatch
+    // -------------------------------------------------------------------------
+
+    private static async Task SeedAsync(AppDbContext db, Guid teacherId, List<Student> students,
+        int scenario, DateTime now, ILogger logger)
+    {
+        // Students ordered as defined in ScenarioStudentDefs
+        var anaVisual  = students[0];
+        var marcoB1    = students[1];
+        var carmenC1   = students[2];
+        var nadiaB2    = students[3];
+        var hansB1     = students[4];
+        var anaSeed    = students[5];
+        var marcoSeed  = students[6];
+        var claraSeed  = students[7];
+        var diegoSeed  = students[8];
+
+        switch (scenario)
+        {
+            case 1: await SeedScenario1Async(db, teacherId, anaVisual,  now, logger); break;
+            case 2: await SeedScenario2Async(db, teacherId, marcoB1, anaVisual, now, logger); break;
+            case 3: SeedScenario3(logger); break;
+            case 4: await SeedScenario4Async(db, teacherId, nadiaB2, now, logger); break;
+            case 5: await SeedScenario5Async(db, teacherId, anaSeed, marcoSeed, claraSeed, diegoSeed, now, logger); break;
+            case 6: await SeedScenario6Async(db, teacherId, hansB1, now, logger); break;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 1 — "Class in 20 minutes" (Ana Visual)
+    // Hero: "IN 20 MIN" badge · planned strip · full briefing card · "Partial" homework card
+    // Agenda: 3 rows with NEXT highlight
+    // -------------------------------------------------------------------------
+
+    private static async Task SeedScenario1Async(AppDbContext db, Guid teacherId, Student anaVisual,
+        DateTime now, ILogger logger)
+    {
+        // Past session (earlier today): populates briefing card sub-sections
+        var pastSession = new SessionLog
+        {
+            Id                     = Guid.NewGuid(),
+            StudentId              = anaVisual.Id,
+            TeacherId              = teacherId,
+            SessionDate            = now.Date.AddHours(8), // 08:00 today
+            TopicTags              = """[{"Tag":"Pretérito indefinido","Category":null},{"Tag":"Verbos reflexivos","Category":null}]""",
+            GeneralNotes           = "Good session, student struggled with reflexive verbs in past tense",
+            HomeworkAssigned       = "Write 10 sentences using reflexive verbs in past tense",
+            PreviousHomeworkStatus = HomeworkStatus.NotApplicable,
+            Duration               = 60,
+            IsDeleted              = false,
+            CreatedAt              = now.Date.AddHours(8),
+            UpdatedAt              = now.Date.AddHours(8),
+        };
+        db.SessionLogs.Add(pastSession);
+        await db.SaveChangesAsync();
+
+        // Followup linked to the past session (populates "Promises made" in briefing)
+        db.TeacherFollowups.Add(new TeacherFollowup
+        {
+            Id                 = Guid.NewGuid(),
+            TeacherId          = teacherId,
+            StudentId          = anaVisual.Id,
+            Text               = "Send link to reflexive verb exercises",
+            Status             = "pending",
+            SourceSessionLogId = pastSession.Id,
+            CreatedAt          = pastSession.SessionDate!.Value,
+        });
+
+        // NEXT session (now + 20 min): hero shows "IN 20 MIN" badge
+        db.SessionLogs.Add(new SessionLog
+        {
+            Id                     = Guid.NewGuid(),
+            StudentId              = anaVisual.Id,
+            TeacherId              = teacherId,
+            SessionDate            = now.AddMinutes(20),
+            PlannedContent         = "Review homework + introduce imperfecto",
+            HomeworkAssigned       = "Complete exercises 3.1-3.4 in workbook",
+            PreviousHomeworkStatus = HomeworkStatus.Partial,
+            IsDeleted              = false,
+            CreatedAt              = now,
+            UpdatedAt              = now,
+        });
+
+        // Third session later today: 3rd agenda row
+        db.SessionLogs.Add(new SessionLog
+        {
+            Id                     = Guid.NewGuid(),
+            StudentId              = anaVisual.Id,
+            TeacherId              = teacherId,
+            SessionDate            = now.Date.AddHours(18), // 18:00 today
+            PlannedContent         = "Grammar consolidation: imperfecto vs indefinido",
+            PreviousHomeworkStatus = HomeworkStatus.NotApplicable,
+            IsDeleted              = false,
+            CreatedAt              = now,
+            UpdatedAt              = now,
+        });
+
+        await db.SaveChangesAsync();
+        logger.LogInformation("Scenario 1 seeded: Ana Visual, IN 20 MIN, 3 agenda rows, full briefing, Partial homework.");
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 2 — "Session this week, quiet day" (Marco B1)
+    // Hero: zinc "IN 3D" · planned strip only (no briefing) · this-week agenda · "2D OLD" followup
+    // -------------------------------------------------------------------------
+
+    private static async Task SeedScenario2Async(AppDbContext db, Guid teacherId, Student marcoB1,
+        Student anaVisual, DateTime now, ILogger logger)
+    {
+        // Marco B1 session in 3 days — hero (no past sessions → briefing invisible)
+        db.SessionLogs.Add(new SessionLog
+        {
+            Id                     = Guid.NewGuid(),
+            StudentId              = marcoB1.Id,
+            TeacherId              = teacherId,
+            SessionDate            = now.Date.AddDays(3).AddHours(10),
+            PlannedContent         = "Subjuntivo en oraciones temporales",
+            PreviousHomeworkStatus = HomeworkStatus.NotApplicable,
+            IsDeleted              = false,
+            CreatedAt              = now,
+            UpdatedAt              = now,
+        });
+
+        // Ana Visual session in 4 days — second entry in this-week list
+        db.SessionLogs.Add(new SessionLog
+        {
+            Id                     = Guid.NewGuid(),
+            StudentId              = anaVisual.Id,
+            TeacherId              = teacherId,
+            SessionDate            = now.Date.AddDays(4).AddHours(10),
+            PlannedContent         = "Travel vocabulary review",
+            PreviousHomeworkStatus = HomeworkStatus.NotApplicable,
+            IsDeleted              = false,
+            CreatedAt              = now,
+            UpdatedAt              = now,
+        });
+
+        // Standalone followup created 2 days ago → "2D OLD" amber badge
+        db.TeacherFollowups.Add(new TeacherFollowup
+        {
+            Id        = Guid.NewGuid(),
+            TeacherId = teacherId,
+            StudentId = marcoB1.Id,
+            Text      = "Check Marco has textbook chapter 4 before next session",
+            Status    = "pending",
+            CreatedAt = now.AddDays(-2),
+        });
+
+        await db.SaveChangesAsync();
+        logger.LogInformation("Scenario 2 seeded: Marco B1 in 3 days, this-week fallback, 2D OLD followup.");
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 3 — "Nothing scheduled" (Carmen C1)
+    // Hero: "No sessions scheduled" · Agenda: "No sessions this week" · Followups: "All caught up"
+    // No data to seed — all students' sessions and followups were wiped in step 2.
+    // -------------------------------------------------------------------------
+
+    private static void SeedScenario3(ILogger logger)
+    {
+        logger.LogInformation("Scenario 3 seeded: all empty states (no sessions, no followups).");
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 4 — "Overdue followups" (Nadia B2)
+    // Followup zone: green "TODAY" · amber "2D OLD" · red "7D OVERDUE"
+    // -------------------------------------------------------------------------
+
+    private static async Task SeedScenario4Async(AppDbContext db, Guid teacherId, Student nadiaB2,
+        DateTime now, ILogger logger)
+    {
+        db.TeacherFollowups.AddRange(
+            new TeacherFollowup
+            {
+                Id        = Guid.NewGuid(),
+                TeacherId = teacherId,
+                StudentId = nadiaB2.Id,
+                Text      = "Check Nadia completed the listening exercises",
+                Status    = "pending",
+                CreatedAt = now, // today → green "TODAY"
+            },
+            new TeacherFollowup
+            {
+                Id        = Guid.NewGuid(),
+                TeacherId = teacherId,
+                StudentId = nadiaB2.Id,
+                Text      = "Send Nadia the verb conjugation reference sheet",
+                Status    = "pending",
+                CreatedAt = now.AddDays(-2), // 2 days ago → amber "2D OLD"
+            },
+            new TeacherFollowup
+            {
+                Id        = Guid.NewGuid(),
+                TeacherId = teacherId,
+                StudentId = nadiaB2.Id,
+                Text      = "Follow up on Nadia's pronunciation practice plan",
+                Status    = "pending",
+                CreatedAt = now.AddDays(-7), // 7 days ago → red "7D OVERDUE"
+            }
+        );
+
+        await db.SaveChangesAsync();
+        logger.LogInformation("Scenario 4 seeded: 3 followups with TODAY / 2D OLD / 7D OVERDUE badges.");
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 5 — "Roster signals" (Ana Seed, Marco Seed, Clara Seed, Diego Seed)
+    // Signals: Cancelled 2x · Inactive 20d · Review pending · no signal
+    // -------------------------------------------------------------------------
+
+    private static async Task SeedScenario5Async(AppDbContext db, Guid teacherId,
+        Student anaSeed, Student marcoSeed, Student claraSeed, Student diegoSeed,
+        DateTime now, ILogger logger)
+    {
+        // Ana Seed: Cancelled 2x (2 cancelled sessions in last 30 days)
+        db.SessionLogs.AddRange(
+            new SessionLog
+            {
+                Id                     = Guid.NewGuid(),
+                StudentId              = anaSeed.Id,
+                TeacherId              = teacherId,
+                SessionDate            = now.AddDays(-20),
+                PreviousHomeworkStatus = HomeworkStatus.NotApplicable,
+                IsCancelled            = true,
+                IsDeleted              = false,
+                CreatedAt              = now.AddDays(-20),
+                UpdatedAt              = now.AddDays(-20),
+            },
+            new SessionLog
+            {
+                Id                     = Guid.NewGuid(),
+                StudentId              = anaSeed.Id,
+                TeacherId              = teacherId,
+                SessionDate            = now.AddDays(-10),
+                PreviousHomeworkStatus = HomeworkStatus.NotApplicable,
+                IsCancelled            = true,
+                IsDeleted              = false,
+                CreatedAt              = now.AddDays(-10),
+                UpdatedAt              = now.AddDays(-10),
+            }
+        );
+
+        // Marco Seed: Inactive 20d (last session 20 days ago, no next session)
+        db.SessionLogs.Add(new SessionLog
+        {
+            Id                     = Guid.NewGuid(),
+            StudentId              = marcoSeed.Id,
+            TeacherId              = teacherId,
+            SessionDate            = now.AddDays(-20),
+            PlannedContent         = "Daily routines vocabulary",
+            PreviousHomeworkStatus = HomeworkStatus.NotApplicable,
+            IsDeleted              = false,
+            IsCancelled            = false,
+            CreatedAt              = now.AddDays(-20),
+            UpdatedAt              = now.AddDays(-20),
+        });
+
+        // Clara Seed: Review pending (1 pending teaching todo)
+        var claraTodoId   = Guid.NewGuid();
+        var claraTodoDate = now.AddDays(-3).ToString("yyyy-MM-ddTHH:mm:ssZ");
+        claraSeed.TeachingTodos = $$"""[{"id":"{{claraTodoId}}","text":"Review Clara's subjunctive triggers — exercises not completed","createdAt":"{{claraTodoDate}}","sourceSessionLogId":null,"status":"pending","coveredInSessionLogId":null}]""";
+        claraSeed.UpdatedAt = now;
+
+        // Diego Seed: no signal (recent past session + upcoming session, no todos)
+        db.SessionLogs.AddRange(
+            new SessionLog
+            {
+                Id                     = Guid.NewGuid(),
+                StudentId              = diegoSeed.Id,
+                TeacherId              = teacherId,
+                SessionDate            = now.AddDays(-3),
+                PlannedContent         = "Third conditional and mixed conditionals",
+                PreviousHomeworkStatus = HomeworkStatus.NotApplicable,
+                IsDeleted              = false,
+                IsCancelled            = false,
+                CreatedAt              = now.AddDays(-3),
+                UpdatedAt              = now.AddDays(-3),
+            },
+            new SessionLog
+            {
+                Id                     = Guid.NewGuid(),
+                StudentId              = diegoSeed.Id,
+                TeacherId              = teacherId,
+                SessionDate            = now.AddDays(5),
+                PlannedContent         = "Academic writing — argument structure",
+                PreviousHomeworkStatus = HomeworkStatus.NotApplicable,
+                IsDeleted              = false,
+                IsCancelled            = false,
+                CreatedAt              = now,
+                UpdatedAt              = now,
+            }
+        );
+
+        await db.SaveChangesAsync();
+        logger.LogInformation("Scenario 5 seeded: Cancelled 2x (Ana Seed) · Inactive 20d (Marco Seed) · Review pending (Clara Seed) · no signal (Diego Seed).");
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 6 — "Full hero briefing" (Hans B1)
+    // Hero: zinc "IN 5D" · planned strip · all 4 briefing sub-sections · green "Completed" homework card
+    // -------------------------------------------------------------------------
+
+    private static async Task SeedScenario6Async(AppDbContext db, Guid teacherId, Student hansB1,
+        DateTime now, ILogger logger)
+    {
+        // Past session (7 days ago): all 4 briefing fields populated
+        var pastSession = new SessionLog
+        {
+            Id                     = Guid.NewGuid(),
+            StudentId              = hansB1.Id,
+            TeacherId              = teacherId,
+            SessionDate            = now.AddDays(-7),
+            TopicTags              = """[{"Tag":"Ser vs estar","Category":null},{"Tag":"Subjuntivo","Category":null}]""",
+            GeneralNotes           = "Strong session, needs more practice with subjunctive triggers",
+            HomeworkAssigned       = "Read article and summarize in Spanish",
+            PreviousHomeworkStatus = HomeworkStatus.NotApplicable,
+            Duration               = 60,
+            IsDeleted              = false,
+            CreatedAt              = now.AddDays(-7),
+            UpdatedAt              = now.AddDays(-7),
+        };
+        db.SessionLogs.Add(pastSession);
+        await db.SaveChangesAsync();
+
+        // Followups linked to past session (populates "Promises made" in briefing)
+        db.TeacherFollowups.AddRange(
+            new TeacherFollowup
+            {
+                Id                 = Guid.NewGuid(),
+                TeacherId          = teacherId,
+                StudentId          = hansB1.Id,
+                Text               = "Find recording of native speaker conversation for Hans",
+                Status             = "pending",
+                SourceSessionLogId = pastSession.Id,
+                CreatedAt          = pastSession.SessionDate!.Value,
+            },
+            new TeacherFollowup
+            {
+                Id                 = Guid.NewGuid(),
+                TeacherId          = teacherId,
+                StudentId          = hansB1.Id,
+                Text               = "Prepare vocabulary list on travel for Hans",
+                Status             = "pending",
+                SourceSessionLogId = pastSession.Id,
+                CreatedAt          = pastSession.SessionDate!.Value,
+            }
+        );
+
+        // NEXT session in 5 days: hero shows "IN 5D"
+        db.SessionLogs.Add(new SessionLog
+        {
+            Id                     = Guid.NewGuid(),
+            StudentId              = hansB1.Id,
+            TeacherId              = teacherId,
+            SessionDate            = now.AddDays(5).Date.AddHours(10),
+            PlannedContent         = "Subjuntivo: triggers and common patterns",
+            HomeworkAssigned       = "Complete workbook p.45-47",
+            PreviousHomeworkStatus = HomeworkStatus.Done,
+            IsDeleted              = false,
+            CreatedAt              = now,
+            UpdatedAt              = now,
+        });
+
+        await db.SaveChangesAsync();
+        logger.LogInformation("Scenario 6 seeded: Hans B1, IN 5D, all 4 briefing sub-sections, Completed homework.");
+    }
+}

--- a/backend/LangTeach.Api/Data/ScenarioSeeder.cs
+++ b/backend/LangTeach.Api/Data/ScenarioSeeder.cs
@@ -53,13 +53,14 @@ public static class ScenarioSeeder
             return false;
         }
 
+        var now = DateTime.UtcNow;
+
         if (!teacher.IsApproved || !teacher.HasCompletedOnboarding)
         {
             teacher.IsApproved = true;
             teacher.HasCompletedOnboarding = true;
+            teacher.UpdatedAt = now;
         }
-
-        var now = DateTime.UtcNow;
         logger.LogInformation("Seeding scenario {Scenario} for teacher {Email}...", scenario, teacher.Email);
 
         // Step 1: ensure all 9 scenario students exist

--- a/backend/LangTeach.Api/Program.cs
+++ b/backend/LangTeach.Api/Program.cs
@@ -258,6 +258,31 @@ if (seedIndex >= 0)
     return seeded ? 0 : 1;
 }
 
+// Scenario seed: dotnet LangTeach.Api.dll --seed-scenario <1-6> <auth0-user-id|email>
+var seedScenarioIndex = Array.IndexOf(args, "--seed-scenario");
+if (seedScenarioIndex >= 0)
+{
+    var scenarioStr  = seedScenarioIndex + 1 < args.Length ? args[seedScenarioIndex + 1] : null;
+    var teacherArg   = seedScenarioIndex + 2 < args.Length ? args[seedScenarioIndex + 2] : null;
+
+    if (!int.TryParse(scenarioStr, out var scenario) || scenario < 1 || scenario > 6)
+    {
+        Console.Error.WriteLine("Usage: --seed-scenario <1-6> <auth0-user-id|email>");
+        return 1;
+    }
+    if (string.IsNullOrWhiteSpace(teacherArg))
+    {
+        Console.Error.WriteLine("Usage: --seed-scenario <1-6> <auth0-user-id|email>");
+        return 1;
+    }
+
+    using var scenarioScope  = app.Services.CreateScope();
+    var scenarioDb     = scenarioScope.ServiceProvider.GetRequiredService<AppDbContext>();
+    var scenarioLogger = scenarioScope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+    var seeded = await ScenarioSeeder.SeedScenarioAsync(scenarioDb, scenario, teacherArg, scenarioLogger);
+    return seeded ? 0 : 1;
+}
+
 // Visual seed: dotnet run -- --visual-seed <auth0-user-id|email>
 var visualSeedIndex = Array.IndexOf(args, "--visual-seed");
 if (visualSeedIndex >= 0)

--- a/plan/langteach-beta/task766-seed-scenario.md
+++ b/plan/langteach-beta/task766-seed-scenario.md
@@ -1,0 +1,122 @@
+# Task 766 — Dashboard Scenario Seed Script
+
+## Goal
+
+Idempotent CLI command (`--seed-scenario <N> <teacher>`) that switches the DB to one of 6 named dashboard test scenarios, plus a shell wrapper `scripts/seed-scenario.sh`.
+
+## Files to create/modify
+
+| File | Change |
+|------|--------|
+| `backend/LangTeach.Api/Data/ScenarioSeeder.cs` | New static class |
+| `backend/LangTeach.Api/Data/DemoSeeder.cs` | Make `UpsertStudentAsync` internal |
+| `backend/LangTeach.Api/Program.cs` | Add `--seed-scenario N teacher` arg handling |
+| `scripts/seed-scenario.sh` | New shell wrapper |
+
+## Implementation
+
+### ScenarioSeeder.cs
+
+Static class with entry point:
+```
+SeedScenarioAsync(AppDbContext db, int scenario, string teacherLookup, ILogger logger)
+```
+
+Execution steps per call:
+1. Resolve teacher by email or auth0 ID (same pattern as DemoSeeder)
+2. Ensure teacher is approved + onboarding complete
+3. Find-or-create the 9 scenario students (by name; create-only, no profile overwrite for existing students)
+4. **Wipe**: delete all SessionLogs for those 9 students; delete all TeacherFollowups for the teacher; reset TeachingTodos = "[]" on all 9 students; SaveChanges
+5. Reseed via per-scenario private method
+
+### 9 scenario students
+
+Students created if absent (minimal profile, PersonalNotes = "[scenario-seed]"):
+- Ana Visual, Marco B1, Carmen C1, Nadia B2, Hans B1 (+ Ana Seed, Marco Seed, Clara Seed, Diego Seed for Scenario 5)
+
+For Ana Visual: reuse existing profile from DemoSeeder (find-or-create, no update).
+For the 4 new students: LearningLanguage=English, appropriate CEFR level, NativeLanguages per spec.
+
+### Scenario data
+
+**Scenario 1 (Ana Visual — "IN 20 MIN")**
+- Past session: now-3h; TopicTags=[{"Tag":"Pretérito indefinido"},{"Tag":"Verbos reflexivos"}], GeneralNotes, HomeworkAssigned
+- TeacherFollowup with SourceSessionLogId=pastSession.Id: "Send link to reflexive verb exercises"
+- NEXT session: now+20min; PlannedContent, HomeworkAssigned, PreviousHomeworkStatus=Partial
+- Third session: now+4h (populates 3rd agenda row)
+
+**Scenario 2 (Marco B1 — "IN 3D")**
+- Marco B1: session in 3 days; PlannedContent set; no past sessions
+- Ana Visual: session in 4 days (populates this-week list with 2 entries)
+- 1 standalone TeacherFollowup created 2 days ago (triggers "2D OLD" badge)
+
+**Scenario 3 (Carmen C1 — all empty states)**
+- No sessions seeded; no followups (already wiped); no todos
+- Hero: "No sessions scheduled" — Agenda: "No sessions this week" — Followups: "All caught up"
+
+**Scenario 4 (Nadia B2 — overdue followups)**
+- No sessions for anyone (hero shows no-session state)
+- 3 standalone TeacherFollowups (StudentId=NadiaB2.Id): CreatedAt=now, now-2d, now-7d
+
+**Scenario 5 (Roster signals — 4 states)**
+- Ana Seed: 2 cancelled sessions in last 30 days (now-20d cancelled, now-10d cancelled)
+- Marco Seed: 1 past session at now-20d (not cancelled), no future session → Inactive 20d
+- Clara Seed: TeachingTodos=[{id,text,status:"pending"}] → Review pending
+- Diego Seed: past session now-3d + upcoming now+5d, TeachingTodos=[] → no signal
+
+**Scenario 6 (Hans B1 — full hero briefing)**
+- Past session: now-7d; TopicTags=[{"Tag":"Ser vs estar"},{"Tag":"Subjuntivo"}]; GeneralNotes; HomeworkAssigned="Read article and summarize in Spanish"
+- 2 TeacherFollowups with SourceSessionLogId=pastSession.Id: "Find recording of native speaker conversation", "Prepare vocabulary list on travel"
+- NEXT session: now+5d; PlannedContent set; HomeworkAssigned="Complete workbook p.45-47"; PreviousHomeworkStatus=Done
+
+### Program.cs — new arg handling
+
+```csharp
+var seedScenarioIndex = Array.IndexOf(args, "--seed-scenario");
+if (seedScenarioIndex >= 0)
+{
+    var scenarioStr  = seedScenarioIndex + 1 < args.Length ? args[seedScenarioIndex + 1] : null;
+    var teacherArg   = seedScenarioIndex + 2 < args.Length ? args[seedScenarioIndex + 2] : null;
+    if (!int.TryParse(scenarioStr, out var scenario) || string.IsNullOrWhiteSpace(teacherArg))
+    {
+        Console.Error.WriteLine("Usage: --seed-scenario <1-6> <auth0-user-id|email>");
+        return 1;
+    }
+    using var scope  = app.Services.CreateScope();
+    var db     = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    var sLogger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+    var seeded = await ScenarioSeeder.SeedScenarioAsync(db, scenario, teacherArg, sLogger);
+    return seeded ? 0 : 1;
+}
+```
+
+### scripts/seed-scenario.sh
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+SCENARIO="${1:-}"
+TEACHER="${2:-${SEED_TEACHER:-}}"
+if [ -z "$SCENARIO" ]; then echo "Usage: seed-scenario.sh <N> [teacher-email]" >&2; exit 1; fi
+if [ -z "$TEACHER" ] && [ -f ".env.e2e" ]; then
+  TEACHER=$(grep -E '^E2E_TEST_EMAIL=' .env.e2e | cut -d= -f2 | tr -d '"' || true)
+fi
+if [ -z "$TEACHER" ]; then echo "ERROR: teacher not set. Pass as arg 2 or set SEED_TEACHER." >&2; exit 1; fi
+CONTAINER=$(MSYS_NO_PATHCONV=1 docker ps --filter "name=langteach" --filter "name=api" --format "{{.Names}}" | head -1)
+if [ -z "$CONTAINER" ]; then
+  CONTAINER=$(docker ps --format "{{.Names}}\t{{.Ports}}" | grep ":5000" | awk '{print $1}' | head -1)
+fi
+if [ -z "$CONTAINER" ]; then echo "ERROR: API container not running. Start the stack first." >&2; exit 1; fi
+echo "Seeding scenario $SCENARIO via container $CONTAINER (teacher: $TEACHER)..."
+MSYS_NO_PATHCONV=1 docker exec "$CONTAINER" dotnet LangTeach.Api.dll --seed-scenario "$SCENARIO" "$TEACHER"
+```
+
+## Idempotency guarantee
+
+Wipe step deletes all sessions for the 9 students and all teacher followups before each reseed. Running the same command twice produces identical DB state.
+
+## Out of scope
+
+- No changes to DemoSeeder logic or production seeding paths
+- Scenarios for other screens (student detail, lesson editor)
+- Scenario 7 (slow connection — browser only)

--- a/scripts/seed-scenario.sh
+++ b/scripts/seed-scenario.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# seed-scenario.sh <N> [teacher-email-or-auth0-id]
+#
+# Switches the local Docker DB to one of 6 named dashboard test scenarios.
+# Runs inside the already-running API container — start the stack first.
+#
+# Usage:
+#   scripts/seed-scenario.sh 1                         # uses E2E_TEST_EMAIL from .env.e2e
+#   scripts/seed-scenario.sh 1 teacher@example.com     # explicit teacher
+#   SEED_TEACHER=me@example.com scripts/seed-scenario.sh 3
+#
+# Scenarios:
+#   1 — "Class in 20 minutes"   (Ana Visual)
+#   2 — "Session this week"     (Marco B1)
+#   3 — "Nothing scheduled"     (Carmen C1, all empty states)
+#   4 — "Overdue followups"     (Nadia B2)
+#   5 — "Roster signals"        (Ana/Marco/Clara/Diego Seed, 4 signal states)
+#   6 — "Full hero briefing"    (Hans B1)
+
+set -euo pipefail
+
+SCENARIO="${1:-}"
+TEACHER="${2:-${SEED_TEACHER:-}}"
+
+if [ -z "$SCENARIO" ]; then
+  echo "Usage: seed-scenario.sh <N> [teacher-email-or-auth0-id]" >&2
+  echo "       Valid scenarios: 1-6" >&2
+  exit 1
+fi
+
+if ! [[ "$SCENARIO" =~ ^[1-6]$ ]]; then
+  echo "ERROR: scenario must be 1-6, got: $SCENARIO" >&2
+  exit 1
+fi
+
+# Resolve teacher: arg > env var > E2E_TEST_EMAIL from .env.e2e
+if [ -z "$TEACHER" ] && [ -f ".env.e2e" ]; then
+  TEACHER=$(grep -E '^E2E_TEST_EMAIL=' .env.e2e | cut -d= -f2 | tr -d '"' || true)
+fi
+
+if [ -z "$TEACHER" ]; then
+  echo "ERROR: teacher not set. Pass as arg 2, set SEED_TEACHER, or add E2E_TEST_EMAIL to .env.e2e" >&2
+  exit 1
+fi
+
+# Find the running API container (matches name containing "api" on port 5000)
+CONTAINER=$(MSYS_NO_PATHCONV=1 docker ps \
+  --filter "status=running" \
+  --format "{{.Names}}\t{{.Ports}}" \
+  | grep ":5000" \
+  | awk '{print $1}' \
+  | head -1 || true)
+
+if [ -z "$CONTAINER" ]; then
+  echo "ERROR: No running API container found (expected one with port 5000 exposed)." >&2
+  echo "       Start the stack first, e.g.: docker compose -f docker-compose.e2e.yml --env-file .env.e2e up -d" >&2
+  exit 1
+fi
+
+echo "Seeding scenario $SCENARIO via container '$CONTAINER' (teacher: $TEACHER)..."
+MSYS_NO_PATHCONV=1 docker exec "$CONTAINER" dotnet LangTeach.Api.dll --seed-scenario "$SCENARIO" "$TEACHER"

--- a/scripts/seed-scenario.sh
+++ b/scripts/seed-scenario.sh
@@ -47,7 +47,7 @@ fi
 CONTAINER=$(MSYS_NO_PATHCONV=1 docker ps \
   --filter "status=running" \
   --format "{{.Names}}\t{{.Ports}}" \
-  | grep ":5000" \
+  | grep -E ':5000([^0-9]|$)' \
   | awk '{print $1}' \
   | head -1 || true)
 


### PR DESCRIPTION
## Summary

- Adds `ScenarioSeeder.cs`: idempotent wipe-then-reseed for 6 named dashboard test scenarios (Ana Visual, Marco B1, Carmen C1, Nadia B2, Hans B1, + the 4 Seed students)
- Adds `--seed-scenario <N> <teacher>` CLI arg to `Program.cs` (same pattern as `--seed` and `--visual-seed`)
- Adds `scripts/seed-scenario.sh`: finds the running API container by port 5000, resolves teacher from arg/env var/.env.e2e, calls `dotnet LangTeach.Api.dll --seed-scenario N teacher`

## Test plan

- [ ] Build passes: `dotnet build` in `backend/LangTeach.Api`
- [ ] Script fails loudly when container not running: `scripts/seed-scenario.sh 1` with no stack → "ERROR: No running API container found"
- [ ] Scenario 1: `scripts/seed-scenario.sh 1` → hero shows "IN 20 MIN", 3 agenda rows, full briefing, amber Partial homework card
- [ ] Scenario 2: `scripts/seed-scenario.sh 2` → hero "IN 3D", this-week agenda, "2D OLD" followup, no briefing
- [ ] Scenario 3: `scripts/seed-scenario.sh 3` → all three empty states simultaneously
- [ ] Scenario 4: `scripts/seed-scenario.sh 4` → TODAY / 2D OLD / 7D OVERDUE followup badges
- [ ] Scenario 5: `scripts/seed-scenario.sh 5` → Cancelled 2x / Inactive 20d / Review pending / no signal in roster
- [ ] Scenario 6: `scripts/seed-scenario.sh 6` → hero "IN 5D", all 4 briefing sub-sections, green Completed homework card
- [ ] Idempotency: run same scenario twice, dashboard state identical

Closes #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scenario seeding functionality to populate the system with predefined test data for dashboard scenarios
  * Supports six different scenario configurations for testing and development purposes
  * Includes command-line interface and automation script for streamlined scenario setup in local development environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->