### PR TITLE
feat(t793): dashboard UX polish - roster click, followup nav, hero identity

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
@@ -109,6 +109,39 @@ public class DashboardServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetAsync_NextSession_PopulatesTeachingLanguageAndTotalSessionCount()
+    {
+        var past1 = DateTime.UtcNow.AddDays(-14);
+        var past2 = DateTime.UtcNow.AddDays(-7);
+        var future = DateTime.UtcNow.AddDays(1);
+        _db.SessionLogs.Add(MakeSession(_studentId, past1));
+        _db.SessionLogs.Add(MakeSession(_studentId, past2));
+        _db.SessionLogs.Add(MakeSession(_studentId, future));
+        _db.SaveChanges();
+
+        var result = await _sut.GetAsync(_teacherId);
+
+        result.NextSession!.TeachingLanguage.Should().Be("Spanish");
+        result.NextSession.TotalSessionCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetAsync_NextSession_ExcludesCancelledFromTotalSessionCount()
+    {
+        var past = DateTime.UtcNow.AddDays(-7);
+        var pastCancelled = DateTime.UtcNow.AddDays(-3);
+        var future = DateTime.UtcNow.AddDays(1);
+        _db.SessionLogs.Add(MakeSession(_studentId, past));
+        _db.SessionLogs.Add(MakeSession(_studentId, pastCancelled, isCancelled: true));
+        _db.SessionLogs.Add(MakeSession(_studentId, future));
+        _db.SaveChanges();
+
+        var result = await _sut.GetAsync(_teacherId);
+
+        result.NextSession!.TotalSessionCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task GetAsync_FutureSessionWithPastSession_PopulatesLastSessionNotes()
     {
         var past = DateTime.UtcNow.AddDays(-7);

--- a/backend/LangTeach.Api/DTOs/DashboardDtos.cs
+++ b/backend/LangTeach.Api/DTOs/DashboardDtos.cs
@@ -32,7 +32,9 @@ public record NextSessionDto(
     string? PreviousHomeworkStatus,
     List<string> LastSessionTopicTags,
     string? LastSessionHomework,
-    List<string> LastSessionFollowups
+    List<string> LastSessionFollowups,
+    string? TeachingLanguage,
+    int TotalSessionCount
 );
 
 public record UpcomingSessionDto(

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -79,6 +79,15 @@ public class DashboardService : IDashboardService
                 .ToListAsync(cancellationToken)
             : [];
 
+        var totalSessionCount = await _db.SessionLogs
+            .CountAsync(sl => sl.StudentId == next.StudentId
+                           && sl.TeacherId == teacherId
+                           && !sl.IsDeleted
+                           && !sl.IsCancelled
+                           && sl.SessionDate.HasValue
+                           && sl.SessionDate.Value <= now,
+                cancellationToken);
+
         return new NextSessionDto(
             SessionLogId: next.Id,
             StudentId: next.StudentId,
@@ -92,7 +101,9 @@ public class DashboardService : IDashboardService
             PreviousHomeworkStatus: next.PreviousHomeworkStatus.ToString(),
             LastSessionTopicTags: lastSessionTopicTags,
             LastSessionHomework: lastPast?.HomeworkAssigned,
-            LastSessionFollowups: lastSessionFollowups
+            LastSessionFollowups: lastSessionFollowups,
+            TeachingLanguage: string.IsNullOrWhiteSpace(next.Student.LearningLanguage) ? null : next.Student.LearningLanguage,
+            TotalSessionCount: totalSessionCount
         );
     }
 

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -84,6 +84,7 @@ public class DashboardService : IDashboardService
                            && sl.TeacherId == teacherId
                            && !sl.IsDeleted
                            && !sl.IsCancelled
+                           && sl.Status == SessionLogStatus.Confirmed
                            && sl.SessionDate.HasValue
                            && sl.SessionDate.Value <= now,
                 cancellationToken);

--- a/frontend/src/api/dashboard.ts
+++ b/frontend/src/api/dashboard.ts
@@ -24,6 +24,8 @@ export interface NextSession {
   lastSessionTopicTags: string[]
   lastSessionHomework: string | null
   lastSessionFollowups: string[]
+  teachingLanguage: string | null
+  totalSessionCount: number
 }
 
 export interface UpcomingSession {

--- a/frontend/src/components/dashboard/NextSessionHero.test.tsx
+++ b/frontend/src/components/dashboard/NextSessionHero.test.tsx
@@ -19,6 +19,8 @@ function makeSession(overrides: Partial<NextSession> = {}): NextSession {
     lastSessionTopicTags: ['Subjuntivo', 'Concesivas'],
     lastSessionHomework: 'Redacción mi ciudad ideal',
     lastSessionFollowups: ['Prometí ejercicios de por/para'],
+    teachingLanguage: 'Spanish',
+    totalSessionCount: 14,
     ...overrides,
   }
 }
@@ -80,6 +82,26 @@ describe('NextSessionHero', () => {
       </MemoryRouter>,
     )
     expect(screen.getByRole('link', { name: /View profile/ })).toHaveAttribute('href', '/students/student-1')
+  })
+
+  it('shows identity subtitle with language and session count', () => {
+    render(
+      <MemoryRouter>
+        <NextSessionHero session={makeSession({ teachingLanguage: 'Spanish', totalSessionCount: 14 })} />
+      </MemoryRouter>,
+    )
+    const subtitle = screen.getByTestId('hero-identity-subtitle')
+    expect(subtitle).toHaveTextContent('Spanish')
+    expect(subtitle).toHaveTextContent('Session #14')
+  })
+
+  it('hides identity subtitle when no language and count is 0', () => {
+    render(
+      <MemoryRouter>
+        <NextSessionHero session={makeSession({ teachingLanguage: null, totalSessionCount: 0 })} />
+      </MemoryRouter>,
+    )
+    expect(screen.queryByTestId('hero-identity-subtitle')).not.toBeInTheDocument()
   })
 
   it('shows green gradient badge for session within 2 hours', () => {

--- a/frontend/src/components/dashboard/NextSessionHero.tsx
+++ b/frontend/src/components/dashboard/NextSessionHero.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { Play } from 'lucide-react'
 import { CefrBadge } from './CefrBadge'
 import type { NextSession } from '@/api/dashboard'
 
@@ -105,21 +106,27 @@ export function NextSessionHero({ session }: NextSessionHeroProps) {
           <h2 className="font-manrope text-[1.75rem] font-bold text-[#1A1B22] leading-tight">
             {session.studentName}
           </h2>
+          {(session.teachingLanguage || session.totalSessionCount > 0) && (
+            <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mt-0.5" data-testid="hero-identity-subtitle">
+              {[session.teachingLanguage, session.totalSessionCount > 0 ? `Session #${session.totalSessionCount}` : null].filter(Boolean).join(' · ')}
+            </p>
+          )}
         </div>
         <div className="flex flex-col items-end gap-2">
           <CefrBadge level={session.studentCefrLevel} />
           <div className="flex items-center gap-3">
             <Link
               to={`/students/${session.studentId}`}
-              className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-indigo-600 hover:text-indigo-800 font-inter transition-colors"
+              className="inline-flex items-center rounded-xl border border-[#3525CD] px-3 py-1.5 text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-[#3525CD] font-inter transition-colors hover:bg-[#F4F2FD]"
             >
               View profile
             </Link>
             <Link
               to={`/students/${session.studentId}/log-session`}
-              className="inline-flex items-center rounded-xl bg-gradient-to-br from-[#3525CD] to-indigo-500 px-3 py-1.5 text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-white font-inter transition-opacity hover:opacity-90"
+              className="inline-flex items-center gap-1.5 rounded-xl bg-gradient-to-br from-[#3525CD] to-indigo-500 px-3 py-1.5 text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-white font-inter transition-opacity hover:opacity-90"
               data-testid="start-session-btn"
             >
+              <Play className="h-3 w-3 fill-white" />
               Start session
             </Link>
           </div>
@@ -172,7 +179,7 @@ export function NextSessionHero({ session }: NextSessionHeroProps) {
 
           {/* Homework status card */}
           {session.homeworkAssigned && (
-            <div className="rounded-xl bg-amber-50 border border-amber-100 p-4">
+            <div className="rounded-xl bg-amber-50 p-4">
               <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-amber-700 font-inter mb-1">
                 Homework pending &middot; <span className={hwStatus.color}>{hwStatus.label}</span>
               </p>

--- a/frontend/src/components/dashboard/PendingFollowups.test.tsx
+++ b/frontend/src/components/dashboard/PendingFollowups.test.tsx
@@ -1,5 +1,7 @@
+import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
 import { PendingFollowups } from './PendingFollowups'
 import type { TeacherFollowup } from '@/api/followups'
 
@@ -23,58 +25,96 @@ function makeFollowup(overrides: Partial<TeacherFollowup> = {}): TeacherFollowup
   }
 }
 
+const wrap = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>)
+
 describe('PendingFollowups', () => {
   it('shows all caught up when no followups', () => {
-    render(<PendingFollowups followups={[]} />)
+    wrap(<PendingFollowups followups={[]} />)
     expect(screen.getByText(/All caught up/)).toBeInTheDocument()
   })
 
   it('renders followup text and student name', () => {
-    render(<PendingFollowups followups={[makeFollowup()]} />)
+    wrap(<PendingFollowups followups={[makeFollowup()]} />)
     expect(screen.getByText('Enviar ejercicio')).toBeInTheDocument()
     expect(screen.getByText('Ana García')).toBeInTheDocument()
   })
 
   it('renders zone2-pending-followups testid', () => {
-    render(<PendingFollowups followups={[]} />)
+    wrap(<PendingFollowups followups={[]} />)
     expect(screen.getByTestId('zone2-pending-followups')).toBeInTheDocument()
   })
 
   it('shows followups from multiple students', () => {
     const followups = [
-      makeFollowup({ id: 'f1', studentName: 'Ana', text: 'Todo A' }),
-      makeFollowup({ id: 'f2', studentName: 'Marco', text: 'Todo B' }),
+      makeFollowup({ id: 'f1', studentId: 's1', studentName: 'Ana', text: 'Todo A' }),
+      makeFollowup({ id: 'f2', studentId: 's2', studentName: 'Marco', text: 'Todo B' }),
     ]
-    render(<PendingFollowups followups={followups} />)
+    wrap(<PendingFollowups followups={followups} />)
     expect(screen.getByText('Todo A')).toBeInTheDocument()
     expect(screen.getByText('Todo B')).toBeInTheDocument()
   })
 
   it('renders mark-done button for each followup', () => {
-    render(<PendingFollowups followups={[makeFollowup({ id: 'f1' })]} />)
+    wrap(<PendingFollowups followups={[makeFollowup({ id: 'f1' })]} />)
     expect(screen.getByTestId('followup-dot-f1')).toBeInTheDocument()
   })
 
+  it('mark-done button has title="Mark as done"', () => {
+    wrap(<PendingFollowups followups={[makeFollowup({ id: 'f1' })]} />)
+    expect(screen.getByTestId('followup-dot-f1')).toHaveAttribute('title', 'Mark as done')
+  })
+
   it('shows TODAY badge for followup created today', () => {
-    render(<PendingFollowups followups={[makeFollowup({ id: 'f1', createdAt: new Date().toISOString() })]} />)
+    wrap(<PendingFollowups followups={[makeFollowup({ id: 'f1', createdAt: new Date().toISOString() })]} />)
     expect(screen.getByTestId('followup-age-f1')).toHaveTextContent('TODAY')
   })
 
   it('shows DAYS OVERDUE badge for followup more than 3 days old', () => {
     const old = new Date(Date.now() - 7 * 86400000).toISOString()
-    render(<PendingFollowups followups={[makeFollowup({ id: 'f1', createdAt: old })]} />)
+    wrap(<PendingFollowups followups={[makeFollowup({ id: 'f1', createdAt: old })]} />)
     expect(screen.getByTestId('followup-age-f1')).toHaveTextContent('DAYS OVERDUE')
   })
 
   it('shows YESTERDAY badge for followup 1 day old', () => {
     const yesterday = new Date(Date.now() - 1 * 86400000).toISOString()
-    render(<PendingFollowups followups={[makeFollowup({ id: 'f1', createdAt: yesterday })]} />)
+    wrap(<PendingFollowups followups={[makeFollowup({ id: 'f1', createdAt: yesterday })]} />)
     expect(screen.getByTestId('followup-age-f1')).toHaveTextContent('YESTERDAY')
   })
 
   it('shows DAYS AGO badge for followup 2-3 days old', () => {
     const twoDaysAgo = new Date(Date.now() - 2 * 86400000).toISOString()
-    render(<PendingFollowups followups={[makeFollowup({ id: 'f1', createdAt: twoDaysAgo })]} />)
+    wrap(<PendingFollowups followups={[makeFollowup({ id: 'f1', createdAt: twoDaysAgo })]} />)
     expect(screen.getByTestId('followup-age-f1')).toHaveTextContent('DAYS AGO')
+  })
+
+  it('student name chip links to student profile', () => {
+    wrap(<PendingFollowups followups={[makeFollowup({ id: 'f1', studentId: 'student-1' })]} />)
+    expect(screen.getByTestId('followup-student-link-f1')).toHaveAttribute('href', '/students/student-1')
+  })
+
+  it('does not show chip for second followup from same student', () => {
+    const followups = [
+      makeFollowup({ id: 'f1', studentId: 'student-1', studentName: 'Ana García' }),
+      makeFollowup({ id: 'f2', studentId: 'student-1', studentName: 'Ana García', text: 'Second todo' }),
+    ]
+    wrap(<PendingFollowups followups={followups} />)
+    expect(screen.getByTestId('followup-student-link-f1')).toBeInTheDocument()
+    expect(screen.queryByTestId('followup-student-link-f2')).not.toBeInTheDocument()
+  })
+
+  it('shows SEE ALL link when more than 5 followups', () => {
+    const followups = Array.from({ length: 6 }, (_, i) =>
+      makeFollowup({ id: `f${i}`, studentId: `s${i}`, text: `Todo ${i}` }),
+    )
+    wrap(<PendingFollowups followups={followups} />)
+    expect(screen.getByTestId('followups-see-all')).toBeInTheDocument()
+  })
+
+  it('does not show SEE ALL when 5 or fewer followups', () => {
+    const followups = Array.from({ length: 5 }, (_, i) =>
+      makeFollowup({ id: `f${i}`, studentId: `s${i}`, text: `Todo ${i}` }),
+    )
+    wrap(<PendingFollowups followups={followups} />)
+    expect(screen.queryByTestId('followups-see-all')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/dashboard/PendingFollowups.tsx
+++ b/frontend/src/components/dashboard/PendingFollowups.tsx
@@ -63,13 +63,13 @@ export function PendingFollowups({ followups }: PendingFollowupsProps) {
       <div className="flex items-center justify-between mb-4">
         <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22]">Pending Followups</h3>
         {showSeeAll && (
-          <a
-            href="#"
+          <Link
+            to="#"
             className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-indigo-600 hover:text-indigo-800 font-inter transition-colors"
             data-testid="followups-see-all"
           >
             See all ({visible.length})
-          </a>
+          </Link>
         )}
       </div>
 

--- a/frontend/src/components/dashboard/PendingFollowups.tsx
+++ b/frontend/src/components/dashboard/PendingFollowups.tsx
@@ -1,6 +1,9 @@
 import type { TeacherFollowup } from '@/api/followups'
 import { updateFollowupStatus } from '@/api/followups'
 import { useState } from 'react'
+import { Link } from 'react-router-dom'
+
+const SEE_ALL_THRESHOLD = 5
 
 interface PendingFollowupsProps {
   followups: TeacherFollowup[]
@@ -53,17 +56,31 @@ export function PendingFollowups({ followups }: PendingFollowupsProps) {
   }
 
   const visible = followups.filter(f => !hidden.has(f.id))
+  const showSeeAll = visible.length > SEE_ALL_THRESHOLD
 
   return (
     <div className="rounded-2xl bg-white p-5 shadow-[0_12px_40px_rgba(26,27,34,0.06)] ring-1 ring-[#C7C4D8]/20" data-testid="zone2-pending-followups">
-      <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22] mb-4">Pending Followups</h3>
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22]">Pending Followups</h3>
+        {showSeeAll && (
+          <a
+            href="#"
+            className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-indigo-600 hover:text-indigo-800 font-inter transition-colors"
+            data-testid="followups-see-all"
+          >
+            See all ({visible.length})
+          </a>
+        )}
+      </div>
 
       {visible.length === 0 ? (
         <p className="text-sm text-zinc-400 font-inter py-4 text-center">All caught up</p>
       ) : (
         <div className="space-y-2">
-          {visible.map(f => {
+          {visible.map((f, index) => {
             const badge = ageBadge(f.createdAt)
+            const prevStudentId = index > 0 ? visible[index - 1].studentId : null
+            const showChip = f.studentId && f.studentName && f.studentId !== prevStudentId
             return (
               <div
                 key={f.id}
@@ -72,14 +89,19 @@ export function PendingFollowups({ followups }: PendingFollowupsProps) {
                 <button
                   onClick={() => handleMarkDone(f.id)}
                   aria-label="Mark done"
-                  className={`mt-0.5 shrink-0 w-3.5 h-3.5 rounded-full border-2 ${badge.dotColor} border-transparent hover:opacity-80 transition-opacity`}
+                  title="Mark as done"
+                  className={`mt-0.5 shrink-0 w-3.5 h-3.5 rounded-full border-2 ${badge.dotColor} border-transparent hover:opacity-80 hover:scale-125 transition-all`}
                   data-testid={`followup-dot-${f.id}`}
                 />
                 <div className="flex-1 min-w-0">
-                  {f.studentName && (
-                    <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mb-0.5">
+                  {showChip && (
+                    <Link
+                      to={`/students/${f.studentId}`}
+                      className="block text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-indigo-600 hover:text-indigo-800 font-inter mb-0.5 transition-colors"
+                      data-testid={`followup-student-link-${f.id}`}
+                    >
                       {f.studentName}
-                    </p>
+                    </Link>
                   )}
                   <p className="text-sm text-[#1A1B22] font-inter">{f.text}</p>
                 </div>

--- a/frontend/src/components/dashboard/StudentRoster.test.tsx
+++ b/frontend/src/components/dashboard/StudentRoster.test.tsx
@@ -145,6 +145,29 @@ describe('StudentRoster', () => {
     expect(screen.getByText('Today')).toBeInTheDocument()
   })
 
+  it('shows only "Today" when last and next session are on the same day', () => {
+    const today = new Date().toISOString()
+    render(
+      <MemoryRouter>
+        <StudentRoster students={[makeStudent({ lastSessionDate: today, nextSessionDate: today })]} />
+      </MemoryRouter>,
+    )
+    // Should show "Today" but not "Today → Today"
+    const row = screen.getByTestId('zone3-student-row')
+    expect(row.textContent).not.toMatch(/Today.*→.*Today/)
+    expect(row.textContent).toContain('Today')
+  })
+
+  it('row has cursor-pointer class for full-row navigation', () => {
+    render(
+      <MemoryRouter>
+        <StudentRoster students={[makeStudent()]} />
+      </MemoryRouter>,
+    )
+    const row = screen.getByTestId('zone3-student-row')
+    expect(row.className).toContain('cursor-pointer')
+  })
+
   it('shows Review pending signal when student has pending todos', () => {
     const student = makeStudent({ pendingTodos: [
       { id: 't1', text: 'Todo 1', createdAt: new Date().toISOString(), status: 'pending', sourceSessionLogId: null, coveredInSessionLogId: null },

--- a/frontend/src/components/dashboard/StudentRoster.tsx
+++ b/frontend/src/components/dashboard/StudentRoster.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { ChevronsUpDown } from 'lucide-react'
 import { CefrBadge } from './CefrBadge'
 import type { ActiveStudent } from '@/api/dashboard'
@@ -110,6 +110,7 @@ const SORT_OPTIONS: { value: SortOption; label: string }[] = [
 ]
 
 export function StudentRoster({ students }: StudentRosterProps) {
+  const navigate = useNavigate()
   const [sortBy, setSortBy] = useState<SortOption>('lastSession')
   const [sortOpen, setSortOpen] = useState(false)
   const sortRef = useRef<HTMLDivElement>(null)
@@ -209,8 +210,9 @@ export function StudentRoster({ students }: StudentRosterProps) {
                 return (
                   <tr
                     key={student.studentId}
-                    className="group hover:bg-[#F4F2FD] transition-colors"
+                    className="group hover:bg-[#ECEAFD] transition-colors cursor-pointer"
                     data-testid="zone3-student-row"
+                    onClick={() => navigate(`/students/${student.studentId}`)}
                   >
                     <td className="px-6 py-2.5">
                       <Link
@@ -228,7 +230,11 @@ export function StudentRoster({ students }: StudentRosterProps) {
                     </td>
                     <td className="px-3 py-2.5 text-zinc-500 hidden sm:table-cell">
                       {student.nextSessionDate
-                        ? `${formatRelativeDate(student.lastSessionDate)} → ${formatRelativeDate(student.nextSessionDate)}`
+                        ? (() => {
+                            const last = formatRelativeDate(student.lastSessionDate)
+                            const next = formatRelativeDate(student.nextSessionDate)
+                            return last === next ? last : `${last} → ${next}`
+                          })()
                         : formatRelativeDate(student.lastSessionDate)}
                     </td>
                     <td className="px-3 py-2.5 hidden md:table-cell">

--- a/frontend/src/components/dashboard/TodayAgenda.tsx
+++ b/frontend/src/components/dashboard/TodayAgenda.tsx
@@ -29,7 +29,7 @@ export function TodayAgenda({ sessions, nextSessionId, upcomingThisWeek }: Today
         <div className="rounded-2xl bg-white p-5 shadow-[0_12px_40px_rgba(26,27,34,0.06)] ring-1 ring-[#C7C4D8]/20" data-testid="zone2-today-agenda">
           <div className="flex items-center justify-between mb-2">
             <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22]">Today's Agenda</h3>
-            <a href="#" className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hover:text-zinc-600 font-inter transition-colors" data-testid="agenda-calendar-view">Calendar view</a>
+            <Link to="#" className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hover:text-zinc-600 font-inter transition-colors" data-testid="agenda-calendar-view">Calendar view</Link>
           </div>
           <p className="text-sm text-zinc-400 font-inter py-4 text-center">No sessions this week</p>
         </div>
@@ -43,7 +43,7 @@ export function TodayAgenda({ sessions, nextSessionId, upcomingThisWeek }: Today
             <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22]">Today's Agenda</h3>
             <span className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter">No sessions · This Week</span>
           </div>
-          <a href="#" className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hover:text-zinc-600 font-inter transition-colors" data-testid="agenda-calendar-view">Calendar view</a>
+          <Link to="#" className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hover:text-zinc-600 font-inter transition-colors" data-testid="agenda-calendar-view">Calendar view</Link>
         </div>
         <div className="space-y-2" data-testid="this-week-sessions">
           {upcomingThisWeek.map(session => (
@@ -99,13 +99,13 @@ export function TodayAgenda({ sessions, nextSessionId, upcomingThisWeek }: Today
     <div className="rounded-2xl bg-white p-5 shadow-[0_12px_40px_rgba(26,27,34,0.06)] ring-1 ring-[#C7C4D8]/20" data-testid="zone2-today-agenda">
       <div className="flex items-center justify-between mb-4">
         <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22]">Today's Agenda</h3>
-        <a
-          href="#"
+        <Link
+          to="#"
           className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hover:text-zinc-600 font-inter transition-colors"
           data-testid="agenda-calendar-view"
         >
           Calendar view
-        </a>
+        </Link>
       </div>
 
       <div className="space-y-2">

--- a/frontend/src/components/dashboard/TodayAgenda.tsx
+++ b/frontend/src/components/dashboard/TodayAgenda.tsx
@@ -27,7 +27,10 @@ export function TodayAgenda({ sessions, nextSessionId, upcomingThisWeek }: Today
     if (upcomingThisWeek.length === 0) {
       return (
         <div className="rounded-2xl bg-white p-5 shadow-[0_12px_40px_rgba(26,27,34,0.06)] ring-1 ring-[#C7C4D8]/20" data-testid="zone2-today-agenda">
-          <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22] mb-2">Today's Agenda</h3>
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22]">Today's Agenda</h3>
+            <a href="#" className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hover:text-zinc-600 font-inter transition-colors" data-testid="agenda-calendar-view">Calendar view</a>
+          </div>
           <p className="text-sm text-zinc-400 font-inter py-4 text-center">No sessions this week</p>
         </div>
       )
@@ -35,9 +38,12 @@ export function TodayAgenda({ sessions, nextSessionId, upcomingThisWeek }: Today
 
     return (
       <div className="rounded-2xl bg-white p-5 shadow-[0_12px_40px_rgba(26,27,34,0.06)] ring-1 ring-[#C7C4D8]/20" data-testid="zone2-today-agenda">
-        <div className="flex items-baseline gap-2 mb-4">
-          <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22]">Today's Agenda</h3>
-          <span className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter">No sessions · This Week</span>
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-baseline gap-2">
+            <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22]">Today's Agenda</h3>
+            <span className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter">No sessions · This Week</span>
+          </div>
+          <a href="#" className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hover:text-zinc-600 font-inter transition-colors" data-testid="agenda-calendar-view">Calendar view</a>
         </div>
         <div className="space-y-2" data-testid="this-week-sessions">
           {upcomingThisWeek.map(session => (
@@ -91,7 +97,16 @@ export function TodayAgenda({ sessions, nextSessionId, upcomingThisWeek }: Today
 
   return (
     <div className="rounded-2xl bg-white p-5 shadow-[0_12px_40px_rgba(26,27,34,0.06)] ring-1 ring-[#C7C4D8]/20" data-testid="zone2-today-agenda">
-      <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22] mb-4">Today's Agenda</h3>
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="font-manrope text-[1.25rem] font-bold text-[#1A1B22]">Today's Agenda</h3>
+        <a
+          href="#"
+          className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 hover:text-zinc-600 font-inter transition-colors"
+          data-testid="agenda-calendar-view"
+        >
+          Calendar view
+        </a>
+      </div>
 
       <div className="space-y-2">
         {sessions.map(session => {

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -31,6 +31,8 @@ function makeDashboard(overrides: Partial<DashboardData> = {}): DashboardData {
       lastSessionTopicTags: [],
       lastSessionHomework: null,
       lastSessionFollowups: [],
+      teachingLanguage: 'Spanish',
+      totalSessionCount: 5,
     },
     todaySessions: [
       {

--- a/plan/langteach-beta/task793-dashboard-ux-polish.md
+++ b/plan/langteach-beta/task793-dashboard-ux-polish.md
@@ -1,0 +1,55 @@
+# Task 793 — Dashboard UX Polish
+
+**Issue:** #793  
+**Branch:** worktree-task-t793-dashboard-ux-polish  
+**Sprint:** sprint/ui-redesign-student-polish
+
+## Source
+`plan/ui-redesign-feedback3.md` findings N1-N5, S1, S3-S6, SD3.
+
+## Acceptance Criteria Summary
+
+### Roster row navigation (HIGH)
+- Clicking anywhere on a roster row navigates to `/students/:id`
+- Fix "Today -> Today" display (show just "Today" when both dates are the same day)
+- Strengthen row hover contrast
+
+### Followup improvements (MEDIUM)
+- Student name chip links to `/students/:id`
+- Mark-done dot: `title="Mark as done"` + `hover:scale-125`
+- Show student chip only when different from previous item (grouping)
+- "SEE ALL (N)" link in card header when there are many followups (> 5)
+
+### Hero Stitch alignment (MEDIUM)
+- Identity subtitle under student name: "{language} . Session #{count}"
+  - Backend: extend `NextSessionDto` with `TeachingLanguage` (from `Student.LearningLanguage`) and `TotalSessionCount` (count of completed sessions)
+- "View profile" -> secondary button style (not ghost text link)
+- "Start session" -> add play icon
+- Remove `border border-amber-100` from homework status card
+- "CALENDAR VIEW" dead link right-aligned in Today's Agenda card header
+
+## Implementation Plan
+
+### Backend
+1. `DashboardDtos.cs`: add `TeachingLanguage` (string?) and `TotalSessionCount` (int) to `NextSessionDto`
+2. `DashboardService.cs`: populate them in `GetNextSessionAsync`
+   - `TeachingLanguage`: `next.Student.LearningLanguage`
+   - `TotalSessionCount`: count completed/past sessions for that student
+
+### Frontend
+3. `dashboard.ts`: add `teachingLanguage: string | null` and `totalSessionCount: number` to `NextSession`
+4. `NextSessionHero.tsx`: subtitle, button styles, remove border
+5. `StudentRoster.tsx`: row click, Today fix, hover contrast
+6. `PendingFollowups.tsx`: chip link, dot tooltip, grouping, SEE ALL
+7. `TodayAgenda.tsx`: CALENDAR VIEW link
+
+### Tests
+- `DashboardServiceTests.cs`: assert `TeachingLanguage` and `TotalSessionCount`
+- `NextSessionHero.test.tsx`: assert subtitle presence
+- `StudentRoster.test.tsx`: assert row is clickable (cursor-pointer / navigate)
+- `PendingFollowups.test.tsx`: assert chip is a link, SEE ALL appears
+
+## Notes
+- `Student.TeachingLanguage` in the issue body is actually `Student.LearningLanguage` in the model.
+- "SEE ALL" link uses href="#" (no followup list page exists yet)
+- "CALENDAR VIEW" link uses href="#" (no calendar screen exists yet)


### PR DESCRIPTION
## Summary

- **StudentRoster**: full-row click navigation (cursor-pointer + useNavigate onClick), stronger hover contrast (#ECEAFD), fix "Today -> Today" dedup when last and next session are same day
- **PendingFollowups**: student name chip links to profile (/students/:id) with grouping (chip only when student differs from previous), mark-done dot gets `title="Mark as done"` + `hover:scale-125`, "SEE ALL (N)" Link in header when >5 items
- **NextSessionHero**: identity subtitle ("{language} · Session #{count}") under student name, "View profile" as secondary bordered button, "Start session" with play icon, remove amber border from homework card
- **TodayAgenda**: "CALENDAR VIEW" dead Link in card header (href="#", no calendar screen yet)
- **Backend**: extend `NextSessionDto` with `TeachingLanguage` (from `Student.LearningLanguage`) and `TotalSessionCount` (count of confirmed non-cancelled past sessions)

Closes #793

## Test plan

- [ ] Build passes: dotnet build + npm build
- [ ] All tests pass: dotnet test + npm test (1297 tests)
- [ ] Click anywhere on roster row navigates to student detail
- [ ] "Today -> Today" shows just "Today" in Last/Next column
- [ ] Student chip in followups links to /students/:id
- [ ] Chip grouping: same student on consecutive items shows chip only on first
- [ ] SEE ALL appears in followup header when >5 items
- [ ] Hero subtitle shows "Spanish · Session #N" under student name
- [ ] "View profile" is a bordered secondary button
- [ ] "Start session" has a play icon
- [ ] Homework card has no amber border
- [ ] "CALENDAR VIEW" link appears in Today's Agenda header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added teaching language and session count display to next session information
  - Made student roster rows clickable for profile navigation
  - Added "See all" link for pending followups exceeding 5 items
  - Added "Calendar view" link to today's agenda header

* **Style**
  - Enhanced button styling for action links with improved hover states
  - Added play icon to session start action
  - Improved interactive transitions and visual feedback

* **Bug Fixes**
  - Fixed date range display when last and next sessions occur on the same day

<!-- end of auto-generated comment: release notes by coderabbit.ai -->