### PR TITLE
feat(#823): add append/replace/skip mode to voice note extraction fields

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/LessonNotesControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/LessonNotesControllerTests.cs
@@ -337,11 +337,11 @@ public class LessonNotesControllerTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var dto = await response.Content.ReadFromJsonAsync<ExtractedReflectionDto>();
-        dto!.WhatWasCovered.Should().Be("[Extracted] What was covered");
-        dto.AreasToImprove.Should().Be("[Extracted] Areas to improve");
+        dto!.WhatWasCovered!.Value.Should().Be("[Extracted] What was covered");
+        dto.AreasToImprove!.Value.Should().Be("[Extracted] Areas to improve");
         dto.EmotionalSignals.Should().Be("[Extracted] Emotional signals");
-        dto.HomeworkAssigned.Should().Be("[Extracted] Homework assigned");
-        dto.NextLessonIdeas.Should().Be("[Extracted] Next lesson ideas");
+        dto.HomeworkAssigned!.Value.Should().Be("[Extracted] Homework assigned");
+        dto.NextLessonIdeas!.Value.Should().Be("[Extracted] Next lesson ideas");
     }
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/Controllers/SessionsControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/SessionsControllerTests.cs
@@ -69,11 +69,13 @@ public class SessionsControllerTests
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var dto = await response.Content.ReadFromJsonAsync<ExtractedReflectionDto>();
-        dto!.WhatWasCovered.Should().Be("[Extracted] What was covered");
-        dto.AreasToImprove.Should().Be("[Extracted] Areas to improve");
+        dto!.WhatWasCovered!.Value.Should().Be("[Extracted] What was covered");
+        dto.WhatWasCovered.Mode.Should().Be("replace");
+        dto.AreasToImprove!.Value.Should().Be("[Extracted] Areas to improve");
         dto.EmotionalSignals.Should().Be("[Extracted] Emotional signals");
-        dto.HomeworkAssigned.Should().Be("[Extracted] Homework assigned");
-        dto.NextLessonIdeas.Should().Be("[Extracted] Next lesson ideas");
+        dto.HomeworkAssigned!.Value.Should().Be("[Extracted] Homework assigned");
+        dto.NextLessonIdeas!.Value.Should().Be("[Extracted] Next lesson ideas");
+        dto.NextLessonIdeas.Mode.Should().Be("append");
     }
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
@@ -684,4 +684,17 @@ public class ReflectionExtractionServiceTests
         result.WhatWasCovered!.Value.Should().Be("Some content");
         result.WhatWasCovered.Mode.Should().Be("skip");
     }
+
+    [Theory]
+    [InlineData("""{"whatWasCovered": { "value": null, "mode": "replace" }}""")]
+    [InlineData("""{"whatWasCovered": { "value": "", "mode": "replace" }}""")]
+    [InlineData("""{"whatWasCovered": { "value": "   ", "mode": "replace" }}""")]
+    public void ParseResponse_ObjectFormWithNullOrEmptyValue_ReturnsNullDto(string json)
+    {
+        var sut = CreateSut("{}");
+
+        var result = sut.ParseResponse(json);
+
+        result.WhatWasCovered.Should().BeNull();
+    }
 }

--- a/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
@@ -73,11 +73,12 @@ public class ReflectionExtractionServiceTests
 
         var result = sut.ParseResponse(json);
 
-        result.WhatWasCovered.Should().Be("Past tense verbs");
-        result.AreasToImprove.Should().Be("Irregular verbs");
+        result.WhatWasCovered!.Value.Should().Be("Past tense verbs");
+        result.WhatWasCovered.Mode.Should().Be("replace"); // legacy plain-string fallback
+        result.AreasToImprove!.Value.Should().Be("Irregular verbs");
         result.EmotionalSignals.Should().Be("Very engaged");
-        result.HomeworkAssigned.Should().Be("Exercises 1-5");
-        result.NextLessonIdeas.Should().Be("Present perfect");
+        result.HomeworkAssigned!.Value.Should().Be("Exercises 1-5");
+        result.NextLessonIdeas!.Value.Should().Be("Present perfect");
         result.SessionDate.Should().BeNull();
         result.SuggestedDifficulties.Should().BeEmpty();
     }
@@ -181,7 +182,7 @@ public class ReflectionExtractionServiceTests
 
         var result = sut.ParseResponse(json);
 
-        result.WhatWasCovered.Should().Be("Ser vs estar");
+        result.WhatWasCovered!.Value.Should().Be("Ser vs estar");
         result.AreasToImprove.Should().BeNull();
         result.EmotionalSignals.Should().BeNull();
         result.HomeworkAssigned.Should().BeNull();
@@ -229,7 +230,7 @@ public class ReflectionExtractionServiceTests
 
         var result = await sut.ExtractAsync("We practiced vocabulary today.");
 
-        result.WhatWasCovered.Should().Be("Vocab");
+        result.WhatWasCovered!.Value.Should().Be("Vocab");
         result.SuggestedDifficulties.Should().BeEmpty();
         captured.Should().NotBeNull();
         captured!.Model.Should().Be(ClaudeModel.Haiku);
@@ -267,7 +268,7 @@ public class ReflectionExtractionServiceTests
         var result = sut.ParseResponse(json);
 
         result.SessionDate.Should().Be("2026-04-08");
-        result.WhatWasCovered.Should().Be("los condicionales");
+        result.WhatWasCovered!.Value.Should().Be("los condicionales");
     }
 
     [Fact]
@@ -607,5 +608,80 @@ public class ReflectionExtractionServiceTests
         captured.Should().NotBeNull();
         captured!.SystemPrompt.Should().Contain("Subjuntivo en concesivas");
         captured.SystemPrompt.Should().Contain("Ser vs Estar");
