### PR TITLE
fix(t812): normalize TeachingTodo status to PascalCase to fix 400 on checkbox toggle

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
@@ -260,8 +260,8 @@ public class DashboardServiceTests : IDisposable
     public async Task GetAsync_ActiveStudents_ReturnsPendingTodos()
     {
         _db.Students.First(s => s.Id == _studentId).TeachingTodos =
-            "[{\"id\":\"t1\",\"text\":\"Focus on subjunctive\",\"createdAt\":\"2026-04-01T10:00:00Z\",\"status\":\"pending\",\"sourceSessionLogId\":null,\"coveredInSessionLogId\":null}," +
-            "{\"id\":\"t2\",\"text\":\"Review homework\",\"createdAt\":\"2026-04-02T10:00:00Z\",\"status\":\"covered\",\"sourceSessionLogId\":null,\"coveredInSessionLogId\":null}]";
+            "[{\"id\":\"t1\",\"text\":\"Focus on subjunctive\",\"createdAt\":\"2026-04-01T10:00:00Z\",\"status\":\"Pending\",\"sourceSessionLogId\":null,\"coveredInSessionLogId\":null}," +
+            "{\"id\":\"t2\",\"text\":\"Review homework\",\"createdAt\":\"2026-04-02T10:00:00Z\",\"status\":\"Covered\",\"sourceSessionLogId\":null,\"coveredInSessionLogId\":null}]";
         _db.SaveChanges();
 
         var result = await _sut.GetAsync(_teacherId);
@@ -271,7 +271,7 @@ public class DashboardServiceTests : IDisposable
         student.PendingTodos.Should().HaveCount(1);
         student.PendingTodos[0].Id.Should().Be("t1");
         student.PendingTodos[0].Text.Should().Be("Focus on subjunctive");
-        student.PendingTodos[0].Status.Should().Be("pending");
+        student.PendingTodos[0].Status.Should().Be("Pending");
     }
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs
@@ -309,7 +309,7 @@ public class StudentServiceTests : IDisposable
 
     // TeachingTodos tests
 
-    private static TeachingTodoDto MakeTodo(string id, string text = "Work on ser/estar", string status = "pending") =>
+    private static TeachingTodoDto MakeTodo(string id, string text = "Work on ser/estar", string status = "Pending") =>
         new(id, text, DateTime.UtcNow, null, status, null);
 
     [Fact]
@@ -342,9 +342,9 @@ public class StudentServiceTests : IDisposable
             TeachingTodos = [MakeTodo("todo-1")],
         });
 
-        var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "todo-1", new UpdateTeachingTodoDto("covered", null, null));
+        var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "todo-1", new UpdateTeachingTodoDto("Covered", null, null));
 
-        result!.TeachingTodos.Single().Status.Should().Be("covered");
+        result!.TeachingTodos.Single().Status.Should().Be("Covered");
     }
 
     [Fact]
@@ -357,9 +357,9 @@ public class StudentServiceTests : IDisposable
             TeachingTodos = [MakeTodo("todo-1")],
         });
 
-        var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "todo-1", new UpdateTeachingTodoDto("dismissed", null, null));
+        var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "todo-1", new UpdateTeachingTodoDto("Dismissed", null, null));
 
-        result!.TeachingTodos.Single().Status.Should().Be("dismissed");
+        result!.TeachingTodos.Single().Status.Should().Be("Dismissed");
     }
 
     [Fact]
@@ -398,7 +398,7 @@ public class StudentServiceTests : IDisposable
     {
         var created = await _sut.CreateAsync(_teacherId, BaseRequest());
 
-        var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "nonexistent-id", new UpdateTeachingTodoDto("covered", null, null));
+        var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "nonexistent-id", new UpdateTeachingTodoDto("Covered", null, null));
 
         result.Should().BeNull();
     }
@@ -423,7 +423,7 @@ public class StudentServiceTests : IDisposable
 
         result!.TeachingTodos.Should().HaveCount(1);
         result.TeachingTodos[0].Text.Should().Be("Trabajar ser/estar");
