### PR TITLE
feat(t799): Stitch alignment polish - Edit Student + Log Session

### DIFF
--- a/frontend/src/components/dashboard/CefrBadge.tsx
+++ b/frontend/src/components/dashboard/CefrBadge.tsx
@@ -1,17 +1,10 @@
 import { cn } from '@/lib/utils'
+import { cefrColors } from '@/lib/cefr-colors'
 
 interface CefrBadgeProps {
   level: string
   className?: string
   'data-testid'?: string
-}
-
-function cefrColors(level: string): string {
-  const prefix = level[0]?.toUpperCase()
-  if (prefix === 'A') return 'bg-[#DDE8F5] text-[#1A4B7A]'
-  if (prefix === 'B') return 'bg-[#ECEAFD] text-[#3525CD]'
-  if (prefix === 'C') return 'bg-[#F8E9D6] text-[#7E3000]'
-  return 'bg-zinc-100 text-zinc-700'
 }
 
 export function CefrBadge({ level, className, 'data-testid': dataTestId }: CefrBadgeProps) {

--- a/frontend/src/lib/cefr-colors.ts
+++ b/frontend/src/lib/cefr-colors.ts
@@ -1,5 +1,13 @@
 export const CEFR_LEVELS = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'] as const
 
+export function cefrColors(level: string): string {
+  const prefix = level[0]?.toUpperCase()
+  if (prefix === 'A') return 'bg-[#DDE8F5] text-[#1A4B7A]'
+  if (prefix === 'B') return 'bg-[#ECEAFD] text-[#3525CD]'
+  if (prefix === 'C') return 'bg-[#F8E9D6] text-[#7E3000]'
+  return 'bg-zinc-100 text-zinc-700'
+}
+
 /**
  * Returns the absolute gap between two CEFR levels (e.g. A1 vs C1 = 4).
  * Returns 0 if either level is unknown or undefined.

--- a/frontend/src/pages/LogSession.test.tsx
+++ b/frontend/src/pages/LogSession.test.tsx
@@ -427,6 +427,19 @@ describe('LogSession', () => {
       expect(screen.queryByTestId('topic-tag-suggestions')).toBeNull()
     })
   })
+
+  it('C5: topic tag suggestion chips have no border-indigo class', async () => {
+    renderLogSession()
+    await screen.findByTestId('actual-content')
+    fireEvent.change(screen.getByTestId('actual-content'), {
+      target: { value: 'Revisamos el subjuntivo en oraciones temporales' },
+    })
+    await waitFor(() => {
+      const chip = screen.getByTestId('tag-suggestion-subjuntivo')
+      expect(chip.className).not.toContain('border-indigo')
+      expect(chip.className).toContain('bg-indigo-100')
+    })
+  })
 })
 
 const SESSION_ID = 'session-edit-1'
@@ -650,6 +663,15 @@ describe('LogSession — back arrow behavior', () => {
     fireEvent.click(screen.getByTestId('keep-editing-btn'))
     expect(screen.queryByTestId('discard-confirm-bar')).not.toBeInTheDocument()
     expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('C6: discard button has no red border class', async () => {
+    renderLogSession()
+    await screen.findByTestId('actual-content')
+    fireEvent.change(screen.getByTestId('actual-content'), { target: { value: 'Some content' } })
+    fireEvent.click(screen.getByTestId('back-button'))
+    const btn = screen.getByTestId('discard-btn')
+    expect(btn.className).not.toContain('border-red')
   })
 })
 

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -876,9 +876,9 @@ export default function LogSession() {
                 <Button
                   type="button"
                   size="sm"
-                  variant="outline"
+                  variant="ghost"
                   onClick={handleDiscard}
-                  className="text-red-600 border-red-200 hover:bg-red-50"
+                  className="text-red-600 hover:bg-red-50"
                   data-testid="discard-btn"
                 >
                   Discard
@@ -1047,7 +1047,7 @@ export default function LogSession() {
                           setTopicTags(next)
                           markChangedAndSaveNow({ topicTags: serializeTopicTags(next) })
                         }}
-                        className="inline-flex items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-3 py-1.5 min-h-[36px] text-sm font-medium text-indigo-700 hover:bg-indigo-100 transition-colors"
+                        className="inline-flex items-center gap-1 rounded-full bg-indigo-100 px-3 py-1.5 min-h-[36px] text-sm font-medium text-indigo-700 hover:bg-indigo-200 transition-colors"
                         data-testid={`tag-suggestion-${suggestion}`}
                       >
                         <Plus className="h-3 w-3" />

--- a/frontend/src/pages/StudentForm.test.tsx
+++ b/frontend/src/pages/StudentForm.test.tsx
@@ -1084,6 +1084,39 @@ describe('StudentForm', () => {
     await user.click(ghostBadge)
     expect(await screen.findByTestId('student-official-cefr')).toBeInTheDocument()
   })
+
+  it('C1: Skill Override pills show skill name with placeholder when no level set', async () => {
+    renderEdit()
+    await screen.findByRole('heading', { name: 'Edit Student' })
+    expect(screen.getByText('Reading --')).toBeInTheDocument()
+    expect(screen.getByText('Writing --')).toBeInTheDocument()
+    expect(screen.getByText('Speaking --')).toBeInTheDocument()
+    expect(screen.getByText('Listening --')).toBeInTheDocument()
+  })
+
+  it('C2: Scrollspy nav uses shadow-sm, not border-b', async () => {
+    renderEdit()
+    const nav = await screen.findByTestId('section-nav')
+    expect(nav.className).toContain('shadow-sm')
+    expect(nav.className).not.toContain('border-b')
+  })
+
+  it('C3: Inactive badge has no border class', async () => {
+    mockGetStudent.mockResolvedValue({
+      id: 'stu-1', name: 'Ana', learningLanguage: 'Spanish', cefrLevel: 'B1',
+      interests: [], nativeLanguages: [], learningGoals: [],
+      weaknesses: [] as { description: string; weaknessType: string }[],
+      difficulties: [], personalNotes: null, teachingNotes: null,
+      shortTermObjectives: [], spokenLanguages: [], teachingTodos: [],
+      birthYear: null, profession: null, countryOfOrigin: null, cityOfOrigin: null,
+      countryOfResidence: null, cityOfResidence: null, reasonForStudying: null,
+      officialCefrLevel: null, isActive: false, isCorporate: false, rate: null,
+      skillLevelOverrides: {}, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z',
+    })
+    renderEdit()
+    const badge = await screen.findByTestId('inactive-badge')
+    expect(badge.className).not.toContain('border')
+  })
 })
 
 describe('StudentForm – language combobox with full options', () => {

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -30,7 +30,8 @@ import { SectionHeader } from '@/components/student/SectionHeader'
 import { getFollowups } from '@/api/followups'
 import { FieldTooltip } from '@/components/FieldTooltip'
 import { PageHeader } from '@/components/PageHeader'
-import { CEFR_LEVELS } from '@/lib/cefr-colors'
+import { CEFR_LEVELS, cefrColors } from '@/lib/cefr-colors'
+import { cn } from '@/lib/utils'
 import { CefrBadge } from '@/components/dashboard/CefrBadge'
 import { ALL_LANGUAGE_OPTIONS } from '@/lib/languages'
 import { useStudentAutosave } from '@/hooks/useStudentAutosave'
@@ -643,7 +644,7 @@ export default function StudentForm() {
       {isEdit && !isActive && (
         <div className="mt-2">
           <span
-            className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-zinc-100 text-zinc-500 border border-zinc-200"
+            className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-zinc-100 text-zinc-500"
             data-testid="inactive-badge"
           >
             Inactive
@@ -653,7 +654,7 @@ export default function StudentForm() {
 
       {/* Sticky section nav — edit mode only, renders below header so it sticks as header scrolls away */}
       {isEdit && (
-        <div className="sticky top-14 lg:top-0 z-30 bg-white/95 backdrop-blur-sm border-b border-zinc-100 flex items-center gap-3 py-2 -mx-4 lg:-mx-6 px-4 lg:px-6 mt-4 mb-6" data-testid="section-nav">
+        <div className="sticky top-14 lg:top-0 z-30 bg-white/95 backdrop-blur-sm shadow-sm flex items-center gap-3 py-2 -mx-4 lg:-mx-6 px-4 lg:px-6 mt-4 mb-6" data-testid="section-nav">
           <nav className="flex items-center gap-1 overflow-x-auto shrink min-w-0" style={{ scrollbarWidth: 'none' }} aria-label="Form sections">
             {FORM_SECTIONS.map((s) => (
               <button
@@ -837,7 +838,7 @@ export default function StudentForm() {
                     </div>
 
                     {/* Languages — merged into Basic Info card */}
-                    <div className="pt-4 border-t border-zinc-100 space-y-4">
+                    <div className="pt-6 space-y-4">
                       {/* Native Languages */}
                       <div className="space-y-1.5">
                         <Label className="inline-flex items-center gap-1">Native Languages <FieldTooltip fieldKey="nativeLanguages" /></Label>
@@ -887,36 +888,30 @@ export default function StudentForm() {
                   <p className="text-xs text-zinc-400 mb-4">Override the general CEFR level per skill for AI generation. Leave empty to inherit the general level.</p>
                   <div className="grid grid-cols-2 gap-3">
                     {(['Reading', 'Writing', 'Speaking', 'Listening'] as const).map((skill) => (
-                      <div key={skill} className="space-y-1.5">
-                        <Label className="text-xs">{skill}</Label>
-                        {skillLevelOverrides[skill] && editingCefrField !== `skill-${skill}` ? (
-                          <button
-                            type="button"
-                            onClick={() => setEditingCefrField(`skill-${skill}`)}
-                            className="block"
-                            aria-label={`Edit ${skill} override`}
-                            data-testid={`skill-override-${skill.toLowerCase()}-badge`}
-                          >
-                            <CefrBadge level={skillLevelOverrides[skill]} className="cursor-pointer hover:opacity-80 transition-opacity" />
-                          </button>
-                        ) : (
-                          <Select
-                            value={skillLevelOverrides[skill] ?? ''}
-                            onValueChange={(v) => { const next = !v || v === '__none__' ? '' : v; setSkillOverride(skill, next); setEditingCefrField(null); if (isEdit) { const nextOverrides = next ? { ...skillLevelOverrides, [skill]: next } : Object.fromEntries(Object.entries(skillLevelOverrides).filter(([k]) => k !== skill)); saveNow({ skillLevelOverrides: nextOverrides }) } }}
-                            open={editingCefrField === `skill-${skill}` || undefined}
-                            onOpenChange={(open) => { if (!open) setEditingCefrField(null) }}
-                          >
-                            <SelectTrigger data-testid={`skill-override-${skill.toLowerCase()}`} className="h-8 text-xs">
-                              <SelectValue placeholder="--" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="__none__">--</SelectItem>
-                              {CEFR_LEVELS.map((level) => (
-                                <SelectItem key={level} value={level}>{level}</SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        )}
+                      <div key={skill} className="relative">
+                        <div
+                          aria-hidden="true"
+                          className={cn(
+                            'flex items-center justify-center rounded-md px-2 py-1 text-xs font-bold uppercase tracking-[0.05em] font-inter pointer-events-none select-none',
+                            skillLevelOverrides[skill] ? cefrColors(skillLevelOverrides[skill]) : 'bg-zinc-100 text-zinc-500',
+                          )}
+                        >
+                          {skill} {skillLevelOverrides[skill] || '--'}
+                        </div>
+                        <Select
+                          value={skillLevelOverrides[skill] ?? ''}
+                          onValueChange={(v) => { const next = !v || v === '__none__' ? '' : v; setSkillOverride(skill, next); if (isEdit) { const nextOverrides = next ? { ...skillLevelOverrides, [skill]: next } : Object.fromEntries(Object.entries(skillLevelOverrides).filter(([k]) => k !== skill)); saveNow({ skillLevelOverrides: nextOverrides }) } }}
+                        >
+                          <SelectTrigger data-testid={`skill-override-${skill.toLowerCase()}`} className="absolute inset-0 !w-full !h-full opacity-0 cursor-pointer">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="__none__">--</SelectItem>
+                            {CEFR_LEVELS.map((level) => (
+                              <SelectItem key={level} value={level}>{level}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
                       </div>
                     ))}
                   </div>
@@ -1110,7 +1105,7 @@ export default function StudentForm() {
                   </div>
 
                   {/* Short-Term Objectives */}
-                  <div className="space-y-3 pt-2 border-t border-zinc-100">
+                  <div className="space-y-3 pt-4">
                     <div className="flex items-center justify-between">
                       <div>
                         <Label>Short-Term Objectives</Label>
@@ -1225,7 +1220,7 @@ export default function StudentForm() {
                   </div>
 
                   {/* Structured Difficulties */}
-                  <div className="space-y-3 pt-2 border-t border-zinc-100">
+                  <div className="space-y-3 pt-4">
                     <div className="flex items-center justify-between">
                       <div>
                         <Label className="inline-flex items-center gap-1">Specific Difficulties <FieldTooltip fieldKey="difficulties" /></Label>
@@ -1462,7 +1457,7 @@ export default function StudentForm() {
 
           {/* Danger zone — delete action at bottom of page */}
           {isEdit && id && (
-            <div className="pt-6 border-t border-zinc-100 space-y-2" data-testid="danger-zone">
+            <div className="pt-8 space-y-2" data-testid="danger-zone">
               {deleteError && (
                 <p className="text-sm text-red-600 font-medium" data-testid="delete-error">{deleteError}</p>
               )}

--- a/plan/langteach-beta/task799-stitch-alignment-polish.md
+++ b/plan/langteach-beta/task799-stitch-alignment-polish.md
@@ -1,0 +1,74 @@
+# Task 799: Edit Student + Log Session Stitch Alignment Polish
+
+## Issue
+#799 - Edit Student + Log Session: Stitch alignment polish
+
+## Branch
+`worktree-task-t799-stitch-alignment-polish` -> PR to `sprint/ui-redesign-student-polish`
+
+## Context
+Vera UX review (feedback3, sections 3D + 3E). Six targeted visual fixes: one medium (skill override pill redesign) and five low (border removals).
+
+## Files Changed
+- `frontend/src/pages/StudentForm.tsx`
+- `frontend/src/pages/LogSession.tsx`
+- `frontend/src/components/dashboard/CefrBadge.tsx` (export `cefrColors`)
+
+## Acceptance Criteria and Implementation Plan
+
+### AC1: Skill Overrides visual upgrade (MEDIUM) - StudentForm.tsx
+
+**Current behavior:** Label above + CefrBadge (click-to-edit) when set, Label above + Select when not set.
+
+**Requested:** Each skill shows a single pill with "skill name + CEFR level" (e.g. "Reading B2"), color-coded by CEFR band. No separate Label element.
+
+**Implementation:**
+
+1. Export `cefrColors` from `CefrBadge.tsx` (currently unexported).
+
+2. In StudentForm.tsx, replace the current 2x2 grid (Label + badge/Select per skill) with 4 pills arranged in a 2x2 grid:
+   - Each pill is a `<button>` showing "{skill} {level}" (e.g. "Reading B2") when a level is set, or "{skill} --" when not set.
+   - Uses `cefrColors(level)` for set values; `bg-zinc-100 text-zinc-500` for unset.
+   - On click: `setEditingCefrField(`skill-${skill}`)` (same as current).
+   - The Select (invisible trigger) renders below the pill when `editingCefrField === `skill-${skill}`` to open the dropdown. Use a zero-height wrapper with `<Select open={true}>` to pop the dropdown without rendering a visible trigger.
+   - Keep all `data-testid` attributes: pill button gets `data-testid={`skill-override-${skill.toLowerCase()}-badge`}`, Select trigger keeps `data-testid={`skill-override-${skill.toLowerCase()}`}`.
+
+3. Layout: keep the `grid grid-cols-2 gap-3` wrapper, remove the `<Label>` element per skill.
+
+### AC2: Remove section separator borders (LOW) - StudentForm.tsx
+
+Replace `border-t border-zinc-100` with extra vertical padding:
+- Line 840: `pt-4 border-t border-zinc-100 space-y-4` -> `pt-6 space-y-4`
+- Line 1113: `space-y-3 pt-2 border-t border-zinc-100` -> `space-y-3 pt-4`
+- Line 1228: `space-y-3 pt-2 border-t border-zinc-100` -> `space-y-3 pt-4`
+- Line 1465: `pt-6 border-t border-zinc-100 space-y-2` -> `pt-8 space-y-2`
+
+### AC3: Scrollspy nav bar border (LOW) - StudentForm.tsx
+
+Line 656: `border-b border-zinc-100` -> `shadow-sm` (drop the border, add subtle shadow).
+
+### AC4: Inactive badge border (LOW) - StudentForm.tsx
+
+Line 646: Remove `border border-zinc-200` from the inactive student badge. Keep `bg-zinc-100 text-zinc-500` for tonal-only styling.
+
+### AC5: Topic tag chip border (LOW) - LogSession.tsx
+
+Line 1050: Remove `border border-indigo-200`, bump bg to `bg-indigo-100` and hover to `hover:bg-indigo-200` for tonal-only:
+`bg-indigo-100 text-indigo-700 hover:bg-indigo-200`
+
+### AC6: Discard button border (LOW) - LogSession.tsx
+
+Line 881: Change `variant="outline"` to `variant="ghost"` and update className to `text-red-600 hover:bg-red-50`. This fully removes the border (ghost variant has no border) while keeping tonal red styling.
+
+## E2E Coverage
+
+No new e2e tests needed: all changes are visual-only. Existing e2e tests cover skill override functional behavior and button actions. The `data-testid` attributes are preserved.
+
+## Unit Tests
+
+No new unit tests needed. Logic is unchanged. CefrBadge already has its own test; exporting `cefrColors` does not require a new test.
+
+## Review Routing
+
+- `area:frontend` + `area:design` -> qa-verify, architecture-reviewer, review-ui
+- No prompt changes -> no pedagogy/Sophy/prompt-health review


### PR DESCRIPTION
## Summary

- **Skill Overrides redesign**: Replace 4 separate label+select dropdowns with always-visible CEFR pills (e.g. "Reading B2") using an invisible SelectTrigger overlay; moves `cefrColors` to `cefr-colors.ts` to satisfy fast-refresh lint rule
- **Edit Student border cleanup**: Remove `border-t border-zinc-100` separators at 4 locations; replace scrollspy nav `border-b` with `shadow-sm`; remove `border border-zinc-200` from inactive badge
- **Log Session border cleanup**: Remove `border-indigo-200` from topic tag chips (tonal-only); change discard button from `outline` to `ghost` variant (removes red border)

## Test plan

- [ ] Edit Student: Skill Overrides section shows 4 colored pills (Reading --, Writing --, etc.); clicking a pill opens CEFR dropdown
- [ ] Edit Student: No visible separator borders between sections (spacing only)
- [ ] Edit Student: Scrollspy nav has subtle shadow, no bottom border
- [ ] Log Session: Topic suggestion chips are borderless indigo tonal pills
- [ ] Log Session: Discard confirmation bar shows borderless red ghost button
- [ ] All 1305 unit tests pass
- [ ] E2e: student create flow with skill override still works (`skill-override-reading` testid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined button, badge, and suggestion chip styling in session logging and student management interfaces.
  * Updated section navigation and dividers for improved visual consistency.
  * Enhanced skill override display styling.

* **Tests**
  * Added test coverage for UI styling validation in session logging and student management components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->