+    }
+
+    [Fact]
+    public void ParseResponse_ParsesModeAppend()
+    {
+        var sut = CreateSut("{}");
+        var json = """
+            {
+              "whatWasCovered": { "value": "Present perfect", "mode": "append" },
+              "nextLessonIdeas": { "value": "Subjunctive", "mode": "append" }
+            }
+            """;
+
+        var result = sut.ParseResponse(json);
+
+        result.WhatWasCovered!.Value.Should().Be("Present perfect");
+        result.WhatWasCovered.Mode.Should().Be("append");
+        result.NextLessonIdeas!.Value.Should().Be("Subjunctive");
+        result.NextLessonIdeas.Mode.Should().Be("append");
+    }
+
+    [Fact]
+    public void ParseResponse_ParsesModeReplace()
+    {
+        var sut = CreateSut("{}");
+        var json = """
+            {
+              "homeworkAssigned": { "value": "Page 5 exercises", "mode": "replace" },
+              "areasToImprove": { "value": "Verb conjugation", "mode": "replace" }
+            }
+            """;
+
+        var result = sut.ParseResponse(json);
+
+        result.HomeworkAssigned!.Value.Should().Be("Page 5 exercises");
+        result.HomeworkAssigned.Mode.Should().Be("replace");
+        result.AreasToImprove!.Value.Should().Be("Verb conjugation");
+        result.AreasToImprove.Mode.Should().Be("replace");
+    }
+
+    [Fact]
+    public void ParseResponse_ParsesModeSkip()
+    {
+        var sut = CreateSut("{}");
+        var json = """{"whatWasCovered": { "value": "Past tense", "mode": "skip" }}""";
+
+        var result = sut.ParseResponse(json);
+
+        result.WhatWasCovered!.Mode.Should().Be("skip");
+    }
+
+    [Fact]
+    public void ParseResponse_HandlesLegacyStringFallback_TreatsAsReplace()
+    {
+        var sut = CreateSut("{}");
+        var json = """{"whatWasCovered": "Plain string value", "homeworkAssigned": "Homework text"}""";
+
+        var result = sut.ParseResponse(json);
+
+        result.WhatWasCovered!.Value.Should().Be("Plain string value");
+        result.WhatWasCovered.Mode.Should().Be("replace");
+        result.HomeworkAssigned!.Value.Should().Be("Homework text");
+        result.HomeworkAssigned.Mode.Should().Be("replace");
+    }
+
+    [Fact]
+    public void ParseResponse_InvalidModeDefaultsToSkip()
+    {
+        var sut = CreateSut("{}");
+        var json = """{"whatWasCovered": { "value": "Some content", "mode": "unknown" }}""";
+
+        var result = sut.ParseResponse(json);
+
+        result.WhatWasCovered!.Value.Should().Be("Some content");
+        result.WhatWasCovered.Mode.Should().Be("skip");
     }
 }

