### PR TITLE
feat(#814): add 25 and 50 min duration options; change default to 50 min

### DIFF
--- a/frontend/src/pages/LogSession.test.tsx
+++ b/frontend/src/pages/LogSession.test.tsx
@@ -500,6 +500,13 @@ describe('LogSession — edit mode', () => {
     expect(screen.getByTestId('actual-content')).toHaveValue('Covered irregular preterite')
   })
 
+  it.each([25, 50])('pre-selects duration %i in edit mode', async (dur) => {
+    vi.mocked(sessionLogsApi.getSession).mockResolvedValue({ ...EDIT_SESSION, duration: dur })
+    renderEditSession()
+    await screen.findByTestId('duration-select')
+    expect(screen.getByTestId('duration-select')).toHaveTextContent(String(dur))
+  })
+
   it('pre-fills time from sessionDate in edit mode', async () => {
     vi.mocked(sessionLogsApi.getSession).mockResolvedValue({
       ...EDIT_SESSION,

--- a/frontend/src/pages/LogSession.test.tsx
+++ b/frontend/src/pages/LogSession.test.tsx
@@ -178,10 +178,19 @@ describe('LogSession', () => {
     expect(screen.getByTestId('session-date')).toHaveValue(today)
   })
 
-  it('duration defaults to 60', async () => {
+  it('duration defaults to 50', async () => {
     renderLogSession()
     await screen.findByTestId('duration-select')
-    expect(screen.getByTestId('duration-select')).toHaveTextContent(/60/)
+    expect(screen.getByTestId('duration-select')).toHaveTextContent(/50/)
+  })
+
+  it('duration dropdown includes 25 and 50 min options', async () => {
+    const user = userEvent.setup()
+    renderLogSession()
+    await screen.findByTestId('duration-select')
+    await user.click(screen.getByTestId('duration-select'))
+    expect(await screen.findByRole('option', { name: '25 min' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: '50 min' })).toBeInTheDocument()
   })
 
   it('reveals custom duration input when "Other" selected', async () => {
@@ -247,7 +256,7 @@ describe('LogSession', () => {
           actualContent: 'Great session',
           isCancelled: false,
           status: 'Confirmed',
-          duration: 60,
+          duration: 50,
         }),
       )
     })

--- a/frontend/src/pages/LogSession.test.tsx
+++ b/frontend/src/pages/LogSession.test.tsx
@@ -507,6 +507,14 @@ describe('LogSession — edit mode', () => {
     expect(screen.getByTestId('duration-select')).toHaveTextContent(String(dur))
   })
 
+  it('shows Other with empty input when session has null duration', async () => {
+    vi.mocked(sessionLogsApi.getSession).mockResolvedValue({ ...EDIT_SESSION, duration: null })
+    renderEditSession()
+    await screen.findByTestId('duration-select')
+    expect(screen.getByTestId('duration-select')).toHaveTextContent(/other/i)
+    expect(screen.getByTestId('duration-other')).toHaveValue(null)
+  })
+
   it('pre-fills time from sessionDate in edit mode', async () => {
     vi.mocked(sessionLogsApi.getSession).mockResolvedValue({
       ...EDIT_SESSION,

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -28,8 +28,10 @@ import { useSessionAutosave } from '@/hooks/useSessionAutosave'
 import { logger } from '@/lib/logger'
 
 const DURATION_OPTIONS = [
+  { value: '25', label: '25 min' },
   { value: '30', label: '30 min' },
   { value: '45', label: '45 min' },
+  { value: '50', label: '50 min' },
   { value: '60', label: '60 min' },
   { value: '90', label: '90 min' },
   { value: 'other', label: 'Other' },
@@ -133,7 +135,7 @@ export default function LogSession() {
   // Form state
   const [sessionDate, setSessionDate] = useState(todayISO())
   const [sessionTime, setSessionTime] = useState(nowTimeHHMM())
-  const [durationChoice, setDurationChoice] = useState('60')
+  const [durationChoice, setDurationChoice] = useState('50')
   const [durationOther, setDurationOther] = useState('')
   const [isCancelled, setIsCancelled] = useState(false)
   const [prevHomeworkStatus, setPrevHomeworkStatus] = useState<string | null>(null)
@@ -248,7 +250,7 @@ export default function LogSession() {
     setReassessmentLevel(editSession.levelReassessmentLevel ?? '')
     setSelectedLessonId(editSession.linkedLessonId ?? '')
     const dur = editSession.duration
-    if (dur === 30 || dur === 45 || dur === 60 || dur === 90) {
+    if (dur === 25 || dur === 30 || dur === 45 || dur === 50 || dur === 60 || dur === 90) {
       setDurationChoice(String(dur))
     } else if (dur) {
       setDurationChoice('other')

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -250,9 +250,13 @@ export default function LogSession() {
     setReassessmentLevel(editSession.levelReassessmentLevel ?? '')
     setSelectedLessonId(editSession.linkedLessonId ?? '')
     const dur = editSession.duration
-    if (dur === 25 || dur === 30 || dur === 45 || dur === 50 || dur === 60 || dur === 90) {
+    if (dur === null || dur === undefined) {
+      setDurationChoice('other')
+      setDurationOther('')
+    } else if ([25, 30, 45, 50, 60, 90].includes(dur)) {
       setDurationChoice(String(dur))
-    } else if (dur) {
+      setDurationOther('')
+    } else {
       setDurationChoice('other')
       setDurationOther(String(dur))
     }

--- a/plan/langteach-beta/task814-log-session-duration-options.md
+++ b/plan/langteach-beta/task814-log-session-duration-options.md
@@ -1,0 +1,25 @@
+# Task 814: Add 25 and 50 min duration options to Log Session
+
+## Issue
+https://github.com/Robert-Freire/langTeachSaaS/issues/814
+
+## Summary
+Add 25 min and 50 min to the Log Session duration dropdown and change the default from 60 to 50 min.
+
+## Acceptance Criteria
+- [x] Duration dropdown options: 25, 30, 45, 50, 60, 90 min, Other (in that order)
+- [x] Default selection in create mode is 50 min
+- [x] Edit mode pre-selects stored duration correctly for all values including 25 and 50
+- [x] "Other" custom input still works for any duration not in the list
+
+## Implementation
+
+### Changes
+- `frontend/src/pages/LogSession.tsx`:
+  - `DURATION_OPTIONS`: added `{ value: '25', label: '25 min' }` and `{ value: '50', label: '50 min' }`
+  - `useState('60')` -> `useState('50')` for default durationChoice
+  - Edit-mode guard updated: `dur === 25 || ... || dur === 50 || ...`
+
+- `frontend/src/pages/LogSession.test.tsx`:
+  - Updated "defaults to 60" test to "defaults to 50"
+  - Added test: "duration dropdown includes 25 and 50 min options"


### PR DESCRIPTION
## Summary
- Add 25 min and 50 min options to the Log Session duration dropdown (order: 25, 30, 45, 50, 60, 90, Other)
- Change default duration in create mode from 60 to 50 min
- Update edit-mode guard to pre-select 25 and 50 from stored session data

## Test plan
- [x] Unit: "duration defaults to 50" confirms new default
- [x] Unit: "duration dropdown includes 25 and 50 min options" confirms both options present
- [x] Unit: parametrized edit-mode test for durations 25 and 50
- [x] UI review: PASS (dropdown renders correctly, create default is 50, edit pre-selection works)
- [x] Architecture review: PASS
- [x] All 1306 frontend unit tests pass

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 25-minute and 50-minute duration options for session logging
  * Changed default session duration to 50 minutes

* **Tests**
  * Updated test suite to validate new duration options and default value
  * Expanded coverage for duration selection in edit mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->