### PR TITLE
fix(#835): rewrite session-log e2e tests for full-page autosave flow

### DIFF
--- a/e2e/tests/session-log.spec.ts
+++ b/e2e/tests/session-log.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { createMockAuthContext } from '../helpers/auth-helper'
 import { setupMockTeacher } from '../helpers/mock-teacher-helper'
+import { NAV_TIMEOUT, UI_TIMEOUT, FEEDBACK_TIMEOUT } from '../helpers/timeouts'
 
 const API_BASE = process.env.VITE_API_BASE_URL ?? 'http://localhost:5000'
 
@@ -33,24 +34,24 @@ test('log session from student detail page', async ({ browser }) => {
   const student = await createRes.json()
 
   await page.goto(`/students/${student.id}`)
-  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
+  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
 
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Fill in what happened
   await page.getByTestId('actual-content').fill('Practiced preterito indefinido with reading exercises.')
 
   // Autosave should trigger and complete
-  await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: 10000 })
+  await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: UI_TIMEOUT })
 
   // Click Done to navigate back
   await page.getByTestId('done-btn').click()
-  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: 10000 })
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: UI_TIMEOUT })
 
   // Session should appear in history
   await page.getByRole('tab', { name: /history/i }).click()
-  await expect(page.getByTestId('session-entry').first()).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('session-entry').first()).toBeVisible({ timeout: UI_TIMEOUT })
 
   await context.close()
 })
@@ -86,12 +87,12 @@ test('log session page: prev homework status shows when prev session has homewor
   })
 
   await page.goto(`/students/${student.id}`)
-  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
+  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Previous homework status should appear since prior session had homework
-  await expect(page.getByTestId('prev-homework-status')).toBeVisible({ timeout: 8000 })
+  await expect(page.getByTestId('prev-homework-status')).toBeVisible({ timeout: UI_TIMEOUT })
 
   await context.close()
 })
@@ -126,11 +127,11 @@ test('expand session entry shows full detail without duplicating preview content
   })
 
   await page.goto(`/students/${student.id}`)
-  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
+  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
   await page.getByRole('tab', { name: /history/i }).click()
 
   const entry = page.getByTestId('session-entry').first()
-  await expect(entry).toBeVisible({ timeout: 10000 })
+  await expect(entry).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Collapsed: preview content visible
   await expect(entry.getByText(/Preterito indefinido intro/)).toBeVisible()
@@ -179,17 +180,17 @@ test('delete session requires confirmation dialog', async ({ browser }) => {
   })
 
   await page.goto(`/students/${student.id}`)
-  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
+  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
   await page.getByRole('tab', { name: /history/i }).click()
 
   const entry = page.getByTestId('session-entry').first()
-  await expect(entry).toBeVisible({ timeout: 10000 })
+  await expect(entry).toBeVisible({ timeout: UI_TIMEOUT })
   await entry.getByTestId('session-entry-toggle').click()
 
   // Click delete — confirmation dialog should appear
   await entry.getByTestId('delete-session-btn').click()
   const confirmBtn = page.getByTestId('confirm-delete-session')
-  await expect(confirmBtn).toBeVisible({ timeout: 5000 })
+  await expect(confirmBtn).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
 
   // Cancel — session should remain
   await page.getByRole('button', { name: /cancel/i }).click()
@@ -198,11 +199,11 @@ test('delete session requires confirmation dialog', async ({ browser }) => {
 
   // Delete again and confirm
   await entry.getByTestId('delete-session-btn').click()
-  await expect(confirmBtn).toBeVisible({ timeout: 5000 })
+  await expect(confirmBtn).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await confirmBtn.click()
 
   // Session entry should be removed from the list
-  await expect(page.getByTestId('session-history-empty')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('session-history-empty')).toBeVisible({ timeout: UI_TIMEOUT })
 
   await context.close()
 })
@@ -227,9 +228,9 @@ test('topic tag category dropdown has all four curriculum-aligned options', asyn
   const student = await createRes.json() as { id: string }
 
   await page.goto(`/students/${student.id}`)
-  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
+  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Open the category dropdown and verify all four options exist
   await page.getByTestId('topic-tag-category').click()
@@ -265,9 +266,9 @@ test('future session date is accepted and appears in history', async ({ browser 
   const student = await createRes.json() as { id: string }
 
   await page.goto(`/students/${student.id}`)
-  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
+  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Set a future date (tomorrow)
   const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000)
@@ -276,14 +277,14 @@ test('future session date is accepted and appears in history', async ({ browser 
   await page.getByTestId('actual-content').fill('Planned grammar session')
 
   // Autosave should complete -- no validation error for future dates
-  await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: 10000 })
+  await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: UI_TIMEOUT })
 
   await page.getByTestId('done-btn').click()
-  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: 10000 })
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: UI_TIMEOUT })
 
   // Session appears in history
   await page.getByRole('tab', { name: /history/i }).click()
