### PR TITLE
feat(#853): extract createStudentViaUI and createStudentViaApi e2e helpers

### DIFF
--- a/e2e/helpers/students.ts
+++ b/e2e/helpers/students.ts
@@ -1,0 +1,58 @@
+import { Page, expect } from '@playwright/test'
+import { NAV_TIMEOUT, UI_TIMEOUT } from './timeouts'
+
+const API_BASE = process.env.VITE_API_BASE_URL ?? 'http://localhost:5000'
+
+export interface CreateStudentUIOptions {
+  name: string
+  language: string
+  cefrLevel: string
+  nativeLanguage?: string
+}
+
+export async function createStudentViaUI(
+  page: Page,
+  options: CreateStudentUIOptions
+): Promise<void> {
+  const { name, language, cefrLevel, nativeLanguage } = options
+  await page.goto('/students/new')
+  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: NAV_TIMEOUT })
+  await page.getByTestId('student-name').fill(name)
+  await page.getByTestId('student-language').click()
+  await page.getByRole('option', { name: language }).click()
+  await page.getByTestId('student-cefr').click()
+  await page.getByRole('option', { name: cefrLevel }).click()
+  if (nativeLanguage) {
+    await page.getByTestId('student-native-language').click()
+    await page.getByRole('option', { name: nativeLanguage }).click()
+    await page.keyboard.press('Escape')
+  }
+  await page.getByRole('button', { name: 'Save Student' }).click()
+  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
+}
+
+export interface CreateStudentApiOptions {
+  name: string
+  language?: string
+  cefrLevel?: string
+}
+
+export async function createStudentViaApi(
+  page: Page,
+  options: CreateStudentApiOptions
+): Promise<{ id: string; name: string }> {
+  const res = await page.request.post(`${API_BASE}/api/students`, {
+    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
+    data: {
+      name: options.name,
+      learningLanguage: options.language ?? 'Spanish',
+      cefrLevel: options.cefrLevel ?? 'B1',
+      interests: [],
+      learningGoals: [],
+      weaknesses: [],
+      difficulties: [],
+    },
+  })
+  expect(res.ok()).toBeTruthy()
+  return res.json() as Promise<{ id: string; name: string }>
+}

--- a/e2e/tests/followups.spec.ts
+++ b/e2e/tests/followups.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test'
 import { createMockAuthContext } from '../helpers/auth-helper'
 import { setupMockTeacher } from '../helpers/mock-teacher-helper'
 import { UI_TIMEOUT, NAV_TIMEOUT } from '../helpers/timeouts'
