### PR TITLE
refactor: ExtractionMode and ExtractedHomeworkStatus enums for extraction DTOs (#826)

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/SessionsControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/SessionsControllerTests.cs
@@ -70,12 +70,12 @@ public class SessionsControllerTests
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var dto = await response.Content.ReadFromJsonAsync<ExtractedReflectionDto>();
         dto!.WhatWasCovered!.Value.Should().Be("[Extracted] What was covered");
-        dto.WhatWasCovered.Mode.Should().Be("replace");
+        dto.WhatWasCovered.Mode.Should().Be(ExtractionMode.Replace);
         dto.AreasToImprove!.Value.Should().Be("[Extracted] Areas to improve");
         dto.EmotionalSignals.Should().Be("[Extracted] Emotional signals");
         dto.HomeworkAssigned!.Value.Should().Be("[Extracted] Homework assigned");
         dto.NextLessonIdeas!.Value.Should().Be("[Extracted] Next lesson ideas");
-        dto.NextLessonIdeas.Mode.Should().Be("append");
+        dto.NextLessonIdeas.Mode.Should().Be(ExtractionMode.Append);
     }
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/Helpers/TestJsonOptions.cs
+++ b/backend/LangTeach.Api.Tests/Helpers/TestJsonOptions.cs
@@ -1,5 +1,4 @@
 using LangTeach.Api.Data.Models;
-using LangTeach.Api.DTOs;
 using System.Text.Json;
 
 namespace LangTeach.Api.Tests.Helpers;
@@ -10,6 +9,6 @@ internal static class TestJsonOptions
     {
         PropertyNameCaseInsensitive = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        Converters = { new ContentBlockTypeJsonConverter(), new CamelCaseStringEnumConverter() },
+        Converters = { new ContentBlockTypeJsonConverter() },
     };
 }

--- a/backend/LangTeach.Api.Tests/Helpers/TestJsonOptions.cs
+++ b/backend/LangTeach.Api.Tests/Helpers/TestJsonOptions.cs
@@ -1,4 +1,5 @@
 using LangTeach.Api.Data.Models;
+using LangTeach.Api.DTOs;
 using System.Text.Json;
 
 namespace LangTeach.Api.Tests.Helpers;
@@ -9,6 +10,6 @@ internal static class TestJsonOptions
     {
         PropertyNameCaseInsensitive = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        Converters = { new ContentBlockTypeJsonConverter() },
+        Converters = { new ContentBlockTypeJsonConverter(), new CamelCaseStringEnumConverter() },
     };
 }

--- a/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using LangTeach.Api.AI;
+using LangTeach.Api.DTOs;
 using LangTeach.Api.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -74,7 +75,7 @@ public class ReflectionExtractionServiceTests
         var result = sut.ParseResponse(json);
 
         result.WhatWasCovered!.Value.Should().Be("Past tense verbs");
-        result.WhatWasCovered.Mode.Should().Be("replace"); // legacy plain-string fallback
+        result.WhatWasCovered.Mode.Should().Be(ExtractionMode.Replace); // legacy plain-string fallback
         result.AreasToImprove!.Value.Should().Be("Irregular verbs");
         result.EmotionalSignals.Should().Be("Very engaged");
         result.HomeworkAssigned!.Value.Should().Be("Exercises 1-5");
@@ -436,17 +437,17 @@ public class ReflectionExtractionServiceTests
     }
 
     [Theory]
-    [InlineData("Done")]
-    [InlineData("Partial")]
-    [InlineData("NotDone")]
-    public void ParseResponse_ExtractsPreviousHomeworkStatus_ValidValues(string status)
+    [InlineData("Done", ExtractedHomeworkStatus.Done)]
+    [InlineData("Partial", ExtractedHomeworkStatus.Partial)]
+    [InlineData("NotDone", ExtractedHomeworkStatus.NotDone)]
+    public void ParseResponse_ExtractsPreviousHomeworkStatus_ValidValues(string jsonValue, ExtractedHomeworkStatus expected)
     {
         var sut = CreateSut("{}");
-        var json = $$"""{"suggestedDifficulties":[],"previousHomeworkStatus":"{{status}}"}""";
+        var json = $$"""{"suggestedDifficulties":[],"previousHomeworkStatus":"{{jsonValue}}"}""";
 
         var result = sut.ParseResponse(json);
 
-        result.PreviousHomeworkStatus.Should().Be(status);
+        result.PreviousHomeworkStatus.Should().Be(expected);
     }
 
     [Fact]
