### PR TITLE
chore(#855): audit StudentGoals emission - add migration comments and guard tests

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -99,6 +99,27 @@ public class PromptServiceTests
     }
 
     [Fact]
+    public void SystemPrompt_OmitsLearningGoalsLine_WhenGoalsArrayIsEmpty()
+    {
+        var ctx = BaseCtx("Ana") with { StudentGoals = [] };
+
+        var req = _sut.BuildVocabularyPrompt(ctx);
+
+        req.SystemPrompt.Should().Contain("Student profile:");
+        req.SystemPrompt.Should().NotContain("Learning goals:");
+    }
+
+    [Fact]
+    public void SystemPrompt_OmitsLearningGoalsLine_WhenGoalsIsNull()
+    {
+        var ctx = BaseCtx("Ana") with { StudentGoals = null };
+
+        var req = _sut.BuildVocabularyPrompt(ctx);
+
+        req.SystemPrompt.Should().NotContain("Learning goals:");
+    }
+
+    [Fact]
     public void SystemPrompt_OmitsInterestsLine_WhenInterestsArrayIsEmpty()
     {
         var ctx = BaseCtx("Ana") with { StudentInterests = [] };

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -424,6 +424,7 @@ public class PromptService : IPromptService
             if (interests.Length > 0)
                 sb.AppendLine($"- Interests: {string.Join(", ", interests)}");
 
+            // Legacy LearningGoals field; will be superseded by ShortTermObjectives (see #855)
             if (goals.Length > 0)
                 sb.AppendLine($"- Learning goals: {string.Join(", ", goals)}");
 

--- a/backend/LangTeach.Api/Controllers/GenerateController.cs
+++ b/backend/LangTeach.Api/Controllers/GenerateController.cs
@@ -185,6 +185,7 @@ public class GenerateController : ControllerBase
             StudentName: student?.Name,
             StudentNativeLanguage: student?.Languages.NativeLanguages.FirstOrDefault(),
             StudentInterests: student?.Profile.Interests.ToArray(),
+            // LearningGoals is a legacy field; migrate to ShortTermObjectives (see #855)
             StudentGoals: student?.Profile.LearningGoals.SelectMany(g => new[] { g.Text }.Concat(g.Children.Select(c => c.Text))).ToArray(),
             StudentWeaknesses: student?.Profile.Weaknesses.Select(w => new StudentWeakness(w.Description, w.WeaknessType)).ToArray(),
             ExistingNotes: request.ExistingNotes,
@@ -352,6 +353,7 @@ public class GenerateController : ControllerBase
             StudentName: student?.Name,
             StudentNativeLanguage: student?.Languages.NativeLanguages.FirstOrDefault(),
             StudentInterests: student?.Profile.Interests.ToArray(),
+            // LearningGoals is a legacy field; migrate to ShortTermObjectives (see #855)
             StudentGoals: student?.Profile.LearningGoals.SelectMany(g => new[] { g.Text }.Concat(g.Children.Select(c => c.Text))).ToArray(),
             StudentWeaknesses: student?.Profile.Weaknesses.Select(w => new StudentWeakness(w.Description, w.WeaknessType)).ToArray(),
             ExistingNotes: request.ExistingNotes,

--- a/backend/LangTeach.Api/Services/CourseService.cs
+++ b/backend/LangTeach.Api/Services/CourseService.cs
@@ -341,6 +341,7 @@ public class CourseService : ICourseService
             StudentInterests: student is not null
                 ? JsonStorageHelper.DeserializeList<string>(student.Interests).ToArray()
                 : null,
+            // LearningGoals is a legacy field; migrate to ShortTermObjectives (see #855)
             StudentGoals: student is not null
                 ? LearningGoalHelper.FlattenGoals(student.LearningGoals)
                 : null,

--- a/plan/stabilisation/task855-studentgoals-audit.md
+++ b/plan/stabilisation/task855-studentgoals-audit.md
@@ -1,0 +1,49 @@
+# Task 855 - Audit and clean up StudentGoals emission in PromptService
+
+## Findings
+
+### Is StudentGoals still populated?
+
+YES. `LearningGoals` is still an active field:
+- `StudentService.cs` lines 126, 180: writes `LearningGoals` on student create/update
+- `StudentForm.tsx` lines 179, 245, 282: UI still renders and submits learningGoals
+- `GenerateController.cs` lines 188, 355: passes `student?.Profile.LearningGoals.SelectMany(...)` as `StudentGoals` to `GenerationContext`
+- `CourseService.cs` line 344-345: passes `LearningGoalHelper.FlattenGoals(student.LearningGoals)` as `StudentGoals` to `CurriculumContext`
+
+### Emission sites
+
+1. `PromptService.cs:428` (BuildSystemPrompt): `$"- Learning goals: {string.Join(", ", goals)}"` - guarded by `if (goals.Length > 0)` (line 427). No empty lines emitted.
+2. `PromptService.cs:1268-1269` (CurriculumSystemPrompt): `$"Goals: ..."` - guarded by `if (ctx.StudentGoals?.Length > 0)`. No empty lines emitted.
+
+### ShortTermObjectives gap
+
+`ShortTermObjectives` is NOT in `GenerationContext` or `CurriculumContext`. It is stored in DB and returned in StudentDto, but never passed to any prompt. This is a separate gap to track.
+
+`ReasonForStudying` IS in `GenerationContext` as `StudentReasonForStudying` and IS emitted at line 458-459.
+
+## Conclusion
+
+Per the issue: "If still populated (legacy migration path): add a comment noting it and plan a migration."
+
+The 4th AC (`Prompt logs no longer contain '- Learning goals:' with an empty value`) is already satisfied by the existing guards.
+
+## Changes
+
+1. Add comments in `GenerateController.cs` and `CourseService.cs` at the `StudentGoals` assignment noting it is populated from the legacy `LearningGoals` field and should eventually be migrated to `ShortTermObjectives`.
+2. Add a comment in `PromptService.cs` near the `Learning goals:` emission noting the migration plan.
+3. Add a test to `PromptServiceTests.cs` confirming that an empty `StudentGoals` array does NOT emit `- Learning goals:` (to lock in the guard behaviour).
+4. File a follow-up issue to add `ShortTermObjectives` to `GenerationContext`/`CurriculumContext`.
+
+## Files
+
+- `backend/LangTeach.Api/Controllers/GenerateController.cs` (lines 188, 355) - add comment
+- `backend/LangTeach.Api/Services/CourseService.cs` (line 344) - add comment
+- `backend/LangTeach.Api/AI/PromptService.cs` (line 428) - add comment
+- `backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs` - add guard test
+
+## Acceptance Criteria Check
+
+- [x] `StudentGoals` emission status verified: still populated via LearningGoals
+- [x] Not removed (still populated) - legacy path applies
+- [x] N/A: not removed, so no gap-fill needed now
+- [x] Prompt logs no longer contain `- Learning goals:` with empty value: already guarded, test added to lock in


### PR DESCRIPTION
## Summary

- Audited `StudentGoals` emission in `PromptService`: **`LearningGoals` is still actively populated** by `StudentService` and the `StudentForm` UI, so emission is not a no-op
- Added migration comments at all three `StudentGoals` assignment sites (`GenerateController.cs` x2, `CourseService.cs`) noting the field as legacy and pointing to `ShortTermObjectives` migration (#883)
- Added comment in `PromptService.cs` at the `- Learning goals:` emission site
- Added two `PromptServiceTests` to lock in the existing empty-array and null guards so `- Learning goals:` never appears with an empty value
- Filed follow-up issue #883 to add `ShortTermObjectives` to `GenerationContext`/`CurriculumContext`

## Test plan

- [ ] `dotnet test` passes (2 new unit tests: `OmitsLearningGoalsLine_WhenGoalsArrayIsEmpty`, `OmitsLearningGoalsLine_WhenGoalsIsNull`)
- [ ] No production behavior change (comments-only + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)