-  await expect(page.getByTestId('session-entry').first()).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('session-entry').first()).toBeVisible({ timeout: UI_TIMEOUT })
 
   await context.close()
 })
@@ -325,13 +326,13 @@ test('selecting a lesson in log session page links it to the session', async ({ 
   const lesson = await createLessonRes.json() as { id: string }
 
   await page.goto(`/students/${student.id}`)
-  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
+  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Linked lesson selector is inside the secondary section
   await page.getByTestId('toggle-secondary').click()
-  await expect(page.getByTestId('linked-lesson')).toBeVisible({ timeout: 8000 })
+  await expect(page.getByTestId('linked-lesson')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Select the lesson
   await page.getByTestId('linked-lesson').click()
@@ -339,9 +340,9 @@ test('selecting a lesson in log session page links it to the session', async ({ 
 
   // Save — session should have the lesson linked
   await page.getByTestId('actual-content').fill('Covered subjunctive intro.')
-  await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: 10000 })
+  await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: UI_TIMEOUT })
   await page.getByTestId('done-btn').click()
-  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: 10000 })
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: UI_TIMEOUT })
 
   // Verify via API that lesson was linked
   const sessionsRes = await page.request.get(`${API_BASE}/api/students/${student.id}/sessions`, {
@@ -391,9 +392,9 @@ test('cancelled session shows Cancelled badge and is excluded from summary count
 
   // Cancelled badge visible in history
   await page.goto(`/students/${student.id}`)
-  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
+  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
   await page.getByRole('tab', { name: /history/i }).click()
-  await expect(page.getByTestId('session-entry').first()).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('session-entry').first()).toBeVisible({ timeout: UI_TIMEOUT })
   await expect(page.getByTestId('cancelled-badge')).toBeVisible()
 
   // Summary count = 1 (only the non-cancelled session)
@@ -434,31 +435,31 @@ test('un-cancel a session removes the Cancelled badge', async ({ browser }) => {
 
   // View history -- badge present
   await page.goto(`/students/${student.id}`)
-  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
+  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
   await page.getByRole('tab', { name: /history/i }).click()
-  await expect(page.getByTestId('cancelled-badge')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('cancelled-badge')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Open expanded view and click "Edit full session"
   const entry = page.getByTestId('session-entry').first()
   await entry.getByTestId('session-entry-toggle').click()
   await entry.getByTestId('edit-full-session-link').click()
-  await expect(page).toHaveURL(new RegExp(`/students/${student.id}/sessions/${session.id}/edit`), { timeout: 10000 })
-  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}/sessions/${session.id}/edit`), { timeout: UI_TIMEOUT })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Cancelled toggle should be checked
   await expect(page.getByTestId('cancelled-toggle')).toBeChecked()
 
   // Uncheck cancelled -- autosave fires immediately (saveNow)
   await page.getByTestId('cancelled-toggle').click()
-  await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: 10000 })
+  await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: UI_TIMEOUT })
 
   await page.getByTestId('done-btn').click()
   // Edit mode navigates to ?tab=sessions
-  await expect(page).toHaveURL(new RegExp(`/students/${student.id}`), { timeout: 10000 })
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}`), { timeout: UI_TIMEOUT })
 
   // Badge should be gone
   await page.getByRole('tab', { name: /history/i }).click()
-  await expect(page.getByTestId('cancelled-badge')).toBeHidden({ timeout: 5000 })
+  await expect(page.getByTestId('cancelled-badge')).toBeHidden({ timeout: FEEDBACK_TIMEOUT })
 
   // Verify via API -- session is no longer cancelled
   const updated = await page.request.get(`${API_BASE}/api/students/${student.id}/sessions/${session.id}`, {
@@ -500,12 +501,12 @@ test('summary header appears on history tab after logging a session', async ({ b
   })
 
   await page.goto(`/students/${student.id}`)
-  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
+  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
 
   // Navigate to History tab
   await page.getByRole('tab', { name: /history/i }).click()
 
-  await expect(page.getByTestId('session-summary-header')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('session-summary-header')).toBeVisible({ timeout: UI_TIMEOUT })
   await expect(page.getByTestId('session-summary-action-items-toggle')).toBeVisible()
 
   // Expand action items
@@ -650,13 +651,13 @@ test('lesson dropdown in session log shows only lessons for the selected student
 
   // Open log session page for student A
   await page.goto(`/students/${studentA.id}`)
-  await expect(page.getByTestId('student-detail-name')).toHaveText(`Student A ${ts}`, { timeout: 15000 })
+  await expect(page.getByTestId('student-detail-name')).toHaveText(`Student A ${ts}`, { timeout: NAV_TIMEOUT })
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Linked lesson selector is inside the secondary section
   await page.getByTestId('toggle-secondary').click()
-  await expect(page.getByTestId('linked-lesson')).toBeVisible({ timeout: 8000 })
+  await expect(page.getByTestId('linked-lesson')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Open the lesson dropdown
   await page.getByTestId('linked-lesson').click()
@@ -689,10 +690,10 @@ test('unsaved-changes guard: back button with data shows discard confirmation', 
   const student = await createRes.json()
 
   await page.goto(`/students/${student.id}`)
-  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
+  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
 
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Enter some data to make the form dirty
   await page.getByTestId('actual-content').fill('We covered the present tense.')
@@ -701,11 +702,11 @@ test('unsaved-changes guard: back button with data shows discard confirmation', 
   await page.getByTestId('back-button').click()
 
   // Discard confirmation bar should appear
-  await expect(page.getByTestId('discard-confirm-bar')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByTestId('discard-confirm-bar')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
 
   // Click Discard — form should navigate back
   await page.getByTestId('discard-btn').click()
-  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: 5000 })
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: FEEDBACK_TIMEOUT })
 
   await context.close()
 })
@@ -731,19 +732,19 @@ test('unsaved-changes guard: Keep editing returns to the form', async ({ browser
   const student = await createRes.json()
 
   await page.goto(`/students/${student.id}`)
-  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
+  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
 
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: UI_TIMEOUT })
 
   await page.getByTestId('actual-content').fill('Some notes.')
   await page.getByTestId('back-button').click()
-  await expect(page.getByTestId('discard-confirm-bar')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByTestId('discard-confirm-bar')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
 
   await page.getByTestId('keep-editing-btn').click()
 
   // Form stays open with data intact
-  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await expect(page.getByTestId('actual-content')).toHaveValue('Some notes.')
 
   await context.close()
@@ -785,20 +786,20 @@ test('start next session button navigates to log session page with planned topic
 
   // Navigate to student page, go to Sessions tab
   await page.goto(`/students/${student.id}`)
-  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
+  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
   await page.getByRole('tab', { name: /history/i }).click()
 
   // Expand the session entry
-  await expect(page.getByTestId('session-entry')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('session-entry')).toBeVisible({ timeout: UI_TIMEOUT })
   await page.getByTestId('session-entry-toggle').click()
-  await expect(page.getByTestId('session-entry-detail')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByTestId('session-entry-detail')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
 
   // "Start next session" button should be visible
-  await expect(page.getByTestId('start-next-session-button')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByTestId('start-next-session-button')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
 
   // Click it -- navigates to log-session page
   await page.getByTestId('start-next-session-button').click()
-  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: UI_TIMEOUT })
   await expect(page).toHaveURL(new RegExp(`/students/${student.id}/log-session`))
 
   // Planned topics from the previous session appear as a reference in the left panel
@@ -806,13 +807,13 @@ test('start next session button navigates to log session page with planned topic
 
   // Log the next session
   await page.getByTestId('actual-content').fill('Covered irregular verbs')
-  await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: 10000 })
+  await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: UI_TIMEOUT })
   await page.getByTestId('done-btn').click()
-  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: 10000 })
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: UI_TIMEOUT })
 
   // Two sessions should now be present
   await page.getByRole('tab', { name: /history/i }).click()
