### PR TITLE
fix(t806): edit student test plan - followup Plus icon + NEAR DATE threshold

### DIFF
--- a/frontend/src/components/student/StudentFollowupsCard.tsx
+++ b/frontend/src/components/student/StudentFollowupsCard.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from 'react'
+import { Plus } from 'lucide-react'
 import { useMutation } from '@tanstack/react-query'
 import type { TeacherFollowup } from '@/api/followups'
 import { createFollowup, updateFollowupStatus } from '@/api/followups'
@@ -122,10 +123,10 @@ export function StudentFollowupsCard({ followups, studentId, onFollowupChange, e
           type="button"
           onClick={handleAdd}
           disabled={createMutation.isPending || !newText.trim()}
-          className="rounded-md bg-amber-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-600 disabled:opacity-40 transition-colors"
+          className="shrink-0 rounded-lg bg-amber-500 p-1.5 text-white hover:bg-amber-600 disabled:opacity-40 transition-colors"
           data-testid="followup-add-btn"
         >
-          Add
+          <Plus className="h-4 w-4" />
         </button>
       </div>
     </div>

--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -435,11 +435,11 @@ describe('StudentProfileTab', () => {
       expect(screen.getByTestId('objective-overdue-label')).toBeInTheDocument()
     })
 
-    it('shows Critical label for objective within 6 weeks', () => {
+    it('shows Critical label for objective within 3 days', () => {
       const student = {
         ...FULL_STUDENT,
         shortTermObjectives: [
-          { id: 'obj-1', text: 'Critical objective', targetDate: dateOffset(20) },
+          { id: 'obj-1', text: 'Critical objective', targetDate: dateOffset(2) },
         ],
       }
       renderProfile(student)

--- a/frontend/src/lib/objectiveUrgency.test.ts
+++ b/frontend/src/lib/objectiveUrgency.test.ts
@@ -27,12 +27,12 @@ describe('getObjectiveUrgency', () => {
     expect(getObjectiveUrgency(dateString(0))).toBe('critical')
   })
 
-  it('returns critical for date within 42 days', () => {
-    expect(getObjectiveUrgency(dateString(42))).toBe('critical')
+  it('returns critical for date within 3 days', () => {
+    expect(getObjectiveUrgency(dateString(3))).toBe('critical')
   })
 
-  it('returns normal for date beyond 42 days', () => {
-    expect(getObjectiveUrgency(dateString(43))).toBe('normal')
+  it('returns normal for date beyond 3 days', () => {
+    expect(getObjectiveUrgency(dateString(4))).toBe('normal')
   })
 })
 

--- a/frontend/src/lib/objectiveUrgency.ts
+++ b/frontend/src/lib/objectiveUrgency.ts
@@ -3,8 +3,8 @@ export type UrgencyStatus = 'overdue' | 'critical' | 'normal'
 /**
  * Returns the urgency status for a short-term objective based on its target date.
  * - 'overdue': past due
- * - 'critical': due within 6 weeks (42 days)
- * - 'normal': more than 6 weeks away or no date
+ * - 'critical': due within 3 days (shows NEAR DATE badge)
+ * - 'normal': more than 3 days away or no date
  */
 export function getObjectiveUrgency(targetDate: string | null): UrgencyStatus {
   if (!targetDate) return 'normal'
@@ -13,7 +13,7 @@ export function getObjectiveUrgency(targetDate: string | null): UrgencyStatus {
   const due = new Date(targetDate + 'T00:00:00')
   const diffDays = Math.floor((due.getTime() - today.getTime()) / 86400000)
   if (diffDays < 0) return 'overdue'
-  if (diffDays <= 42) return 'critical'
+  if (diffDays <= 3) return 'critical'
   return 'normal'
 }
 

--- a/frontend/src/lib/objectiveUrgency.ts
+++ b/frontend/src/lib/objectiveUrgency.ts
@@ -1,5 +1,16 @@
 export type UrgencyStatus = 'overdue' | 'critical' | 'normal'
 
+const MS_PER_DAY = 86_400_000
+
+function calendarDaysRemaining(targetDate: string): number {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(targetDate)
+  if (!match) return 0
+  const today = new Date()
+  const todayUtc = Date.UTC(today.getFullYear(), today.getMonth(), today.getDate())
+  const dueUtc = Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3]))
+  return Math.floor((dueUtc - todayUtc) / MS_PER_DAY)
+}
+
 /**
  * Returns the urgency status for a short-term objective based on its target date.
  * - 'overdue': past due
@@ -8,10 +19,7 @@ export type UrgencyStatus = 'overdue' | 'critical' | 'normal'
  */
 export function getObjectiveUrgency(targetDate: string | null): UrgencyStatus {
   if (!targetDate) return 'normal'
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-  const due = new Date(targetDate + 'T00:00:00')
-  const diffDays = Math.floor((due.getTime() - today.getTime()) / 86400000)
+  const diffDays = calendarDaysRemaining(targetDate)
   if (diffDays < 0) return 'overdue'
   if (diffDays <= 3) return 'critical'
   return 'normal'
@@ -22,10 +30,7 @@ export function getObjectiveUrgency(targetDate: string | null): UrgencyStatus {
  */
 export function getDaysRemaining(targetDate: string | null): number | null {
   if (!targetDate) return null
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-  const due = new Date(targetDate + 'T00:00:00')
-  return Math.floor((due.getTime() - today.getTime()) / 86400000)
+  return calendarDaysRemaining(targetDate)
 }
 
 export function formatDaysRemaining(days: number): string {

--- a/plan/langteach-beta/task806-edit-student-test-plan.md
+++ b/plan/langteach-beta/task806-edit-student-test-plan.md
@@ -1,0 +1,65 @@
+# Task 806: Edit Student Exhaustive Test Plan Pass
+
+## Goal
+Run the exhaustive Edit Student test plan and fix all bugs found.
+
+## Bugs Found (Pass 1 - Chrome)
+
+### B1: StudentFollowupsCard add button missing Plus icon
+**File:** `frontend/src/components/student/StudentFollowupsCard.tsx`
+**Problem:** The followup add button used "Add" text instead of a Plus icon, violating design system cross-screen consistency rule C6 (should match LogSession and TeachingTodosCard pattern).
+**Fix:** Changed button class to `rounded-lg bg-amber-500 p-1.5 text-white hover:bg-amber-600`, added `<Plus className="h-4 w-4" />`, imported `Plus` from lucide-react.
+
+### B2: NEAR DATE badge shows for objectives up to 42 days away
+**File:** `frontend/src/lib/objectiveUrgency.ts`
+**Problem:** `getObjectiveUrgency` used a 42-day threshold for 'critical' status, causing the "NEAR DATE" badge to appear for objectives up to 6 weeks away. Test plan 9.2.6 specifies < 3 days.
+**Fix:** Changed threshold from `diffDays <= 42` to `diffDays <= 3`. Updated unit test to match.
+
+## Pass 1 Results
+
+| Section | Result | Notes |
+|---------|--------|-------|
+| 1.1 Entry points | PASS | All navigation paths work |
+| 1.1.4 Invalid URL | PASS | Shows "Student not found. Go back" |
+| 2.1 Header | PASS | Title, subtitle, back link, Create Course, Done all correct |
+| 3.1 Section nav | PASS | 7 pills, active state highlight correct |
+| 4.1-4.6 Basic Info | PASS | Name, Learning Language, CEFR badge (click-to-edit), Official Level, Native/Spoken Languages |
+| 4.3.2 Pencil on hover | SKIP | Could not verify via screenshot at scale |
+| 4.3.3 Click opens select | PASS | Dropdown opens with A1-C2 options |
+| 4.4.1 Not set dashed | PASS | Dashed border visible |
+| 5 Skill Overrides | PASS | 2x2 grid, correct layout in right column |
+| 6 Personal Background | SKIP | No data for this teacher's "Ana Visual" (seeder gap) |
+| 7 Reason for Studying | SKIP | No data seeded |
+| 8 Interests | SKIP | No data seeded |
+| 9.2 Short-Term Objectives | PASS (after fix) | Amber border, NEAR DATE threshold fixed |
+| 10.1 Areas to Improve | PASS | Empty state shown correctly |
+| 10.2 Specific Difficulties | PASS | Severity bar, trend indicators, Active/Covered toggle |
+| 11 Notes | PASS | Two-column layout, labels, tooltips |
+| 12.1-12.4 Commercial Info | PASS | Account Status, Student Type, Hourly Rate |
+| 12.2.2 Toggle dimensions | PASS | h-6 w-11 track, h-4 w-4 thumb confirmed via DOM |
+| 13.1 Sidebar | PASS | Visible, sticky, white rounded-2xl cards |
+| 13.2 Teaching Todos | PASS | Custom button checkbox, "Add a teaching idea...", Plus button (indigo) |
+| 13.3 Pending Followups | PASS (after fix) | Custom circle toggle, Plus icon fixed |
+| 14.1-14.2 Autosave | PASS | Correct position, idle = nothing shown |
+| 15 Done/Cancel | PASS | Correct styles and placement |
+| 16 Delete | PASS | Red ghost button at bottom |
+| 17 Courses card | PASS | Visible below form in edit mode |
+| 18 Create mode | PASS | Title, buttons, no section nav, no sidebar |
+| C6 Cross-screen followup btn | PASS (after fix) | Now matches LogSession Plus icon style |
+| C7 Toggle size | PASS | Same h-6 w-11 dimensions |
+
+## Pass 2 (Playwright)
+
+Existing e2e tests in `e2e/tests/students.spec.ts` cover:
+- Invalid edit URL error state (F1.2)
+- Autosave mechanics and persistence
+- Difficulty round-trip
+- Learning goals
+
+No new Playwright tests were added since the bugs found (B1 visual, B2 threshold) are covered by the updated unit tests and the existing e2e suite.
+
+## Files Changed
+
+- `frontend/src/components/student/StudentFollowupsCard.tsx` - Plus icon on add button
+- `frontend/src/lib/objectiveUrgency.ts` - threshold 42 → 3 days
+- `frontend/src/lib/objectiveUrgency.test.ts` - updated test cases to match new threshold


### PR DESCRIPTION
## Summary

Exhaustive Edit Student test plan pass (#806). Two bugs found and fixed:

- **B1 (StudentFollowupsCard):** Followup add button used "Add" text instead of Plus icon, breaking cross-screen consistency with TeachingTodosCard and LogSession (design system C6). Now `rounded-lg bg-amber-500 p-1.5` with `<Plus className="h-4 w-4" />`.
- **B2 (objectiveUrgency):** `getObjectiveUrgency` threshold was 42 days, causing NEAR DATE badge to appear for objectives up to 6 weeks away. Reduced to 3 days per test plan 9.2.6. Unit tests updated.

## Test plan

- [x] Pass 1 (Chrome): all sections visually verified - PASS or justified SKIP
- [x] Architecture review: PASS
- [x] UI review: PASS (both add buttons symmetric, NEAR DATE suppressed correctly)
- [x] Unit tests pass (`objectiveUrgency.test.ts`, `StudentFollowupsCard.test.tsx`)
- [x] No conflicts with sprint branch

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adjusted objective urgency classification—critical urgency now triggers for objectives due within 3 days (previously 6 weeks).

* **Style**
  * Updated the add button to display an icon instead of text for improved visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->