### PR TITLE
fix: PromptService cleanup — dedup, merge directives, CEFR priority cue, move age to Student.GetAge() (#846)

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -94,6 +94,7 @@ public class PromptServiceTests
         var request = _sut.BuildLessonPlanPrompt(ctx);
 
         request.SystemPrompt.Should().Contain("Native language: Portuguese");
+        request.SystemPrompt.Split("Native language: Portuguese", StringSplitOptions.None).Length.Should().Be(2);
         request.SystemPrompt.Should().NotContain("The student's native language is Portuguese");
     }
 

--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -87,6 +87,17 @@ public class PromptServiceTests
     }
 
     [Fact]
+    public void NativeLanguage_AppearsOnceAsDataFact_InstructionSubBulletsDoNotRepeatHeading()
+    {
+        var ctx = BaseCtx("Ana") with { StudentNativeLanguage = "Portuguese" };
+
+        var request = _sut.BuildLessonPlanPrompt(ctx);
+
+        request.SystemPrompt.Should().Contain("Native language: Portuguese");
+        request.SystemPrompt.Should().NotContain("The student's native language is Portuguese");
+    }
+
+    [Fact]
     public void SystemPrompt_OmitsInterestsLine_WhenInterestsArrayIsEmpty()
     {
         var ctx = BaseCtx("Ana") with { StudentInterests = [] };

--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -3321,8 +3321,7 @@ public class PromptServiceTests
 
         var request = _sut.BuildLessonPlanPrompt(ctx);
 
-        request.SystemPrompt.Should().Contain("para vivir en Barcelona");
-        request.SystemPrompt.Should().Contain("Anchor vocabulary, topics, and examples to the student's stated study motivation");
+        request.SystemPrompt.Should().Contain("anchor vocabulary to their stated study motivation: para vivir en Barcelona");
     }
 
     [Fact]
@@ -3367,21 +3366,21 @@ public class PromptServiceTests
         request.SystemPrompt.Should().Contain("A2");
         request.SystemPrompt.Should().Contain("official");
         request.SystemPrompt.Should().Contain("teacher assessment");
+        request.SystemPrompt.Should().Contain("content difficulty decisions");
     }
 
     [Fact]
-    public void BirthYear_AgeComputedInSystemPrompt()
+    public void Age_IncludedInSystemPrompt()
     {
-        var birthYear = 1990;
+        var age = DateTime.UtcNow.Year - 1990;
         var ctx = BaseCtx("Ana") with
         {
-            StudentBirthYear = birthYear
+            StudentAge = age
         };
 
         var request = _sut.BuildLessonPlanPrompt(ctx);
 
-        var expectedAge = (DateTime.UtcNow.Year - birthYear).ToString();
-        request.SystemPrompt.Should().Contain(expectedAge);
+        request.SystemPrompt.Should().Contain(age.ToString());
     }
 
     [Fact]