-        result.TeachingTodos[0].Status.Should().Be("pending");
+        result.TeachingTodos[0].Status.Should().Be("Pending");
         result.TeachingTodos[0].Id.Should().NotBeNullOrEmpty();
     }
 
@@ -479,7 +479,7 @@ public class StudentServiceTests : IDisposable
         });
 
         var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "todo-1",
-            new UpdateTeachingTodoDto("pending", null, "Updated text"));
+            new UpdateTeachingTodoDto("Pending", null, "Updated text"));
 
         result!.TeachingTodos.Single().Text.Should().Be("Updated text");
     }
@@ -495,7 +495,7 @@ public class StudentServiceTests : IDisposable
         });
 
         var act = () => _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, "todo-1",
-            new UpdateTeachingTodoDto("pending", null, new string('x', 501)));
+            new UpdateTeachingTodoDto("Pending", null, new string('x', 501)));
 
         await act.Should().ThrowAsync<ValidationException>();
     }

--- a/backend/LangTeach.Api/Data/DemoSeeder.cs
+++ b/backend/LangTeach.Api/Data/DemoSeeder.cs
@@ -257,7 +257,7 @@ public static class DemoSeeder
             Weaknesses         = """["Listening to fast native speech","Idiomatic expressions"]""",
             PersonalNotes      = "[scenario-seed]",
             TeachingNotes      = "Responds well to visual aids. Prefers structured grammar drills over free conversation. Review subjunctive triggers next session.",
-            TeachingTodos      = """[{"id":"a1b2c3d4-0000-0000-0000-000000000010","text":"Review subjunctive trigger verbs — she confuses querer vs desear contexts","createdAt":"2026-04-10T10:00:00Z","sourceSessionLogId":null,"status":"pending","coveredInSessionLogId":null}]""",
+            TeachingTodos      = """[{"id":"a1b2c3d4-0000-0000-0000-000000000010","text":"Review subjunctive trigger verbs — she confuses querer vs desear contexts","createdAt":"2026-04-10T10:00:00Z","sourceSessionLogId":null,"status":"Pending","coveredInSessionLogId":null}]""",
             SkillLevelOverrides = """{"Reading":"B2","Speaking":"B1","Writing":"A2","Listening":"B1"}""",
             BirthYear          = 1992,
             Profession         = "Marketing Manager",
@@ -511,7 +511,7 @@ public static class DemoSeeder
             Difficulties     = "[]",
             Weaknesses       = "[]",
             PersonalNotes    = "[scenario-seed]",
-            TeachingTodos    = """[{"id":"a1b2c3d4-0000-0000-0000-000000000011","text":"Check if introduction homework sentences were completed before next session","createdAt":"2026-04-10T10:00:00Z","sourceSessionLogId":null,"status":"pending","coveredInSessionLogId":null}]""",
+            TeachingTodos    = """[{"id":"a1b2c3d4-0000-0000-0000-000000000011","text":"Check if introduction homework sentences were completed before next session","createdAt":"2026-04-10T10:00:00Z","sourceSessionLogId":null,"status":"Pending","coveredInSessionLogId":null}]""",
             IsActive         = true,
         }, now);
 

--- a/backend/LangTeach.Api/Data/ScenarioSeeder.cs
+++ b/backend/LangTeach.Api/Data/ScenarioSeeder.cs
@@ -415,7 +415,7 @@ public static class ScenarioSeeder
         // Clara Seed: Review pending (1 pending teaching todo)
         var claraTodoId   = Guid.NewGuid();
         var claraTodoDate = now.AddDays(-3).ToString("yyyy-MM-ddTHH:mm:ssZ");
