### PR TITLE
chore: truncate raw Claude response in debug log to 200 chars (#839)

### DIFF
--- a/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
@@ -82,7 +82,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to parse reflection extraction JSON (length: {Length})", json?.Length ?? 0);
-            _logger.LogDebug("Unparseable Claude response: {Json}", json);
+            _logger.LogDebug("Unparseable Claude response: {Preview}...", json is null ? null : json[..Math.Min(200, json.Length)]);
             return new ExtractedReflectionDto(
                 WhatWasCovered: null, AreasToImprove: null, EmotionalSignals: null,
                 HomeworkAssigned: null, NextLessonIdeas: null, SessionDate: null,

--- a/plan/stabilisation/task839-truncate-claude-debug-logs.md
+++ b/plan/stabilisation/task839-truncate-claude-debug-logs.md
@@ -1,0 +1,25 @@
+# Task 839: Truncate raw Claude response in debug logs
+
+## Issue
+#839 — chore: truncate raw Claude response in debug logs to prevent session content leakage
+
+## Problem
+`ReflectionExtractionService.cs:85` logs the full raw Claude JSON at Debug level when parsing fails, potentially exposing full session content (topics, student difficulties, notes) in logs.
+
+## Fix
+One-line change in `backend/LangTeach.Api/Services/ReflectionExtractionService.cs` line 85:
+
+```csharp
+// Before
+_logger.LogDebug("Unparseable Claude response: {Json}", json);
+
+// After
+_logger.LogDebug("Unparseable Claude response: {Preview}...", json is null ? null : json[..Math.Min(200, json.Length)]);
+```
+
+## Acceptance Criteria
+- [ ] Debug log capped at ~200 characters
+- [ ] Log still identifies parse failure and shows enough payload to diagnose format issues
+
+## Tests
+Existing `ReflectionExtractionServiceTests.cs` — verify no changes needed (no test asserts on log output). No new tests required for a log truncation change.


### PR DESCRIPTION
## Summary
- Truncates the raw Claude JSON payload in `ReflectionExtractionService` debug log from full content to 200 characters
- Prevents session content (topics discussed, student difficulties, notes) from leaking into debug logs on parse failure
- Log still identifies parse failure and shows enough context to diagnose malformed JSON

## Test plan
- [ ] `dotnet build` passes
- [ ] `dotnet test` passes
- [ ] Verify `ReflectionExtractionService.cs:85` logs `{Preview}...` capped at 200 chars

Closes #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)