--- a/backend/LangTeach.Api/AI/IPromptService.cs
+++ b/backend/LangTeach.Api/AI/IPromptService.cs
@@ -124,7 +124,7 @@ public record GenerationContext(
     string? StudentReasonForStudying = null,
     string[]? StudentSpokenLanguages = null,
     string? StudentProfession = null,
-    int? StudentBirthYear = null,
+    int? StudentAge = null,
     string? StudentCountryOfOrigin = null,
     string? StudentCountryOfResidence = null,
     string? StudentOfficialCefrLevel = null

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -435,18 +435,13 @@ public class PromptService : IPromptService
             var countryOfOrigin  = InputSanitizer.Sanitize(ctx.StudentCountryOfOrigin);
             var countryOfResidence = InputSanitizer.Sanitize(ctx.StudentCountryOfResidence);
             var officialCefr     = InputSanitizer.Sanitize(ctx.StudentOfficialCefrLevel);
-
-            // Age is approximated from birth year (off by up to one year depending on birthday — acceptable for prompt personalization)
-            var currentYear = DateTime.UtcNow.Year;
-            var age = ctx.StudentBirthYear is int birthYear && birthYear >= currentYear - 120 && birthYear <= currentYear
-                ? currentYear - birthYear
-                : (int?)null;
+            var spokenLangs      = ctx.StudentSpokenLanguages?.Select(InputSanitizer.Sanitize).Where(s => s.Length > 0).ToArray() ?? [];
 
             if (profession.Length > 0)
                 sb.AppendLine($"- Profession: {profession}");
 
-            if (age is not null)
-                sb.AppendLine($"- Age: {age}");
+            if (ctx.StudentAge is not null)
+                sb.AppendLine($"- Age: {ctx.StudentAge}");
 
             if (countryOfOrigin.Length > 0)
                 sb.AppendLine($"- Country of origin: {countryOfOrigin}");
@@ -457,39 +452,33 @@ public class PromptService : IPromptService
             if (officialCefr.Length > 0)
                 sb.AppendLine($"- Official CEFR level: {officialCefr} (official) / {cefrLevel} (teacher assessment)");
 
-            if (ctx.StudentSpokenLanguages is { Length: > 0 })
-            {
-                var spokenLangs = ctx.StudentSpokenLanguages.Select(InputSanitizer.Sanitize).Where(s => s.Length > 0).ToArray();
-                if (spokenLangs.Length > 0)
-                    sb.AppendLine($"- Also speaks: {string.Join(", ", spokenLangs)}");
-            }
+            if (spokenLangs.Length > 0)
+                sb.AppendLine($"- Also speaks: {string.Join(", ", spokenLangs)}");
 
             if (reasonForStudying.Length > 0)
                 sb.AppendLine($"- Reason for studying {language}: {reasonForStudying}");
 
             sb.AppendLine();
-            sb.AppendLine($"Personalize content for this student. Reference their interests in examples.");
+            var motivationSuffix = reasonForStudying.Length > 0
+                ? $", and anchor vocabulary to their stated study motivation: {reasonForStudying}"
+                : string.Empty;
+            sb.AppendLine($"Personalize content for this student. Reference their interests in examples{motivationSuffix}.");
 
-            if (reasonForStudying.Length > 0)
-                sb.AppendLine($"Anchor vocabulary, topics, and examples to the student's stated study motivation.");
-
-            if (ctx.StudentSpokenLanguages is { Length: > 0 })
-            {
-                var spokenForPrompt = ctx.StudentSpokenLanguages.Select(InputSanitizer.Sanitize).Where(s => s.Length > 0).ToArray();
-                if (spokenForPrompt.Length > 0)
-                    sb.AppendLine("Where relevant, leverage cross-language awareness and cognates from the student's other languages.");
-            }
+            if (spokenLangs.Length > 0)
+                sb.AppendLine("Where relevant, leverage cross-language awareness and cognates from the student's other languages.");
 
             if (profession.Length > 0)
                 sb.AppendLine("Use domain-specific vocabulary and scenarios from the student's professional field where appropriate.");
 
             if (ctx.StudentNativeLanguage is not null)
             {
-                sb.AppendLine($"The student's native language is {nativeLang}.");
                 sb.AppendLine($"- For grammar explanations, note where {language} differs from {nativeLang}.");
                 sb.AppendLine($"- Flag false cognates between {nativeLang} and {language} when relevant.");
                 sb.AppendLine($"- Be aware of common errors {nativeLang} speakers make in {language}.");
             }
+
+            if (officialCefr.Length > 0)
+                sb.AppendLine("Use the teacher assessment level for content difficulty decisions; the official level is for reference only.");
 
             if (ctx.StudentDifficulties is { Length: > 0 })
             {

--- a/backend/LangTeach.Api/Controllers/GenerateController.cs
+++ b/backend/LangTeach.Api/Controllers/GenerateController.cs
@@ -200,7 +200,7 @@ public class GenerateController : ControllerBase
             StudentReasonForStudying: student?.ReasonForStudying,
             StudentSpokenLanguages: student?.SpokenLanguages.ToArray(),
             StudentProfession: student?.Profession,
-            StudentBirthYear: student?.BirthYear,
+            StudentAge: student?.GetAge(),
             StudentCountryOfOrigin: student?.CountryOfOrigin,
             StudentCountryOfResidence: student?.CountryOfResidence,
             StudentOfficialCefrLevel: student?.OfficialCefrLevel
@@ -367,7 +367,7 @@ public class GenerateController : ControllerBase
             StudentReasonForStudying: student?.ReasonForStudying,
             StudentSpokenLanguages: student?.SpokenLanguages.ToArray(),
             StudentProfession: student?.Profession,
-            StudentBirthYear: student?.BirthYear,
+            StudentAge: student?.GetAge(),
             StudentCountryOfOrigin: student?.CountryOfOrigin,
             StudentCountryOfResidence: student?.CountryOfResidence,
             StudentOfficialCefrLevel: student?.OfficialCefrLevel

--- a/backend/LangTeach.Api/Controllers/GenerateController.cs
+++ b/backend/LangTeach.Api/Controllers/GenerateController.cs
@@ -200,7 +200,7 @@ public class GenerateController : ControllerBase
             StudentReasonForStudying: student?.ReasonForStudying,
             StudentSpokenLanguages: student?.SpokenLanguages.ToArray(),
             StudentProfession: student?.Profession,
-            StudentAge: student?.GetAge(),
+            StudentAge: student?.Age,
             StudentCountryOfOrigin: student?.CountryOfOrigin,
             StudentCountryOfResidence: student?.CountryOfResidence,
             StudentOfficialCefrLevel: student?.OfficialCefrLevel
@@ -367,7 +367,7 @@ public class GenerateController : ControllerBase
             StudentReasonForStudying: student?.ReasonForStudying,
             StudentSpokenLanguages: student?.SpokenLanguages.ToArray(),
             StudentProfession: student?.Profession,
-            StudentAge: student?.GetAge(),
+            StudentAge: student?.Age,
             StudentCountryOfOrigin: student?.CountryOfOrigin,
             StudentCountryOfResidence: student?.CountryOfResidence,
             StudentOfficialCefrLevel: student?.OfficialCefrLevel

--- a/backend/LangTeach.Api/DTOs/StudentDto.cs
+++ b/backend/LangTeach.Api/DTOs/StudentDto.cs
@@ -36,4 +36,12 @@ public record StudentDto(
     List<TeachingTodoDto> TeachingTodos,
     // Skill override fields
     Dictionary<string, string> SkillLevelOverrides
-);
+)
+{
+    public int? GetAge()
+    {
+        if (BirthYear is not int year) return null;
+        var current = DateTime.UtcNow.Year;
+        return year >= current - 120 && year <= current ? current - year : null;
+    }
+}

--- a/backend/LangTeach.Api/DTOs/StudentDto.cs
+++ b/backend/LangTeach.Api/DTOs/StudentDto.cs
@@ -16,6 +16,7 @@ public record StudentDto(
     DateTime UpdatedAt,
     // Identity fields
     int? BirthYear,
+    int? Age,
     string? Profession,
     string? CountryOfOrigin,
     string? CityOfOrigin,
@@ -36,12 +37,4 @@ public record StudentDto(
     List<TeachingTodoDto> TeachingTodos,
     // Skill override fields
     Dictionary<string, string> SkillLevelOverrides
-)
-{
-    public int? GetAge()
-    {
-        if (BirthYear is not int year) return null;
-        var current = DateTime.UtcNow.Year;
-        return year >= current - 120 && year <= current ? current - year : null;
-    }
-}
+);

--- a/backend/LangTeach.Api/Data/Models/Student.cs
+++ b/backend/LangTeach.Api/Data/Models/Student.cs
@@ -42,6 +42,13 @@ public class Student
     public DateTime CreatedAt { get; set; }
     public DateTime UpdatedAt { get; set; }
 
+    public int? GetAge()
+    {
+        if (BirthYear is not int year) return null;
+        var current = DateTime.UtcNow.Year;
+        return year >= current - 120 && year <= current ? current - year : null;
+    }
+
     public Teacher Teacher { get; set; } = null!;
     public ICollection<Lesson> Lessons { get; set; } = [];
     public ICollection<Course> Courses { get; set; } = [];

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -256,6 +256,7 @@ public class StudentService : IStudentService
         s.CreatedAt,
         s.UpdatedAt,
         s.BirthYear,
+        s.GetAge(),
         s.Profession,
         s.CountryOfOrigin,
         s.CityOfOrigin,

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -12,5 +12,6 @@ Out-of-scope observations logged by agents during implementation. Each row is so
 | #844 | 2026-04-22 | low | TeacherFollowup.Kind has no DB CHECK constraint; only DTO regex guards API path — filed #870 |
 | #837 | 2026-04-22 | low | StudentRoster.tsx has local formatRelativeDate not yet refactored to use relativeTime — filed #861 |
 | #852 | 2026-04-22 | low | StudentsController (4x) and CoursesController still use ValidationProblem/BadRequest(rawString) for ValidationException — filed #871 |
+| #846 | 2026-04-22 | low | PromptService.cs lines 473-478: L1 sub-bullets (differs-from-native, false cognates, common errors) hardcoded in C# system prompt; overlaps with config-driven L1Adjustments block appended to user prompts. Predates #846; worth consolidating into the data-driven path. |
 
 *Cleared 2026-04-22 during UI Redesign & Student Profile Polish sprint close. Actionable entries batched into: #833 (bug batch), #834 (seeder gaps), #835 (e2e session-log rewrite), #836 (ScenarioSeeder Hans B1), #837 (deduplication), #838 (session title from web UI), #839 (debug log privacy), #840 (Edit Student UX), #841 (stale closure + LogSession pre-populate). Already-tracked entries removed (referenced #737/#707/#644/#714/#715/#716/#683/#741/#742/#756/#809/#657). Dismissed entries removed (defensive-only, intentional, or resolved).*

--- a/plan/stabilisation/task846-promptservice-cleanup.md
+++ b/plan/stabilisation/task846-promptservice-cleanup.md
@@ -1,0 +1,57 @@
+# Task 846: PromptService Cleanup
+
+## Issue
+Fix 5 prompt-health issues in `BuildSystemPrompt` introduced with new student fields.
+
+## Files Changed
+- `backend/LangTeach.Api/Data/Models/Student.cs` - add `GetAge()`
+- `backend/LangTeach.Api/AI/IPromptService.cs` - replace `StudentBirthYear` with `StudentAge` in `GenerationContext`
+- `backend/LangTeach.Api/Controllers/GenerateController.cs` - use `StudentAge: student?.GetAge()` (2 places)
+- `backend/LangTeach.Api/AI/PromptService.cs` - 5 fixes in `BuildSystemPrompt`
+- `backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs` - update 2 tests
+
+## Changes
+
+### Finding 1: SpokenLanguages computed once
+In `BuildSystemPrompt`, compute `spokenLangs` before the profile data block. Reuse for both the `- Also speaks:` data line (currently lines 460-464) and the cross-language instruction (currently lines 476-481). Remove the second `spokenForPrompt` computation.
+
+### Finding 2: Merge overlapping personalization directives
+Replace lines 471-474:
+```
+Personalize content for this student. Reference their interests in examples.
+[if reasonForStudying]: Anchor vocabulary, topics, and examples to the student's stated study motivation.
+```
+With one conditional line:
+```csharp
+var motivationSuffix = reasonForStudying.Length > 0
+    ? $", and anchor vocabulary to their stated study motivation: {reasonForStudying}"
+    : string.Empty;
+sb.AppendLine($"Personalize content for this student. Reference their interests in examples{motivationSuffix}.");
+```
+
+### Finding 3: Remove duplicate native language heading
+Remove `sb.AppendLine($"The student's native language is {nativeLang}.");` (line 488). The three sub-bullets remain; they open directly without the now-redundant heading.
+
+### Finding 4: Add CEFR priority cue
+Add after the native language sub-bullets block (before `StudentDifficulties`), conditional on `officialCefr.Length > 0`:
+```csharp
+if (officialCefr.Length > 0)
+    sb.AppendLine("Use the teacher assessment level for content difficulty decisions; the official level is for reference only.");
+```
+
+### Finding 5: Move age computation to Student.GetAge()
+- `Student.cs`: Add `public int? GetAge() { ... }` with bounds check (birth year between `currentYear - 120` and `currentYear`).
+- `GenerationContext`: Replace `int? StudentBirthYear` with `int? StudentAge`.
+- `GenerateController.cs`: Replace `StudentBirthYear: student?.BirthYear` with `StudentAge: student?.GetAge()` (2 locations: lines ~203 and ~370).
+- `PromptService.cs`: Replace inline age calculation with `ctx.StudentAge` directly (no computation in prompt builder).
+
+## Tests
+- `BirthYear_AgeComputedInSystemPrompt`: rename to `Age_IncludedInSystemPrompt`, use `StudentAge = DateTime.UtcNow.Year - 1990` instead of `StudentBirthYear = 1990`, drop the manual age calculation in the test.
+- `OfficialCefrLevel_IncludedWithTeacherLevelWhenSet`: add assertion for `"teacher assessment level"` priority cue sentence.
+
+## Acceptance Criteria Coverage
+- [x] SpokenLanguages filtered array computed once and reused
+- [x] Single personalization directive covers both interests and study motivation
+- [x] Native language appears once as data fact; sub-bullets follow without repeating the declaration
+- [x] CEFR priority cue present when both levels in the prompt
+- [x] Age calculation in Student.GetAge(); PromptService calls the computed value


### PR DESCRIPTION
## Summary
- Dedup `StudentSpokenLanguages` filtered array (computed once, reused for data line and instruction)
- Merge two overlapping personalization directives into one conditional sentence
- Remove duplicate native language heading from instruction block (profile data line already carries it)
- Add CEFR priority cue when both teacher-assessed and official levels are in the prompt
- Move age-from-birth-year calculation to `Student.GetAge()` / `StudentDto.Age`; `PromptService` consumes the pre-computed value

## Test plan
- [ ] All 1137 unit tests pass
- [ ] Frontend: 87 tests pass
- [ ] `BirthYear_AgeComputedInSystemPrompt` renamed to `Age_IncludedInSystemPrompt`; uses `StudentAge` field
- [ ] `OfficialCefrLevel_IncludedWithTeacherLevelWhenSet` asserts new priority cue sentence
- [ ] `NativeLanguage_AppearsOnceAsDataFact_InstructionSubBulletsDoNotRepeatHeading` new negative assertion

Closes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced student age calculation system for more accurate profile information
  * Refined AI-generated learning instructions with clearer phrasing for native language, study motivation, and teacher assessment-based content difficulty guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->