### PR TITLE
fix(#841): stale closure in voice note extraction + actualContent pre-populate

### DIFF
--- a/frontend/src/pages/LogSession.test.tsx
+++ b/frontend/src/pages/LogSession.test.tsx
@@ -211,6 +211,34 @@ describe('LogSession', () => {
   })
 
 
+  it('pre-populates actualContent from plannedForToday in create mode', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SAMPLE_SESSION, nextSessionTopics: 'Subjunctive revision' },
+    ])
+    renderLogSession()
+    await screen.findByTestId('actual-content')
+    await waitFor(() => {
+      expect((screen.getByTestId('actual-content') as HTMLTextAreaElement).value).toBe('Subjunctive revision')
+    })
+  })
+
+  it('does not re-pre-populate actualContent after user edits it (pre-populate runs only once)', async () => {
+    vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
+      { ...SAMPLE_SESSION, nextSessionTopics: 'Subjunctive revision' },
+    ])
+    renderLogSession()
+    await screen.findByTestId('actual-content')
+    await waitFor(() => {
+      expect((screen.getByTestId('actual-content') as HTMLTextAreaElement).value).toBe('Subjunctive revision')
+    })
+    // User clears the field and writes their own notes
+    fireEvent.change(screen.getByTestId('actual-content'), { target: { value: 'My own notes' } })
+    // The pre-populate effect must not fire again and reset the field
+    await waitFor(() => {
+      expect((screen.getByTestId('actual-content') as HTMLTextAreaElement).value).toBe('My own notes')
+    })
+  })
+
   it('shows planned-for-today reference panel when prev session has nextSessionTopics', async () => {
     vi.mocked(sessionLogsApi.listSessions).mockResolvedValue([
       { ...SAMPLE_SESSION, nextSessionTopics: 'Subjunctive revision' },
@@ -987,6 +1015,37 @@ describe('LogSession — voice note extraction', () => {
     })
 
     expect(sessionLogsApi.extractSessionReflection).not.toHaveBeenCalled()
+  })
+
+  it('preserves manually edited sessionDate when extraction provides only time (stale closure fix)', async () => {
+    let resolveExtract!: (result: typeof EXTRACTED & { sessionStartTime?: string }) => void
+    vi.mocked(sessionLogsApi.extractSessionReflection).mockReturnValue(
+      new Promise<typeof EXTRACTED>(resolve => { resolveExtract = resolve as typeof resolveExtract })
+    )
+    renderLogSession()
+    await screen.findByTestId('log-session-page')
+
+    // Start extraction
+    await act(async () => {
+      capturedOnVoiceNote?.({ id: 'note-1', transcription: 'La clase fue a las 10.' })
+    })
+    expect(screen.getByTestId('extracting-indicator')).toBeDefined()
+
+    // User manually edits date while extraction is in flight
+    fireEvent.change(screen.getByTestId('session-date'), { target: { value: '2026-03-15' } })
+
+    // Extraction resolves with a time but no date — without the fix, stale sessionDate from closure would be used
+    await act(async () => { resolveExtract({ ...EXTRACTED, sessionStartTime: '10:30' }) })
+    await waitFor(() => {
+      expect(screen.queryByTestId('extracting-indicator')).toBeNull()
+    })
+
+    await waitFor(() => {
+      expect(sessionLogsApi.createSession).toHaveBeenCalled()
+    })
+    const lastPayload = vi.mocked(sessionLogsApi.createSession).mock.calls.slice(-1)[0][1]
+    // The save must use the manually entered date, not the stale closure value from extraction start
+    expect(lastPayload.sessionDate).toContain('2026-03-15')
   })
 
   it('populates date picker from extracted sessionDate', async () => {

--- a/frontend/src/pages/LogSession.test.tsx
+++ b/frontend/src/pages/LogSession.test.tsx
@@ -1048,6 +1048,37 @@ describe('LogSession — voice note extraction', () => {
     expect(lastPayload.sessionDate).toContain('2026-03-15')
   })
 
+  it('preserves manually edited sessionStartTime when extraction provides only date (stale closure fix)', async () => {
+    let resolveExtract!: (result: typeof EXTRACTED & { sessionDate?: string }) => void
+    vi.mocked(sessionLogsApi.extractSessionReflection).mockReturnValue(
+      new Promise<typeof EXTRACTED>(resolve => { resolveExtract = resolve as typeof resolveExtract })
+    )
+    renderLogSession()
+    await screen.findByTestId('log-session-page')
+
+    // Start extraction
+    await act(async () => {
+      capturedOnVoiceNote?.({ id: 'note-1', transcription: 'La clase fue el 15 de enero.' })
+    })
+    expect(screen.getByTestId('extracting-indicator')).toBeDefined()
+
+    // User manually edits time while extraction is in flight
+    fireEvent.change(screen.getByTestId('session-time'), { target: { value: '14:45' } })
+
+    // Extraction resolves with a date but no time
+    await act(async () => { resolveExtract({ ...EXTRACTED, sessionDate: '2026-01-15' }) })
+    await waitFor(() => {
+      expect(screen.queryByTestId('extracting-indicator')).toBeNull()
+    })
+
+    await waitFor(() => {
+      expect(sessionLogsApi.createSession).toHaveBeenCalled()
+    })
+    const lastPayload = vi.mocked(sessionLogsApi.createSession).mock.calls.slice(-1)[0][1]
+    // The save must use the manually entered time, not the stale closure value from extraction start
+    expect(lastPayload.sessionDate).toContain('14:45')
+  })
+
   it('populates date picker from extracted sessionDate', async () => {
     vi.mocked(sessionLogsApi.extractSessionReflection).mockResolvedValue({
       ...EXTRACTED,

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -135,6 +135,8 @@ export default function LogSession() {
   const [durationChoice, setDurationChoice] = useState('50')
   const durationChoiceRef = useRef('50')
   const latestFieldsRef = useRef({ actualContent: '', generalNotes: '', homeworkAssigned: '', nextSessionTopics: '' })
+  const sessionDateRef = useRef(sessionDate)
+  const sessionTimeRef = useRef(sessionTime)
   const [durationOther, setDurationOther] = useState('')
   const [isCancelled, setIsCancelled] = useState(false)
   const [prevHomeworkStatus, setPrevHomeworkStatus] = useState<string | null>(null)
@@ -182,6 +184,8 @@ export default function LogSession() {
 
   // Edit mode: track whether we've initialized form state from the fetched session
   const [didInitEdit, setDidInitEdit] = useState(false)
+  // Create mode: track whether we've pre-populated actualContent from plannedForToday
+  const [didInitContent, setDidInitContent] = useState(false)
 
   // Data fetching
   const { data: student, isLoading: studentLoading } = useQuery({
@@ -284,6 +288,19 @@ export default function LogSession() {
   useEffect(() => {
     latestFieldsRef.current = { actualContent, generalNotes, homeworkAssigned, nextSessionTopics }
   }, [actualContent, generalNotes, homeworkAssigned, nextSessionTopics])
+  // Keep sessionDateRef and sessionTimeRef current so extraction callbacks read the value the teacher
+  // may have edited while extraction was in flight, not the stale closure value from when extraction started
+  useEffect(() => { sessionDateRef.current = sessionDate }, [sessionDate])
+  useEffect(() => { sessionTimeRef.current = sessionTime }, [sessionTime])
+
+  // In create mode, pre-populate actualContent from the previous session's planned topics once data loads
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    if (isEditMode || didInitContent || sessionsLoading) return
+    setDidInitContent(true)
+    if (plannedForToday) setActualContent(prev => prev || plannedForToday)
+  }, [isEditMode, didInitContent, sessionsLoading, plannedForToday])
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   // Autosave setup - keep ref current after every render (StudentForm pattern)
   const getFormDataRef = useRef<(() => CreateSessionLogRequest) | null>(null)
@@ -962,8 +979,8 @@ export default function LogSession() {
                       saveOverride.suggestedDifficulties = extracted.suggestedDifficulties
                       setSuggestedDifficulties(extracted.suggestedDifficulties)
                     }
-                    const nextDate = extracted.sessionDate || sessionDate
-                    const nextTime = extracted.sessionStartTime || sessionTime
+                    const nextDate = extracted.sessionDate || sessionDateRef.current
+                    const nextTime = extracted.sessionStartTime || sessionTimeRef.current
                     if (extracted.sessionDate) setSessionDate(extracted.sessionDate)
                     if (extracted.sessionStartTime) setSessionTime(extracted.sessionStartTime)
                     if (extracted.sessionDate || extracted.sessionStartTime) {


### PR DESCRIPTION
## Summary

- Adds `sessionDateRef` and `sessionTimeRef` so the voice note extraction `.then()` callback reads the value the teacher currently has in the date/time fields, not the stale closure value captured when extraction started. This prevents a racing scenario where the teacher edits the date or time while a 5-10 second extraction is in flight and the extraction result overwrites the manual change.
- Adds a create-mode `useEffect` (with `didInitContent` guard, matching the existing `didInitEdit` pattern) that pre-populates `actualContent` from `plannedForToday` once session data loads. Runs exactly once; `prev => prev || plannedForToday` guards against overwriting user-typed content.
- Adds 3 new unit tests: date stale-closure scenario, time stale-closure scenario, and create-mode pre-populate behaviour.

## Test plan

- [ ] `npm test` passes (87 files, 1337+ tests)
- [ ] Open LogSession for a student with a previous session that has `nextSessionTopics` — the `actualContent` textarea should start pre-filled with those topics
- [ ] Start a voice recording that triggers extraction, then manually change the date picker during the ~5s extraction window — the manually entered date should persist after extraction completes
- [ ] Start a voice recording, manually change the time picker during extraction — the manually entered time should persist after extraction completes

Closes #841

🤖 Generated with [Claude Code](https://claude.com/claude-code)