-        claraSeed.TeachingTodos = $$"""[{"id":"{{claraTodoId}}","text":"Review Clara's subjunctive triggers — exercises not completed","createdAt":"{{claraTodoDate}}","sourceSessionLogId":null,"status":"pending","coveredInSessionLogId":null}]""";
+        claraSeed.TeachingTodos = $$"""[{"id":"{{claraTodoId}}","text":"Review Clara's subjunctive triggers — exercises not completed","createdAt":"{{claraTodoDate}}","sourceSessionLogId":null,"status":"Pending","coveredInSessionLogId":null}]""";
         claraSeed.UpdatedAt = now;
 
         // Diego Seed: no signal (recent past session + upcoming session, no todos)
@@ -595,7 +595,7 @@ public static class ScenarioSeeder
         var todoId2 = Guid.NewGuid();
         var todoDate1 = now.AddDays(-5).ToString("yyyy-MM-ddTHH:mm:ssZ");
         var todoDate2 = now.AddDays(-2).ToString("yyyy-MM-ddTHH:mm:ssZ");
-        anaVisual.TeachingTodos = $$"""[{"id":"{{todoId1}}","text":"Prepare a set of subjunctive trigger cards for next class","createdAt":"{{todoDate1}}","sourceSessionLogId":null,"status":"pending","coveredInSessionLogId":null},{"id":"{{todoId2}}","text":"Find an authentic news article about Latin American culture at B2 level","createdAt":"{{todoDate2}}","sourceSessionLogId":null,"status":"pending","coveredInSessionLogId":null}]""";
+        anaVisual.TeachingTodos = $$"""[{"id":"{{todoId1}}","text":"Prepare a set of subjunctive trigger cards for next class","createdAt":"{{todoDate1}}","sourceSessionLogId":null,"status":"Pending","coveredInSessionLogId":null},{"id":"{{todoId2}}","text":"Find an authentic news article about Latin American culture at B2 level","createdAt":"{{todoDate2}}","sourceSessionLogId":null,"status":"Pending","coveredInSessionLogId":null}]""";
 
         anaVisual.ShortTermObjectives = $$"""[{"id":"obj1","text":"Master subjunctive in nominal clauses (WEIRDO verbs)","targetDate":"{{now.AddDays(-3):yyyy-MM-dd}}"},{"id":"obj2","text":"Achieve confident use of ser vs estar in all tenses","targetDate":"{{now.AddDays(5):yyyy-MM-dd}}"},{"id":"obj3","text":"Build travel and business vocabulary to 500 items","targetDate":"{{now.AddDays(28):yyyy-MM-dd}}"}]""";
 

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -256,7 +256,7 @@ public class DashboardService : IDashboardService
         return rows.Select(r =>
         {
             var allTodos = JsonStorageHelper.DeserializeList<TeachingTodoDto>(r.TeachingTodos);
-            var pendingTodos = allTodos.Where(t => t.Status == "pending").ToList();
+            var pendingTodos = allTodos.Where(t => t.Status == "Pending").ToList();
 
             // NearestObjectiveDeadline: earliest future targetDate from ShortTermObjectives JSON
             // DefaultIfEmpty() on empty sequence returns DateTime.MinValue — treated as null below

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -256,7 +256,7 @@ public class DashboardService : IDashboardService
         return rows.Select(r =>
         {
             var allTodos = JsonStorageHelper.DeserializeList<TeachingTodoDto>(r.TeachingTodos);
-            var pendingTodos = allTodos.Where(t => t.Status == "Pending").ToList();
+            var pendingTodos = allTodos.Where(t => string.Equals(t.Status, "Pending", StringComparison.OrdinalIgnoreCase)).ToList();
 
             // NearestObjectiveDeadline: earliest future targetDate from ShortTermObjectives JSON
             // DefaultIfEmpty() on empty sequence returns DateTime.MinValue — treated as null below

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -46,7 +46,7 @@ public class StudentService : IStudentService
 
     private static readonly HashSet<string> AllowedTodoStatuses =
     [
-        "pending", "covered", "dismissed"
+        "Pending", "Covered", "Dismissed"
     ];
 
     private static readonly HashSet<string> AllowedWeaknessTypes =
@@ -399,7 +399,7 @@ public class StudentService : IStudentService
             request.Text,
             DateTime.UtcNow,
             request.SourceSessionLogId,
-            "pending",
+            "Pending",
             null);
 
         todos.Add(newTodo);

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -44,8 +44,21 @@ public class StudentService : IStudentService
         "Active", "Covered"
     ];
 
-    private static readonly HashSet<string> AllowedTodoStatuses =
-        new(StringComparer.OrdinalIgnoreCase) { "Pending", "Covered", "Dismissed" };
+    private static readonly Dictionary<string, string> CanonicalTodoStatuses =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Pending"] = "Pending",
+            ["Covered"] = "Covered",
+            ["Dismissed"] = "Dismissed",
+        };
+
+    private static string NormalizeTodoStatus(string? status)
+    {
+        if (!string.IsNullOrWhiteSpace(status) && CanonicalTodoStatuses.TryGetValue(status, out var canonical))
+            return canonical;
+        throw new ValidationException(
+            $"Todo status '{status}' is not valid. Allowed: {string.Join(", ", CanonicalTodoStatuses.Values)}.");
+    }
 
     private static readonly HashSet<string> AllowedWeaknessTypes =
         new(StringComparer.OrdinalIgnoreCase) { "grammatical", "lexical", "orthographic" };
@@ -419,8 +432,7 @@ public class StudentService : IStudentService
         if (student is null)
             return null;
 
-        if (!AllowedTodoStatuses.Contains(request.Status))
-            throw new ValidationException($"Todo status '{request.Status}' is not valid. Allowed: {string.Join(", ", AllowedTodoStatuses)}.");
+        var canonicalStatus = NormalizeTodoStatus(request.Status);
 
         var todos = JsonStorageHelper.DeserializeList<TeachingTodoDto>(student.TeachingTodos);
         var index = todos.FindIndex(t => t.Id == todoId);
@@ -428,7 +440,7 @@ public class StudentService : IStudentService
         if (index < 0)
             return null;
 
-        var updated = todos[index] with { Status = request.Status, CoveredInSessionLogId = request.CoveredInSessionLogId };
+        var updated = todos[index] with { Status = canonicalStatus, CoveredInSessionLogId = request.CoveredInSessionLogId };
         if (request.Text is not null)
         {
             if (string.IsNullOrWhiteSpace(request.Text) || request.Text.Length > 500)
@@ -441,7 +453,7 @@ public class StudentService : IStudentService
 
         await _db.SaveChangesAsync(cancellationToken);
         _logger.LogInformation("Teaching todo updated. TeacherId={TeacherId} StudentId={StudentId} TodoId={TodoId} Status={Status}",
-            teacherId, student.Id, todoId, request.Status);
+            teacherId, student.Id, todoId, canonicalStatus);
 
         return MapToDto(student);
     }