@@ -624,9 +625,9 @@ public class ReflectionExtractionServiceTests
         var result = sut.ParseResponse(json);
 
         result.WhatWasCovered!.Value.Should().Be("Present perfect");
-        result.WhatWasCovered.Mode.Should().Be("append");
+        result.WhatWasCovered.Mode.Should().Be(ExtractionMode.Append);
         result.NextLessonIdeas!.Value.Should().Be("Subjunctive");
-        result.NextLessonIdeas.Mode.Should().Be("append");
+        result.NextLessonIdeas.Mode.Should().Be(ExtractionMode.Append);
     }
 
     [Fact]
@@ -643,9 +644,9 @@ public class ReflectionExtractionServiceTests
         var result = sut.ParseResponse(json);
 
         result.HomeworkAssigned!.Value.Should().Be("Page 5 exercises");
-        result.HomeworkAssigned.Mode.Should().Be("replace");
+        result.HomeworkAssigned.Mode.Should().Be(ExtractionMode.Replace);
         result.AreasToImprove!.Value.Should().Be("Verb conjugation");
-        result.AreasToImprove.Mode.Should().Be("replace");
+        result.AreasToImprove.Mode.Should().Be(ExtractionMode.Replace);
     }
 
     [Fact]
@@ -656,7 +657,7 @@ public class ReflectionExtractionServiceTests
 
         var result = sut.ParseResponse(json);
 
-        result.WhatWasCovered!.Mode.Should().Be("skip");
+        result.WhatWasCovered!.Mode.Should().Be(ExtractionMode.Skip);
     }
 
     [Fact]
@@ -668,9 +669,9 @@ public class ReflectionExtractionServiceTests
         var result = sut.ParseResponse(json);
 
         result.WhatWasCovered!.Value.Should().Be("Plain string value");
-        result.WhatWasCovered.Mode.Should().Be("replace");
+        result.WhatWasCovered.Mode.Should().Be(ExtractionMode.Replace);
         result.HomeworkAssigned!.Value.Should().Be("Homework text");
-        result.HomeworkAssigned.Mode.Should().Be("replace");
+        result.HomeworkAssigned.Mode.Should().Be(ExtractionMode.Replace);
     }
 
     [Fact]
@@ -682,7 +683,7 @@ public class ReflectionExtractionServiceTests
         var result = sut.ParseResponse(json);
 
         result.WhatWasCovered!.Value.Should().Be("Some content");
-        result.WhatWasCovered.Mode.Should().Be("skip");
+        result.WhatWasCovered.Mode.Should().Be(ExtractionMode.Skip);
     }
 
     [Theory]

