### PR TITLE
fix(#833): case-insensitive difficulty status, stale countdown, silent toggle error

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/StudentsControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/StudentsControllerTests.cs
@@ -365,6 +365,27 @@ public class StudentsControllerTests
     }
 
     [Fact]
+    public async Task Create_WithLowercaseDifficultyStatus_Succeeds()
+    {
+        var client = _factory.CreateAuthenticatedClient("auth0|difficulty-lowercase-status-test", "difficulty-lowercase-status@example.com");
+
+        var request = new CreateStudentRequest
+        {
+            Name = "Lowercase Status",
+            LearningLanguage = "English",
+            CefrLevel = "A1",
+            Difficulties =
+            [
+                new DifficultyDto("d1", "some description", "Grammar", "", "high", "stable", "active"),
+            ],
+        };
+
+        var response = await client.PostAsJsonAsync("/api/students", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
     public async Task Create_WithEmptyDifficulties_Succeeds()
     {
         var client = _factory.CreateAuthenticatedClient("auth0|difficulty-empty-test", "difficulty-empty@example.com");

--- a/backend/LangTeach.Api.Tests/Controllers/StudentsControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/StudentsControllerTests.cs
@@ -437,6 +437,27 @@ public class StudentsControllerTests
     }
 
     [Fact]
+    public async Task UpdateTeachingTodo_WithCapitalizedPendingStatus_Succeeds()
+    {
+        var client = _factory.CreateAuthenticatedClient("auth0|todo-capitalized-status-test", "todo-capitalized-status@example.com");
+        var student = await CreateStudentAsync(client, "Todo Capitalized Status Student");
+
+        var appendResponse = await client.PostAsJsonAsync(
+            $"/api/students/{student.Id}/teaching-todos",
+            new CreateTeachingTodoDto("Practicar subjuntivo", null));
+        appendResponse.EnsureSuccessStatusCode();
+        var withTodo = await appendResponse.Content.ReadFromJsonAsync<StudentDto>();
+        var todoId = withTodo!.TeachingTodos[0].Id;
+
+        // "Pending" capitalized should be accepted (OrdinalIgnoreCase)
+        var updateResponse = await client.PatchAsJsonAsync(
+            $"/api/students/{student.Id}/teaching-todos/{todoId}",
+            new UpdateTeachingTodoDto("Pending", null, null));
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
     public async Task Create_WithNestedLearningGoals_RoundTripsHierarchy()
     {
         var client = _factory.CreateAuthenticatedClient("auth0|nested-goals-test", "nested-goals@example.com");

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -40,9 +40,7 @@ public class StudentService : IStudentService
     ];
 
     private static readonly HashSet<string> AllowedStatuses =
-    [
-        "Active", "Covered"
-    ];
+        new(StringComparer.OrdinalIgnoreCase) { "Active", "Covered" };
 
     private static readonly Dictionary<string, string> CanonicalTodoStatuses =
         new(StringComparer.OrdinalIgnoreCase)

--- a/frontend/src/components/dashboard/NextSessionHero.test.tsx
+++ b/frontend/src/components/dashboard/NextSessionHero.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { NextSessionHero } from './NextSessionHero'
 import type { NextSession } from '@/api/dashboard'
@@ -24,6 +24,10 @@ function makeSession(overrides: Partial<NextSession> = {}): NextSession {
     ...overrides,
   }
 }
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 describe('NextSessionHero', () => {
   it('renders empty state when no session', () => {
@@ -178,5 +182,25 @@ describe('NextSessionHero', () => {
     )
     expect(screen.queryByText('Topics')).not.toBeInTheDocument()
     expect(screen.queryByText('Promises made')).not.toBeInTheDocument()
+  })
+
+  it('refreshes countdown badge after 60 seconds', async () => {
+    vi.useFakeTimers()
+    // Session is 45 minutes away — renders as "IN 45 MIN"
+    const sessionDate = new Date(Date.now() + 45 * 60000).toISOString()
+    render(
+      <MemoryRouter>
+        <NextSessionHero session={makeSession({ sessionDate })} />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/IN 45 MIN/)).toBeInTheDocument()
+
+    // Advance 61 seconds so the 60s interval fires and Date.now() moves forward
+    await act(async () => {
+      vi.advanceTimersByTime(61000)
+    })
+
+    // Badge label should now reflect the reduced time (~44 min)
+    expect(screen.getByText(/IN 44 MIN/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/dashboard/NextSessionHero.tsx
+++ b/frontend/src/components/dashboard/NextSessionHero.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { Play } from 'lucide-react'
 import { CefrBadge } from './CefrBadge'
@@ -64,6 +65,12 @@ function homeworkStatusLabel(status: string | null): { label: string; color: str
 }
 
 export function NextSessionHero({ session }: NextSessionHeroProps) {
+  const [, setTick] = useState(0)
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 60000)
+    return () => clearInterval(id)
+  }, [])
+
   if (!session) {
     return (
       <div

--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -98,6 +98,7 @@ function renderProfile(
   student: Student,
   opts?: {
     onToggle?: (id: string, status: 'Active' | 'Covered') => void
+    difficultyToggleError?: string | null
     onSaveReason?: (value: string) => Promise<void>
     onSaveInterests?: (value: string[]) => Promise<void>
     onSaveLearningGoal?: (text: string) => Promise<void>
@@ -113,6 +114,7 @@ function renderProfile(
         <StudentProfileTab
           student={student}
           onStudentChange={() => {}}
+          difficultyToggleError={opts?.difficultyToggleError}
           onToggleDifficultyStatus={opts?.onToggle}
           onSaveReasonForStudying={opts?.onSaveReason}
           onSaveInterests={opts?.onSaveInterests}
@@ -664,6 +666,21 @@ describe('StudentProfileTab', () => {
       renderProfile(EMPTY_STUDENT)
       fireEvent.click(screen.getByTestId('show-empty-sections-btn'))
       expect(screen.queryByTestId('show-empty-sections-btn')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('difficulty toggle error', () => {
+    it('shows error message when difficultyToggleError is set', () => {
+      renderProfile(FULL_STUDENT, {
+        difficultyToggleError: 'Could not update difficulty status. Please try again.',
+      })
+      expect(screen.getByTestId('difficulty-toggle-error')).toBeInTheDocument()
+      expect(screen.getByText('Could not update difficulty status. Please try again.')).toBeInTheDocument()
+    })
+
+    it('does not show error message when difficultyToggleError is null', () => {
+      renderProfile(FULL_STUDENT, { difficultyToggleError: null })
+      expect(screen.queryByTestId('difficulty-toggle-error')).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -20,6 +20,7 @@ interface Props {
   followups?: TeacherFollowup[]
   onFollowupChange?: () => void
   onStudentChange: () => void
+  difficultyToggleError?: string | null
   onToggleDifficultyStatus?: (id: string, status: 'Active' | 'Covered') => void
   onSaveReasonForStudying?: (value: string) => Promise<void>
   onSaveInterests?: (value: string[]) => Promise<void>
@@ -516,6 +517,7 @@ export function StudentProfileTab({
   followups = [],
   onFollowupChange,
   onStudentChange,
+  difficultyToggleError,
   onToggleDifficultyStatus,
   onSaveReasonForStudying,
   onSaveInterests,
@@ -685,6 +687,9 @@ export function StudentProfileTab({
                   <p className="text-xs font-bold uppercase tracking-widest text-zinc-500">Focus Areas &amp; Difficulties</p>
                   {onSaveDifficulty && <InlineAddDifficulty onSave={onSaveDifficulty} />}
                 </div>
+                {difficultyToggleError && (
+                  <span className="text-xs text-red-500 mb-2 block" data-testid="difficulty-toggle-error">{difficultyToggleError}</span>
+                )}
                 {student.difficulties.length === 0 && student.weaknesses.length === 0 ? (
                   <EmptyState text="No focus areas tracked" />
                 ) : (

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { useParams, useNavigate, Link, useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft, NotebookPen, Pencil, CalendarClock } from 'lucide-react'
@@ -114,6 +114,7 @@ export default function StudentDetail() {
   const [searchParams, setSearchParams] = useSearchParams()
   const activeTab = searchParams.get('tab') ?? 'overview'
   const [difficultyToggleError, setDifficultyToggleError] = useState<string | null>(null)
+  const difficultyToggleAttemptRef = useRef(0)
 
 
   const { data: student, isLoading, isError } = useQuery({
@@ -175,18 +176,26 @@ export default function StudentDetail() {
   }
 
   const { mutate: toggleDifficultyStatus } = useMutation({
-    mutationFn: (vars: { difficultyId: string; status: 'Active' | 'Covered' }) => {
+    onMutate: () => {
+      const attempt = ++difficultyToggleAttemptRef.current
       setDifficultyToggleError(null)
+      return { attempt }
+    },
+    mutationFn: (vars: { difficultyId: string; status: 'Active' | 'Covered' }) => {
       const updated = student!.difficulties.map((d) =>
         d.id === vars.difficultyId ? { ...d, status: vars.status } : d
       )
       return updateStudent(id!, { ...buildStudentPayload(), difficulties: updated })
     },
-    onSuccess: () => {
+    onSuccess: (_data, _vars, context) => {
+      if (context?.attempt === difficultyToggleAttemptRef.current) {
+        setDifficultyToggleError(null)
+      }
       queryClient.invalidateQueries({ queryKey: ['student', id] })
     },
-    onError: (err) => {
+    onError: (err, _vars, context) => {
       logger.error('StudentDetail', 'Failed to update difficulty status', err)
+      if (context?.attempt !== difficultyToggleAttemptRef.current) return
       setDifficultyToggleError('Could not update difficulty status. Please try again.')
     },
   })

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useState } from 'react'
 import { useParams, useNavigate, Link, useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft, NotebookPen, Pencil, CalendarClock } from 'lucide-react'
@@ -113,6 +113,7 @@ export default function StudentDetail() {
   const queryClient = useQueryClient()
   const [searchParams, setSearchParams] = useSearchParams()
   const activeTab = searchParams.get('tab') ?? 'overview'
+  const [difficultyToggleError, setDifficultyToggleError] = useState<string | null>(null)
 
 
   const { data: student, isLoading, isError } = useQuery({
@@ -175,6 +176,7 @@ export default function StudentDetail() {
 
   const { mutate: toggleDifficultyStatus } = useMutation({
     mutationFn: (vars: { difficultyId: string; status: 'Active' | 'Covered' }) => {
+      setDifficultyToggleError(null)
       const updated = student!.difficulties.map((d) =>
         d.id === vars.difficultyId ? { ...d, status: vars.status } : d
       )
@@ -185,6 +187,7 @@ export default function StudentDetail() {
     },
     onError: (err) => {
       logger.error('StudentDetail', 'Failed to update difficulty status', err)
+      setDifficultyToggleError('Could not update difficulty status. Please try again.')
     },
   })
 
@@ -461,6 +464,7 @@ export default function StudentDetail() {
           followups={followups}
           onFollowupChange={onFollowupChange}
           onStudentChange={onStudentChange}
+          difficultyToggleError={difficultyToggleError}
           onToggleDifficultyStatus={(difficultyId, status) =>
             toggleDifficultyStatus({ difficultyId, status })
           }

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -6,6 +6,12 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 
 *Cleared 2026-04-13 during UI Redesign sprint triage. Actionable entries batched into #713 (deduplication), #713 (MaxLength redundancy). Remaining entries deleted (verified safe, intentional per spec, defensive-only, or consistent with existing patterns).*
 
+## #833 — 2026-04-22
+
+| Reviewer | Severity | Note |
+|---|---|---|
+| architecture-reviewer | minor | `toggleDifficultyStatus` is the only mutation in `StudentDetail.tsx` that sets inline error state; all others only log. Inconsistency is intentional (discrete toggle vs autosave fields have different UX needs) but worth aligning if additional discrete mutations are added to that file. |
+
 ## #742 — 2026-04-15
 
 | Reviewer | Severity | Note |

--- a/plan/langteach-beta/task833-bug-batch-validation-countdown-toast.md
+++ b/plan/langteach-beta/task833-bug-batch-validation-countdown-toast.md
@@ -1,0 +1,69 @@
+# Task 833: Sprint backlog bug batch
+
+**Issue:** #833  
+**Branch:** task/t833-bug-batch-validation-countdown-toast  
+**Sprint:** sprint/ui-redesign-student-polish
+
+## Bugs to fix
+
+### 1. AllowedStatuses case-sensitive comparison (backend)
+
+**File:** `backend/LangTeach.Api/Services/StudentService.cs`
+
+`AllowedStatuses` (line 42) is a plain `HashSet<string>` storing `"Active"` and `"Covered"` with the default ordinal case-sensitive comparer. The `Contains` call at line 351 rejects `"active"` or `"ACTIVE"`.
+
+`CanonicalTodoStatuses` (line 47) already uses `OrdinalIgnoreCase`, so todo status validation is already correct.
+
+**Fix:** Change `AllowedStatuses` from `HashSet<string>` to `HashSet<string>(StringComparer.OrdinalIgnoreCase)`.
+
+**Test:** Add a test to `StudentsControllerTests` that sends a difficulty with `"active"` (lowercase) and asserts the request succeeds.
+
+---
+
+### 2. NextSessionHero countdown goes stale (frontend)
+
+**File:** `frontend/src/components/dashboard/NextSessionHero.tsx`
+
+`getUrgencyBadge` computes `Date.now()` at render time only. The badge shows the correct value on load but never updates.
+
+**Fix:**
+- Convert `NextSessionHero` from a pure functional component to one with a `useState<number>` tick counter
+- `useEffect` sets up a `setInterval` every 60 seconds that increments the tick, forcing re-render
+- `getUrgencyBadge` already takes `sessionDate` as a string and calls `Date.now()` inside, so re-rendering is enough to refresh the label
+
+**Test:** Add a test in `NextSessionHero.test.tsx` that uses `vi.useFakeTimers`, advances time by 60s, and verifies the badge label updates.
+
+---
+
+### 3. toggleDifficultyStatus silent failure (frontend)
+
+**Files:** `frontend/src/pages/StudentDetail.tsx`, `frontend/src/components/student/StudentProfileTab.tsx`
+
+The `toggleDifficultyStatus` mutation at line 176 only logs to console on error. No user-visible feedback.
+
+**Pattern in the app:** Other mutations in `StudentProfileTab` use a local `useState` error string with inline `<span className="text-xs text-red-500">` display.
+
+**Fix:**
+- Add `mutationError` state to `StudentDetail` for difficulty toggle failures
+- Pass it as a new prop `difficultyToggleError?: string | null` to `StudentProfileTab`
+- Clear the error on each toggle attempt (optimistic clear)
+- Show it inline in the difficulties section near the toggle button
+
+**Test:** Add a test in `StudentDetail.test.tsx` (or `StudentProfileTab.test.tsx`) that mocks the mutation to reject, triggers the toggle, and asserts the error message is visible.
+
+---
+
+## Files to change
+
+| File | Change |
+|------|--------|
+| `backend/LangTeach.Api/Services/StudentService.cs` | OrdinalIgnoreCase on AllowedStatuses |
+| `backend/LangTeach.Api.Tests/Controllers/StudentsControllerTests.cs` | Case-insensitive status test |
+| `frontend/src/components/dashboard/NextSessionHero.tsx` | setInterval tick |
+| `frontend/src/components/dashboard/NextSessionHero.test.tsx` | Fake timer test |
+| `frontend/src/pages/StudentDetail.tsx` | Error state + pass to tab |
+| `frontend/src/components/student/StudentProfileTab.tsx` | Receive + render error |
+
+## E2E coverage
+
+No new e2e tests needed. These are unit-level bugs. Existing e2e tests exercise the full difficulty update + dashboard flow. The fixes are low-risk, deterministic, and fully covered by unit tests.

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -3,6 +3,7 @@
 Out-of-scope observations logged by agents during implementation. Each row is something an agent noticed but did not fix because it was outside the current task's scope. These get batched into future GitHub issues by the PM.
 
 | Source issue | Date | Severity | Observation |
+| #833 | 2026-04-22 | low | `e2e/.env` does not set `VITE_API_BASE_URL`; start-visual-stack.sh comment documents port 5178 but env file does not reflect it. Pre-existing gap. |
 | #724 | 2026-04-14 | info | CodeRabbit #739 flagged dual-casing risk in mentionedDifficultyPairs. Dismissed: SerializePairs uses CamelCaseOptions so both API and seeder produce lowercase keys. No mixed-casing rows exist. |
 | #724 | 2026-04-14 | medium | No seeded student has SkillLevelOverrides set; Skill Imbalance Analysis always shows empty state in visual review. Consider adding skill overrides to Ana Visual or Ana Seed for visual QA coverage. |
 | #721 | 2026-04-14 | low | Ana Seed has no SkillLevelOverrides in seeder so horizontal Skill Assessment badges on Profile tab cannot be visually verified. Consider adding skill overrides to Ana Seed seeder entry. |


### PR DESCRIPTION
## Summary

- `AllowedStatuses` HashSet in `StudentService` now uses `OrdinalIgnoreCase` so `"active"`, `"ACTIVE"`, etc. pass difficulty validation without rejection
- `NextSessionHero` countdown badge now refreshes every 60 seconds via `setInterval` so the "IN X MIN" label stays accurate during a page visit
- `toggleDifficultyStatus` mutation now shows an inline error message above the difficulties table on failure instead of silently logging

## Test plan

- [ ] Backend: `dotnet test` — new tests for lowercase difficulty status (`Create_WithLowercaseDifficultyStatus_Succeeds`) and capitalized Pending todo status (`UpdateTeachingTodo_WithCapitalizedPendingStatus_Succeeds`)
- [ ] Frontend: `vitest run` — new fake-timer test in `NextSessionHero.test.tsx`; two new error tests in `StudentProfileTab.test.tsx`
- [ ] Manual: dashboard hero card renders countdown badge correctly; student profile tab has no extra whitespace in normal state

Closes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session countdown timer updates automatically every 60 seconds without requiring page refresh
  * Error messages now display when difficulty status updates fail

* **Bug Fixes**
  * Difficulty status field now accepts both uppercase and lowercase input (e.g., "active" and "Active")

* **Tests**
  * Added tests for case-insensitive difficulty status validation, countdown timer updates, and error message display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->