@@ -484,8 +496,8 @@ public class StudentService : IStudentService
                 throw new ValidationException($"Duplicate teaching todo Id '{t.Id}'.");
             if (string.IsNullOrWhiteSpace(t.Text) || t.Text.Length > 500)
                 throw new ValidationException("Each teaching todo Text must be between 1 and 500 characters.");
-            if (string.IsNullOrWhiteSpace(t.Status) || !AllowedTodoStatuses.Contains(t.Status))
-                throw new ValidationException($"Teaching todo status '{t.Status}' is not valid. Allowed: {string.Join(", ", AllowedTodoStatuses)}.");
+            if (string.IsNullOrWhiteSpace(t.Status) || !CanonicalTodoStatuses.ContainsKey(t.Status))
+                throw new ValidationException($"Teaching todo status '{t.Status}' is not valid. Allowed: {string.Join(", ", CanonicalTodoStatuses.Values)}.");
         }
     }
 

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -45,9 +45,7 @@ public class StudentService : IStudentService
     ];
 
     private static readonly HashSet<string> AllowedTodoStatuses =
-    [
-        "Pending", "Covered", "Dismissed"
-    ];
+        new(StringComparer.OrdinalIgnoreCase) { "Pending", "Covered", "Dismissed" };
 
     private static readonly HashSet<string> AllowedWeaknessTypes =
         new(StringComparer.OrdinalIgnoreCase) { "grammatical", "lexical", "orthographic" };