+import { createStudentViaUI } from '../helpers/students'
 
 test.beforeAll(async ({ browser }) => {
   const ctx = await createMockAuthContext(browser)
@@ -18,19 +19,7 @@ test('followup happy path: create, appear on dashboard, mark done', async ({ bro
   try {
     // Step 1: Create a student to attach the followup to
     const studentName = `Followup Test ${Date.now()}`
-    await page.goto('/students/new')
-    await expect(page.locator('h1')).toHaveText('Add Student', { timeout: NAV_TIMEOUT })
-    await page.getByTestId('student-name').fill(studentName)
-    await page.getByTestId('student-language').click()
-    await page.getByRole('option', { name: 'Spanish' }).click()
-    await page.getByTestId('student-cefr').click()
-    await page.getByRole('option', { name: 'A1' }).click()
-    await page.getByTestId('student-native-language').click()
-    await page.getByRole('option', { name: 'English' }).click()
-    await page.keyboard.press('Escape')
-    await page.getByRole('button', { name: 'Save Student' }).click()
-
-    await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
+    await createStudentViaUI(page, { name: studentName, language: 'Spanish', cefrLevel: 'A1', nativeLanguage: 'English' })
     await expect(page.getByTestId('tab-profile')).toBeVisible({ timeout: UI_TIMEOUT })
 
     // Step 2: Add a followup from the Profile tab

--- a/e2e/tests/session-log.spec.ts
+++ b/e2e/tests/session-log.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test'
 import { createMockAuthContext } from '../helpers/auth-helper'
 import { setupMockTeacher } from '../helpers/mock-teacher-helper'
 import { NAV_TIMEOUT, UI_TIMEOUT, FEEDBACK_TIMEOUT } from '../helpers/timeouts'
+import { createStudentViaApi } from '../helpers/students'
 
 const API_BASE = process.env.VITE_API_BASE_URL ?? 'http://localhost:5000'
 
@@ -18,20 +19,7 @@ test('log session from student detail page', async ({ browser }) => {
   const page = await context.newPage()
 
   const studentName = `Session Test Student ${Date.now()}`
-  const createRes = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: {
-      name: studentName,
-      learningLanguage: 'Spanish',
-      cefrLevel: 'B1',
-      interests: [],
-      learningGoals: [],
-      weaknesses: [],
-      difficulties: [],
-    },
-  })
-  expect(createRes.ok()).toBeTruthy()
-  const student = await createRes.json()
+  const student = await createStudentViaApi(page, { name: studentName })
 
   await page.goto(`/students/${student.id}`)
   await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
@@ -66,19 +54,7 @@ test('log session page: prev homework status shows when prev session has homewor
   const page = await context.newPage()
 
   const studentName = `Homework Cond Student ${Date.now()}`
-  const createRes = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: {
-      name: studentName,
-      learningLanguage: 'Spanish',
-      cefrLevel: 'A2',
-      interests: [],
-      learningGoals: [],
-      weaknesses: [],
-      difficulties: [],
-    },
-  })
-  const student = await createRes.json()
+  const student = await createStudentViaApi(page, { name: studentName, cefrLevel: 'A2' })
 
   // Create a prior session with homework
   await page.request.post(`${API_BASE}/api/students/${student.id}/sessions`, {
@@ -107,19 +83,7 @@ test('expand session entry shows full detail without duplicating preview content
   const page = await context.newPage()
 
   const studentName = `Expand Test Student ${Date.now()}`
-  const createRes = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: {
-      name: studentName,
-      learningLanguage: 'Spanish',
-      cefrLevel: 'B1',
-      interests: [],
-      learningGoals: [],
-      weaknesses: [],
-      difficulties: [],
-    },
-  })
-  const student = await createRes.json() as { id: string }
+  const student = await createStudentViaApi(page, { name: studentName })
 
   await page.request.post(`${API_BASE}/api/students/${student.id}/sessions`, {
     headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
@@ -161,19 +125,7 @@ test('delete session requires confirmation dialog', async ({ browser }) => {
   const page = await context.newPage()
 
   const studentName = `Delete Confirm Test ${Date.now()}`
-  const createRes = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: {
-      name: studentName,
-      learningLanguage: 'Spanish',
-      cefrLevel: 'A2',
-      interests: [],
-      learningGoals: [],
-      weaknesses: [],
-      difficulties: [],
-    },
-  })
-  const student = await createRes.json() as { id: string }
+  const student = await createStudentViaApi(page, { name: studentName, cefrLevel: 'A2' })
 
   await page.request.post(`${API_BASE}/api/students/${student.id}/sessions`, {
     headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
@@ -218,19 +170,7 @@ test('topic tag category dropdown has all four curriculum-aligned options', asyn
   const page = await context.newPage()
 
   const studentName = `Tag Category Test ${Date.now()}`
-  const createRes = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: {
-      name: studentName,
-      learningLanguage: 'Spanish',
-      cefrLevel: 'B1',
-      interests: [],
-      learningGoals: [],
-      weaknesses: [],
-      difficulties: [],
-    },
-  })
-  const student = await createRes.json() as { id: string }
+  const student = await createStudentViaApi(page, { name: studentName })
 
   await page.goto(`/students/${student.id}`)
   await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
@@ -261,14 +201,7 @@ test('future session date is accepted and appears in history', async ({ browser 
   const page = await context.newPage()
 
   const studentName = `Future Date Student ${Date.now()}`
-  const createRes = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: {
-      name: studentName, learningLanguage: 'Spanish', cefrLevel: 'B1',
-      interests: [], learningGoals: [], weaknesses: [], difficulties: [],
-    },
-  })
-  const student = await createRes.json() as { id: string }
+  const student = await createStudentViaApi(page, { name: studentName })
 
   await page.goto(`/students/${student.id}`)
   await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
@@ -299,20 +232,7 @@ test('selecting a lesson in log session page links it to the session', async ({ 
   const page = await context.newPage()
 
   const studentName = `Lesson Link Test ${Date.now()}`
-  const createStudentRes = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: {
-      name: studentName,
-      learningLanguage: 'Spanish',
-      cefrLevel: 'B1',
-      interests: [],
-      learningGoals: [],
-      weaknesses: [],
-      difficulties: [],
-    },
-  })
-  expect(createStudentRes.ok()).toBeTruthy()
-  const student = await createStudentRes.json() as { id: string }
+  const student = await createStudentViaApi(page, { name: studentName })
 
   // Create a lesson linked to this student
   const createLessonRes = await page.request.post(`${API_BASE}/api/lessons`, {
@@ -366,14 +286,7 @@ test('cancelled session shows Cancelled badge and is excluded from summary count
   const page = await context.newPage()
 
   const studentName = `Cancelled Session Student ${Date.now()}`
-  const createRes = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: {
-      name: studentName, learningLanguage: 'Spanish', cefrLevel: 'B1',
-      interests: [], learningGoals: [], weaknesses: [], difficulties: [],
-    },
-  })
-  const student = await createRes.json() as { id: string }
+  const student = await createStudentViaApi(page, { name: studentName })
 
   // Create a normal session and a cancelled session via API
   await page.request.post(`${API_BASE}/api/students/${student.id}/sessions`, {
@@ -418,14 +331,7 @@ test('un-cancel a session removes the Cancelled badge', async ({ browser }) => {
   const page = await context.newPage()
 
   const studentName = `Uncancel Student ${Date.now()}`
-  const createRes = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: {
-      name: studentName, learningLanguage: 'Spanish', cefrLevel: 'B1',
-      interests: [], learningGoals: [], weaknesses: [], difficulties: [],
-    },
-  })
-  const student = await createRes.json() as { id: string }
+  const student = await createStudentViaApi(page, { name: studentName })
 
   const sessionRes = await page.request.post(`${API_BASE}/api/students/${student.id}/sessions`, {
     headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
@@ -481,19 +387,7 @@ test('summary header appears on history tab after logging a session', async ({ b
   const page = await context.newPage()
 
   const studentName = `Summary Header Test ${Date.now()}`
-  const createRes = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: {
-      name: studentName,
-      learningLanguage: 'Spanish',
-      cefrLevel: 'B1',
-      interests: [],
-      learningGoals: [],
-      weaknesses: [],
-      difficulties: [],
-    },
-  })
-  const student = await createRes.json() as { id: string }
+  const student = await createStudentViaApi(page, { name: studentName })
 
   await page.request.post(`${API_BASE}/api/students/${student.id}/sessions`, {
     headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
@@ -536,19 +430,7 @@ test('confirming session with suggestedDifficulties upserts them to student prof
   const context = await createMockAuthContext(browser)
   const page = await context.newPage()
 
-  const createRes = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: {
-      name: `Difficulty Upsert Test ${Date.now()}`,
-      learningLanguage: 'Spanish',
-      cefrLevel: 'B1',
-      interests: [],
-      learningGoals: [],
-      weaknesses: [],
-      difficulties: [],
-    },
-  })
-  const student = await createRes.json() as { id: string }
+  const student = await createStudentViaApi(page, { name: `Difficulty Upsert Test ${Date.now()}` })
 
   // Create a confirmed session with suggested difficulties
   const sessionRes = await page.request.post(`${API_BASE}/api/students/${student.id}/sessions`, {
@@ -632,17 +514,8 @@ test('lesson dropdown in session log shows only lessons for the selected student
   const ts = Date.now()
 
   // Create two students
-  const createStudentA = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: { name: `Student A ${ts}`, learningLanguage: 'Spanish', cefrLevel: 'B1', interests: [], learningGoals: [], weaknesses: [], difficulties: [] },
-  })
-  const studentA = await createStudentA.json() as { id: string }
-
-  const createStudentB = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: { name: `Student B ${ts}`, learningLanguage: 'French', cefrLevel: 'A2', interests: [], learningGoals: [], weaknesses: [], difficulties: [] },
-  })
-  const studentB = await createStudentB.json() as { id: string }
+  const studentA = await createStudentViaApi(page, { name: `Student A ${ts}` })
+  const studentB = await createStudentViaApi(page, { name: `Student B ${ts}`, language: 'French', cefrLevel: 'A2' })
 
   // Create one lesson per student
   await page.request.post(`${API_BASE}/api/lessons`, {
@@ -679,20 +552,7 @@ test('unsaved-changes guard: back button with data shows discard confirmation', 
   const page = await context.newPage()
 
   const studentName = `Guard Test Student ${Date.now()}`
-  const createRes = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: {
-      name: studentName,
-      learningLanguage: 'Spanish',
-      cefrLevel: 'B1',
-      interests: [],
-      learningGoals: [],
-      weaknesses: [],
-      difficulties: [],
-    },
-  })
-  expect(createRes.ok()).toBeTruthy()
-  const student = await createRes.json()
+  const student = await createStudentViaApi(page, { name: studentName })
 
   await page.goto(`/students/${student.id}`)
   await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
@@ -721,20 +581,7 @@ test('unsaved-changes guard: Keep editing returns to the form', async ({ browser
   const page = await context.newPage()
 
   const studentName = `Guard Keep Test ${Date.now()}`
-  const createRes = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: {
-      name: studentName,
-      learningLanguage: 'Spanish',
-      cefrLevel: 'B1',
-      interests: [],
-      learningGoals: [],
-      weaknesses: [],
-      difficulties: [],
-    },
-  })
-  expect(createRes.ok()).toBeTruthy()
-  const student = await createRes.json()
+  const student = await createStudentViaApi(page, { name: studentName })
 
   await page.goto(`/students/${student.id}`)
   await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
@@ -760,20 +607,7 @@ test('start next session button navigates to log session page with planned topic
   const page = await context.newPage()
 
   const studentName = `Start Next Session Test ${Date.now()}`
-  const createRes = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: {
-      name: studentName,
-      learningLanguage: 'Spanish',
-      cefrLevel: 'B1',
-      interests: [],
-      learningGoals: [],
-      weaknesses: [],
-      difficulties: [],
-    },
-  })
-  expect(createRes.ok()).toBeTruthy()
-  const student = await createRes.json()
+  const student = await createStudentViaApi(page, { name: studentName })
 
   // Create a session with NextSessionTopics set
   const sessionRes = await page.request.post(`${API_BASE}/api/students/${student.id}/sessions`, {
@@ -833,20 +667,7 @@ test('unsaved-changes guard: back button on empty form navigates without confirm
   const page = await context.newPage()
 
   const studentName = `Guard Empty Test ${Date.now()}`
-  const createRes = await page.request.post(`${API_BASE}/api/students`, {
-    headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-    data: {
-      name: studentName,
-      learningLanguage: 'Spanish',
-      cefrLevel: 'B1',
-      interests: [],
-      learningGoals: [],
-      weaknesses: [],
-      difficulties: [],
-    },
-  })
-  expect(createRes.ok()).toBeTruthy()
-  const student = await createRes.json()
+  const student = await createStudentViaApi(page, { name: studentName })
 
   await page.goto(`/students/${student.id}`)
   await expect(page.getByTestId('student-detail-name')).toHaveText(studentName, { timeout: NAV_TIMEOUT })
@@ -872,20 +693,7 @@ test('log session page: autosave creates session without submit button', async (
 
   try {
     const studentName = `Autosave Test Student ${Date.now()}`
-    const createRes = await page.request.post(`${API_BASE}/api/students`, {
-      headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-      data: {
-        name: studentName,
-        learningLanguage: 'Spanish',
-        cefrLevel: 'B1',
-        interests: [],
-        learningGoals: [],
-        weaknesses: [],
-        difficulties: [],
-      },
-    })
-    expect(createRes.ok()).toBeTruthy()
-    const student = await createRes.json()
+    const student = await createStudentViaApi(page, { name: studentName })
 
     // Navigate directly to log-session page
     await page.goto(`/students/${student.id}/log-session`)
@@ -920,20 +728,7 @@ test('log session page: Done navigates back without saving if no changes made', 
 
   try {
     const studentName = `No Change Test ${Date.now()}`
-    const createRes = await page.request.post(`${API_BASE}/api/students`, {
-      headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-      data: {
-        name: studentName,
-        learningLanguage: 'Spanish',
-        cefrLevel: 'A2',
-        interests: [],
-        learningGoals: [],
-        weaknesses: [],
-        difficulties: [],
-      },
-    })
-    expect(createRes.ok()).toBeTruthy()
-    const student = await createRes.json()
+    const student = await createStudentViaApi(page, { name: studentName, cefrLevel: 'A2' })
 
     await page.goto(`/students/${student.id}/log-session`)
     await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: NAV_TIMEOUT })
@@ -960,20 +755,7 @@ test('session title: typing a title saves it and appears in session list and edi
 
   try {
     const studentName = `Title Test Student ${Date.now()}`
-    const createRes = await page.request.post(`${API_BASE}/api/students`, {
-      headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-      data: {
-        name: studentName,
-        learningLanguage: 'Spanish',
-        cefrLevel: 'B1',
-        interests: [],
-        learningGoals: [],
-        weaknesses: [],
-        difficulties: [],
-      },
-    })
-    expect(createRes.ok()).toBeTruthy()
-    const student = await createRes.json() as { id: string }
+    const student = await createStudentViaApi(page, { name: studentName })
 
     await page.goto(`/students/${student.id}/log-session`)
     await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: NAV_TIMEOUT })
@@ -1014,20 +796,7 @@ test('session title: blank title shows date fallback in session list', async ({ 
 
   try {
     const studentName = `No Title Student ${Date.now()}`
-    const createRes = await page.request.post(`${API_BASE}/api/students`, {
-      headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
-      data: {
-        name: studentName,
-        learningLanguage: 'Spanish',
-        cefrLevel: 'B1',
-        interests: [],
-        learningGoals: [],
-        weaknesses: [],
-        difficulties: [],
-      },
-    })
-    expect(createRes.ok()).toBeTruthy()
-    const student = await createRes.json() as { id: string }
+    const student = await createStudentViaApi(page, { name: studentName })
 
     await page.goto(`/students/${student.id}/log-session`)
     await expect(page.getByTestId('log-session-page')).toBeVisible({ timeout: NAV_TIMEOUT })

--- a/e2e/tests/students.spec.ts
+++ b/e2e/tests/students.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test'
 import { createMockAuthContext } from '../helpers/auth-helper'
 import { setupMockTeacher } from '../helpers/mock-teacher-helper'
 import { NAV_TIMEOUT, UI_TIMEOUT, FEEDBACK_TIMEOUT } from '../helpers/timeouts'
+import { createStudentViaUI } from '../helpers/students'
 
 test.beforeAll(async ({ browser }) => {
   const ctx = await createMockAuthContext(browser)
@@ -377,15 +378,7 @@ test('"Create Course" button on student edit page navigates to CourseNew with st
 
   // Create a student with full profile
   const studentName = `Create Course Test ${Date.now()}`
-  await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
-  await page.getByTestId('student-name').fill(studentName)
-  await page.getByTestId('student-language').click()
-  await page.getByRole('option', { name: 'Spanish' }).click()
-  await page.getByTestId('student-cefr').click()
-  await page.getByRole('option', { name: 'B2' }).click()
-  await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
+  await createStudentViaUI(page, { name: studentName, language: 'Spanish', cefrLevel: 'B2' })
 
   // Navigate to list then to edit page
   await page.goto('/students')
@@ -427,20 +420,7 @@ test('student detail shows 4 tabs and overview content by default', async ({ bro
   const studentName = `Profile Tab Test ${Date.now()}`
 
   // Create a student with native language set
-  await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
-  await page.getByTestId('student-name').fill(studentName)
-  await page.getByTestId('student-language').click()
-  await page.getByRole('option', { name: 'Spanish' }).click()
-  await page.getByTestId('student-cefr').click()
-  await page.getByRole('option', { name: 'B1' }).click()
-  await page.getByTestId('student-native-language').click()
-  await page.getByRole('option', { name: 'Portuguese' }).click()
-  await page.keyboard.press('Escape')
-  await page.getByRole('button', { name: 'Save Student' }).click()
-
-  // Should redirect directly to student detail page
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
+  await createStudentViaUI(page, { name: studentName, language: 'Spanish', cefrLevel: 'B1', nativeLanguage: 'Portuguese' })
 
   // All 4 tabs should be visible
   await expect(page.getByTestId('tab-overview')).toBeVisible({ timeout: UI_TIMEOUT })
@@ -754,15 +734,7 @@ test('teaching todos: add, toggle covered, verify ordering on overview tab', asy
   const studentName = `Todo E2E Test ${Date.now()}`
 
   // Create a student to work with
-  await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
-  await page.getByTestId('student-name').fill(studentName)
-  await page.getByTestId('student-language').click()
-  await page.getByRole('option', { name: 'Spanish' }).click()
-  await page.getByTestId('student-cefr').click()
-  await page.getByRole('option', { name: 'B1' }).click()
-  await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
+  await createStudentViaUI(page, { name: studentName, language: 'Spanish', cefrLevel: 'B1' })
 
   // Verify we're on the overview tab (default)
   await expect(page.getByTestId('tab-overview')).toHaveAttribute('aria-selected', 'true', { timeout: FEEDBACK_TIMEOUT })
@@ -827,15 +799,7 @@ test('teaching todos: toggle persists after reload and can be toggled back to pe
   const studentName = `TodoPersist_${Date.now()}`
 
   // Create a student
-  await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
-  await page.getByTestId('student-name').fill(studentName)
-  await page.getByTestId('student-language').click()
-  await page.getByRole('option', { name: 'Spanish' }).click()
-  await page.getByTestId('student-cefr').click()
-  await page.getByRole('option', { name: 'B1' }).click()
-  await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
+  await createStudentViaUI(page, { name: studentName, language: 'Spanish', cefrLevel: 'B1' })
   const detailUrl = page.url()
 
   // Navigate to edit student and add a todo via the sidebar card
@@ -906,15 +870,7 @@ test('log session page: create session from full-page form and redirect back', a
   const studentName = `LogSessionTest_${Date.now()}`
 
   // Create a student
-  await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
-  await page.getByTestId('student-name').fill(studentName)
-  await page.getByTestId('student-language').click()
-  await page.getByRole('option', { name: 'Spanish' }).click()
-  await page.getByTestId('student-cefr').click()
-  await page.getByRole('option', { name: 'B1' }).click()
-  await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
+  await createStudentViaUI(page, { name: studentName, language: 'Spanish', cefrLevel: 'B1' })
 
   // Click "Log Session" button - should navigate to full page
   await expect(page.getByTestId('log-session-button')).toBeVisible({ timeout: UI_TIMEOUT })
@@ -969,15 +925,7 @@ test('overview tab: header badges, pedagogical profile, teaching notes panel vis
   const page = await context.newPage()
   const studentName = `OverviewSectionsTest_${Date.now()}`
 
-  await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
-  await page.getByTestId('student-name').fill(studentName)
-  await page.getByTestId('student-language').click()
-  await page.getByRole('option', { name: 'Spanish' }).click()
-  await page.getByTestId('student-cefr').click()
-  await page.getByRole('option', { name: 'B1' }).click()
-  await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
+  await createStudentViaUI(page, { name: studentName, language: 'Spanish', cefrLevel: 'B1' })
 
   // Header status badge should show Active + Private
   await expect(page.getByTestId('student-status-badge')).toBeVisible({ timeout: UI_TIMEOUT })
@@ -1017,14 +965,7 @@ test('commercial fields round-trip: isActive, isCorporate, rate', async ({ brows
   const studentName = `CommercialTest_${Date.now()}`
 
   // Create a student
-  await page.goto('/students/new')
-  await page.getByTestId('student-name').fill(studentName)
-  await page.getByTestId('student-language').click()
-  await page.getByRole('option', { name: 'Spanish' }).click()
-  await page.getByTestId('student-cefr').click()
-  await page.getByRole('option', { name: 'B1' }).click()
-  await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
+  await createStudentViaUI(page, { name: studentName, language: 'Spanish', cefrLevel: 'B1' })
 
   // Navigate to edit
   await page.getByTestId('edit-profile-link').click()
@@ -1231,14 +1172,7 @@ test('Notes section nav link scrolls to Notes fields', async ({ browser }) => {
   const studentName = `NotesNavTest_${Date.now()}`
 
   // Create a student
-  await page.goto('/students/new')
-  await page.getByTestId('student-name').fill(studentName)
-  await page.getByTestId('student-language').click()
-  await page.getByRole('option', { name: 'Spanish' }).click()
-  await page.getByTestId('student-cefr').click()
-  await page.getByRole('option', { name: 'B1' }).click()
-  await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
+  await createStudentViaUI(page, { name: studentName, language: 'Spanish', cefrLevel: 'B1' })
 
   // Navigate to edit
   await page.getByTestId('edit-profile-link').click()
@@ -1265,15 +1199,7 @@ test('Ukrainian native language saves and persists after reload', async ({ brows
   const studentName = `Ukrainian Test ${Date.now()}`
 
   // Create a student
-  await page.goto('/students/new')
-  await expect(page.locator('h1')).toHaveText('Add Student', { timeout: UI_TIMEOUT })
-  await page.getByTestId('student-name').fill(studentName)
-  await page.getByTestId('student-language').click()
-  await page.getByRole('option', { name: 'Spanish' }).click()
-  await page.getByTestId('student-cefr').click()
-  await page.getByRole('option', { name: 'A2' }).click()
-  await page.getByRole('button', { name: 'Save Student' }).click()
-  await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: UI_TIMEOUT })
+  await createStudentViaUI(page, { name: studentName, language: 'Spanish', cefrLevel: 'A2' })
 
   // Navigate to edit
   await page.getByTestId('edit-profile-link').click()

--- a/plan/stabilisation/task853-e2e-helper-extract.md
+++ b/plan/stabilisation/task853-e2e-helper-extract.md
@@ -1,0 +1,20 @@
+# Task #853: Extract createStudentViaUI e2e Helper
+
+## Summary
+
+Extract repeated student-creation logic from e2e spec files into shared helpers in `e2e/helpers/students.ts`.
+
+## Helpers Created
+
+### `createStudentViaUI(page, options)`
+- Navigates to `/students/new`, fills name + language + CEFR + optional native language, saves.
+- Used by `followups.spec.ts` (1 occurrence) and `students.spec.ts` (9 occurrences).
+
+### `createStudentViaApi(page, options)`
+- POSTs to `/api/students` with defaults (Spanish, B1).
+- Used by `session-log.spec.ts` (20 of 21 API creation blocks; 1 kept inline due to non-empty `difficulties`).
+
+## Not Replaced
+
+- `students.spec.ts` occurrences that add extra fields (weakness, goals, identity, skill overrides) before save: left inline as they test the creation form itself.
+- `session-log.spec.ts` line ~467: creates student with pre-seeded difficulty; kept inline since the helper always uses empty arrays.


### PR DESCRIPTION
## Summary

- Extracts the repeated student-creation UI sequence into `createStudentViaUI(page, options)` in `e2e/helpers/students.ts`
- Adds `createStudentViaApi(page, options)` for the API-based creation pattern used in `session-log.spec.ts`
- `followups.spec.ts`: 1 inline block replaced
- `students.spec.ts`: 9 inline blocks replaced (complex creation-form tests left inline)
- `session-log.spec.ts`: 21 inline API blocks replaced (1 left inline due to non-empty seeded difficulties)

## Test plan

- [ ] Build verify: all checks pass (bicep, dotnet, npm lint, npm build, npm test)
- [ ] QA verify: PASS
- [ ] Architecture review: PASS

Closes #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added reusable helper utilities for student creation in end-to-end tests via UI and API endpoints.
  * Consolidated duplicated test setup code across multiple test files to reduce maintenance overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->