### PR TITLE
feat(#838): add optional title field to LogSession form

### DIFF
--- a/e2e/tests/session-log.spec.ts
+++ b/e2e/tests/session-log.spec.ts
@@ -953,3 +953,98 @@ test('log session page: Done navigates back without saving if no changes made', 
     await context.close()
   }
 })
+
+test('session title: typing a title saves it and appears in session list and edit mode', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    const studentName = `Title Test Student ${Date.now()}`
+    const createRes = await page.request.post(`${API_BASE}/api/students`, {
+      headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
+      data: {
+        name: studentName,
+        learningLanguage: 'Spanish',
+        cefrLevel: 'B1',
+        interests: [],
+        learningGoals: [],
+        weaknesses: [],
+        difficulties: [],
+      },
+    })
+    expect(createRes.ok()).toBeTruthy()
+    const student = await createRes.json() as { id: string }
+
+    await page.goto(`/students/${student.id}/log-session`)
+    await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: NAV_TIMEOUT })
+
+    // Title input is visible with correct placeholder
+    const titleInput = page.getByTestId('log-session-title-input')
+    await expect(titleInput).toBeVisible()
+    await expect(titleInput).toHaveAttribute('placeholder', 'What did you work on? (optional)')
+    await expect(titleInput).toHaveAttribute('maxlength', '120')
+
+    // Type a title and session content
+    await titleInput.fill('Present tense practice')
+    await page.getByTestId('actual-content').fill('Covered present tense conjugations.')
+    await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: UI_TIMEOUT })
+
+    await page.getByTestId('done-btn').click()
+    await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: UI_TIMEOUT })
+
+    // Session list shows the typed title
+    await page.getByRole('tab', { name: /history/i }).click()
+    const entry = page.getByTestId('session-entry').first()
+    await expect(entry).toBeVisible({ timeout: UI_TIMEOUT })
+    await expect(entry).toContainText('Present tense practice')
+
+    // Open edit mode and verify title is pre-populated
+    await entry.getByTestId('session-entry-toggle').click()
+    await entry.getByTestId('edit-full-session-link').click()
+    await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: UI_TIMEOUT })
+    await expect(page.getByTestId('log-session-title-input')).toHaveValue('Present tense practice')
+  } finally {
+    await context.close()
+  }
+})
+
+test('session title: blank title shows date fallback in session list', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    const studentName = `No Title Student ${Date.now()}`
+    const createRes = await page.request.post(`${API_BASE}/api/students`, {
+      headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
+      data: {
+        name: studentName,
+        learningLanguage: 'Spanish',
+        cefrLevel: 'B1',
+        interests: [],
+        learningGoals: [],
+        weaknesses: [],
+        difficulties: [],
+      },
+    })
+    expect(createRes.ok()).toBeTruthy()
+    const student = await createRes.json() as { id: string }
+
+    await page.goto(`/students/${student.id}/log-session`)
+    await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: NAV_TIMEOUT })
+
+    // Leave title blank, fill content
+    await page.getByTestId('actual-content').fill('Covered vocabulary.')
+    await expect(page.getByTestId('autosave-status')).toContainText('All changes saved', { timeout: UI_TIMEOUT })
+
+    await page.getByTestId('done-btn').click()
+    await expect(page).toHaveURL(new RegExp(`/students/${student.id}$`), { timeout: UI_TIMEOUT })
+
+    // Session list shows date fallback (contains "Session,")
+    await page.getByRole('tab', { name: /history/i }).click()
+    const entry = page.getByTestId('session-entry').first()
+    await expect(entry).toBeVisible({ timeout: UI_TIMEOUT })
+    await expect(entry).toContainText('Session,')
+  } finally {
+    await context.close()
+  }
+})

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -254,6 +254,7 @@ export default function LogSession() {
     setReassessmentEnabled(!!editSession.levelReassessmentSkill)
     setReassessmentLevel(editSession.levelReassessmentLevel ?? '')
     setSelectedLessonId(editSession.linkedLessonId ?? '')
+    setSessionTitle(editSession.title ?? undefined)
     const dur = editSession.duration
     if (dur === null || dur === undefined) {
       setDurationChoice('other')
@@ -1073,6 +1074,22 @@ export default function LogSession() {
                 />
               </div>
             </div>
+          </div>
+
+          {/* Session Title */}
+          <div className="space-y-1">
+            <Label htmlFor="session-title" className="text-[0.6875rem] font-medium uppercase tracking-[0.05em] text-zinc-400">
+              Title <span className="normal-case tracking-normal font-normal">(optional)</span>
+            </Label>
+            <Input
+              id="session-title"
+              value={sessionTitle ?? ''}
+              onChange={e => { setSessionTitle(e.target.value || undefined); markChangedAndSchedule() }}
+              placeholder="What did you work on? (optional)"
+              maxLength={120}
+              className="text-sm bg-white"
+              data-testid="log-session-title-input"
+            />
           </div>
 
           {/* ── Editorial headline + Previous HW + What Happened ── */}

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -3,6 +3,8 @@
 Out-of-scope observations logged by agents during implementation. Each row is something an agent noticed but did not fix because it was outside the current task's scope. These get batched into future GitHub issues by the PM.
 
 | Source issue | Date | Severity | Observation |
+| #838 | 2026-04-22 | low | LogSession: checkboxes in Teaching Todos/Followups left panel use native input instead of design-system custom controls (pre-existing) |
+| #838 | 2026-04-22 | low | LogSession: local ToggleSwitch focus ring uses ring-indigo-500 instead of ring-indigo-600 (pre-existing, design-system 11.5) |
 | #837 | 2026-04-22 | low | TeachingTodosCard.tsx has local relativeTime duplicating formatDate.ts — filed #860 |
 | #837 | 2026-04-22 | low | StudentRoster.tsx has local formatRelativeDate not yet refactored to use relativeTime — filed #861 |
 

--- a/plan/stabilisation/task838-log-session-title-field.md
+++ b/plan/stabilisation/task838-log-session-title-field.md
@@ -1,0 +1,44 @@
+# Task 838: Add optional title field to LogSession form
+
+## Issue
+https://github.com/Robert-Freire/langTeachSaaS/issues/838
+
+## Analysis
+
+**Backend:** `Title` field already exists on `SessionLog` entity with `HasMaxLength(120)` in `AppDbContext.cs` (line 211). No backend changes needed.
+
+**Frontend state:** `sessionTitle` state (`useState<string | undefined>()`) already exists at `LogSession.tsx:152` and is already included in the autosave payload as `title: sessionTitle || null` (line 316). The voice note extraction path already sets `sessionTitle` (line 919).
+
+**Session list rendering:** `getSessionTitle` and `getDisplayTitle` in `lib/sessionUtils.ts` already handle the `title` field correctly. No rendering changes needed.
+
+**Gaps to fix:**
+1. No Input field exists for the user to type a title manually.
+2. Edit mode `useEffect` (line 242) does not initialize `sessionTitle` from `editSession.title`.
+
+## Changes
+
+### `frontend/src/pages/LogSession.tsx`
+1. In the edit-mode `useEffect` (around line 256), add: `setSessionTitle(editSession.title ?? undefined)`
+2. Add a Title Input field between the metadata grid (line 1076) and the `!isCancelled` block (line 1079).
+   - Position: after closing `</div>` of metadata grid, before `{!isCancelled && (`
+   - Label: "Title" with "(optional)" hint
+   - Placeholder: "What did you work on? (optional)"
+   - `maxLength={120}`
+   - `onChange`: `setSessionTitle(e.target.value || undefined); markChangedAndSchedule()`
+   - `data-testid="session-title-input"`
+
+## Acceptance Criteria Check
+
+- [x] Form has optional Title input below date/time fields -- new field added
+- [x] Typing a title and navigating away saves it -- autosave already includes `title` in payload
+- [x] Session list shows typed title -- `getSessionTitle` already handles it
+- [x] Session list shows date fallback when null -- already works
+- [x] Blank produces no validation error -- optional field, no required constraint
+- [x] Session History tab shows typed title -- `getDisplayTitle` already handles it
+- [x] Max-length enforced on input -- `maxLength={120}` on the input
+
+## E2E Tests
+
+Add tests to `e2e/tests/session-log.spec.ts`:
+- Type a title, navigate away, re-open session in edit mode, verify title persists
+- Leave title blank, verify session list shows date fallback


### PR DESCRIPTION
## Summary

- Adds an optional **Title** input field (maxLength 120) to the LogSession form, positioned between the date/time/duration/cancelled metadata grid and the main content area
- Renders for both normal and cancelled sessions
- Fixes edit-mode initialisation: `useEffect` now seeds `sessionTitle` from `editSession.title` (was missing)
- Uses `data-testid="log-session-title-input"` to avoid collision with the existing `session-title-input` in `SessionHistoryTab`'s inline editor
- No backend changes needed: `title` was already accepted by `POST/PUT /api/session-logs` and the autosave payload already included it
- No session-list rendering changes needed: `getSessionTitle`/`getDisplayTitle` already handle the `title` field

## Test plan

- [x] Build verify: PASS (87 unit tests, 0 failed)
- [x] QA verify: PASS (all 7 ACs covered)
- [x] Architecture review: PASS
- [x] UI review: PASS (two pre-existing design-system violations noted, logged to observed-issues.md)
- [x] E2E: two new tests — title persists + pre-populates in edit mode; blank title shows date fallback

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)