--- a/backend/LangTeach.Api.Tests/Services/TelegramConversationServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/TelegramConversationServiceTests.cs
@@ -290,11 +290,11 @@ public class TelegramConversationServiceTests : IDisposable
         var student = await CreateStudentAsync("Marco");
 
         _extractionService.Result = new ExtractedReflectionDto(
-            WhatWasCovered: new ExtractedTextFieldDto("ser vs estar", "replace"),
-            AreasToImprove: new ExtractedTextFieldDto("needs more practice with preterite", "replace"),
+            WhatWasCovered: new ExtractedTextFieldDto("ser vs estar", ExtractionMode.Replace),
+            AreasToImprove: new ExtractedTextFieldDto("needs more practice with preterite", ExtractionMode.Replace),
             EmotionalSignals: "engaged",
-            HomeworkAssigned: new ExtractedTextFieldDto("complete exercises 3 and 4", "replace"),
-            NextLessonIdeas: new ExtractedTextFieldDto("past tenses review", "replace"),
+            HomeworkAssigned: new ExtractedTextFieldDto("complete exercises 3 and 4", ExtractionMode.Replace),
+            NextLessonIdeas: new ExtractedTextFieldDto("past tenses review", ExtractionMode.Replace),
             SessionDate: null,
             SuggestedDifficulties: new List<SuggestedDifficultyDto>
             {
@@ -329,7 +329,7 @@ public class TelegramConversationServiceTests : IDisposable
         var student = await CreateStudentAsync("Marco");
 
         _extractionService.Result = new ExtractedReflectionDto(
-            WhatWasCovered: new ExtractedTextFieldDto("ser vs estar", "replace"),
+            WhatWasCovered: new ExtractedTextFieldDto("ser vs estar", ExtractionMode.Replace),
             AreasToImprove: null,
             EmotionalSignals: null,
             HomeworkAssigned: null,
@@ -365,7 +365,7 @@ public class TelegramConversationServiceTests : IDisposable
         var student = await CreateStudentAsync("Marco");
 
         _extractionService.Result = new ExtractedReflectionDto(
-            WhatWasCovered: new ExtractedTextFieldDto("condicionales", "replace"),
+            WhatWasCovered: new ExtractedTextFieldDto("condicionales", ExtractionMode.Replace),
             AreasToImprove: null,
             EmotionalSignals: null,
             HomeworkAssigned: null,
@@ -432,7 +432,7 @@ public class TelegramConversationServiceTests : IDisposable
             // Default: echo input into AreasToImprove so existing tests asserting GeneralNotes == raw text keep passing.
             var result = Result ?? new ExtractedReflectionDto(
                 WhatWasCovered: null,
-                AreasToImprove: new ExtractedTextFieldDto(text, "replace"),
+                AreasToImprove: new ExtractedTextFieldDto(text, ExtractionMode.Replace),
                 EmotionalSignals: null,
                 HomeworkAssigned: null,
                 NextLessonIdeas: null,

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1549,7 +1549,7 @@ public class PromptService : IPromptService
             - sessionTitle: string or null — a concise title (under 60 chars) for this session derived from what was covered. Examples: "Subjunctive in time clauses", "Pasado compuesto — revisión". Null if no content is mentioned.
             - suggestedDifficulties: array of objects (can be empty []) — structured breakdown of the same difficulties mentioned in areasToImprove
             - topicTags: array of objects with "tag" (string) and "category" (string or null) — topics, grammar structures, vocabulary areas covered. Each tag as a concise noun phrase. Empty array if none mentioned.
-            - previousHomeworkStatus: "Done" | "Partial" | "NotDone" | null — whether the student completed homework from the previous session. Null if not mentioned.
+            - previousHomeworkStatus: "done" | "partial" | "notDone" | null — whether the student completed homework from the previous session. Null if not mentioned.
             - teachingTodos: array of strings — pedagogical ideas for future sessions (see distinction above). Empty array if none.
             - teacherFollowups: array of strings — operational actions owed by the teacher (see distinction above). Empty array if none.
             - levelReassessment: CEFR level string (e.g. "B1", "B2+") or null — if the teacher mentions reassessing or updating the student's level. Null if not mentioned.

--- a/backend/LangTeach.Api/DTOs/ReflectionExtractionDtos.cs
+++ b/backend/LangTeach.Api/DTOs/ReflectionExtractionDtos.cs
@@ -4,6 +4,9 @@ using System.Text.Json.Serialization;
 
 namespace LangTeach.Api.DTOs;
 
+// These extraction enums use camelCase (not PascalCase) because the AI prompt contract
+// specifies lowercase values ("append", "replace", "skip"). Other domain enums in the
+// project use PascalCase via plain JsonStringEnumConverter — do not change this.
 public sealed class CamelCaseStringEnumConverter : JsonStringEnumConverter
 {
     public CamelCaseStringEnumConverter() : base(JsonNamingPolicy.CamelCase) { }

--- a/backend/LangTeach.Api/DTOs/ReflectionExtractionDtos.cs
+++ b/backend/LangTeach.Api/DTOs/ReflectionExtractionDtos.cs
@@ -1,6 +1,19 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace LangTeach.Api.DTOs;
+
+public sealed class CamelCaseStringEnumConverter : JsonStringEnumConverter
+{
+    public CamelCaseStringEnumConverter() : base(JsonNamingPolicy.CamelCase) { }
+}
+
+[JsonConverter(typeof(CamelCaseStringEnumConverter))]
+public enum ExtractionMode { Append, Replace, Skip }
+
+[JsonConverter(typeof(CamelCaseStringEnumConverter))]
+public enum ExtractedHomeworkStatus { Done, Partial, NotDone }
 
 public class ExtractReflectionRequest
 {
@@ -9,7 +22,7 @@ public class ExtractReflectionRequest
     public string Text { get; set; } = string.Empty;
 }
 
-public record ExtractedTextFieldDto(string? Value, string Mode); // Mode: "append" | "replace" | "skip"
+public record ExtractedTextFieldDto(string? Value, ExtractionMode Mode);
 
 public record SuggestedDifficultyDto(
     string Description,
@@ -31,7 +44,7 @@ public record ExtractedReflectionDto(
     string? RawExtractionJson,
     string? SessionTitle,
     List<TopicTagDto> TopicTags,
-    string? PreviousHomeworkStatus,
+    ExtractedHomeworkStatus? PreviousHomeworkStatus,
     List<string> TeachingTodos,
     List<string> TeacherFollowups,
     string? LevelReassessment,

--- a/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
@@ -2,7 +2,6 @@ using System.Globalization;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using LangTeach.Api.AI;
-using LangTeach.Api.Data.Models;
 using LangTeach.Api.DTOs;
 using LangTeach.Api.Helpers;
 
@@ -133,11 +132,11 @@ public class ReflectionExtractionService : IReflectionExtractionService
         if (prop.ValueKind == JsonValueKind.Object)
         {
             var value = GetStringOrNull(prop, "value");
-            var mode = GetStringOrNull(prop, "mode") ?? "skip";
-            if (mode is not ("append" or "replace" or "skip"))
+            var modeStr = GetStringOrNull(prop, "mode") ?? "skip";
+            if (!Enum.TryParse<ExtractionMode>(modeStr, ignoreCase: true, out var mode))
             {
-                _logger.LogWarning("Unrecognized extraction mode '{Mode}' for key '{Key}', defaulting to skip", mode, key);
-                mode = "skip";
+                _logger.LogWarning("Unrecognized extraction mode '{Mode}' for key '{Key}', defaulting to skip", modeStr, key);
+                mode = ExtractionMode.Skip;
             }
             return value is null ? null : new ExtractedTextFieldDto(value, mode);
         }
@@ -145,7 +144,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
         if (prop.ValueKind == JsonValueKind.String)
         {
             var value = prop.GetString();
-            return string.IsNullOrWhiteSpace(value) ? null : new ExtractedTextFieldDto(value, "replace");
+            return string.IsNullOrWhiteSpace(value) ? null : new ExtractedTextFieldDto(value, ExtractionMode.Replace);
         }
         return null;
     }
@@ -232,12 +231,12 @@ public class ReflectionExtractionService : IReflectionExtractionService
         return result;
     }
 
-    private static string? ParseHomeworkStatus(JsonElement root)
+    private static ExtractedHomeworkStatus? ParseHomeworkStatus(JsonElement root)
     {
         var raw = GetStringOrNull(root, "previousHomeworkStatus");
         if (raw is null) return null;
-        return Enum.TryParse<HomeworkStatus>(raw, out var parsed) && parsed != HomeworkStatus.NotApplicable
-            ? raw
+        return Enum.TryParse<ExtractedHomeworkStatus>(raw, ignoreCase: true, out var parsed)
+            ? parsed
             : null;
     }
 

--- a/backend/LangTeach.Api/Services/StubReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/StubReflectionExtractionService.cs
@@ -15,11 +15,11 @@ public class StubReflectionExtractionService : IReflectionExtractionService
     {
         _logger.LogInformation("StubReflectionExtractionService.ExtractAsync called with {Length} chars", text.Length);
         return Task.FromResult(new ExtractedReflectionDto(
-            WhatWasCovered: new ExtractedTextFieldDto("[Extracted] What was covered", "replace"),
-            AreasToImprove: new ExtractedTextFieldDto("[Extracted] Areas to improve", "replace"),
+            WhatWasCovered: new ExtractedTextFieldDto("[Extracted] What was covered", ExtractionMode.Replace),
+            AreasToImprove: new ExtractedTextFieldDto("[Extracted] Areas to improve", ExtractionMode.Replace),
             EmotionalSignals: "[Extracted] Emotional signals",
-            HomeworkAssigned: new ExtractedTextFieldDto("[Extracted] Homework assigned", "replace"),
-            NextLessonIdeas: new ExtractedTextFieldDto("[Extracted] Next lesson ideas", "append"),
+            HomeworkAssigned: new ExtractedTextFieldDto("[Extracted] Homework assigned", ExtractionMode.Replace),
+            NextLessonIdeas: new ExtractedTextFieldDto("[Extracted] Next lesson ideas", ExtractionMode.Append),
             SessionDate: "2026-01-15",
             SuggestedDifficulties: [],
             RawExtractionJson: null,

--- a/plan/langteach-beta/task826-extraction-mode-enum.md
+++ b/plan/langteach-beta/task826-extraction-mode-enum.md
@@ -1,0 +1,55 @@
+# Task 826 — ExtractionMode enum refactor
+
+## Goal
+Replace string fields in `ExtractedTextFieldDto` and `ExtractedReflectionDto` with typed enums.
+
+## Files to change
+
+| File | Change |
+|------|--------|
+| `backend/LangTeach.Api/DTOs/ReflectionExtractionDtos.cs` | Add `ExtractionMode` and `ExtractedHomeworkStatus` enums; update record fields |
+| `backend/LangTeach.Api/Services/ReflectionExtractionService.cs` | Update `ParseTextFieldOrNull` and `ParseHomeworkStatus` to return enum values |
+| `backend/LangTeach.Api/Services/StubReflectionExtractionService.cs` | Replace string literals with enum values |
+| `backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs` | Update Mode and PreviousHomeworkStatus assertions |
+| `backend/LangTeach.Api.Tests/Controllers/SessionsControllerTests.cs` | Update Mode assertions |
+| `backend/LangTeach.Api.Tests/Services/TelegramConversationServiceTests.cs` | Update `ExtractedTextFieldDto` constructor calls |
+
+## Enum design
+
+```csharp
+[JsonConverter(typeof(JsonStringEnumConverter<ExtractionMode>), NamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+// OR: attribute + converter instance
+```
+
+Actually, since we're on .NET 8+, we can use:
+```csharp
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ExtractionMode { Append, Replace, Skip }
+```
+with a global naming policy or instance-level. But the issue specifies `JsonStringEnumConverter(JsonNamingPolicy.CamelCase)` — this requires passing it as a converter attribute argument, which isn't directly supported in C# attributes.
+
+The idiomatic pattern used in the project is: decorate each enum with `[JsonConverter(typeof(JsonStringEnumConverter))]` and configure `JsonNamingPolicy.CamelCase` globally, OR apply per-property with `[JsonPropertyName]` on each enum member. 
+
+The cleanest approach for attribute-based is:
+```csharp
+[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonStringEnumMemberName] // per member if needed
+```
+
+Actually on .NET 8, `JsonStringEnumConverter` can take a naming policy in its constructor. In an attribute, this isn't directly injectable. The project pattern is to decorate with `[JsonConverter(typeof(JsonStringEnumConverter))]` and rely on camelCase being configured globally (ASP.NET Core JSON options usually configure this).
+
+Let me check how the existing code handles this for other enums. The simplest approach: 
+- Decorate with `[JsonConverter(typeof(JsonStringEnumConverter))]`
+- The enum members named `Append`, `Replace`, `Skip` will serialize based on the global JSON options (which in ASP.NET Core with `AddJsonOptions` can include `JsonNamingPolicy.CamelCase`)
+
+OR: use per-member `[JsonPropertyName("append")]` attributes.
+
+## Acceptance criteria
+
+- `ExtractionMode` enum with `Append`, `Replace`, `Skip`
+- `ExtractedHomeworkStatus` enum with `Done`, `Partial`, `NotDone`
+- Both use camelCase JSON serialization
+- `ExtractedTextFieldDto.Mode` is `ExtractionMode`
+- `ExtractedReflectionDto.PreviousHomeworkStatus` is `ExtractedHomeworkStatus?`
+- All existing tests pass (with assertions updated)
+- No frontend contract change (mode values remain lowercase)


### PR DESCRIPTION
## Summary

- Adds `ExtractionMode` enum (`Append/Replace/Skip`) replacing manual string validation in `ExtractedTextFieldDto.Mode`
- Adds `ExtractedHomeworkStatus` enum (`Done/Partial/NotDone`) replacing `string?` in `ExtractedReflectionDto.PreviousHomeworkStatus`
- Both enums use `CamelCaseStringEnumConverter` to preserve the lowercase wire format the frontend expects
- Removes `HomeworkStatus` domain enum dependency from `ReflectionExtractionService` (it was used only for parsing validation)
- Updates `PromptService` to use lowercase values for `previousHomeworkStatus` to match the new serialization contract

## Test plan

- [ ] `dotnet test` passes (1137 pass, 5 pre-existing skips)
- [ ] All Mode assertions updated to use `ExtractionMode.*` enum values
- [ ] All `PreviousHomeworkStatus` assertions updated to use `ExtractedHomeworkStatus.*` enum values

Closes #826

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced API data consistency by converting extraction mode and homework status fields from string-based responses to strongly-typed enumerations, providing better type safety and clearer documentation of valid values.
  * Improved JSON serialization standards with consistent camel-case formatting across API responses.
  * Updated API prompt specifications for improved compatibility with response parsing and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->