-  await expect(page.getByTestId('session-entry')).toHaveCount(2, { timeout: 10000 })
+  await expect(page.getByTestId('session-entry')).toHaveCount(2, { timeout: UI_TIMEOUT })
 
   // Original session still shows its NextSessionTopics preview
   const previews = page.getByTestId('next-session-topics-preview')
@@ -843,16 +844,16 @@ test('unsaved-changes guard: back button on empty form navigates without confirm
   const student = await createRes.json()
 
   await page.goto(`/students/${student.id}`)
-  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
+  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
 
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // Click back without entering data
   await page.getByTestId('back-button').click()
 
   // Navigates back immediately, no confirmation
-  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: 5000 })
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: FEEDBACK_TIMEOUT })
   await expect(page.getByTestId('discard-confirm-bar')).not.toBeVisible()
 
   await context.close()
@@ -883,17 +884,17 @@ test('log session page: autosave creates session without submit button', async (
 
     // Navigate directly to log-session page
     await page.goto(`/students/${student.id}/log-session`)
-    await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: NAV_TIMEOUT })
 
     // Type in "What Happened?" - triggers autosave
     await page.getByTestId('actual-content').fill('Practiced subjunctive with reading exercises.')
 
     // Wait for autosave to complete (status shows "All changes saved")
