### PR TITLE
fix(#824): show SCHEDULED badge for future Confirmed sessions

### DIFF
--- a/frontend/src/components/session/SessionHistoryTab.test.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.test.tsx
@@ -693,4 +693,42 @@ describe('SessionHistoryTab', () => {
     expect(link).toBeInTheDocument()
     expect(link).toHaveAttribute('href', '/students/student-1/sessions/session-1/edit')
   })
+
+  it('shows Scheduled badge for a Confirmed session with a far-future date', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SESSION_BASE, sessionDate: '2099-01-15T00:00:00Z' },
+    ])
+    wrapper()
+    expect(await screen.findByTestId('scheduled-badge')).toBeInTheDocument()
+    expect(screen.getByTestId('scheduled-badge')).toHaveTextContent('Scheduled')
+    expect(screen.queryByTestId('completed-badge')).not.toBeInTheDocument()
+  })
+
+  it('shows Completed badge for a Confirmed session with a past date', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SESSION_BASE, sessionDate: '2020-06-10T00:00:00Z' },
+    ])
+    wrapper()
+    expect(await screen.findByTestId('completed-badge')).toBeInTheDocument()
+    expect(screen.getByTestId('completed-badge')).toHaveTextContent('Completed')
+    expect(screen.queryByTestId('scheduled-badge')).not.toBeInTheDocument()
+  })
+
+  it('does not show Scheduled badge for a Draft session with a future date', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SESSION_BASE, sessionDate: '2099-01-15T00:00:00Z', status: 1, statusName: 'Draft' as const },
+    ])
+    wrapper()
+    expect(await screen.findByTestId('draft-badge')).toBeInTheDocument()
+    expect(screen.queryByTestId('scheduled-badge')).not.toBeInTheDocument()
+  })
+
+  it('does not show Scheduled badge for a cancelled session with a future date', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SESSION_BASE, sessionDate: '2099-01-15T00:00:00Z', isCancelled: true },
+    ])
+    wrapper()
+    expect(await screen.findByTestId('cancelled-badge')).toBeInTheDocument()
+    expect(screen.queryByTestId('scheduled-badge')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/session/SessionHistoryTab.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.tsx
@@ -137,6 +137,9 @@ function SessionEntry({
   const isDraft = session.statusName === 'Draft'
   const showHwIcon = Boolean(hwStatus && hwStatus !== 'NotApplicable')
 
+  // Single-tenant beta: sessionDate may be UTC ISO (e.g. "2026-05-17T00:00:00Z"); slice(0,10)
+  // yields the UTC date, which is compared against the local date from todayLocalDateStr().
+  // Acceptable for now (one timezone); revisit when multi-timezone support is added.
   const isScheduled = !isCancelled && !isDraft && session.sessionDate != null && session.sessionDate.slice(0, 10) > todayLocalDateStr()
 
   // Right column is only needed when there's actual homework content or a next plan

--- a/frontend/src/components/session/SessionHistoryTab.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.tsx
@@ -137,6 +137,10 @@ function SessionEntry({
   const isDraft = session.statusName === 'Draft'
   const showHwIcon = Boolean(hwStatus && hwStatus !== 'NotApplicable')
 
+  const today = new Date()
+  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
+  const isScheduled = !isCancelled && !isDraft && session.sessionDate != null && session.sessionDate.slice(0, 10) > todayStr
+
   // Right column is only needed when there's actual homework content or a next plan
   const hasRightColumn = Boolean(session.homeworkAssigned) || Boolean(session.nextSessionTopics)
 
@@ -195,9 +199,15 @@ function SessionEntry({
                     </span>
                   )}
                   {!isCancelled && !isDraft && (
-                    <span className="px-2 py-0.5 rounded bg-emerald-50 text-emerald-600 text-[9px] font-bold uppercase">
-                      Completed
-                    </span>
+                    isScheduled ? (
+                      <span className="px-2 py-0.5 rounded bg-indigo-50 text-indigo-600 text-[9px] font-bold uppercase" data-testid="scheduled-badge">
+                        Scheduled
+                      </span>
+                    ) : (
+                      <span className="px-2 py-0.5 rounded bg-emerald-50 text-emerald-600 text-[9px] font-bold uppercase" data-testid="completed-badge">
+                        Completed
+                      </span>
+                    )
                   )}
                   {hasActionItem && (
                     <span className="inline-flex items-center gap-1 text-xs text-amber-600" data-testid="action-item-count">

--- a/frontend/src/components/session/SessionHistoryTab.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.tsx
@@ -16,7 +16,7 @@ import {
 import { logger } from '../../lib/logger'
 import { Link, useNavigate } from 'react-router-dom'
 import { listSessions, deleteSession, patchSessionField, parseTopicTags, type SessionLog } from '../../api/sessionLogs'
-import { formatMonth, formatDay, relativeTime } from '../../utils/formatDate'
+import { formatMonth, formatDay, relativeTime, todayLocalDateStr } from '../../utils/formatDate'
 import { getSessionTitle } from '../../lib/sessionUtils'
 import { HOMEWORK_STATUS_INFO } from '../../utils/homeworkStatusStyles'
 import { Button } from '@/components/ui/button'
@@ -137,9 +137,7 @@ function SessionEntry({
   const isDraft = session.statusName === 'Draft'
   const showHwIcon = Boolean(hwStatus && hwStatus !== 'NotApplicable')
 
-  const today = new Date()
-  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
-  const isScheduled = !isCancelled && !isDraft && session.sessionDate != null && session.sessionDate.slice(0, 10) > todayStr
+  const isScheduled = !isCancelled && !isDraft && session.sessionDate != null && session.sessionDate.slice(0, 10) > todayLocalDateStr()
 
   // Right column is only needed when there's actual homework content or a next plan
   const hasRightColumn = Boolean(session.homeworkAssigned) || Boolean(session.nextSessionTopics)

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -25,7 +25,7 @@ import { AudioRecorder } from '@/components/audio/AudioRecorder'
 import { COMPETENCY_OPTIONS } from '@/lib/studentOptions'
 import { getObjectiveUrgency, getDaysRemaining } from '@/lib/objectiveUrgency'
 import { suggestTopicTags } from '@/lib/suggestTopicTags'
-import { formatDate as formatDateUtil, relativeTime } from '@/utils/formatDate'
+import { formatDate as formatDateUtil, relativeTime, todayLocalDateStr } from '@/utils/formatDate'
 import { useSessionAutosave } from '@/hooks/useSessionAutosave'
 import { logger } from '@/lib/logger'
 
@@ -51,10 +51,7 @@ const CEFR_SUBLEVELS = [
   'C1.1','C1.2','C2.1','C2.2',
 ]
 
-function todayISO(): string {
-  const now = new Date()
-  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
-}
+const todayISO = todayLocalDateStr
 
 function nowTimeHHMM(): string {
   const now = new Date()

--- a/frontend/src/utils/formatDate.ts
+++ b/frontend/src/utils/formatDate.ts
@@ -58,3 +58,9 @@ export function formatDay(dateStr: string | null): string {
   if (!dateStr) return ''
   return String(new Date(dateStr).getDate())
 }
+
+/** Returns today's local date as a YYYY-MM-DD string (for comparisons against sessionDate). */
+export function todayLocalDateStr(): string {
+  const now = new Date()
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
+}

--- a/plan/ui-review-backlog.md
+++ b/plan/ui-review-backlog.md
@@ -56,3 +56,9 @@ Non-blocking findings from review-ui runs. Periodically review this file and bat
 | Low | Dashboard / Pending Followups | Mock teacher has no pending followups, so OVERDUE/OLD/TODAY badge designs and colored priority dots are unverified visually. Unit tests verify all badge variants. |
 | Low | Log Session / Toggle text | Toggle button text ('Show homework, cultural notes, error patterns...' / 'Hide additional sections') is below the fold in the visual spec screenshot. Verified by unit tests (38 pass) and e2e. |
 | Low | Log Session / Followup label | 'Open followups from previous sessions' label + subtitle not visually verified (Diego Seed has no open followups seeded). Verified by code review. |
+
+## 2026-04-21 (task #824 review-ui)
+
+| Severity | Screen | Finding |
+|----------|--------|---------|
+| Blocked | Session History tab | Visual stack blocked: e2e teacher account not seeded (`approveE2ETestTeacher: no teacher found with Email "e2e-test@langteach.io"`). Pre-existing infrastructure issue. SCHEDULED/COMPLETED badge visual difference is purely a Tailwind class change (indigo vs emerald), covered by unit test data-testid assertions. |


### PR DESCRIPTION
## Summary
- Confirmed sessions with `sessionDate > today` now show an indigo **SCHEDULED** badge instead of the misleading green **COMPLETED** badge
- `todayLocalDateStr()` extracted to `frontend/src/utils/formatDate.ts` (removes duplicate implementation from `LogSession.tsx`)
- 4 new unit tests covering future/past/draft/cancelled session badge states

## Test plan
- [ ] All 1322 frontend unit tests pass
- [ ] `session-history.visual.spec.ts` runs (visual stack seed issue logged to ui-review-backlog.md — pre-existing, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session status badges now clearly display "Scheduled" for upcoming sessions and "Completed" for past sessions, improving visibility into session timelines.

* **Tests**
  * Added comprehensive test coverage for session status badge rendering across various session states and date combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->