### PR TITLE
fix(t795): Students List load more, signal priority, and Stitch alignment

### DIFF
--- a/frontend/src/pages/Students.test.tsx
+++ b/frontend/src/pages/Students.test.tsx
@@ -157,12 +157,13 @@ describe('Students page', () => {
     expect(badge.className).not.toContain('rounded-full')
   })
 
-  it('renders ALERTS column header (not SIGNALS)', async () => {
+  it('renders SIGNALS, CEFR LEVEL and LANGUAGE column headers', async () => {
     vi.mocked(studentsApi.getStudents).mockResolvedValue(makeListResponse([makeStudent()]))
     wrapper(<Students />)
     await screen.findByTestId('student-name')
-    expect(screen.getByText('Alerts')).toBeInTheDocument()
-    expect(screen.queryByText('Signals')).not.toBeInTheDocument()
+    expect(screen.getByText('SIGNALS')).toBeInTheDocument()
+    expect(screen.getByText('CEFR LEVEL')).toBeInTheDocument()
+    expect(screen.getByText('LANGUAGE')).toBeInTheDocument()
   })
 
   it('filters students by name when search query is entered', async () => {
@@ -450,6 +451,22 @@ describe('Students page', () => {
     expect(screen.queryByText(/Inactive/)).not.toBeInTheDocument()
   })
 
+  it('shows RETURNING badge for student inactive 22 days who has upcoming session (threshold is 21d)', async () => {
+    const lastSession = new Date(Date.now() - 22 * 24 * 60 * 60 * 1000).toISOString()
+    const nextSession = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString()
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([makeStudent({ id: 'abc-123' })])
+    )
+    vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
+      nextSession: null, todaySessions: [], pendingFollowups: [], upcomingThisWeek: [],
+      activeStudents: [makeActiveStudent({ studentId: 'abc-123', lastSessionDate: lastSession, nextSessionDate: nextSession })],
+    })
+    wrapper(<Students />)
+    await screen.findByTestId('student-name')
+    expect(screen.getByText('RETURNING')).toBeInTheDocument()
+    expect(screen.queryByText(/Inactive/)).not.toBeInTheDocument()
+  })
+
   it('shows load more button when students exceed page size and loads more on click', async () => {
     const students = Array.from({ length: 13 }, (_, i) =>
       makeStudent({ id: `s${i}`, name: `Student ${String(i).padStart(2, '0')}` })
@@ -491,7 +508,7 @@ describe('Students page', () => {
     expect(screen.getByText('Showing 1 of 1 student')).toBeInTheDocument()
   })
 
-  it('subtitle shows total count without "active" when no filter is active', async () => {
+  it('subtitle shows total count including "active" qualifier when no filter is active', async () => {
     vi.mocked(studentsApi.getStudents).mockResolvedValue(
       makeListResponse([
         makeStudent({ id: 'a', name: 'Ana' }),
@@ -500,7 +517,7 @@ describe('Students page', () => {
     )
     wrapper(<Students />)
     await screen.findAllByTestId('student-name')
-    expect(screen.getByText('Managing 2 language learners in your atelier')).toBeInTheDocument()
+    expect(screen.getByText('Managing 2 active language learners in your atelier')).toBeInTheDocument()
   })
 
   it('subtitle updates when CEFR filter is active', async () => {

--- a/frontend/src/pages/Students.test.tsx
+++ b/frontend/src/pages/Students.test.tsx
@@ -549,4 +549,42 @@ describe('Students page', () => {
 
     expect(screen.getByText("Showing 1 result for 'Ana'")).toBeInTheDocument()
   })
+
+  it('shows only highest-priority signal when student matches multiple conditions', async () => {
+    // Student has Cancelled 2x AND is inactive 22d with next session (RETURNING) — should show Cancelled 2x only
+    const lastSession = new Date(Date.now() - 22 * 24 * 60 * 60 * 1000).toISOString()
+    const nextSession = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString()
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([makeStudent({ id: 'abc-123' })])
+    )
+    vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
+      nextSession: null, todaySessions: [], pendingFollowups: [], upcomingThisWeek: [],
+      activeStudents: [makeActiveStudent({
+        studentId: 'abc-123',
+        lastSessionDate: lastSession,
+        nextSessionDate: nextSession,
+        cancelledSessionsLast30Days: 2,
+      })],
+    })
+    wrapper(<Students />)
+    await screen.findByTestId('student-name')
+    expect(screen.getByText('Cancelled 2x')).toBeInTheDocument()
+    expect(screen.queryByText('RETURNING')).not.toBeInTheDocument()
+  })
+
+  it('shows absolute date format for next session more than 6 days in the future', async () => {
+    const futureDate = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000)
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(
+      makeListResponse([makeStudent({ id: 'abc-123' })])
+    )
+    vi.mocked(dashboardApi.getDashboard).mockResolvedValue({
+      nextSession: null, todaySessions: [], pendingFollowups: [], upcomingThisWeek: [],
+      activeStudents: [makeActiveStudent({ studentId: 'abc-123', nextSessionDate: futureDate.toISOString() })],
+    })
+    wrapper(<Students />)
+    await screen.findByTestId('student-name')
+    const expectedDate = futureDate.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
+    expect(screen.getByText(expectedDate)).toBeInTheDocument()
+    expect(screen.queryByText(/in \d+d/)).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/Students.tsx
+++ b/frontend/src/pages/Students.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { Search, UserPlus, Users, ChevronsUpDown } from 'lucide-react'
+import { Search, UserPlus, Users, ChevronsUpDown, ChevronDown } from 'lucide-react'
 import { PageHeader } from '@/components/PageHeader'
 import { getStudents, type Student } from '../api/students'
 import { getDashboard, type ActiveStudent } from '../api/dashboard'
@@ -66,9 +66,11 @@ function formatRelativeDate(dateStr: string | null | undefined, showTime = false
       const dayAbbr = date.toLocaleDateString('en-GB', { weekday: 'short' })
       return `${dayAbbr} ${timeStr}`
     }
+    return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
   }
   if (futureDays === 1) return 'Tomorrow'
-  return `in ${futureDays}d`
+  if (futureDays <= 6) return `in ${futureDays}d`
+  return date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
 }
 
 // ── Signal badges ───────────────────────────────────────────────────────────
@@ -86,7 +88,6 @@ function buildSignals(student: Student, dash: ActiveStudent | undefined): Signal
 
   if (!dash) return []
 
-  const signals: Signal[] = []
   const now = Date.now()
 
   const lastSessionMs = dash.lastSessionDate ? new Date(dash.lastSessionDate).getTime() : null
@@ -96,27 +97,11 @@ function buildSignals(student: Student, dash: ActiveStudent | undefined): Signal
 
   const hasNextSession = !!dash.nextSessionDate
 
-  // RETURNING: was inactive 30+ days and now has a scheduled next session
-  const isReturning = lastSessionGapDays != null && lastSessionGapDays >= 30 && hasNextSession
-  if (isReturning) {
-    signals.push({ label: 'RETURNING', className: 'bg-[#1A1B22] text-white' })
-  } else if (lastSessionGapDays != null && lastSessionGapDays >= 14) {
-    // Inactive Xd: last session 14+ days ago and no upcoming session (or < 30d gap)
-    signals.push({ label: `Inactive ${lastSessionGapDays}d`, className: 'bg-amber-500 text-white' })
-  }
+  // Priority order: Cancelled 2x > Exam prep > RETURNING > Review pending > Inactive Xd > NEW
 
-  // Cancelled 2x
+  // Cancelled 2x (highest priority)
   if (dash.cancelledSessionsLast30Days >= 2) {
-    signals.push({ label: 'Cancelled 2x', className: 'bg-[#1A1B22] text-white', redDot: true })
-  }
-
-  // NEW: created in last 14 days with fewer than 3 sessions
-  if (student.createdAt) {
-    const createdMs = new Date(student.createdAt).getTime()
-    const daysSinceCreation = Math.floor((now - createdMs) / (1000 * 60 * 60 * 24))
-    if (daysSinceCreation <= 14 && dash.totalSessions < 3) {
-      signals.push({ label: 'NEW', className: 'bg-green-500 text-white' })
-    }
+    return [{ label: 'Cancelled 2x', className: 'bg-[#1A1B22] text-white', redDot: true }]
   }
 
   // Exam prep: short-term objective with targetDate within 6 weeks
@@ -128,15 +113,35 @@ function buildSignals(student: Student, dash: ActiveStudent | undefined): Signal
     return msUntil >= 0 && msUntil <= sixWeeksMs
   })
   if (hasExamPrep) {
-    signals.push({ label: 'Exam prep', className: 'bg-[#3525CD] text-white' })
+    return [{ label: 'Exam prep', className: 'bg-[#3525CD] text-white' }]
+  }
+
+  // RETURNING: was inactive 21+ days and now has a scheduled next session
+  const isReturning = lastSessionGapDays != null && lastSessionGapDays >= 21 && hasNextSession
+  if (isReturning) {
+    return [{ label: 'RETURNING', className: 'bg-[#1A1B22] text-white' }]
   }
 
   // Review pending: has pending teaching todos
   if (dash.pendingTodos.length > 0) {
-    signals.push({ label: 'Review pending', className: 'bg-[#3525CD] text-white' })
+    return [{ label: 'Review pending', className: 'bg-[#3525CD] text-white' }]
   }
 
-  return signals
+  // Inactive Xd: last session 14+ days ago and no upcoming session
+  if (lastSessionGapDays != null && lastSessionGapDays >= 14) {
+    return [{ label: `Inactive ${lastSessionGapDays}d`, className: 'bg-amber-500 text-white' }]
+  }
+
+  // NEW: created in last 14 days with fewer than 3 sessions
+  if (student.createdAt) {
+    const createdMs = new Date(student.createdAt).getTime()
+    const daysSinceCreation = Math.floor((now - createdMs) / (1000 * 60 * 60 * 24))
+    if (daysSinceCreation <= 14 && dash.totalSessions < 3) {
+      return [{ label: 'NEW', className: 'bg-green-500 text-white' }]
+    }
+  }
+
+  return []
 }
 
 // ── Sort ────────────────────────────────────────────────────────────────────
@@ -190,7 +195,7 @@ const CEFR_FILTER_OPTIONS = ['All', ...CEFR_LEVELS] as const
 const PAGE_SIZE = 12
 
 const COL_CLASSES = 'grid-cols-[32px_minmax(160px,2fr)_80px_120px_110px_140px_1fr]'
-const TABLE_HEADERS = ['', 'Name', 'Level', 'Native Language', 'Last Session', 'Next Session', 'Alerts'] as const
+const TABLE_HEADERS = ['', 'Name', 'CEFR LEVEL', 'LANGUAGE', 'Last Session', 'Next Session', 'SIGNALS'] as const
 
 // ── Component ───────────────────────────────────────────────────────────────
 
@@ -207,6 +212,7 @@ export default function Students() {
   const [sortOpen, setSortOpen] = useState(false)
   const sortRef = useRef<HTMLDivElement>(null)
   const didInitSearchRef = useRef(false)
+  const lastWrittenSearchRef = useRef(qFromUrl)
 
   // Sync input when URL changes via back/forward navigation
   useEffect(() => {
@@ -220,10 +226,12 @@ export default function Students() {
       return
     }
     const timer = setTimeout(() => {
+      const searchChanged = localSearch !== lastWrittenSearchRef.current
+      lastWrittenSearchRef.current = localSearch
       setSearchParams(prev => {
         const next = new URLSearchParams(prev)
         if (localSearch) { next.set('q', localSearch) } else { next.delete('q') }
-        next.delete('count')
+        if (searchChanged) next.delete('count')
         return next
       }, { replace: true })
     }, 300)
@@ -294,7 +302,7 @@ export default function Students() {
       const count = allStudents.filter(s => s.cefrLevel === cefrFilter).length
       return `Managing ${count} ${cefrFilter} learner${count === 1 ? '' : 's'} in your atelier`
     }
-    return `Managing ${total} language learner${total === 1 ? '' : 's'} in your atelier`
+    return `Managing ${total} active language learner${total === 1 ? '' : 's'} in your atelier`
   }
 
   const currentSortLabel = SORT_OPTIONS.find(o => o.value === sortBy)?.label ?? 'Last Session'
@@ -310,7 +318,7 @@ export default function Students() {
           <Skeleton className="h-8 w-32" />
         </div>
         <div className="bg-white rounded-xl overflow-hidden">
-          <div className={cn('grid gap-4 px-4 py-2 border-b border-zinc-100', COL_CLASSES)}>
+          <div className={cn('grid gap-4 px-4 py-2', COL_CLASSES)}>
             {TABLE_HEADERS.map((_h, i) => (
               <Skeleton key={i} className="h-3 w-full" />
             ))}
@@ -407,7 +415,7 @@ export default function Students() {
             {sortOpen && (
               <div
                 role="listbox"
-                className="absolute right-0 top-full mt-1 w-40 bg-white rounded-lg shadow-lg border border-zinc-100 z-10 py-1"
+                className="absolute right-0 top-full mt-1 w-40 bg-white rounded-lg shadow-lg z-10 py-1"
               >
                 {SORT_OPTIONS.map(opt => (
                   <button
@@ -566,7 +574,7 @@ export default function Students() {
 
           {/* Pagination footer */}
           {sortedStudents.length > 0 && (
-            <div className="px-4 py-3 grid grid-cols-[1fr_auto_1fr] items-center border-t border-zinc-50">
+            <div className="px-4 py-3 grid grid-cols-[1fr_auto_1fr] items-center">
               <span className="text-xs text-zinc-400">
                 Showing {Math.min(visibleCount, sortedStudents.length)} of {sortedStudents.length} student{sortedStudents.length === 1 ? '' : 's'}
               </span>
@@ -578,6 +586,7 @@ export default function Students() {
                   data-testid="load-more"
                 >
                   Load more
+                  <ChevronDown className="h-3.5 w-3.5 ml-1" />
                 </Button>
               ) : <span />}
               <span />

--- a/plan/langteach-beta/task795-students-list-fixes.md
+++ b/plan/langteach-beta/task795-students-list-fixes.md
@@ -1,0 +1,63 @@
+# Task 795: Students List — Load More, signal logic, and Stitch alignment
+
+## Issue
+https://github.com/Robert-Freire/langTeachSaaS/issues/795
+
+## Scope
+All changes are in `frontend/src/pages/Students.tsx`.
+
+## Changes
+
+### F1 (HIGH) — Fix Load More pagination
+**Root cause:** The debounce `useEffect` depends on `[localSearch, setSearchParams]`. When `updateParam` calls `setSearchParams` (e.g. on Load More), React Router creates a new `setSearchParams` identity, causing the effect to re-fire and delete `?count` even though search text didn't change.
+
+**Fix:** Track the last-written search value in a ref. Only delete `count` when `localSearch` actually differs from the last committed value.
+
+Add `lastWrittenSearchRef = useRef(qFromUrl)`. Inside the timeout:
+```ts
+const searchChanged = localSearch !== lastWrittenSearchRef.current
+lastWrittenSearchRef.current = localSearch
+// only if (searchChanged): next.delete('count')
+```
+
+### F2 (MEDIUM) — Column header labels
+`TABLE_HEADERS` at line 193:
+- `'Level'` -> `'CEFR LEVEL'`
+- `'Native Language'` -> `'LANGUAGE'`
+- `'Alerts'` -> `'SIGNALS'`
+
+### F3 (MEDIUM) — Remove border violations
+- Line 313 skeleton header: remove `border-b border-zinc-100`
+- Line 410 sort dropdown: remove `border border-zinc-100` (keep `shadow-lg`)
+- Line 569 pagination footer: remove `border-t border-zinc-50`
+
+### F4 (MEDIUM) — RETURNING threshold
+Line 100: `>= 30` -> `>= 21`
+
+### F5 (MEDIUM) — Single signal, priority-ordered
+Refactor `buildSignals()` to return `Signal | null` (or `Signal[]` with max 1 item) using priority order:
+Cancelled 2x > EXAM Xw > Returning > Review pending > Inactive Xd > NEW > none
+
+(HMWK NOT DONE/PARTIAL not yet in data model; skip for now.)
+
+Render site at line 535-553 already handles array; keep return type as `Signal[]` but return at most one item.
+
+### F6 (LOW) — "active" in subtitle
+Line 297: `"Managing ${total} language learner"` -> `"Managing ${total} active language learner"`
+
+### F7 (LOW) — ChevronDown on Load More
+Add `ChevronDown` to lucide import. Add `<ChevronDown className="h-3.5 w-3.5 ml-1" />` inside Load More button.
+
+### F8 (LOW) — Absolute date for future >6d
+`formatRelativeDate` at lines 41-72: for future dates > 6 days, return `"17 May"` format (`date.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })`).
+
+## Test plan (manual + e2e)
+- Load More expands from 12 to 24; URL shows `?count=24`
+- After search and clear, Load More still works
+- Headers show CEFR LEVEL, LANGUAGE, SIGNALS
+- No 1px borders on footer, sort dropdown, skeleton
+- Student with 22-day gap + next session shows RETURNING
+- Only one signal badge per student
+- Subtitle includes "active"
+- Load More button has chevron
+- Future date >6d shows "17 May" style


### PR DESCRIPTION
Closes #795

## Summary

- **F1 (HIGH)**: Fix Load More pagination — debounce effect now tracks last-written search value via ref; only deletes `?count` when search text actually changed (not on every `setSearchParams` identity change)
- **F2**: Rename column headers to CEFR LEVEL, LANGUAGE, SIGNALS
- **F3**: Remove no-line border violations from skeleton header, sort dropdown, pagination footer
- **F4**: RETURNING threshold 30d → 21d per behavior doc
- **F5**: `buildSignals()` returns at most one signal per priority: Cancelled 2x > Exam prep > RETURNING > Review pending > Inactive Xd > NEW
- **F6**: Subtitle includes "active" qualifier
- **F7**: ChevronDown icon on Load More button
- **F8**: Future next-session dates >6 days show absolute "17 May" format

## Test plan

- [x] 36 unit tests pass (added: RETURNING 21d threshold, multi-condition single-signal, absolute date format)
- [x] build verify: dotnet build PASS, dotnet test PASS, npm lint PASS
- [x] qa-verify: PASS
- [x] architecture-reviewer: PASS WITH NOTES (pre-existing en-GB locale, not introduced here)
- [x] review-ui: PASS (column headers, single signal badges, no border artifacts, layout matches Stitch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)