--- a/backend/LangTeach.Api.Tests/Services/TelegramConversationServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/TelegramConversationServiceTests.cs
@@ -290,11 +290,11 @@ public class TelegramConversationServiceTests : IDisposable
         var student = await CreateStudentAsync("Marco");
 
         _extractionService.Result = new ExtractedReflectionDto(
-            WhatWasCovered: "ser vs estar",
-            AreasToImprove: "needs more practice with preterite",
+            WhatWasCovered: new ExtractedTextFieldDto("ser vs estar", "replace"),
+            AreasToImprove: new ExtractedTextFieldDto("needs more practice with preterite", "replace"),
             EmotionalSignals: "engaged",
-            HomeworkAssigned: "complete exercises 3 and 4",
-            NextLessonIdeas: "past tenses review",
+            HomeworkAssigned: new ExtractedTextFieldDto("complete exercises 3 and 4", "replace"),
+            NextLessonIdeas: new ExtractedTextFieldDto("past tenses review", "replace"),
             SessionDate: null,
             SuggestedDifficulties: new List<SuggestedDifficultyDto>
             {
@@ -329,7 +329,7 @@ public class TelegramConversationServiceTests : IDisposable
         var student = await CreateStudentAsync("Marco");
 
         _extractionService.Result = new ExtractedReflectionDto(
-            WhatWasCovered: "ser vs estar",
+            WhatWasCovered: new ExtractedTextFieldDto("ser vs estar", "replace"),
             AreasToImprove: null,
             EmotionalSignals: null,
             HomeworkAssigned: null,
@@ -365,7 +365,7 @@ public class TelegramConversationServiceTests : IDisposable
         var student = await CreateStudentAsync("Marco");
 
         _extractionService.Result = new ExtractedReflectionDto(
-            WhatWasCovered: "condicionales",
+            WhatWasCovered: new ExtractedTextFieldDto("condicionales", "replace"),
             AreasToImprove: null,
             EmotionalSignals: null,
             HomeworkAssigned: null,
@@ -432,7 +432,7 @@ public class TelegramConversationServiceTests : IDisposable
             // Default: echo input into AreasToImprove so existing tests asserting GeneralNotes == raw text keep passing.
             var result = Result ?? new ExtractedReflectionDto(
                 WhatWasCovered: null,
-                AreasToImprove: text,
+                AreasToImprove: new ExtractedTextFieldDto(text, "replace"),
                 EmotionalSignals: null,
                 HomeworkAssigned: null,
                 NextLessonIdeas: null,

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1523,11 +1523,27 @@ public class PromptService : IPromptService
             - teacherFollowups: operational actions the teacher owes the student (send, share, confirm). Signal: "Le tengo que mandar/enviar/dar X", "Prometí enviar X".
 
             Respond ONLY with a valid JSON object using these exact keys:
-            - whatWasCovered: string or null
-            - areasToImprove: string or null (narrative summary of student difficulties and struggles — prose, not a list)
+            - whatWasCovered: object or null. When present, the object has two keys: "value" (string) and "mode" (one of "append", "replace", or "skip").
+                Set mode to "append" if the teacher adds to existing coverage notes (signal words: "además", "también", "y también cubrimos", "también hicimos").
+                Set mode to "replace" if the teacher corrects or restates what was covered (signal words: "me equivoqué", "en realidad", "no, mejor dicho", "quiero decir", "corrijo").
+                Set mode to "skip" if this field should not be updated.
+                Return null if nothing about session content is mentioned.
+            - areasToImprove: object or null. When present, the object has two keys: "value" (string, narrative summary of student difficulties and struggles — prose, not a list) and "mode" (one of "append", "replace", or "skip").
+                Set mode to "append" if teacher adds new difficulties to existing notes (signal words: "además", "también tiene problemas con", "y otra cosa").
+                Set mode to "replace" if teacher corrects prior notes (signal words: "me equivoqué", "en realidad", "no, mejor").
+                Set mode to "skip" if this field should not be updated.
+                Return null if no difficulties or areas to improve are mentioned.
             - emotionalSignals: string or null (student attitude, mood, motivation, engagement signals)
-            - homeworkAssigned: string or null
-            - nextLessonIdeas: string or null
+            - homeworkAssigned: object or null. When present, the object has two keys: "value" (string) and "mode" (one of "append", "replace", or "skip").
+                Set mode to "append" if teacher adds homework to existing assignments (signal words: "además", "también tienen que", "y también").
+                Set mode to "replace" if teacher corrects the homework (signal words: "me equivoqué", "en realidad", "no, mejor", corrections).
+                Set mode to "skip" if this field should not be updated.
+                Return null if no homework is mentioned.
+            - nextLessonIdeas: object or null. When present, the object has two keys: "value" (string) and "mode" (one of "append", "replace", or "skip").
+                Set mode to "append" if teacher adds ideas to existing next-session plans (signal words: "además", "también", "y otra cosa", "y en la próxima").
+                Set mode to "replace" if teacher corrects prior plans (signal words: "me equivoqué", "en realidad", "no, mejor", corrections).
+                Set mode to "skip" if this field should not be updated.
+                Return null if no next-session ideas are mentioned.
             - sessionDate: string or null — ISO 8601 date (YYYY-MM-DD) of the session being described. Resolve date references using today's date and day of week: "hoy"/"today" = today, "ayer"/"yesterday" = yesterday, "el lunes pasado"/"el pasado lunes" = the most recent Monday before today (not the Monday of this week if today is Monday), "el martes pasado"/"el pasado martes" = the most recent Tuesday before today, and so on for any weekday. Always pick the last occurrence of the named weekday strictly before today. Null if no date is mentioned.
             - sessionStartTime: string or null — 24-hour time (HH:MM) when the session started (e.g. "09:00", "18:30"). Null if not mentioned.
             - sessionTitle: string or null — a concise title (under 60 chars) for this session derived from what was covered. Examples: "Subjunctive in time clauses", "Pasado compuesto — revisión". Null if no content is mentioned.

--- a/backend/LangTeach.Api/DTOs/ReflectionExtractionDtos.cs
+++ b/backend/LangTeach.Api/DTOs/ReflectionExtractionDtos.cs
@@ -9,6 +9,8 @@ public class ExtractReflectionRequest
     public string Text { get; set; } = string.Empty;
 }
 
+public record ExtractedTextFieldDto(string? Value, string Mode); // Mode: "append" | "replace" | "skip"
+
 public record SuggestedDifficultyDto(
     string Description,
     string Competency,
@@ -19,11 +21,11 @@ public record SuggestedDifficultyDto(
 public record TopicTagDto(string Tag, string? Category);
 
 public record ExtractedReflectionDto(
-    string? WhatWasCovered,
-    string? AreasToImprove,
+    ExtractedTextFieldDto? WhatWasCovered,
+    ExtractedTextFieldDto? AreasToImprove,
     string? EmotionalSignals,
-    string? HomeworkAssigned,
-    string? NextLessonIdeas,
+    ExtractedTextFieldDto? HomeworkAssigned,
+    ExtractedTextFieldDto? NextLessonIdeas,
     string? SessionDate,
     List<SuggestedDifficultyDto> SuggestedDifficulties,
     string? RawExtractionJson,

--- a/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
@@ -126,7 +126,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
         return result;
     }
 
-    private static ExtractedTextFieldDto? ParseTextFieldOrNull(JsonElement root, string key)
+    private ExtractedTextFieldDto? ParseTextFieldOrNull(JsonElement root, string key)
     {
         if (!root.TryGetProperty(key, out var prop)) return null;
         if (prop.ValueKind == JsonValueKind.Null) return null;
@@ -134,7 +134,11 @@ public class ReflectionExtractionService : IReflectionExtractionService
         {
             var value = GetStringOrNull(prop, "value");
             var mode = GetStringOrNull(prop, "mode") ?? "skip";
-            if (mode is not ("append" or "replace" or "skip")) mode = "skip";
+            if (mode is not ("append" or "replace" or "skip"))
+            {
+                _logger.LogWarning("Unrecognized extraction mode '{Mode}' for key '{Key}', defaulting to skip", mode, key);
+                mode = "skip";
+            }
             return new ExtractedTextFieldDto(value, mode);
         }
         // Legacy fallback: plain string response from AI (treat as replace)

--- a/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
@@ -139,7 +139,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
                 _logger.LogWarning("Unrecognized extraction mode '{Mode}' for key '{Key}', defaulting to skip", mode, key);
                 mode = "skip";
             }
-            return new ExtractedTextFieldDto(value, mode);
+            return value is null ? null : new ExtractedTextFieldDto(value, mode);
         }
         // Legacy fallback: plain string response from AI (treat as replace)
         if (prop.ValueKind == JsonValueKind.String)

--- a/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
@@ -60,11 +60,11 @@ public class ReflectionExtractionService : IReflectionExtractionService
             var root = doc.RootElement;
 
             return new ExtractedReflectionDto(
-                WhatWasCovered: GetStringOrNull(root, "whatWasCovered"),
-                AreasToImprove: GetStringOrNull(root, "areasToImprove"),
+                WhatWasCovered: ParseTextFieldOrNull(root, "whatWasCovered"),
+                AreasToImprove: ParseTextFieldOrNull(root, "areasToImprove"),
                 EmotionalSignals: GetStringOrNull(root, "emotionalSignals"),
-                HomeworkAssigned: GetStringOrNull(root, "homeworkAssigned"),
-                NextLessonIdeas: GetStringOrNull(root, "nextLessonIdeas"),
+                HomeworkAssigned: ParseTextFieldOrNull(root, "homeworkAssigned"),
+                NextLessonIdeas: ParseTextFieldOrNull(root, "nextLessonIdeas"),
                 SessionDate: GetIsoDateOrNull(root, "sessionDate"),
                 SuggestedDifficulties: ParseSuggestedDifficulties(root),
                 RawExtractionJson: cleaned,
@@ -124,6 +124,26 @@ public class ReflectionExtractionService : IReflectionExtractionService
         }
 
         return result;
+    }
+
+    private static ExtractedTextFieldDto? ParseTextFieldOrNull(JsonElement root, string key)
+    {
+        if (!root.TryGetProperty(key, out var prop)) return null;
+        if (prop.ValueKind == JsonValueKind.Null) return null;
+        if (prop.ValueKind == JsonValueKind.Object)
+        {
+            var value = GetStringOrNull(prop, "value");
+            var mode = GetStringOrNull(prop, "mode") ?? "skip";
+            if (mode is not ("append" or "replace" or "skip")) mode = "skip";
+            return new ExtractedTextFieldDto(value, mode);
+        }
+        // Legacy fallback: plain string response from AI (treat as replace)
+        if (prop.ValueKind == JsonValueKind.String)
+        {
+            var value = prop.GetString();
+            return string.IsNullOrWhiteSpace(value) ? null : new ExtractedTextFieldDto(value, "replace");
+        }
+        return null;
     }
 
     private static string? GetStringOrNull(JsonElement root, string key)

--- a/backend/LangTeach.Api/Services/StubReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/StubReflectionExtractionService.cs
@@ -15,11 +15,11 @@ public class StubReflectionExtractionService : IReflectionExtractionService
     {
         _logger.LogInformation("StubReflectionExtractionService.ExtractAsync called with {Length} chars", text.Length);
         return Task.FromResult(new ExtractedReflectionDto(
-            WhatWasCovered: "[Extracted] What was covered",
-            AreasToImprove: "[Extracted] Areas to improve",
+            WhatWasCovered: new ExtractedTextFieldDto("[Extracted] What was covered", "replace"),
+            AreasToImprove: new ExtractedTextFieldDto("[Extracted] Areas to improve", "replace"),
             EmotionalSignals: "[Extracted] Emotional signals",
-            HomeworkAssigned: "[Extracted] Homework assigned",
-            NextLessonIdeas: "[Extracted] Next lesson ideas",
+            HomeworkAssigned: new ExtractedTextFieldDto("[Extracted] Homework assigned", "replace"),
+            NextLessonIdeas: new ExtractedTextFieldDto("[Extracted] Next lesson ideas", "append"),
             SessionDate: "2026-01-15",
             SuggestedDifficulties: [],
             RawExtractionJson: null,

--- a/backend/LangTeach.Api/Services/TelegramConversationService.cs
+++ b/backend/LangTeach.Api/Services/TelegramConversationService.cs
@@ -238,15 +238,15 @@ public class TelegramConversationService : ITelegramConversationService
         // Mirror of SessionLogDialog.tsx:316-346 — join AreasToImprove + EmotionalSignals into GeneralNotes,
         // map the rest onto their structured fields.
         var generalNotes = string.Join("\n",
-            new[] { extracted.AreasToImprove, extracted.EmotionalSignals }
+            new[] { extracted.AreasToImprove?.Value, extracted.EmotionalSignals }
                 .Where(s => !string.IsNullOrWhiteSpace(s)));
 
         return new CreateSessionLogRequest
         {
             SessionDate = ParseSessionDate(extracted.SessionDate),
-            ActualContent = extracted.WhatWasCovered,
-            HomeworkAssigned = extracted.HomeworkAssigned,
-            NextSessionTopics = extracted.NextLessonIdeas,
+            ActualContent = extracted.WhatWasCovered?.Value,
+            HomeworkAssigned = extracted.HomeworkAssigned?.Value,
+            NextSessionTopics = extracted.NextLessonIdeas?.Value,
             GeneralNotes = string.IsNullOrEmpty(generalNotes) ? null : generalNotes,
             SuggestedDifficulties = extracted.SuggestedDifficulties.Count > 0
                 ? extracted.SuggestedDifficulties

--- a/e2e/tests/session-log-voice.spec.ts
+++ b/e2e/tests/session-log-voice.spec.ts
@@ -270,3 +270,110 @@ test('second voice note updates draft, does not create a duplicate', async ({ br
 
   await context.close()
 })
+
+test('voice extraction append mode: concatenates extracted value with existing field content', async ({ browser }) => {
+  // StubReflectionExtractionService returns nextLessonIdeas with mode "append".
+  // This test verifies that when a Draft session has pre-existing nextSessionTopics,
+  // the extracted value is appended rather than ignored or replaced.
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  const student = await createStudent(page, `Append Mode Student ${Date.now()}`)
+
+  // Create a Draft session with pre-existing nextSessionTopics
+  const sessionRes = await page.request.post(`${API_BASE}/api/students/${student.id}/sessions`, {
+    headers: AUTH_HEADER,
+    data: {
+      nextSessionTopics: 'Existing topics',
+      previousHomeworkStatus: 'NotApplicable',
+      status: 'Draft',
+    },
+  })
+  expect(sessionRes.ok()).toBeTruthy()
+
+  // Navigate to student detail and open session history tab
+  await page.goto(`/students/${student.id}`)
+  await expect(page.getByTestId('student-detail-name')).toBeVisible({ timeout: 15000 })
+
+  await page.getByRole('tab', { name: /history/i }).click()
+  await expect(page.getByTestId('session-history-list')).toBeVisible({ timeout: 10000 })
+
+  // Open the Draft in edit mode
+  await page.getByTestId('session-entry-toggle').click()
+  await page.getByTestId('edit-session-button').click()
+  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
+
+  // Verify the field is pre-populated before uploading audio
+  await expect(page.getByTestId('next-session-topics')).toHaveValue('Existing topics', { timeout: 5000 })
+
+  // Upload audio — stub returns nextLessonIdeas with mode "append"
+  const audioPath = path.join(__dirname, '../fixtures/test-audio.webm')
+  await page.getByTestId('audio-file-input').setInputFiles(audioPath)
+
+  // Wait for extraction to complete
+  await expect(page.getByTestId('extracting-indicator')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByTestId('extracting-indicator')).toBeHidden({ timeout: 20000 })
+
+  // Verify append: existing content + " " + extracted value
+  await expect(page.getByTestId('next-session-topics')).toHaveValue(
+    'Existing topics [Extracted] Next lesson ideas',
+    { timeout: 5000 }
+  )
+
+  await context.close()
+})
+
+test('voice extraction replace mode: overwrites existing field content', async ({ browser }) => {
+  // StubReflectionExtractionService returns whatWasCovered with mode "replace".
+  // This test verifies that when a Draft session has pre-existing actualContent,
+  // the extracted value replaces it rather than being ignored.
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  const student = await createStudent(page, `Replace Mode Student ${Date.now()}`)
+
+  // Create a Draft session with pre-existing actualContent
+  const sessionRes = await page.request.post(`${API_BASE}/api/students/${student.id}/sessions`, {
+    headers: AUTH_HEADER,
+    data: {
+      actualContent: 'Old content that should be replaced',
+      previousHomeworkStatus: 'NotApplicable',
+      status: 'Draft',
+    },
+  })
+  expect(sessionRes.ok()).toBeTruthy()
+
+  // Navigate to student detail and open session history tab
+  await page.goto(`/students/${student.id}`)
+  await expect(page.getByTestId('student-detail-name')).toBeVisible({ timeout: 15000 })
+
+  await page.getByRole('tab', { name: /history/i }).click()
+  await expect(page.getByTestId('session-history-list')).toBeVisible({ timeout: 10000 })
+
+  // Open the Draft in edit mode
+  await page.getByTestId('session-entry-toggle').click()
+  await page.getByTestId('edit-session-button').click()
+  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
+
+  // Verify the field is pre-populated before uploading audio
+  await expect(page.getByTestId('actual-content')).toHaveValue(
+    'Old content that should be replaced',
+    { timeout: 5000 }
+  )
+
+  // Upload audio — stub returns whatWasCovered with mode "replace"
+  const audioPath = path.join(__dirname, '../fixtures/test-audio.webm')
+  await page.getByTestId('audio-file-input').setInputFiles(audioPath)
+
+  // Wait for extraction to complete
+  await expect(page.getByTestId('extracting-indicator')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByTestId('extracting-indicator')).toBeHidden({ timeout: 20000 })
+
+  // Verify replace: old content is overwritten by extracted value
+  await expect(page.getByTestId('actual-content')).toHaveValue(
+    '[Extracted] What was covered',
+    { timeout: 5000 }
+  )
+
+  await context.close()
+})

--- a/frontend/src/api/sessionLogs.ts
+++ b/frontend/src/api/sessionLogs.ts
@@ -39,12 +39,17 @@ export interface SuggestedDifficulty {
   severity: string
 }
 
+export interface ExtractedTextField {
+  value: string | null
+  mode: 'append' | 'replace' | 'skip'
+}
+
 export interface ExtractedReflection {
-  whatWasCovered: string | null
-  areasToImprove: string | null
+  whatWasCovered: ExtractedTextField | null
+  areasToImprove: ExtractedTextField | null
   emotionalSignals: string | null
-  homeworkAssigned: string | null
-  nextLessonIdeas: string | null
+  homeworkAssigned: ExtractedTextField | null
+  nextLessonIdeas: ExtractedTextField | null
   sessionDate?: string | null
   sessionTitle?: string | null
   suggestedDifficulties: SuggestedDifficulty[]

--- a/frontend/src/pages/LogSession.test.tsx
+++ b/frontend/src/pages/LogSession.test.tsx
@@ -842,7 +842,7 @@ describe('LogSession — Ctrl+Enter shortcut', () => {
 describe('LogSession — voice note extraction', () => {
   const EXTRACTED = {
     sessionTitle: 'Pretérito perfecto y viajes',
-    whatWasCovered: 'Repasamos el pretérito perfecto.',
+    whatWasCovered: { value: 'Repasamos el pretérito perfecto.', mode: 'replace' as const },
     areasToImprove: null,
     emotionalSignals: null,
     homeworkAssigned: null,
@@ -931,8 +931,11 @@ describe('LogSession — voice note extraction', () => {
     expect(lastPayload.rawExtractionJson).toBe('{"sessionTitle":"Pretérito perfecto y viajes"}')
   })
 
-  it('does NOT overwrite actualContent already typed by the teacher', async () => {
-    vi.mocked(sessionLogsApi.extractSessionReflection).mockResolvedValue(EXTRACTED)
+  it('does NOT overwrite actualContent when extraction mode is skip', async () => {
+    vi.mocked(sessionLogsApi.extractSessionReflection).mockResolvedValue({
+      ...EXTRACTED,
+      whatWasCovered: { value: 'Repasamos el pretérito perfecto.', mode: 'skip' as const },
+    })
     renderLogSession()
     await screen.findByTestId('log-session-page')
 

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -139,6 +139,7 @@ export default function LogSession() {
   const [sessionTime, setSessionTime] = useState(nowTimeHHMM())
   const [durationChoice, setDurationChoice] = useState('50')
   const durationChoiceRef = useRef('50')
+  const latestFieldsRef = useRef({ actualContent: '', generalNotes: '', homeworkAssigned: '', nextSessionTopics: '' })
   const [durationOther, setDurationOther] = useState('')
   const [isCancelled, setIsCancelled] = useState(false)
   const [prevHomeworkStatus, setPrevHomeworkStatus] = useState<string | null>(null)
@@ -283,6 +284,10 @@ export default function LogSession() {
 
   // Keep durationChoiceRef current so async extraction callbacks read the latest value, not a stale closure
   useEffect(() => { durationChoiceRef.current = durationChoice }, [durationChoice])
+  // Keep latestFieldsRef current so append-mode extraction reads the current field values, not stale closure values
+  useEffect(() => {
+    latestFieldsRef.current = { actualContent, generalNotes, homeworkAssigned, nextSessionTopics }
+  }, [actualContent, generalNotes, homeworkAssigned, nextSessionTopics])
 
   // Autosave setup - keep ref current after every render (StudentForm pattern)
   const getFormDataRef = useRef<(() => CreateSessionLogRequest) | null>(null)
@@ -922,28 +927,31 @@ export default function LogSession() {
                       if (field.mode === 'replace') return field.value
                       return existing ? `${existing} ${field.value}` : field.value
                     }
-                    const nextActualContent = applyMode(actualContent, extracted.whatWasCovered)
+                    const { actualContent: curActualContent, generalNotes: curGeneralNotes,
+                            homeworkAssigned: curHomeworkAssigned, nextSessionTopics: curNextSessionTopics } = latestFieldsRef.current
+                    const nextActualContent = applyMode(curActualContent, extracted.whatWasCovered)
                     if (nextActualContent !== null) {
                       saveOverride.actualContent = nextActualContent
                       setActualContent(nextActualContent)
                     }
                     if (extracted.areasToImprove || extracted.emotionalSignals) {
-                      const combinedValue = [extracted.areasToImprove?.value, extracted.emotionalSignals].filter(Boolean).join(' ')
-                      const combinedField = combinedValue
-                        ? { value: combinedValue, mode: extracted.areasToImprove?.mode ?? 'replace' }
-                        : null
-                      const nextGeneralNotes = applyMode(generalNotes, combinedField)
+                      // emotionalSignals has no mode; always include it. Only include areasToImprove value if mode != 'skip'.
+                      const areasValue = extracted.areasToImprove?.mode !== 'skip' ? extracted.areasToImprove?.value : null
+                      const combinedValue = [areasValue, extracted.emotionalSignals].filter(Boolean).join(' ')
+                      const effectiveMode = areasValue ? (extracted.areasToImprove?.mode ?? 'replace') : 'replace'
+                      const combinedField = combinedValue ? { value: combinedValue, mode: effectiveMode } : null
+                      const nextGeneralNotes = applyMode(curGeneralNotes, combinedField)
                       if (nextGeneralNotes !== null) {
                         saveOverride.generalNotes = nextGeneralNotes
                         setGeneralNotes(nextGeneralNotes)
                       }
                     }
-                    const nextHomeworkAssigned = applyMode(homeworkAssigned, extracted.homeworkAssigned)
+                    const nextHomeworkAssigned = applyMode(curHomeworkAssigned, extracted.homeworkAssigned)
                     if (nextHomeworkAssigned !== null) {
                       saveOverride.homeworkAssigned = nextHomeworkAssigned
                       setHomeworkAssigned(nextHomeworkAssigned)
                     }
-                    const nextSessionTopicsNext = applyMode(nextSessionTopics, extracted.nextLessonIdeas)
+                    const nextSessionTopicsNext = applyMode(curNextSessionTopics, extracted.nextLessonIdeas)
                     if (nextSessionTopicsNext !== null) {
                       saveOverride.nextSessionTopics = nextSessionTopicsNext
                       setNextSessionTopics(nextSessionTopicsNext)

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -914,30 +914,38 @@ export default function LogSession() {
                       setRawExtractionJson(json)
                     }
                     if (extracted.sessionTitle) {
-                      const next = sessionTitle || extracted.sessionTitle
-                      saveOverride.title = next
-                      setSessionTitle(next)
+                      saveOverride.title = extracted.sessionTitle
+                      setSessionTitle(extracted.sessionTitle)
                     }
-                    if (extracted.whatWasCovered) {
-                      const next = actualContent || extracted.whatWasCovered
-                      saveOverride.actualContent = next
-                      setActualContent(next)
+                    const applyMode = (existing: string, field: { value: string | null; mode: string } | null): string | null => {
+                      if (!field || !field.value || field.mode === 'skip') return null
+                      if (field.mode === 'replace') return field.value
+                      return existing ? `${existing} ${field.value}` : field.value
+                    }
+                    const nextActualContent = applyMode(actualContent, extracted.whatWasCovered)
+                    if (nextActualContent !== null) {
+                      saveOverride.actualContent = nextActualContent
+                      setActualContent(nextActualContent)
                     }
                     if (extracted.areasToImprove || extracted.emotionalSignals) {
-                      const combined = [extracted.areasToImprove, extracted.emotionalSignals].filter(Boolean).join(' ')
-                      const next = generalNotes || combined
-                      saveOverride.generalNotes = next
-                      setGeneralNotes(next)
+                      const combinedNew = [extracted.areasToImprove?.value, extracted.emotionalSignals].filter(Boolean).join(' ')
+                      const mode = extracted.areasToImprove?.mode ?? 'replace'
+                      const nextGeneralNotes = mode === 'skip' ? null
+                        : mode === 'append' && generalNotes ? `${generalNotes} ${combinedNew}` : combinedNew
+                      if (nextGeneralNotes !== null) {
+                        saveOverride.generalNotes = nextGeneralNotes
+                        setGeneralNotes(nextGeneralNotes)
+                      }
                     }
-                    if (extracted.homeworkAssigned) {
-                      const next = homeworkAssigned || extracted.homeworkAssigned
-                      saveOverride.homeworkAssigned = next
-                      setHomeworkAssigned(next)
+                    const nextHomeworkAssigned = applyMode(homeworkAssigned, extracted.homeworkAssigned)
+                    if (nextHomeworkAssigned !== null) {
+                      saveOverride.homeworkAssigned = nextHomeworkAssigned
+                      setHomeworkAssigned(nextHomeworkAssigned)
                     }
-                    if (extracted.nextLessonIdeas) {
-                      const next = nextSessionTopics || extracted.nextLessonIdeas
-                      saveOverride.nextSessionTopics = next
-                      setNextSessionTopics(next)
+                    const nextSessionTopicsNext = applyMode(nextSessionTopics, extracted.nextLessonIdeas)
+                    if (nextSessionTopicsNext !== null) {
+                      saveOverride.nextSessionTopics = nextSessionTopicsNext
+                      setNextSessionTopics(nextSessionTopicsNext)
                     }
                     if (extracted.topicTags && extracted.topicTags.length > 0) {
                       const existing = new Set(topicTags.map(t => t.tag.toLowerCase()))

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -928,10 +928,11 @@ export default function LogSession() {
                       setActualContent(nextActualContent)
                     }
                     if (extracted.areasToImprove || extracted.emotionalSignals) {
-                      const combinedNew = [extracted.areasToImprove?.value, extracted.emotionalSignals].filter(Boolean).join(' ')
-                      const mode = extracted.areasToImprove?.mode ?? 'replace'
-                      const nextGeneralNotes = mode === 'skip' ? null
-                        : mode === 'append' && generalNotes ? `${generalNotes} ${combinedNew}` : combinedNew
+                      const combinedValue = [extracted.areasToImprove?.value, extracted.emotionalSignals].filter(Boolean).join(' ')
+                      const combinedField = combinedValue
+                        ? { value: combinedValue, mode: extracted.areasToImprove?.mode ?? 'replace' }
+                        : null
+                      const nextGeneralNotes = applyMode(generalNotes, combinedField)
                       if (nextGeneralNotes !== null) {
                         saveOverride.generalNotes = nextGeneralNotes
                         setGeneralNotes(nextGeneralNotes)

--- a/plan/langteach-beta/task823-voice-note-extraction-mode.md
+++ b/plan/langteach-beta/task823-voice-note-extraction-mode.md
@@ -1,0 +1,209 @@
+# Task 823 — Voice Note Extraction: append/replace/skip mode
+
+**Issue:** #823
+**Branch:** `worktree-task-t823-voice-note-extraction-mode`
+**Sprint:** `sprint/ui-redesign-student-polish`
+
+## Problem
+
+All extracted text fields use a blunt fill-if-empty rule (`existing || extracted`). If a field already has content, the extracted value is silently ignored. This breaks append and replace workflows.
+
+## Solution Overview
+
+Add a `mode` field (`"append"` | `"replace"` | `"skip"`) to the 4 mode-aware text extraction fields. The mode originates in Claude's response and flows through prompt -> backend DTO/parser -> frontend handler.
+
+- **append**: concatenate with `" "` separator (or just use extracted value if existing is empty)
+- **replace**: overwrite regardless of existing content
+- **skip**: leave field unchanged (same as current null behavior)
+
+Fields with mode: `whatWasCovered`, `areasToImprove`, `homeworkAssigned`, `nextLessonIdeas`
+Fields without mode (unchanged behavior):
+- `sessionTitle`: always replaces if non-null
+- `topicTags`: always merges + deduplicates
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `backend/LangTeach.Api/DTOs/ReflectionExtractionDtos.cs` | Add `ExtractedTextFieldDto` record; change 4 fields from `string?` to `ExtractedTextFieldDto?` |
+| `backend/LangTeach.Api/AI/PromptService.cs` (lines 1525-1552) | Update prompt: 4 fields now return `{ value, mode }` object; add signal words |
+| `backend/LangTeach.Api/Services/ReflectionExtractionService.cs` | Add `ParseTextFieldOrNull()` helper; update ParseResponse to use it for 4 fields |
+| `backend/LangTeach.Api/Services/StubReflectionExtractionService.cs` | Return `ExtractedTextFieldDto` for the 4 mode fields; use distinct modes for e2e testability |
+| `backend/LangTeach.Api/Services/TelegramConversationService.cs` | Update any reads of the 4 changed fields to use `.Value` |
+| `backend/LangTeach.Api.Tests/Services/TelegramConversationServiceTests.cs` | Update 4+ test methods that construct `ExtractedReflectionDto` with plain strings for the 4 changed fields |
+| `frontend/src/api/sessionLogs.ts` | Update `ExtractedReflection` interface: 4 fields become `{ value: string \| null; mode: 'append' \| 'replace' \| 'skip' } \| null` |
+| `frontend/src/pages/LogSession.tsx` (lines 916-941) | Replace fill-if-empty with mode-aware logic for the 4 fields |
+| `backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs` | Update JSON fixtures to new shape; add tests for append/replace/skip parsing |
+| `e2e/tests/session-log-voice.spec.ts` | Add 2 new tests: append scenario + replace scenario |
+| `.claude/skills/teacher-qa/output/prior-findings.md` | Update with changed extraction prompt |
+
+## Implementation Steps
+
+### Step 1: Backend DTO
+
+In `ReflectionExtractionDtos.cs`, add:
+```csharp
+public record ExtractedTextFieldDto(string? Value, string Mode); // Mode: "append" | "replace" | "skip"
+```
+
+Change 4 fields in `ExtractedReflectionDto` from `string?` to `ExtractedTextFieldDto?`:
+- `WhatWasCovered`
+- `AreasToImprove`
+- `HomeworkAssigned`
+- `NextLessonIdeas`
+
+### Step 2: Prompt
+
+In `PromptService.cs` `BuildReflectionExtractionPrompt`, replace the 4 field descriptions:
+
+```
+- whatWasCovered: object or null — { "value": string, "mode": "append" | "replace" | "skip" }
+    mode "append" if teacher adds to existing coverage notes (signal: "además", "también", "y también cubrimos")
+    mode "replace" if teacher corrects or restates (signal: "me equivoqué", "en realidad", "no, mejor dicho", "quiero decir")
+    mode "skip" if this field should not be updated
+    Return null if nothing about coverage is mentioned.
+```
+Same pattern for areasToImprove, homeworkAssigned, nextLessonIdeas.
+
+### Step 3: Parser
+
+In `ReflectionExtractionService.cs`, add:
+```csharp
+private static ExtractedTextFieldDto? ParseTextFieldOrNull(JsonElement root, string key)
+{
+    if (!root.TryGetProperty(key, out var prop)) return null;
+    if (prop.ValueKind == JsonValueKind.Null) return null;
+    if (prop.ValueKind == JsonValueKind.Object)
+    {
+        var value = GetStringOrNull(prop, "value");
+        var mode = GetStringOrNull(prop, "mode") ?? "skip";
+        if (mode is not ("append" or "replace" or "skip")) mode = "skip";
+        return new ExtractedTextFieldDto(value, mode);
+    }
+    // Legacy fallback: plain string (treat as replace)
+    if (prop.ValueKind == JsonValueKind.String)
+    {
+        var value = prop.GetString();
+        return string.IsNullOrWhiteSpace(value) ? null : new ExtractedTextFieldDto(value, "replace");
+    }
+    return null;
+}
+```
+
+Use `ParseTextFieldOrNull` for the 4 fields in `ParseResponse`.
+
+### Step 4: Stub Service
+
+Update `StubReflectionExtractionService.cs` to return `ExtractedTextFieldDto` values:
+- `WhatWasCovered`: `new ExtractedTextFieldDto("[Extracted] What was covered", "replace")`
+- `AreasToImprove`: `new ExtractedTextFieldDto("[Extracted] Areas to improve", "replace")`
+- `HomeworkAssigned`: `new ExtractedTextFieldDto("[Extracted] Homework assigned", "replace")`
+- `NextLessonIdeas`: `new ExtractedTextFieldDto("[Extracted] Next lesson ideas", "append")`
+
+(NextLessonIdeas uses "append" mode so e2e tests can verify the concatenation path.)
+
+### Step 5: TelegramConversationService
+
+Find all reads of `WhatWasCovered`, `AreasToImprove`, `HomeworkAssigned`, `NextLessonIdeas` in `TelegramConversationService.cs` and change to `?.Value`.
+
+### Step 6: Frontend interface
+
+In `sessionLogs.ts`, change `ExtractedReflection`:
+```ts
+whatWasCovered: { value: string | null; mode: 'append' | 'replace' | 'skip' } | null
+areasToImprove: { value: string | null; mode: 'append' | 'replace' | 'skip' } | null
+homeworkAssigned: { value: string | null; mode: 'append' | 'replace' | 'skip' } | null
+nextLessonIdeas: { value: string | null; mode: 'append' | 'replace' | 'skip' } | null
+```
+
+### Step 7: Frontend handler (LogSession.tsx)
+
+Helper to apply mode (inline or small local fn):
+```ts
+function applyMode(existing: string, extracted: { value: string | null; mode: string } | null): string | null {
+  if (!extracted || !extracted.value || extracted.mode === 'skip') return null  // null = no change
+  if (extracted.mode === 'replace') return extracted.value
+  // append
+  return existing ? `${existing} ${extracted.value}` : extracted.value
+}
+```
+
+Replace the 4 fill-if-empty blocks with mode-aware calls. Example for actualContent:
+```ts
+const nextActualContent = applyMode(actualContent, extracted.whatWasCovered)
+if (nextActualContent !== null) {
+  saveOverride.actualContent = nextActualContent
+  setActualContent(nextActualContent)
+}
+```
+
+Apply same pattern for generalNotes (combine areasToImprove + emotionalSignals first, then apply areasToImprove's mode), homeworkAssigned, nextSessionTopics.
+
+**Note on generalNotes**: `emotionalSignals` has no mode field (remains `string?`). The governing mode always comes from `areasToImprove`. Exact rules for all 4 cases:
+
+| areasToImprove | emotionalSignals | Result |
+|----------------|-----------------|--------|
+| null | null | no change |
+| null | non-null | treat as mode "replace" for the emotionalSignals value only (emotionalSignals always appends to generalNotes or replaces if empty -- use "replace" since no mode available) |
+| non-null (any mode) | null | apply areasToImprove's mode with only areasToImprove.value |
+| non-null (any mode) | non-null | combine `areasToImprove.value + " " + emotionalSignals`, then apply areasToImprove's mode |
+
+When combining: build `combinedNew = [areasToImprove?.value, emotionalSignals].filter(Boolean).join(' ')`. Then apply mode (append/replace) of `areasToImprove` (or "replace" if only emotionalSignals) to determine the final generalNotes value.
+
+### Step 8: Unit tests
+
+Update `TelegramConversationServiceTests.cs`: find all 4+ test methods that construct `ExtractedReflectionDto` with plain strings for the 4 changed fields and update to `new ExtractedTextFieldDto(value, mode)`. Use `"replace"` for the mode in these tests (behavior is unchanged, they test Telegram flow not extraction logic).
+
+Update `ReflectionExtractionServiceTests.cs`:
+- Change JSON fixtures: `"whatWasCovered": "Past tense verbs"` -> `"whatWasCovered": { "value": "Past tense verbs", "mode": "replace" }`
+- Update assertions: `result.WhatWasCovered.Value.Should().Be("Past tense verbs")` and `result.WhatWasCovered.Mode.Should().Be("replace")`
+- Add tests:
+  - `ParseResponse_ParsesModeAppend` (verifies append mode parsed correctly)
+  - `ParseResponse_ParsesModeSkip` (verifies skip mode)
+  - `ParseResponse_HandlesLegacyStringFallback` (plain string -> mode "replace")
+  - `ParseResponse_ReturnsNullForNullField` (null -> null)
+
+### Step 9: E2E tests
+
+Add to `session-log-voice.spec.ts`:
+
+**Append scenario:**
+1. Create a Draft session via API with `nextSessionTopics = "Existing topics"`
+2. Navigate to student detail, open session history tab
+3. Open the Draft in edit mode (the dialog pre-populates form fields from the saved session on open -- verify `next-session-topics` field shows "Existing topics" before uploading)
+4. Upload audio file (stub returns `nextLessonIdeas` with mode "append", value "[Extracted] Next lesson ideas")
+5. Wait for extraction to complete (extracting indicator appears then clears)
+6. Verify `next-session-topics` field = `"Existing topics [Extracted] Next lesson ideas"`
+
+**Replace scenario:**
+1. Create a Draft session via API with `actualContent = "Old content"`
+2. Open Draft in edit mode
+3. Upload audio file (stub returns `whatWasCovered` with mode "replace", value "[Extracted] What was covered")
+4. Wait for extraction
+5. Verify `actual-content` field = `"[Extracted] What was covered"` (not "Old content [Extracted]...")
+
+### Step 10: Update prior-findings.md
+
+Update `.claude/skills/teacher-qa/output/prior-findings.md` to record that the extraction prompt now returns `{ value, mode }` objects for text fields, and what signal words are used.
+
+## Acceptance Criteria Mapping
+
+| AC | Implementation |
+|----|----------------|
+| Prompt returns mode per text field | Step 2 |
+| DTO/parser handle { value, mode } | Steps 1, 3 |
+| Frontend applies append/replace/skip | Step 7 |
+| Fields in scope: actualContent, nextLessonIdeas, homeworkAssigned, generalNotes, areasToImprove | Steps 1-7 |
+| sessionTitle always replaces | Already true (not changed) |
+| topicTags always merges+deduplicates | Already true (not changed) |
+| E2E: append scenario | Step 9 |
+| E2E: replace scenario | Step 9 |
+| Update prior-findings.md | Step 10 |
+
+## Risk
+
+**TelegramConversationService.cs** uses `ExtractedReflectionDto` - need to audit how it reads the 4 changed fields and update to `.Value`.
+
+**Existing unit tests** assert on plain string values - all must be updated to `.Value` and `.Mode`.
+
+**Existing e2e test** (`voice upload: extracted fields pre-fill form`) starts with an empty form, so mode="replace" and mode="append" both produce the stub value -> test still passes unchanged.


### PR DESCRIPTION
## Summary

- Fixes #823: voice note extraction was using fill-if-empty logic, silently ignoring extracted values when a field already had content
- Extraction prompt now instructs Claude to return `{ value, mode }` per text field with modes `"append"`, `"replace"`, or `"skip"` (with signal words for each)
- New `ExtractedTextFieldDto` record flows through backend DTO, parser, stub service, and Telegram service
- Frontend `applyMode` helper applies the correct behavior: replace overwrites, append concatenates with space, skip leaves unchanged
- `sessionTitle` always replaces; `topicTags` always merges+deduplicates (unchanged)
- 2 new e2e tests verify both append and replace scenarios against pre-filled draft sessions

## Test plan

- [ ] Build verify: PASS (bicep, dotnet, npm)
- [ ] Backend unit tests: 1134 passed (5 new parser tests, updated extraction + controller tests)
- [ ] Frontend unit tests: 1318 passed (updated mock fixture shape, updated skip-mode test)
- [ ] qa-verify: PASS (all ACs covered)
- [ ] architecture-reviewer: PASS WITH NOTES (generalNotes routing fixed; enum refactor deferred to #826)
- [ ] Sophy: CLEAN (warning log added per suggestion)
- [ ] review-ui: PASS (behavioral change only, no visual regression)
- [ ] CI: pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Voice extraction now supports intelligent content handling: extracted session fields can be appended to existing notes, replace existing content, or skipped entirely based on extraction context.
  * Next lesson ideas and similar fields can now accumulate extracted content rather than overwriting previous entries.

* **Bug Fixes**
  * Improved voice extraction accuracy with mode-aware field processing for session notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->