### PR TITLE
fix(#849): UI labeling polish - Settings H1, T-ENGLISH tooltip, Dashboard subtitle casing

### DIFF
--- a/e2e/tests/dashboard.spec.ts
+++ b/e2e/tests/dashboard.spec.ts
@@ -126,7 +126,7 @@ test('sidebar nav links navigate to correct routes', async ({ browser }) => {
   // Nav -> Settings
   await nav.getByRole('link', { name: 'Settings', exact: true }).click()
   await expect(page).toHaveURL('/settings', { timeout: UI_TIMEOUT })
-  await expect(page.locator('h1')).toHaveText('My Profile', { timeout: UI_TIMEOUT })
+  await expect(page.locator('h1')).toHaveText('Settings', { timeout: UI_TIMEOUT })
 
   // Nav -> Dashboard
   await nav.getByRole('link', { name: 'Dashboard', exact: true }).click()

--- a/e2e/tests/teacher-profile.spec.ts
+++ b/e2e/tests/teacher-profile.spec.ts
@@ -27,7 +27,7 @@ test('teacher can save and reload profile settings', async ({ browser }) => {
   const apiBase = process.env.VITE_API_BASE_URL ?? 'http://localhost:5000'
 
   await page.goto('/settings')
-  await expect(page.locator('h1')).toHaveText('My Profile')
+  await expect(page.locator('h1')).toHaveText('Settings')
 
   // Wait for profile to finish loading AND populating the form.
   // The input only appears after isLoading=false, but a React Query background

--- a/frontend/src/components/student/StudentOverviewTab.test.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { StudentOverviewTab } from './StudentOverviewTab'
 import type { Student } from '@/api/students'
 import type { SessionLog } from '@/api/sessionLogs'
@@ -59,9 +60,11 @@ function renderOverview(student: Student, sessions?: SessionLog[], followups?: i
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter>
-        <StudentOverviewTab student={student} sessions={sessions} followups={followups} onStudentChange={() => {}} />
-      </MemoryRouter>
+      <TooltipProvider>
+        <MemoryRouter>
+          <StudentOverviewTab student={student} sessions={sessions} followups={followups} onStudentChange={() => {}} />
+        </MemoryRouter>
+      </TooltipProvider>
     </QueryClientProvider>
   )
 }

--- a/frontend/src/components/student/StudentOverviewTab.test.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -120,6 +121,14 @@ describe('StudentOverviewTab - PedagogicalProfileCard', () => {
     const tagsSection = screen.getByTestId('language-tags')
     expect(tagsSection).toHaveTextContent('L-UKRAINIAN')
     expect(tagsSection).toHaveTextContent('T-SPANISH')
+  })
+
+  it('shows tooltip explaining target language on hover', async () => {
+    const user = userEvent.setup()
+    renderOverview({ ...BASE_STUDENT, learningLanguage: 'Spanish' })
+    const tag = screen.getByTestId('target-language-tag')
+    await user.hover(tag)
+    expect(await screen.findByText(/target language.*spanish/i)).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/student/StudentOverviewTab.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.tsx
@@ -8,6 +8,7 @@ import { StudentFollowupsCard } from './StudentFollowupsCard'
 import { CefrBadge } from '@/components/dashboard/CefrBadge'
 import { SectionHeader } from './SectionHeader'
 import { formatMonthYear } from '@/utils/formatDate'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { CEFR_ORDER } from '@/utils/cefrUtils'
 import { getDisplayTitle } from '@/lib/sessionUtils'
 import { rotatingPrompt } from '@/utils/rotatingPrompt'
@@ -135,12 +136,19 @@ function PedagogicalProfileCard({ student }: { student: Student }) {
             L-{lang.toUpperCase()}
           </span>
         ))}
-        <span
-          className="bg-[#D0F4DE] text-[#1A6636] rounded-md px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide"
-          data-testid="target-language-tag"
-        >
-          T-{student.learningLanguage.toUpperCase()}
-        </span>
+        <Tooltip>
+          <TooltipTrigger render={<span />}>
+            <span
+              className="bg-[#D0F4DE] text-[#1A6636] rounded-md px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide cursor-default"
+              data-testid="target-language-tag"
+            >
+              T-{student.learningLanguage.toUpperCase()}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            Target language: this student is being taught in {student.learningLanguage}
+          </TooltipContent>
+        </Tooltip>
       </div>
     </div>
   )

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -103,6 +103,13 @@ describe('Dashboard', () => {
     expect(await screen.findByRole('heading', { name: 'Dashboard' })).toBeInTheDocument()
   })
 
+  it('renders subtitle in sentence case without uppercase transform', async () => {
+    renderDashboard()
+    const subtitle = await screen.findByText('Your teaching command center')
+    expect(subtitle).toBeInTheDocument()
+    expect(subtitle.className).not.toContain('uppercase')
+  })
+
   it('shows slow connection message after 5 seconds', () => {
     vi.useFakeTimers()
     mockGetDashboard.mockReturnValue(new Promise(() => {}))

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -62,7 +62,7 @@ export default function Dashboard() {
     <div className="space-y-5">
       <div>
         <h1 className="font-manrope text-[1.75rem] font-bold text-[#1A1B22]">Dashboard</h1>
-        <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mt-1">
+        <p className="text-[0.6875rem] font-bold tracking-[0.05em] text-zinc-400 font-inter mt-1">
           Your teaching command center
         </p>
       </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -116,7 +116,7 @@ export default function Settings() {
   return (
     <div className="max-w-2xl space-y-6">
       <PageHeader
-        title="My Profile"
+        title="Settings"
         subtitle="Configure how you appear to students and set your teaching preferences."
         actions={
           <div className="flex items-center gap-3">

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -14,5 +14,7 @@ Out-of-scope observations logged by agents during implementation. Each row is so
 | #837 | 2026-04-22 | low | StudentRoster.tsx has local formatRelativeDate not yet refactored to use relativeTime — filed #861 |
 | #852 | 2026-04-22 | low | StudentsController (4x) and CoursesController still use ValidationProblem/BadRequest(rawString) for ValidationException — filed #871 |
 | #846 | 2026-04-22 | low | PromptService.cs lines 473-478: L1 sub-bullets (differs-from-native, false cognates, common errors) hardcoded in C# system prompt; overlaps with config-driven L1Adjustments block appended to user prompts. Predates #846; worth consolidating into the data-driven path. |
+| #849 | 2026-04-22 | low | Root .dockerignore excludes frontend/ in worktrees, requiring manual bypass during UI review docker build; pre-existing worktree build infrastructure gap. |
+| #849 | 2026-04-22 | low | E2E test student-detail-session-expanded fails on session-title-input not found; pre-existing, unrelated to labeling changes. |
 
 *Cleared 2026-04-22 during UI Redesign & Student Profile Polish sprint close. Actionable entries batched into: #833 (bug batch), #834 (seeder gaps), #835 (e2e session-log rewrite), #836 (ScenarioSeeder Hans B1), #837 (deduplication), #838 (session title from web UI), #839 (debug log privacy), #840 (Edit Student UX), #841 (stale closure + LogSession pre-populate). Already-tracked entries removed (referenced #737/#707/#644/#714/#715/#716/#683/#741/#742/#756/#809/#657). Dismissed entries removed (defensive-only, intentional, or resolved).*

--- a/plan/stabilisation/task849-ui-labeling-polish.md
+++ b/plan/stabilisation/task849-ui-labeling-polish.md
@@ -1,0 +1,12 @@
+# Task 849: UI Labeling Inconsistencies
+
+## Changes
+
+1. **Settings page H1**: `Settings.tsx` - `title="My Profile"` → `title="Settings"`
+2. **T-ENGLISH tooltip**: `StudentOverviewTab.tsx` - wrapped target-language-tag span with `Tooltip/TooltipTrigger/TooltipContent`; text: "Target language: this student is being taught in {language}"
+3. **Dashboard subtitle casing**: `Dashboard.tsx` - removed `uppercase` class from subtitle paragraph
+
+## Tests updated
+- `e2e/tests/dashboard.spec.ts` - h1 assertion changed to "Settings"
+- `e2e/tests/teacher-profile.spec.ts` - h1 assertion changed to "Settings"
+- `frontend/src/components/student/StudentOverviewTab.test.tsx` - added tooltip hover test


### PR DESCRIPTION
## Summary
- Settings page H1 changed from "My Profile" to "Settings" (canonical name per issue decision)
- T-ENGLISH / T-{language} badge in StudentOverviewTab wrapped with tooltip: "Target language: this student is being taught in {language}"
- Dashboard subtitle `uppercase` CSS class removed so "Your teaching command center" renders in sentence case, matching other page subtitles

## Test plan
- [ ] Settings page at `/settings` shows h1 "Settings"
- [ ] Student detail Overview tab shows T-ENGLISH badge with tooltip on hover
- [ ] Dashboard subtitle renders in sentence case (not all-caps)
- Unit tests: Dashboard subtitle casing, StudentOverviewTab tooltip hover
- E2e tests updated for Settings h1 assertion

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tooltip on target-language tag shows the student's learning language on hover.

* **Bug Fixes**
  * Settings page header changed from "My Profile" to "Settings".
  * Dashboard subtitle no longer uses uppercase styling.

* **Tests**
  * Updated end-to-end assertions for Settings navigation.
  * Added tests for tooltip interaction and Dashboard subtitle validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->