### PR TITLE
fix(#819): Log Session panel IA — move Difficulties Observed to right panel

### DIFF
--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -738,7 +738,7 @@ export default function LogSession() {
 
         {/* Active Difficulties */}
         {activeDifficulties.length > 0 && (
-          <PanelSection label="Active Difficulties">
+          <PanelSection label="Student Difficulties">
             <div className="space-y-1.5">
               {activeDifficulties.map(d => {
                 const key = `${d.competency}|${d.subcategory}`
@@ -772,38 +772,6 @@ export default function LogSession() {
             {mentionedDifficultyKeys.size > 0 && (
               <p className="text-[0.6875rem] text-indigo-500 mt-1">Checked items will be recorded as worked on today</p>
             )}
-          </PanelSection>
-        )}
-
-        {/* Suggested Difficulties (AI-extracted chips with dismiss) */}
-        {suggestedDifficulties.length > 0 && (
-          <PanelSection label="Suggested Difficulties">
-            <p className="text-[0.6875rem] text-zinc-400 -mt-1">From session notes — remove any that look wrong</p>
-            <div className="space-y-1">
-              {suggestedDifficulties.map((d, i) => (
-                <div
-                  key={`${d.competency}|${d.subcategory}|${i}`}
-                  className="flex items-center justify-between gap-2 rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm"
-                  data-testid="suggested-difficulty-chip"
-                >
-                  <div className="min-w-0">
-                    <span className="font-medium text-[#1A1B22]">{d.competency} / {d.subcategory}</span>
-                    {d.description && (
-                      <p className="text-xs text-zinc-500 mt-0.5 line-clamp-2">{d.description}</p>
-                    )}
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => setSuggestedDifficulties(prev => prev.filter((_, j) => j !== i))}
-                    className="shrink-0 text-zinc-400 hover:text-zinc-700"
-                    aria-label="Remove difficulty"
-                    data-testid="remove-suggested-difficulty"
-                  >
-                    <X className="h-3.5 w-3.5" />
-                  </button>
-                </div>
-              ))}
-            </div>
           </PanelSection>
         )}
 
@@ -1171,6 +1139,39 @@ export default function LogSession() {
                   onChange={(tags) => { setTopicTags(tags); markChangedAndSaveNow({ topicTags: tags.length > 0 ? serializeTopicTags(tags) : null }) }}
                 />
               </div>
+
+              {/* Difficulties Observed (AI-extracted from voice note) */}
+              {suggestedDifficulties.length > 0 && (
+                <div className="space-y-2" data-testid="difficulties-observed-section">
+                  <Label className="text-[0.6875rem] font-medium uppercase tracking-[0.05em] text-zinc-400">Difficulties Observed</Label>
+                  <p className="text-[0.6875rem] text-zinc-400 -mt-1">Detected from your notes — remove any that don't match what you observed</p>
+                  <div className="space-y-1">
+                    {suggestedDifficulties.map((d, i) => (
+                      <div
+                        key={`${d.competency}|${d.subcategory}|${i}`}
+                        className="flex items-center justify-between gap-2 rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm"
+                        data-testid="suggested-difficulty-chip"
+                      >
+                        <div className="min-w-0">
+                          <span className="font-medium text-[#1A1B22]">{d.competency} / {d.subcategory}</span>
+                          {d.description && (
+                            <p className="text-xs text-zinc-500 mt-0.5 line-clamp-2">{d.description}</p>
+                          )}
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => setSuggestedDifficulties(prev => prev.filter((_, j) => j !== i))}
+                          className="shrink-0 text-zinc-400 hover:text-zinc-700"
+                          aria-label="Remove difficulty"
+                          data-testid="remove-suggested-difficulty"
+                        >
+                          <X className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
 
               {/* Homework Assigned */}
               <div className="space-y-1">

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -22,6 +22,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { CefrBadge } from '@/components/dashboard/CefrBadge'
 import { TopicTagsInput } from '@/components/session/TopicTagsInput'
 import { AudioRecorder } from '@/components/audio/AudioRecorder'
+import { COMPETENCY_OPTIONS } from '@/lib/studentOptions'
 import { getObjectiveUrgency, getDaysRemaining } from '@/lib/objectiveUrgency'
 import { suggestTopicTags } from '@/lib/suggestTopicTags'
 import { formatDate as formatDateUtil, relativeTime } from '@/utils/formatDate'
@@ -157,7 +158,7 @@ export default function LogSession() {
   const [secondaryOpen, setSecondaryOpen] = useState(false)
   const [hasChanges, setHasChanges] = useState(false)
   const [suggestedDifficulties, setSuggestedDifficulties] = useState<SuggestedDifficulty[]>([])
-  const [newDifficultyText, setNewDifficultyText] = useState('')
+  const [newDifficulty, setNewDifficulty] = useState({ description: '', competency: '', subcategory: '' })
 
   // Left panel interactive state
   const [checkedTodoIds, setCheckedTodoIds] = useState<Set<string>>(new Set())
@@ -1173,37 +1174,55 @@ export default function LogSession() {
                     </div>
                   ))}
                 </div>
-                <div className="flex gap-2 pt-0.5">
+                <div className="space-y-1.5 pt-0.5" data-testid="new-difficulty-form">
                   <Input
-                    value={newDifficultyText}
-                    onChange={e => setNewDifficultyText(e.target.value)}
-                    onKeyDown={e => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault()
-                        const text = newDifficultyText.trim()
-                        if (!text) return
-                        setSuggestedDifficulties(prev => [...prev, { competency: '', subcategory: '', description: text, severity: 'Medium' }])
-                        setNewDifficultyText('')
-                      }
-                    }}
-                    placeholder="Note a difficulty observed..."
-                    className="text-sm bg-white flex-1"
+                    value={newDifficulty.description}
+                    onChange={e => setNewDifficulty(prev => ({ ...prev, description: e.target.value }))}
+                    placeholder="e.g. Confuses ser/estar in past tense"
+                    className="text-sm bg-white"
                     data-testid="new-difficulty-input"
                   />
-                  <Button
-                    type="button"
-                    size="sm"
-                    onClick={() => {
-                      const text = newDifficultyText.trim()
-                      if (!text) return
-                      setSuggestedDifficulties(prev => [...prev, { competency: '', subcategory: '', description: text, severity: 'Medium' }])
-                      setNewDifficultyText('')
-                    }}
-                    className="bg-indigo-600 hover:bg-indigo-700 text-white"
-                    data-testid="add-difficulty-btn"
-                  >
-                    <Plus className="h-4 w-4" />
-                  </Button>
+                  <div className="flex gap-1.5">
+                    <Select
+                      value={newDifficulty.competency || undefined}
+                      onValueChange={v => setNewDifficulty(prev => ({ ...prev, competency: v }))}
+                    >
+                      <SelectTrigger className="text-sm bg-white w-[140px] shrink-0" data-testid="new-difficulty-competency">
+                        <SelectValue placeholder="Competency" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {COMPETENCY_OPTIONS.map(opt => (
+                          <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Input
+                      value={newDifficulty.subcategory}
+                      onChange={e => setNewDifficulty(prev => ({ ...prev, subcategory: e.target.value }))}
+                      placeholder="Subcategory (e.g. ser/estar)"
+                      className="text-sm bg-white flex-1"
+                      data-testid="new-difficulty-subcategory"
+                    />
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={() => {
+                        const desc = newDifficulty.description.trim()
+                        if (!desc) return
+                        setSuggestedDifficulties(prev => [...prev, {
+                          competency: newDifficulty.competency,
+                          subcategory: newDifficulty.subcategory,
+                          description: desc,
+                          severity: 'Medium',
+                        }])
+                        setNewDifficulty({ description: '', competency: '', subcategory: '' })
+                      }}
+                      className="bg-indigo-600 hover:bg-indigo-700 text-white shrink-0"
+                      data-testid="add-difficulty-btn"
+                    >
+                      <Plus className="h-4 w-4" />
+                    </Button>
+                  </div>
                 </div>
               </div>
 

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -1164,7 +1164,10 @@ export default function LogSession() {
                       </div>
                       <button
                         type="button"
-                        onClick={() => setSuggestedDifficulties(prev => prev.filter((_, j) => j !== i))}
+                        onClick={() => {
+                          setSuggestedDifficulties(prev => prev.filter((_, j) => j !== i))
+                          markChangedAndSchedule()
+                        }}
                         className="shrink-0 text-zinc-400 hover:text-zinc-700"
                         aria-label="Remove difficulty"
                         data-testid="remove-suggested-difficulty"
@@ -1206,18 +1209,21 @@ export default function LogSession() {
                     <Button
                       type="button"
                       size="sm"
+                      disabled={!newDifficulty.description.trim() || !newDifficulty.competency}
                       onClick={() => {
                         const desc = newDifficulty.description.trim()
-                        if (!desc) return
-                        setSuggestedDifficulties(prev => [...prev, {
+                        if (!desc || !newDifficulty.competency) return
+                        const next = [...suggestedDifficulties, {
                           competency: newDifficulty.competency,
                           subcategory: newDifficulty.subcategory,
                           description: desc,
                           severity: 'Medium',
-                        }])
+                        }]
+                        setSuggestedDifficulties(next)
                         setNewDifficulty({ description: '', competency: '', subcategory: '' })
+                        markChangedAndSaveNow({ suggestedDifficulties: next })
                       }}
-                      className="bg-indigo-600 hover:bg-indigo-700 text-white shrink-0"
+                      className="bg-indigo-600 hover:bg-indigo-700 text-white shrink-0 disabled:opacity-50"
                       data-testid="add-difficulty-btn"
                     >
                       <Plus className="h-4 w-4" />

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -1185,7 +1185,7 @@ export default function LogSession() {
                   <div className="flex gap-1.5">
                     <Select
                       value={newDifficulty.competency || undefined}
-                      onValueChange={v => setNewDifficulty(prev => ({ ...prev, competency: v }))}
+                      onValueChange={v => setNewDifficulty(prev => ({ ...prev, competency: v ?? '' }))}
                     >
                       <SelectTrigger className="text-sm bg-white w-[140px] shrink-0" data-testid="new-difficulty-competency">
                         <SelectValue placeholder="Competency" />

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -157,6 +157,7 @@ export default function LogSession() {
   const [secondaryOpen, setSecondaryOpen] = useState(false)
   const [hasChanges, setHasChanges] = useState(false)
   const [suggestedDifficulties, setSuggestedDifficulties] = useState<SuggestedDifficulty[]>([])
+  const [newDifficultyText, setNewDifficultyText] = useState('')
 
   // Left panel interactive state
   const [checkedTodoIds, setCheckedTodoIds] = useState<Set<string>>(new Set())
@@ -1140,38 +1141,71 @@ export default function LogSession() {
                 />
               </div>
 
-              {/* Difficulties Observed (AI-extracted from voice note) */}
-              {suggestedDifficulties.length > 0 && (
-                <div className="space-y-1" data-testid="difficulties-observed-section">
-                  <Label className="text-[0.6875rem] font-medium uppercase tracking-[0.05em] text-zinc-400">Difficulties Observed</Label>
-                  <p className="text-[0.6875rem] text-zinc-400 -mt-1">Detected from your notes — remove any that don't match what you observed</p>
-                  <div className="space-y-1">
-                    {suggestedDifficulties.map((d, i) => (
-                      <div
-                        key={`${d.competency}|${d.subcategory}|${i}`}
-                        className="flex items-center justify-between gap-2 rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm"
-                        data-testid="suggested-difficulty-chip"
-                      >
-                        <div className="min-w-0">
-                          <span className="font-medium text-[#1A1B22]">{d.competency} / {d.subcategory}</span>
-                          {d.description && (
-                            <p className="text-xs text-zinc-500 mt-0.5 line-clamp-2">{d.description}</p>
-                          )}
-                        </div>
-                        <button
-                          type="button"
-                          onClick={() => setSuggestedDifficulties(prev => prev.filter((_, j) => j !== i))}
-                          className="shrink-0 text-zinc-400 hover:text-zinc-700"
-                          aria-label="Remove difficulty"
-                          data-testid="remove-suggested-difficulty"
-                        >
-                          <X className="h-3.5 w-3.5" />
-                        </button>
+              {/* Difficulties Observed — always visible; populated by AI voice extraction or manual add */}
+              <div className="space-y-1" data-testid="difficulties-observed-section">
+                <Label className="text-[0.6875rem] font-medium uppercase tracking-[0.05em] text-zinc-400">Difficulties Observed</Label>
+                <p className="text-[0.6875rem] text-zinc-400 -mt-1">Add any difficulties you observed — detected from voice notes or added manually</p>
+                <div className="space-y-1">
+                  {suggestedDifficulties.map((d, i) => (
+                    <div
+                      key={`${d.competency}|${d.subcategory}|${i}`}
+                      className="flex items-center justify-between gap-2 rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm"
+                      data-testid="suggested-difficulty-chip"
+                    >
+                      <div className="min-w-0">
+                        {d.competency || d.subcategory
+                          ? <span className="font-medium text-[#1A1B22]">{d.competency} / {d.subcategory}</span>
+                          : <span className="font-medium text-[#1A1B22]">{d.description}</span>
+                        }
+                        {(d.competency || d.subcategory) && d.description && (
+                          <p className="text-xs text-zinc-500 mt-0.5 line-clamp-2">{d.description}</p>
+                        )}
                       </div>
-                    ))}
-                  </div>
+                      <button
+                        type="button"
+                        onClick={() => setSuggestedDifficulties(prev => prev.filter((_, j) => j !== i))}
+                        className="shrink-0 text-zinc-400 hover:text-zinc-700"
+                        aria-label="Remove difficulty"
+                        data-testid="remove-suggested-difficulty"
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  ))}
                 </div>
-              )}
+                <div className="flex gap-2 pt-0.5">
+                  <Input
+                    value={newDifficultyText}
+                    onChange={e => setNewDifficultyText(e.target.value)}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        const text = newDifficultyText.trim()
+                        if (!text) return
+                        setSuggestedDifficulties(prev => [...prev, { competency: '', subcategory: '', description: text, severity: 'Medium' }])
+                        setNewDifficultyText('')
+                      }
+                    }}
+                    placeholder="Note a difficulty observed..."
+                    className="text-sm bg-white flex-1"
+                    data-testid="new-difficulty-input"
+                  />
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => {
+                      const text = newDifficultyText.trim()
+                      if (!text) return
+                      setSuggestedDifficulties(prev => [...prev, { competency: '', subcategory: '', description: text, severity: 'Medium' }])
+                      setNewDifficultyText('')
+                    }}
+                    className="bg-indigo-600 hover:bg-indigo-700 text-white"
+                    data-testid="add-difficulty-btn"
+                  >
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
 
               {/* Homework Assigned */}
               <div className="space-y-1">

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -1142,7 +1142,7 @@ export default function LogSession() {
 
               {/* Difficulties Observed (AI-extracted from voice note) */}
               {suggestedDifficulties.length > 0 && (
-                <div className="space-y-2" data-testid="difficulties-observed-section">
+                <div className="space-y-1" data-testid="difficulties-observed-section">
                   <Label className="text-[0.6875rem] font-medium uppercase tracking-[0.05em] text-zinc-400">Difficulties Observed</Label>
                   <p className="text-[0.6875rem] text-zinc-400 -mt-1">Detected from your notes — remove any that don't match what you observed</p>
                   <div className="space-y-1">

--- a/plan/langteach-beta/task819-log-session-ia-fix.md
+++ b/plan/langteach-beta/task819-log-session-ia-fix.md
@@ -1,0 +1,31 @@
+# Task 819 — Log Session: Fix Panel Information Architecture
+
+## Issue
+https://github.com/Robert-Freire/langTeachSaaS/issues/819
+
+## Changes
+
+All changes in `frontend/src/pages/LogSession.tsx`.
+
+### 1. Left panel: rename section label
+- `PanelSection label="Active Difficulties"` → `PanelSection label="Student Difficulties"`
+- Hint text below ("Checked items will be recorded as worked on today") preserved unchanged.
+
+### 2. Left panel: remove Suggested Difficulties block
+- Removed the `suggestedDifficulties.length > 0` conditional block (lines ~778-808) from the left panel.
+- The block was inside `<LeftPanel>` (the student context panel).
+
+### 3. Right panel: insert Difficulties Observed block
+- Added `suggestedDifficulties.length > 0` conditional block between Topics Covered and Homework Assigned.
+- Section label: "Difficulties Observed"
+- Hint text: "Detected from your notes — remove any that don't match what you observed"
+- Same chip JSX and data-testid attributes as before; dismiss (×) interactions unchanged.
+- `suggestedDifficulties` state and save payload unchanged.
+
+### 4. Todos + Followups position
+- Already above the secondary toggle in the existing code. No move needed.
+
+### 5. Visual snapshots
+- `log-session.visual.spec.ts` and `session-edit.visual.spec.ts` use `page.screenshot()` (not `toMatchSnapshot()`). Screenshots auto-capture on each run. No baseline files to update.
+
+## No backend changes


### PR DESCRIPTION
## Summary

- Move Suggested Difficulties block from left (context) panel to right (session) panel, positioned between Topics Covered and Homework Assigned
- Rename left panel label: "Active Difficulties" → "Student Difficulties"
- Rename right panel section label: "Suggested Difficulties" → "Difficulties Observed"
- Update hint text to: "Detected from your notes — remove any that don't match what you observed"
- Fix outer wrapper spacing to `space-y-1` to match sibling sections
- All dismiss (×) interactions, data-testid attributes, and save payload unchanged
- New Teaching Todos + New Followups were already above the secondary toggle (no move needed)

## Test plan

- [ ] Log Session for a student with active difficulties: left panel shows "STUDENT DIFFICULTIES"
- [ ] Log Session with a processed voice note: right panel shows "DIFFICULTIES OBSERVED" between Topics Covered and Homework Assigned
- [ ] Dismiss (×) on a difficulty chip still removes it
- [ ] New Teaching Todos and New Followups appear above "Show notes..." toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI/UX Changes**
  * Relocated difficulties panel to the right as a persistent "Difficulties Observed" form section
  * Renamed "Active Difficulties" to "Student Difficulties"
* **New Features**
  * Added manual entry form for adding difficulties (description, competency, subcategory) with default severity
  * Preserved dismissible behavior for individual difficulty entries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->