-    await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: 5000 })
+    await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: FEEDBACK_TIMEOUT })
 
     // Click Done to navigate back
     await page.getByTestId('done-btn').click()
-    await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: 10000 })
+    await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: UI_TIMEOUT })
 
     // Verify session was created in the API
     const sessionsRes = await page.request.get(`${API_BASE}/api/students/${student.id}/sessions`, {
@@ -930,11 +931,11 @@ test('log session page: Done navigates back without saving if no changes made', 
     const student = await createRes.json()
 
     await page.goto(`/students/${student.id}/log-session`)
-    await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: NAV_TIMEOUT })
 
     // Click Done without typing anything
     await page.getByTestId('done-btn').click()
-    await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: 10000 })
+    await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: UI_TIMEOUT })
 
     // No session should have been created
     const sessionsRes = await page.request.get(`${API_BASE}/api/students/${student.id}/sessions`, {

--- a/e2e/tests/session-log.spec.ts
+++ b/e2e/tests/session-log.spec.ts
@@ -16,7 +16,6 @@ test('log session from student detail page', async ({ browser }) => {
   const context = await createMockAuthContext(browser)
   const page = await context.newPage()
 
-  // Create a student via API
   const studentName = `Session Test Student ${Date.now()}`
   const createRes = await page.request.post(`${API_BASE}/api/students`, {
     headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
@@ -33,46 +32,33 @@ test('log session from student detail page', async ({ browser }) => {
   expect(createRes.ok()).toBeTruthy()
   const student = await createRes.json()
 
-  // Navigate to student detail page
   await page.goto(`/students/${student.id}`)
   await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
 
-  // Click Log session
   await page.getByTestId('log-session-button').click()
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
 
-  // Dialog should open
-  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
-
-  // Date is already filled (today)
-  const todayIso = await page.evaluate(() => {
-    const d = new Date()
-    const yyyy = d.getFullYear()
-    const mm = String(d.getMonth() + 1).padStart(2, '0')
-    const dd = String(d.getDate()).padStart(2, '0')
-    return `${yyyy}-${mm}-${dd}`
-  })
-  const dateInput = page.getByTestId('session-date')
-  await expect(dateInput).toHaveValue(todayIso)
-
-  // Fill actual content (required)
+  // Fill in what happened
   await page.getByTestId('actual-content').fill('Practiced preterito indefinido with reading exercises.')
 
-  // Submit
-  await page.getByTestId('submit-session-log').click()
+  // Autosave should trigger and complete
+  await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: 10000 })
 
-  // Success confirmation
-  await expect(page.getByTestId('session-log-success')).toBeVisible({ timeout: 10000 })
-  // Dialog should close automatically after success
-  await expect(page.getByTestId('session-log-dialog')).toBeHidden({ timeout: 3000 })
+  // Click Done to navigate back
+  await page.getByTestId('done-btn').click()
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: 10000 })
+
+  // Session should appear in history
+  await page.getByRole('tab', { name: /history/i }).click()
+  await expect(page.getByTestId('session-entry').first()).toBeVisible({ timeout: 10000 })
 
   await context.close()
 })
 
-test('log session dialog prev homework status shows when prev session has homework', async ({ browser }) => {
+test('log session page: prev homework status shows when prev session has homework', async ({ browser }) => {
   const context = await createMockAuthContext(browser)
   const page = await context.newPage()
 
-  // Create student
   const studentName = `Homework Cond Student ${Date.now()}`
   const createRes = await page.request.post(`${API_BASE}/api/students`, {
     headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
@@ -102,7 +88,7 @@ test('log session dialog prev homework status shows when prev session has homewo
   await page.goto(`/students/${student.id}`)
   await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
 
   // Previous homework status should appear since prior session had homework
   await expect(page.getByTestId('prev-homework-status')).toBeVisible({ timeout: 8000 })
@@ -201,7 +187,7 @@ test('delete session requires confirmation dialog', async ({ browser }) => {
   await entry.getByTestId('session-entry-toggle').click()
 
   // Click delete — confirmation dialog should appear
-  await entry.getByTestId('delete-session-button').click()
+  await entry.getByTestId('delete-session-btn').click()
   const confirmBtn = page.getByTestId('confirm-delete-session')
   await expect(confirmBtn).toBeVisible({ timeout: 5000 })
 
@@ -211,7 +197,7 @@ test('delete session requires confirmation dialog', async ({ browser }) => {
   await expect(entry).toBeVisible()
 
   // Delete again and confirm
-  await entry.getByTestId('delete-session-button').click()
+  await entry.getByTestId('delete-session-btn').click()
   await expect(confirmBtn).toBeVisible({ timeout: 5000 })
   await confirmBtn.click()
 
@@ -243,7 +229,7 @@ test('topic tag category dropdown has all four curriculum-aligned options', asyn
   await page.goto(`/students/${student.id}`)
   await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
 
   // Open the category dropdown and verify all four options exist
   await page.getByTestId('topic-tag-category').click()
@@ -278,22 +264,22 @@ test('future session date is accepted and appears in history', async ({ browser 
   })
   const student = await createRes.json() as { id: string }
 
-  // Log a session with a future date via UI
   await page.goto(`/students/${student.id}`)
   await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
 
   // Set a future date (tomorrow)
   const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000)
   const tomorrowIso = tomorrow.toISOString().split('T')[0]
   await page.getByTestId('session-date').fill(tomorrowIso)
-  await page.getByTestId('planned-content').fill('Planned grammar session')
-  await page.getByTestId('submit-session-log').click()
+  await page.getByTestId('actual-content').fill('Planned grammar session')
 
-  // Success -- no validation error
-  await expect(page.getByTestId('session-log-success')).toBeVisible({ timeout: 10000 })
-  await expect(page.getByTestId('session-log-dialog')).toBeHidden({ timeout: 3000 })
+  // Autosave should complete -- no validation error for future dates
+  await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: 10000 })
+
+  await page.getByTestId('done-btn').click()
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: 10000 })
 
   // Session appears in history
   await page.getByRole('tab', { name: /history/i }).click()
@@ -302,7 +288,7 @@ test('future session date is accepted and appears in history', async ({ browser 
   await context.close()
 })
 
-test('selecting a lesson in log session dialog auto-populates planned content', async ({ browser }) => {
+test('selecting a lesson in log session page links it to the session', async ({ browser }) => {
   const context = await createMockAuthContext(browser)
   const page = await context.newPage()
 
@@ -336,23 +322,35 @@ test('selecting a lesson in log session dialog auto-populates planned content', 
     },
   })
   expect(createLessonRes.ok()).toBeTruthy()
+  const lesson = await createLessonRes.json() as { id: string }
 
   await page.goto(`/students/${student.id}`)
   await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
 
-  // The linked lesson selector should be visible (student has a lesson)
+  // Linked lesson selector is inside the secondary section
+  await page.getByTestId('toggle-secondary').click()
   await expect(page.getByTestId('linked-lesson')).toBeVisible({ timeout: 8000 })
 
   // Select the lesson
   await page.getByTestId('linked-lesson').click()
   await page.getByRole('option', { name: 'Subjunctive Intro' }).click()
 
-  // Planned content should be auto-populated
-  await expect(page.getByTestId('planned-content')).toHaveValue(
-    'Subjunctive Intro: Use subjunctive in wishes and doubt'
-  )
+  // Save — session should have the lesson linked
+  await page.getByTestId('actual-content').fill('Covered subjunctive intro.')
+  await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: 10000 })
+  await page.getByTestId('done-btn').click()
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: 10000 })
+
+  // Verify via API that lesson was linked
+  const sessionsRes = await page.request.get(`${API_BASE}/api/students/${student.id}/sessions`, {
+    headers: { Authorization: 'Bearer test-token' },
+  })
+  expect(sessionsRes.ok()).toBeTruthy()
+  const sessions = await sessionsRes.json() as { linkedLessonId: string | null }[]
+  expect(sessions.length).toBeGreaterThan(0)
+  expect(sessions[0].linkedLessonId).toBe(lesson.id)
 
   await context.close()
 })
@@ -440,19 +438,27 @@ test('un-cancel a session removes the Cancelled badge', async ({ browser }) => {
   await page.getByRole('tab', { name: /history/i }).click()
   await expect(page.getByTestId('cancelled-badge')).toBeVisible({ timeout: 10000 })
 
-  // Edit session -- uncheck cancelled
+  // Open expanded view and click "Edit full session"
   const entry = page.getByTestId('session-entry').first()
   await entry.getByTestId('session-entry-toggle').click()
-  await entry.getByTestId('edit-session-button').click()
-  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
+  await entry.getByTestId('edit-full-session-link').click()
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}/sessions/${session.id}/edit`), { timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
+
+  // Cancelled toggle should be checked
   await expect(page.getByTestId('cancelled-toggle')).toBeChecked()
+
+  // Uncheck cancelled -- autosave fires immediately (saveNow)
   await page.getByTestId('cancelled-toggle').click()
-  await page.getByTestId('submit-session-log').click()
-  await expect(page.getByTestId('session-log-success')).toBeVisible({ timeout: 10000 })
-  await expect(page.getByTestId('session-log-dialog')).toBeHidden({ timeout: 3000 })
+  await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: 10000 })
+
+  await page.getByTestId('done-btn').click()
+  // Edit mode navigates to ?tab=sessions
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}`), { timeout: 10000 })
 
   // Badge should be gone
-  await expect(page.getByTestId('cancelled-badge')).toBeHidden()
+  await page.getByRole('tab', { name: /history/i }).click()
+  await expect(page.getByTestId('cancelled-badge')).toBeHidden({ timeout: 5000 })
 
   // Verify via API -- session is no longer cancelled
   const updated = await page.request.get(`${API_BASE}/api/students/${student.id}/sessions/${session.id}`, {
@@ -642,11 +648,14 @@ test('lesson dropdown in session log shows only lessons for the selected student
     data: { title: `Lesson for B ${ts}`, language: 'French', cefrLevel: 'A2', topic: 'Articles', durationMinutes: 60, studentId: studentB.id },
   })
 
-  // Open session log dialog for student A
+  // Open log session page for student A
   await page.goto(`/students/${studentA.id}`)
   await expect(page.getByTestId('student-detail-name')).toHaveText(`Student A ${ts}`, { timeout: 15000 })
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
+
+  // Linked lesson selector is inside the secondary section
+  await page.getByTestId('toggle-secondary').click()
   await expect(page.getByTestId('linked-lesson')).toBeVisible({ timeout: 8000 })
 
   // Open the lesson dropdown
@@ -659,7 +668,7 @@ test('lesson dropdown in session log shows only lessons for the selected student
   await context.close()
 })
 
-test('unsaved-changes guard: clicking outside with data shows discard confirmation', async ({ browser }) => {
+test('unsaved-changes guard: back button with data shows discard confirmation', async ({ browser }) => {
   const context = await createMockAuthContext(browser)
   const page = await context.newPage()
 
@@ -683,20 +692,20 @@ test('unsaved-changes guard: clicking outside with data shows discard confirmati
   await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
 
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
 
   // Enter some data to make the form dirty
   await page.getByTestId('actual-content').fill('We covered the present tense.')
 
-  // Click outside the dialog (top-left corner of viewport)
-  await page.mouse.click(10, 10)
+  // Click the back button
+  await page.getByTestId('back-button').click()
 
-  // Discard confirmation should appear
-  await expect(page.getByTestId('discard-confirm-dialog')).toBeVisible({ timeout: 5000 })
+  // Discard confirmation bar should appear
+  await expect(page.getByTestId('discard-confirm-bar')).toBeVisible({ timeout: 5000 })
 
-  // Click Discard — form should close
+  // Click Discard — form should navigate back
   await page.getByTestId('discard-btn').click()
-  await expect(page.getByTestId('session-log-dialog')).not.toBeVisible({ timeout: 5000 })
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: 5000 })
 
   await context.close()
 })
@@ -725,22 +734,22 @@ test('unsaved-changes guard: Keep editing returns to the form', async ({ browser
   await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
 
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
 
   await page.getByTestId('actual-content').fill('Some notes.')
-  await page.mouse.click(10, 10)
-  await expect(page.getByTestId('discard-confirm-dialog')).toBeVisible({ timeout: 5000 })
+  await page.getByTestId('back-button').click()
+  await expect(page.getByTestId('discard-confirm-bar')).toBeVisible({ timeout: 5000 })
 
   await page.getByTestId('keep-editing-btn').click()
 
   // Form stays open with data intact
-  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 5000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 5000 })
   await expect(page.getByTestId('actual-content')).toHaveValue('Some notes.')
 
   await context.close()
 })
 
-test('start next session button pre-populates planned content from NextSessionTopics', async ({ browser }) => {
+test('start next session button navigates to log session page with planned topics as reference', async ({ browser }) => {
   const context = await createMockAuthContext(browser)
   const page = await context.newPage()
 
@@ -787,30 +796,24 @@ test('start next session button pre-populates planned content from NextSessionTo
   // "Start next session" button should be visible
   await expect(page.getByTestId('start-next-session-button')).toBeVisible({ timeout: 5000 })
 
-  // Click it
+  // Click it -- navigates to log-session page
   await page.getByTestId('start-next-session-button').click()
-  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}/log-session`))
 
-  // Dialog should be in create mode (title "Log Session")
-  await expect(page.getByText('Log Session')).toBeVisible()
+  // Planned topics from the previous session appear as a reference in the left panel
+  await expect(page.getByTestId('log-session-left-panel')).toContainText('Review irregular verbs')
 
-  // PlannedContent should be pre-filled with NextSessionTopics value
-  await expect(page.getByTestId('planned-content')).toHaveValue('Review irregular verbs')
-
-  // Teacher can modify it
-  await page.getByTestId('planned-content').fill('Review irregular verbs + ser/estar')
-
-  // Save the new session
+  // Log the next session
   await page.getByTestId('actual-content').fill('Covered irregular verbs')
-  await page.getByTestId('submit-session-log').click()
-  await expect(page.getByTestId('session-log-success')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: 10000 })
+  await page.getByTestId('done-btn').click()
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: 10000 })
 
-  // Original session's NextSessionTopics should not be modified — reload and check
-  await page.reload()
-  await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
-  await page.getByRole('tab', { name: /history/i }).click()
   // Two sessions should now be present
+  await page.getByRole('tab', { name: /history/i }).click()
   await expect(page.getByTestId('session-entry')).toHaveCount(2, { timeout: 10000 })
+
   // Original session still shows its NextSessionTopics preview
   const previews = page.getByTestId('next-session-topics-preview')
   await expect(previews).toHaveCount(1)
@@ -819,7 +822,7 @@ test('start next session button pre-populates planned content from NextSessionTo
   await context.close()
 })
 
-test('unsaved-changes guard: empty form closes without confirmation', async ({ browser }) => {
+test('unsaved-changes guard: back button on empty form navigates without confirmation', async ({ browser }) => {
   const context = await createMockAuthContext(browser)
   const page = await context.newPage()
 
@@ -843,14 +846,14 @@ test('unsaved-changes guard: empty form closes without confirmation', async ({ b
   await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: 15000 })
 
   await page.getByTestId('log-session-button').click()
-  await expect(page.getByTestId('session-log-dialog')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: 10000 })
 
-  // Click outside without entering data
-  await page.mouse.click(10, 10)
+  // Click back without entering data
+  await page.getByTestId('back-button').click()
 
-  // Dialog closes immediately, no confirmation
-  await expect(page.getByTestId('session-log-dialog')).not.toBeVisible({ timeout: 5000 })
-  await expect(page.getByTestId('discard-confirm-dialog')).not.toBeVisible()
+  // Navigates back immediately, no confirmation
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: 5000 })
+  await expect(page.getByTestId('discard-confirm-bar')).not.toBeVisible()
 
   await context.close()
 })

--- a/e2e/tests/session-log.spec.ts
+++ b/e2e/tests/session-log.spec.ts
@@ -39,6 +39,11 @@ test('log session from student detail page', async ({ browser }) => {
   await page.getByTestId('log-session-button').click()
   await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: UI_TIMEOUT })
 
+  // Date defaults to today and duration defaults to 50 min
+  const todayIso = new Date().toISOString().split('T')[0]
+  await expect(page.getByTestId('session-date')).toHaveValue(todayIso)
+  await expect(page.getByTestId('duration-select')).toBeVisible()
+
   // Fill in what happened
   await page.getByTestId('actual-content').fill('Practiced preterito indefinido with reading exercises.')
 
@@ -455,7 +460,7 @@ test('un-cancel a session removes the Cancelled badge', async ({ browser }) => {
 
   await page.getByTestId('done-btn').click()
   // Edit mode navigates to ?tab=sessions
-  await expect(page).toHaveURL(new RegExp(`/students/${student.id}`), { timeout: UI_TIMEOUT })
+  await expect(page).toHaveURL(new RegExp(`/students/${student.id}(\\?tab=sessions)?$`), { timeout: UI_TIMEOUT })
 
   // Badge should be gone
   await page.getByRole('tab', { name: /history/i }).click()

--- a/plan/stabilisation/task835-session-log-e2e-rewrite.md
+++ b/plan/stabilisation/task835-session-log-e2e-rewrite.md
@@ -1,0 +1,49 @@
+# Task 835: Rewrite session-log e2e tests for full-page autosave flow
+
+## Issue
+`e2e/tests/session-log.spec.ts` references `session-log-dialog` and `submit-session-log` test IDs that no longer exist. The Log Session workflow now navigates to a full-page route (`/students/:id/log-session`) rather than opening a modal.
+
+## Changes needed
+
+### Test ID mapping (old -> new)
+| Old | New |
+|-----|-----|
+| `session-log-dialog` | `log-session-page` + URL check |
+| `submit-session-log` | `autosave-status` + `done-btn` |
+| `session-log-success` | `autosave-status` contains "All changes saved" |
+| `edit-session-button` | `edit-full-session-link` |
+| `delete-session-button` | `delete-session-btn` |
+| `discard-confirm-dialog` | `discard-confirm-bar` |
+
+### Interaction pattern changes
+- Log session button now navigates to `/students/:id/log-session`
+- No submit button; autosave fires on field change (400ms debounce)
+- "Done" button (`done-btn`) navigates back to student page
+- In edit mode, navigates to `/students/:id/sessions/:sessionId/edit`, Done goes to `?tab=sessions`
+- Unsaved guard: clicking `back-button` when dirty shows `discard-confirm-bar` (not click-outside)
+- Linked-lesson selector is inside secondary section, need to click `toggle-secondary` first
+- `planned-content` no longer user-editable; `plannedForToday` is shown as "Planned for Today" in left panel
+- `cancelled-toggle` is a `role="switch"` element with `aria-checked` - `toBeChecked()` still works
+
+### Tests to rewrite
+1. `log session from student detail page` - navigate to page, fill actual-content, wait autosave, done
+2. `log session dialog prev homework status...` - rename, navigate to page
+3. `delete session requires confirmation dialog` - fix `delete-session-btn`
+4. `topic tag category dropdown...` - navigate to page first
+5. `future session date is accepted...` - navigate to page, fill date + content, wait autosave
+6. `selecting a lesson...` - open toggle-secondary, select lesson, verify via API
+7. `un-cancel a session...` - use `edit-full-session-link`, edit page navigation
+8. `lesson dropdown...` - open toggle-secondary to access linked-lesson
+9. `unsaved-changes guard: clicking outside...` -> back-button + discard-confirm-bar
+10. `unsaved-changes guard: Keep editing...` -> back-button + discard-confirm-bar + keep-editing-btn
+11. `start next session button...` - navigate to page, verify planned-for-today text
+12. `unsaved-changes guard: empty form...` -> back-button, no discard confirm, navigates back
+
+### Tests to keep unchanged
+- `expand session entry shows full detail...`
+- `cancelled session shows Cancelled badge...`
+- `summary header appears on history tab...`
+- `confirming session with suggestedDifficulties...`
+- `confirming session updates existing difficulty...`
+- `log session page: autosave creates session...` (already correct)
+- `log session page: Done navigates back...` (already correct)


### PR DESCRIPTION
## Summary

- Replaces all `session-log-dialog` / `submit-session-log` / `session-log-success` references with the current full-page route pattern (`log-session-page`, `autosave-status`, `done-btn`)
- Updates edit button testid (`edit-session-button` -> `edit-full-session-link`) and delete button testid (`delete-session-button` -> `delete-session-btn`)
- Rewrites unsaved-changes guard tests to use `back-button` + `discard-confirm-bar` instead of click-outside behavior
- Adds `toggle-secondary` click before accessing the linked-lesson selector (now inside secondary section)
- Imports named timeout constants (`NAV_TIMEOUT`, `UI_TIMEOUT`, `FEEDBACK_TIMEOUT`) from `helpers/timeouts` to match the convention used in all other e2e spec files

## Test plan

- [ ] Build verify passes (bicep, dotnet build, dotnet test, npm lint, npm build, npm test)
- [ ] No references to removed testids (`session-log-dialog`, `submit-session-log`, `session-log-success`, `edit-session-button`) remain
- [ ] Happy path test: log-session-button navigates to full page, fills content, autosave completes, Done returns to student page, session visible in history
- [ ] Autosave test: filling a field triggers `autosave-status` containing "All changes saved"
- [ ] Unsaved-changes guard: back-button with data shows `discard-confirm-bar`

Closes #835

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated end-to-end test suite to align with current application workflows and navigation patterns, improving test reliability and maintainability.

**No user-facing changes in this release.** This update focuses on internal test infrastructure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->