### PR TITLE
fix(#850): visual polish batch — sentinel guard, truncation, PREVIEW badge, cancelled callout

### DIFF
--- a/e2e/tests/visual/student-detail.visual.spec.ts
+++ b/e2e/tests/visual/student-detail.visual.spec.ts
@@ -122,3 +122,20 @@ test('@visual student detail sessions tab - expanded row with editable fields', 
   expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)
   await context.close()
 })
+
+test('@visual student detail overview tab - with sessions', async ({ browser }) => {
+  fs.mkdirSync('screenshots', { recursive: true })
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  const consoleErrors: string[] = []
+  page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()) })
+
+  await page.goto(`/students/${studentWithSessionsId}`)
+  await expect(page.getByTestId('student-detail-name')).toBeVisible({ timeout: NAV_TIMEOUT })
+  await expect(page.getByTestId('student-overview-tab')).toBeVisible({ timeout: UI_TIMEOUT })
+  await expect(page.getByTestId('recent-sessions')).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.screenshot({ path: 'screenshots/student-detail-overview-sessions.png', fullPage: true })
+
+  expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)
+  await context.close()
+})

--- a/frontend/src/components/student/ProgressDashboard.tsx
+++ b/frontend/src/components/student/ProgressDashboard.tsx
@@ -359,7 +359,7 @@ export function ProgressDashboard({ student, sessions }: Props) {
                               <div className="flex flex-col gap-0.5 mr-2 min-w-0 cursor-default" />
                             }
                           >
-                            <span className="text-xs font-bold text-[#1A1B22] truncate max-w-[140px] block">
+                            <span className="text-xs font-bold text-[#1A1B22] block">
                               {d.description}
                             </span>
                             <span className="text-[0.5625rem] font-bold uppercase text-zinc-400 block">

--- a/frontend/src/components/student/StudentProfileOverview.tsx
+++ b/frontend/src/components/student/StudentProfileOverview.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button'
 import { CefrBadge } from '@/components/dashboard/CefrBadge'
 import { cn } from '@/lib/utils'
 import type { Student } from '@/api/students'
-import { parseNotes } from './studentNoteUtils'
+import { parseNotes, isSentinel } from './studentNoteUtils'
 import { langCode } from './langUtils'
 
 const SKILL_ORDER = ['Reading', 'Writing', 'Speaking', 'Listening']