--- a/e2e/tests/students.spec.ts
+++ b/e2e/tests/students.spec.ts
@@ -821,6 +821,73 @@ test('teaching todos: add, toggle covered, verify ordering on overview tab', asy
   await context.close()
 })
 
+test('teaching todos: toggle persists after reload and can be toggled back to pending', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  const studentName = `TodoPersist_${Date.now()}`
+
+  // Create a student
+  await page.goto('/students/new')
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
+  await page.getByTestId('student-name').fill(studentName)
+  await page.getByTestId('student-language').click()
+  await page.getByRole('option', { name: 'Spanish' }).click()
+  await page.getByTestId('student-cefr').click()
+  await page.getByRole('option', { name: 'B1' }).click()
+  await page.getByRole('button', { name: 'Save Student' }).click()
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
+  const detailUrl = page.url()
+
+  // Navigate to edit student and add a todo via the sidebar card
+  await page.getByTestId('edit-profile-link').click()
+  await expect(page).toHaveURL(/\/edit$/, { timeout: UI_TIMEOUT })
+  await page.goto(detailUrl)
+  await expect(page.getByTestId('teaching-todos-card')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
+
+  // Add a todo
+  await page.getByTestId('todo-add-input').fill('ser vs estar reminder')
+  await page.getByTestId('todo-add-btn').click()
+  await expect(page.getByTestId('teaching-todos-list')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
+
+  // Get the todo id
+  const toggleBtn = page.getByTestId(/^todo-toggle-/).first()
+  const toggleTestId = await toggleBtn.getAttribute('data-testid')
+  const todoId = toggleTestId!.replace('todo-toggle-', '')
+
+  // Toggle to covered — this previously returned 400
+  await toggleBtn.click()
+  await expect(page.getByTestId(`todo-text-${todoId}`)).toHaveClass(/line-through/, { timeout: FEEDBACK_TIMEOUT })
+
+  // Reload and verify persistence
+  await page.reload()
+  await expect(page.getByTestId('teaching-todos-card')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
+  await expect(page.getByTestId(`todo-text-${todoId}`)).toHaveClass(/line-through/, { timeout: FEEDBACK_TIMEOUT })
+
+  // Toggle back to pending
+  await page.getByTestId(`todo-toggle-${todoId}`).click()
+  await expect(page.getByTestId(`todo-text-${todoId}`)).not.toHaveClass(/line-through/, { timeout: FEEDBACK_TIMEOUT })
+
+  // Reload again and verify pending state persists
+  await page.reload()
+  await expect(page.getByTestId('teaching-todos-card')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
+  await expect(page.getByTestId(`todo-text-${todoId}`)).not.toHaveClass(/line-through/, { timeout: FEEDBACK_TIMEOUT })
+
+  // Cleanup
+  await page.goto('/students')
+  const row = page.locator('[data-testid^="student-row-"]').filter({
+    has: page.getByTestId('student-name').filter({ hasText: studentName })
+  })
+  await row.click()
+  await page.getByTestId('edit-profile-link').click()
+  await expect(page).toHaveURL(/\/edit$/, { timeout: UI_TIMEOUT })
+  await page.getByTestId('delete-student-btn').click()
+  await expect(page.getByRole('alertdialog')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
+  await page.getByTestId('confirm-delete').click()
+  await expect(page).toHaveURL('/students', { timeout: UI_TIMEOUT })
+
+  await context.close()
+})
+
 test('log session page: create session from full-page form and redirect back', async ({ browser }) => {
   const context = await createMockAuthContext(browser)
   const page = await context.newPage()

--- a/e2e/tests/students.spec.ts
+++ b/e2e/tests/students.spec.ts
@@ -844,9 +844,17 @@ test('teaching todos: toggle persists after reload and can be toggled back to pe
   await page.goto(detailUrl)
   await expect(page.getByTestId('teaching-todos-card')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
 
-  // Add a todo
+  const waitForTodoWrite = () =>
+    page.waitForResponse(
+      (r) => r.request().method() !== 'GET' && r.url().includes('/teaching-todos') && r.ok(),
+      { timeout: FEEDBACK_TIMEOUT }
+    )
+
+  // Add a todo (wait for server confirm before reading id)
+  const addDone = waitForTodoWrite()
   await page.getByTestId('todo-add-input').fill('ser vs estar reminder')
   await page.getByTestId('todo-add-btn').click()
+  await addDone
   await expect(page.getByTestId('teaching-todos-list')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
 
   // Get the todo id
@@ -855,7 +863,9 @@ test('teaching todos: toggle persists after reload and can be toggled back to pe
   const todoId = toggleTestId!.replace('todo-toggle-', '')
 
   // Toggle to covered — this previously returned 400
+  const coverDone = waitForTodoWrite()
   await toggleBtn.click()
+  await coverDone
   await expect(page.getByTestId(`todo-text-${todoId}`)).toHaveClass(/line-through/, { timeout: FEEDBACK_TIMEOUT })
 
   // Reload and verify persistence
@@ -864,7 +874,9 @@ test('teaching todos: toggle persists after reload and can be toggled back to pe
   await expect(page.getByTestId(`todo-text-${todoId}`)).toHaveClass(/line-through/, { timeout: FEEDBACK_TIMEOUT })
 
   // Toggle back to pending
+  const pendingDone = waitForTodoWrite()
   await page.getByTestId(`todo-toggle-${todoId}`).click()
+  await pendingDone
   await expect(page.getByTestId(`todo-text-${todoId}`)).not.toHaveClass(/line-through/, { timeout: FEEDBACK_TIMEOUT })
 
   // Reload again and verify pending state persists

--- a/plan/langteach-beta/task812-teaching-todo-400.md
+++ b/plan/langteach-beta/task812-teaching-todo-400.md
@@ -1,0 +1,73 @@
+# Task 812 - Fix Teaching Todo Checkbox 400 Error
+
+## Problem
+
+Clicking a Teaching Todo checkbox returns a 400 Bad Request. The root cause is a case mismatch: the backend validates statuses against a lowercase set `["pending", "covered", "dismissed"]`, but the frontend sends PascalCase values (`"Pending"`, `"Covered"`).
+
+## Evidence
+
+- `StudentService.cs:47`: `AllowedTodoStatuses = ["pending", "covered", "dismissed"]`
+- `TeachingTodosCard.tsx:144`: `const next = todo.status === 'Pending' ? 'Covered' : 'Pending'`
+- `LogSession.tsx:373`: `updateTeachingTodo(..., { status: 'Covered', ... })`
+- `StudentService.cs:402`: `AppendTeachingTodoAsync` creates todos with `status: "pending"` (lowercase), making existing stored todos invisible to the frontend's `=== 'Pending'` check
+
+## Acceptance criteria
+
+- [ ] Clicking a pending Teaching Todo checkbox marks it as covered and saves without error
+- [ ] Clicking a covered Teaching Todo unchecks it (back to pending) and saves without error
+- [ ] The status change persists after page reload
+- [ ] No regression on the Followups checkbox
+- [ ] Fix covers both Edit Student sidebar and LogSession left panel
+
+## Fix plan
+
+Normalize all status values to PascalCase throughout the backend (matching what the frontend already sends). No frontend changes needed.
+
+### 1. `backend/LangTeach.Api/Services/StudentService.cs`
+
+- Change `AllowedTodoStatuses` from `["pending", "covered", "dismissed"]` to `["Pending", "Covered", "Dismissed"]`
+- Change `AppendTeachingTodoAsync`: `status: "pending"` → `"Pending"`
+
+### 2. `backend/LangTeach.Api/Services/DashboardService.cs`
+
+- Change `t.Status == "pending"` to `t.Status == "Pending"` (line 259)
+
+### 3. `backend/LangTeach.Api/Data/DemoSeeder.cs`
+
+- Update inline JSON literals: `"status":"pending"` → `"status":"Pending"`
+
+### 4. `backend/LangTeach.Api/Data/ScenarioSeeder.cs`
+
+- Update inline JSON literals: `"status":"pending"` → `"status":"Pending"`
+
+### 5. Tests
+
+Update any test assertions that expect lowercase status strings:
+- `DashboardServiceTests.cs`: `student.PendingTodos[0].Status.Should().Be("pending")` → `"Pending"`
+- `StudentServiceTests.cs`: any `"pending"`/`"covered"` status assertions
+- `StudentsControllerTests.cs`: same
+
+### 6. E2E test
+
+Add/extend e2e test in `e2e/tests/students.spec.ts` to cover:
+- Toggle Teaching Todo to covered (verify no network error, verify persistence after reload)
+- Toggle back to pending
+
+## Scope
+
+- No frontend changes needed (frontend already uses PascalCase correctly)
+- No migration needed (dev DB is re-seeded; existing data will normalize on first toggle)
+- Followups use a separate endpoint (`updateFollowupStatus`) - not affected
+
+## Files to change
+
+| File | Change |
+|------|--------|
+| `backend/LangTeach.Api/Services/StudentService.cs` | PascalCase allowed statuses + append initial status |
+| `backend/LangTeach.Api/Services/DashboardService.cs` | PascalCase status comparison |
+| `backend/LangTeach.Api/Data/DemoSeeder.cs` | PascalCase JSON literals |
+| `backend/LangTeach.Api/Data/ScenarioSeeder.cs` | PascalCase JSON literals |
+| `backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs` | PascalCase assertions |
+| `backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs` | PascalCase assertions |
+| `backend/LangTeach.Api.Tests/Controllers/StudentsControllerTests.cs` | PascalCase assertions |
+| `e2e/tests/students.spec.ts` | Add todo toggle test |


### PR DESCRIPTION
## Summary

- Root cause: `AllowedTodoStatuses` validated against lowercase strings (`"pending"`, `"covered"`, `"dismissed"`) but the frontend sends PascalCase (`"Pending"`, `"Covered"`) on every checkbox click, causing a 400 `ValidationException`
- Fix: normalize all status values to PascalCase throughout the backend; use `OrdinalIgnoreCase` on the validation set (matching the `AllowedWeaknessTypes` pattern) and on the `DashboardService` pending-filter for resilience against any legacy lowercase data
- No frontend changes needed (frontend already sends PascalCase correctly)

## Files changed

| File | Change |
|------|--------|
| `StudentService.cs` | PascalCase allowed statuses with `OrdinalIgnoreCase`; append initial status `"Pending"` |
| `DashboardService.cs` | Case-insensitive pending-todo filter |
| `DemoSeeder.cs`, `ScenarioSeeder.cs` | Seed JSON literals updated to PascalCase |
| `StudentServiceTests.cs`, `DashboardServiceTests.cs` | Test inputs and assertions updated |
| `e2e/tests/students.spec.ts` | New test: toggle covered, reload, toggle back, reload |

## Test plan

- [x] 1123 backend unit tests pass
- [x] 85 frontend unit tests pass
- [x] Build verify PASS (bicep, dotnet, npm lint, npm build, npm test)
- [x] QA verify PASS (all 5 ACs covered)
- [x] Architecture review PASS WITH NOTES (note applied: OrdinalIgnoreCase)
- [x] Sophy APPROVE

Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed teaching todo status handling to be case-insensitive, improving data consistency across the system.
  * Ensured teaching todo state (covered/pending) persists correctly after page reload.

* **Tests**
  * Added comprehensive E2E test validating todo state persistence and toggle functionality across page reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->