### PR TITLE
feat(#840): Edit Student UX polish - MultiSelect summary and Focus Areas description

### DIFF
--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -493,6 +493,19 @@ describe('StudentProfileTab', () => {
       expect(screen.getByText('subjuntivo')).toBeInTheDocument()
     })
 
+    it('shows description as muted secondary line when subcategory and description are both set', () => {
+      renderProfile(FULL_STUDENT)
+      // d1 has subcategory 'subjuntivo' and description 'Subjuntivo en concesivas'
+      expect(screen.getByText('subjuntivo')).toBeInTheDocument()
+      expect(screen.getByText('Subjuntivo en concesivas')).toBeInTheDocument()
+    })
+
+    it('shows description as primary text when subcategory is empty', () => {
+      renderProfile(FULL_STUDENT)
+      // d2 has empty subcategory and description 'Registro formal'
+      expect(screen.getByText('Registro formal')).toBeInTheDocument()
+    })
+
     it('renders trend badge with capitalized value', () => {
       renderProfile(FULL_STUDENT)
       expect(screen.getByText('Stable')).toBeInTheDocument()

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -718,7 +718,14 @@ export function StudentProfileTab({
                               return (
                                 <tr key={d.id} data-testid="difficulty-row" className="hover:bg-[#FAFAFA] transition-colors">
                                   <td className="px-4 py-3 font-semibold text-[#1A1B22] align-top">{d.competency}</td>
-                                  <td className="px-4 py-3 text-zinc-600 align-top">{d.subcategory || d.description}</td>
+                                  <td className="px-4 py-3 text-zinc-600 align-top">
+                                    <div>
+                                      <span>{d.subcategory || d.description}</span>
+                                      {d.subcategory && d.description && (
+                                        <span className="block text-xs text-zinc-400 mt-0.5">{d.description}</span>
+                                      )}
+                                    </div>
+                                  </td>
                                   <td className="px-4 py-3 align-top">
                                     <span className={`inline-block text-xs font-bold rounded px-1.5 py-0.5 ${trendColor}`}>
                                       {trendLabel}

--- a/frontend/src/components/ui/multi-select.test.tsx
+++ b/frontend/src/components/ui/multi-select.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { MultiSelect } from './multi-select'
+
+const OPTIONS = [
+  { value: 'es', label: 'Spanish' },
+  { value: 'en', label: 'English' },
+  { value: 'fr', label: 'French' },
+]
+
+function renderSelect(selected: string[]) {
+  return render(
+    <MultiSelect
+      options={OPTIONS}
+      selected={selected}
+      onChange={() => {}}
+      placeholder="Select languages"
+      triggerId="test-trigger"
+      chipTestId="test-chip"
+    />
+  )
+}
+
+describe('MultiSelect trigger summary', () => {
+  it('shows placeholder when nothing is selected', () => {
+    renderSelect([])
+    expect(screen.getByTestId('test-trigger')).toHaveTextContent('Select languages')
+  })
+
+  it('shows the language name when 1 is selected', () => {
+    renderSelect(['es'])
+    expect(screen.getByTestId('test-trigger')).toHaveTextContent('Spanish')
+  })
+
+  it('shows "FirstLanguage +1 more" when 2 are selected', () => {
+    renderSelect(['es', 'en'])
+    expect(screen.getByTestId('test-trigger')).toHaveTextContent('Spanish +1 more')
+  })
+
+  it('shows "FirstLanguage +2 more" when 3 are selected', () => {
+    renderSelect(['es', 'en', 'fr'])
+    expect(screen.getByTestId('test-trigger')).toHaveTextContent('Spanish +2 more')
+  })
+})

--- a/frontend/src/components/ui/multi-select.tsx
+++ b/frontend/src/components/ui/multi-select.tsx
@@ -88,7 +88,11 @@ export function MultiSelect({
           data-testid={triggerId}
           className="flex w-full max-w-sm items-center justify-between rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-500 hover:bg-zinc-50"
         >
-          {selected.length === 0 ? placeholder : `${selected.length} selected`}
+          {selected.length === 0
+            ? placeholder
+            : selected.length === 1
+              ? (options.find((o) => o.value === selected[0])?.label ?? selected[0])
+              : `${options.find((o) => o.value === selected[0])?.label ?? selected[0]} +${selected.length - 1} more`}
           <ChevronsUpDown className="h-4 w-4 shrink-0 opacity-50" />
         </PopoverTrigger>
         <PopoverContent className="w-64 max-w-[calc(100vw-2rem)] p-0 z-[60]" align="start" side="bottom">

--- a/plan/stabilisation/task840-edit-student-ux-polish.md
+++ b/plan/stabilisation/task840-edit-student-ux-polish.md
@@ -1,0 +1,43 @@
+# Task 840 — Edit Student Form UX Polish
+
+## Issue
+#840: polish: Edit Student form minor UX improvements (language combobox summary, Focus Areas description)
+
+## Changes
+
+### 1. MultiSelect trigger summary (`frontend/src/components/ui/multi-select.tsx` line 91)
+
+**Current:** `${selected.length} selected` for any non-zero selection.
+
+**Fix:** Show a meaningful label:
+- 0 selected: placeholder (unchanged)
+- 1 selected: label of the selected item (e.g. "Spanish")
+- 2+ selected: label of first item + rest count (e.g. "Spanish +2 more")
+
+Look up label via `options.find(o => o.value === selected[0])?.label ?? selected[0]`.
+
+### 2. Focus Areas table subcategory cell (`frontend/src/components/student/StudentProfileTab.tsx` line 721)
+
+**Current:** `{d.subcategory || d.description}` — description is hidden whenever subcategory is set.
+
+**Fix:** Show subcategory as primary, description as secondary muted line below when both are non-empty:
+```
+Verb forms
+Separable vs inseparable phrasal verbs   ← text-xs text-zinc-400
+```
+When subcategory is empty, keep existing fallback (description as primary, no secondary line).
+
+### 3. Unit tests (new file `frontend/src/components/ui/multi-select.test.tsx`)
+
+Cover the trigger label logic:
+- 0 items: shows placeholder
+- 1 item: shows the item's label
+- 2 items: shows "FirstLabel +1 more"
+- 3 items: shows "FirstLabel +2 more"
+
+## Acceptance Criteria Checklist
+- [ ] Combobox 2+ selected: "FirstLanguage +N more"
+- [ ] Combobox 1 selected: language name only
+- [ ] Focus Areas: description as muted secondary line when non-empty
+- [ ] No regressions in Edit Student form
+- [ ] Unit test covers 1, 2, 3+ selections


### PR DESCRIPTION
## Summary
- MultiSelect trigger now shows "FirstLanguage +N more" (2+ selected) or the language name (1 selected), replacing the generic "N selected" label
- Focus Areas table subcategory cell shows description as a muted secondary line (`text-xs text-zinc-400`) below subcategory when both fields are non-empty
- Added unit tests: 4 for MultiSelect summary logic, 2 for Focus Areas cell rendering

Closes #840

## Test plan
- [x] Build verify: all tests pass (88 passing, 0 failing)
- [x] qa-verify: PASS
- [x] Architecture review: PASS
- [x] UI review: PASS (combobox shows "Portuguese +1 more", Focus Areas shows muted description lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MultiSelect dropdown now displays the first selected item label instead of a simple count when selections are made.
  * StudentProfileTab now displays both subcategory and description information together when both are available.

* **Tests**
  * Added test coverage for MultiSelect trigger label behavior.
  * Added test coverage for StudentProfileTab difficulty description rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->