@@ -42,7 +42,7 @@ function FieldRow({ label, children }: { label: string; children: React.ReactNod
 }
 
 export function StudentProfileOverview({ student, onToggleDifficultyStatus }: Props) {
-  const parsedPersonalNotes = parseNotes(student.personalNotes)
+  const parsedPersonalNotes = parseNotes(isSentinel(student.personalNotes) ? null : student.personalNotes)
   const parsedTeachingNotes = parseNotes(student.teachingNotes)
 
   return (

--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -350,6 +350,16 @@ describe('StudentProfileTab', () => {
       expect(screen.queryByTestId('profile-teachers-working-memory')).not.toBeInTheDocument()
     })
 
+    it('is hidden when personalNotes is a sentinel string', () => {
+      renderProfile({ ...EMPTY_STUDENT, personalNotes: '[visual-seed]' })
+      expect(screen.queryByTestId('profile-teachers-working-memory')).not.toBeInTheDocument()
+    })
+
+    it('does not render sentinel personalNotes text', () => {
+      renderProfile({ ...EMPTY_STUDENT, personalNotes: '[scenario-seed]' })
+      expect(screen.queryByText('[scenario-seed]')).not.toBeInTheDocument()
+    })
+
     it('shows when revealed via show-all toggle', () => {
       renderProfile(EMPTY_STUDENT)
       const toggle = screen.getByTestId('show-empty-sections-btn')

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -4,7 +4,7 @@ import { Pencil, X, Plus, Check, GraduationCap, ChevronDown } from 'lucide-react
 import { Badge } from '@/components/ui/badge'
 import type { Student } from '@/api/students'
 import type { TeacherFollowup } from '@/api/followups'
-import { parseNotes } from './studentNoteUtils'
+import { parseNotes, isSentinel } from './studentNoteUtils'
 import { TeachingTodosCard } from './TeachingTodosCard'
 import { StudentFollowupsCard } from './StudentFollowupsCard'
 import { getObjectiveUrgency } from '@/lib/objectiveUrgency'
@@ -14,12 +14,6 @@ import { langCode } from './langUtils'
 import { SavedIndicator } from '@/components/ui/SavedIndicator'
 
 const SKILL_ORDER = ['Reading', 'Writing', 'Speaking', 'Listening']
-
-function isSentinel(s: string | null | undefined): boolean {
-  if (!s) return false
-  const t = s.trim()
-  return t.startsWith('[') && t.endsWith(']')
-}
 
 interface Props {
   student: Student

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -15,6 +15,12 @@ import { SavedIndicator } from '@/components/ui/SavedIndicator'
 
 const SKILL_ORDER = ['Reading', 'Writing', 'Speaking', 'Listening']
 
+function isSentinel(s: string | null | undefined): boolean {
+  if (!s) return false
+  const t = s.trim()
+  return t.startsWith('[') && t.endsWith(']')
+}
+
 interface Props {
   student: Student
   followups?: TeacherFollowup[]
@@ -527,7 +533,8 @@ export function StudentProfileTab({
 }: Props) {
   const [showEmptySections, setShowEmptySections] = useState(false)
 
-  const parsedPersonalNotes = parseNotes(student.personalNotes)
+  const safePersonalNotes = isSentinel(student.personalNotes) ? null : student.personalNotes
+  const parsedPersonalNotes = parseNotes(safePersonalNotes)
   const parsedTeachingNotes = parseNotes(student.teachingNotes)
 
   const hasAbout = !!(
@@ -538,7 +545,7 @@ export function StudentProfileTab({
     student.countryOfResidence ||
     student.cityOfResidence
   )
-  const hasWorkingMemory = !!(student.personalNotes || student.teachingNotes)
+  const hasWorkingMemory = !!(safePersonalNotes || student.teachingNotes)
 
   const location = [student.cityOfResidence, student.countryOfResidence].filter(Boolean).join(', ')
   const origin = [student.cityOfOrigin, student.countryOfOrigin].filter(Boolean).join(', ')
@@ -809,7 +816,7 @@ export function StudentProfileTab({
 
               <div className="space-y-6">
                 {/* Personal notes (Sensitivities / Life Context) */}
-                {(parsedPersonalNotes || student.personalNotes) && (
+                {(parsedPersonalNotes || safePersonalNotes) && (
                   <div>
                     <p className="text-[0.625rem] font-bold uppercase tracking-widest text-white/50 mb-2">
                       Sensitivities / Life Context
@@ -826,14 +833,14 @@ export function StudentProfileTab({
                         ))}
                       </div>
                     ) : (
-                      <p className="text-sm text-white/90 whitespace-pre-wrap leading-relaxed">{student.personalNotes}</p>
+                      <p className="text-sm text-white/90 whitespace-pre-wrap leading-relaxed">{safePersonalNotes}</p>
                     )}
                   </div>
                 )}
 
                 {/* Teaching notes (Pedagogical Observations) */}
                 {(parsedTeachingNotes || student.teachingNotes) && (
-                  <div className={parsedPersonalNotes || student.personalNotes ? 'pt-4 border-t border-white/10' : ''}>
+                  <div className={parsedPersonalNotes || safePersonalNotes ? 'pt-4 border-t border-white/10' : ''}>
                     <p className="text-[0.625rem] font-bold uppercase tracking-widest text-white/50 mb-2">
                       Pedagogical Observations
                     </p>
@@ -856,7 +863,7 @@ export function StudentProfileTab({
                   </div>
                 )}
 
-                {!student.personalNotes && !student.teachingNotes && (
+                {!safePersonalNotes && !student.teachingNotes && (
                   <p className="text-sm text-white/40 italic">No notes added yet</p>
                 )}
               </div>

--- a/frontend/src/components/student/studentNoteUtils.ts
+++ b/frontend/src/components/student/studentNoteUtils.ts
@@ -1,3 +1,9 @@
+export function isSentinel(s: string | null | undefined): boolean {
+  if (!s) return false
+  const t = s.trim()
+  return t.startsWith('[') && t.endsWith(']')
+}
+
 export interface ParsedNotes {
   sections: { label: string; text: string }[]
 }

--- a/frontend/src/pages/LogSession.test.tsx
+++ b/frontend/src/pages/LogSession.test.tsx
@@ -286,6 +286,17 @@ describe('LogSession', () => {
     })
   })
 
+  it('shows amber callout message when cancelled toggle is clicked', async () => {
+    renderLogSession()
+    await screen.findByTestId('cancelled-toggle')
+    fireEvent.click(screen.getByTestId('cancelled-toggle'))
+    await waitFor(() => {
+      expect(screen.getByText(/This session was cancelled/)).toBeInTheDocument()
+    })
+    const callout = screen.getByText(/This session was cancelled/).closest('div')
+    expect(callout?.className).toContain('bg-amber-50')
+  })
+
   it('calls createSession with correct payload when Done is clicked after typing', async () => {
     renderLogSession()
     await screen.findByTestId('actual-content')

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -1476,7 +1476,7 @@ export default function LogSession() {
           {/* Cancelled session: minimal fields */}
           {isCancelled && (
             <div className="space-y-1">
-              <p className="text-sm text-zinc-400 italic">This session was cancelled. Only date, duration, topics covered and notes will be recorded.</p>
+              <div className="bg-amber-50 rounded p-3 text-sm text-amber-800">This session was cancelled. Only date, duration, topics covered and notes will be recorded.</div>
 
               {/* Topics Covered */}
               <div className="space-y-1 pt-4">

--- a/frontend/src/pages/StudyView.tsx
+++ b/frontend/src/pages/StudyView.tsx
@@ -38,7 +38,7 @@ export default function StudyView() {
           title={lesson.title}
           titleTestId="study-title"
           actions={
-            <Badge variant="outline" className="text-xs font-medium text-zinc-500 border-zinc-300 uppercase tracking-wide">Preview</Badge>
+            <Badge variant="outline" className="text-xs font-medium text-indigo-600 border-indigo-300 bg-indigo-50 uppercase tracking-wide">Preview</Badge>
           }
         />
       </div>

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -8,6 +8,7 @@ Out-of-scope observations logged by agents during implementation. Each row is so
 | #848 | 2026-04-22 | low | Issue #848 AC requested visible STATUS label above Cancelled toggle; design-system.md 11.3 prohibits this; AC was fulfilled via invisible spacer for alignment instead |
 | #838 | 2026-04-22 | low | LogSession: checkboxes in Teaching Todos/Followups left panel use native input instead of design-system custom controls (pre-existing) |
 | #838 | 2026-04-22 | low | LogSession: local ToggleSwitch focus ring uses ring-indigo-500 instead of ring-indigo-600 (pre-existing, design-system 11.5) |
+| #850 | 2026-04-23 | low | LogSession.test.tsx "date defaults to today" fails at ~midnight UTC due to UTC vs local timezone mismatch in date comparison; pre-existing flaky test |
 | #837 | 2026-04-22 | low | TeachingTodosCard.tsx has local relativeTime duplicating formatDate.ts — filed #860 |
 | #844 | 2026-04-22 | low | TeachingTodoDto projection duplicated in StudentService.ToTodo() and DashboardService inline LINQ (EF Core constraint) — filed #869 |
 | #844 | 2026-04-22 | low | TeacherFollowup.Kind has no DB CHECK constraint; only DTO regex guards API path — filed #870 |

--- a/plan/stabilisation/task850-visual-polish-batch.md
+++ b/plan/stabilisation/task850-visual-polish-batch.md
@@ -1,0 +1,39 @@
+# Task 850: Visual Polish Batch
+
+## Issue
+https://github.com/Robert-Freire/langTeachSaaS/issues/850
+
+## Fixes
+
+### 1. Sentinel guard in SENSITIVITIES (StudentProfileTab.tsx)
+- Add `isSentinel(s)` helper: true if string starts with `[` and ends with `]`
+- Filter `personalNotes` through sentinel check before rendering in Teacher's Working Memory
+
+### 2. Difficulty label truncation (ProgressDashboard.tsx)
+- Line 362: remove `truncate max-w-[140px]` from the difficulty description span
+- Tooltip already exists for hover, so full text shows on hover
+
+### 3. PREVIEW badge contrast (StudyView.tsx)
+- Line 41: change badge from grey outline to indigo outline style
+
+### 4. Cancelled-state callout (LogSession.tsx)
+- Line ~1479: replace italic grey text with amber callout box
+
+### 5. Official Level select
+- Already uses shadcn Select via PR #877 (task #840). AC already satisfied.
+
+### 6. Spec fixture update
+- Add `@visual student detail - overview with sessions` test to student-detail.visual.spec.ts
+- Uses Diego Seed (who has session logs), screenshots to `screenshots/student-detail-overview-sessions.png`
+
+## Tests to add/update
+- StudentProfileTab.test.tsx: add test for sentinel guard (personalNotes = '[visual-seed]' -> not shown)
+- LogSession.test.tsx: update cancelled-state test to check for amber callout
+- StudyView.tsx: no existing unit test file; skip (covered by visual e2e)
+- ProgressDashboard: tooltip test already exists; no additional test needed
+
+## E2E
+- student-detail.visual.spec.ts: add overview-with-sessions screenshot test
+
+## Review routing
+- area:frontend: architecture-reviewer + review-ui


### PR DESCRIPTION
## Summary

- **Sentinel guard**: `isSentinel()` added to `studentNoteUtils.ts` and applied in both `StudentProfileTab` and `StudentProfileOverview` — personalNotes values like `[visual-seed]` no longer render in Teacher's Working Memory
- **Difficulty truncation**: removed `truncate max-w-[140px]` from Progress tab DIFFICULTIES sidebar; tooltip still provides full text on hover
- **PREVIEW badge**: changed from grey outline (`text-zinc-500 border-zinc-300`) to indigo (`text-indigo-600 border-indigo-300 bg-indigo-50`) in Study View
- **Cancelled callout**: replaced italic grey `<p>` with `bg-amber-50 rounded p-3 text-sm text-amber-800` callout box in Log Session
- **Spec fixture**: added `@visual student detail overview tab - with sessions` test to `student-detail.visual.spec.ts` (post-sprint layout with recent-sessions widget)
- Official Level AC: already satisfied by PR #877 (task #840) — no native `<select>` present

## Test plan

- [ ] Unit: `StudentProfileTab.test.tsx` — two new sentinel guard tests pass
- [ ] Unit: `LogSession.test.tsx` — new amber callout test passes
- [ ] E2E visual: `student-detail.visual.spec.ts` — new overview-with-sessions screenshot test
- [ ] UI review: PASS (PREVIEW badge indigo, cancelled callout amber, sentinel not visible on Ana Visual, difficulty labels not truncated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)