### PR TITLE
feat(#857): add objective type selector to short-term objectives

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -120,6 +120,38 @@ public class PromptServiceTests
     }
 
     [Fact]
+    public void SystemPrompt_EmitsShortTermObjectives_WithTypeLabel()
+    {
+        var ctx = BaseCtx("Ana") with
+        {
+            StudentShortTermObjectives =
+            [
+                new StudentObjectiveContext("Pass DELE B2", new DateOnly(2026, 6, 30), "exam_prep"),
+                new StudentObjectiveContext("Handle a job interview", null, "communicative"),
+                new StudentObjectiveContext("General goal", null, "other")
+            ]
+        };
+
+        var req = _sut.BuildVocabularyPrompt(ctx);
+
+        req.SystemPrompt.Should().Contain("Short-term objectives:");
+        req.SystemPrompt.Should().Contain("[Exam prep] Pass DELE B2");
+        req.SystemPrompt.Should().Contain("[Communicative] Handle a job interview");
+        req.SystemPrompt.Should().Contain("General goal");
+        req.SystemPrompt.Should().NotContain("[Other]");
+    }
+
+    [Fact]
+    public void SystemPrompt_OmitsShortTermObjectivesSection_WhenListIsNull()
+    {
+        var ctx = BaseCtx("Ana") with { StudentShortTermObjectives = null };
+
+        var req = _sut.BuildVocabularyPrompt(ctx);
+
+        req.SystemPrompt.Should().NotContain("Short-term objectives:");
+    }
+
+    [Fact]
     public void SystemPrompt_OmitsInterestsLine_WhenInterestsArrayIsEmpty()
     {
         var ctx = BaseCtx("Ana") with { StudentInterests = [] };

--- a/backend/LangTeach.Api/AI/IPromptService.cs
+++ b/backend/LangTeach.Api/AI/IPromptService.cs
@@ -9,6 +9,8 @@ namespace LangTeach.Api.AI;
 /// </summary>
 public record StudentWeakness(string Description, string WeaknessType = "grammatical");
 
+public record StudentObjectiveContext(string Text, DateOnly? TargetDate, string ObjectiveType = "other");
+
 public interface IPromptService
 {
     ClaudeRequest BuildLessonPlanPrompt(GenerationContext ctx);
@@ -44,7 +46,8 @@ public record CurriculumContext(
     string? TemplateLevel = null,
     IReadOnlyList<TemplateUnitContext>? TemplateUnits = null,
     string? TeacherNotes = null,
-    string CourseType = "general"
+    string CourseType = "general",
+    IReadOnlyList<StudentObjectiveContext>? StudentShortTermObjectives = null
 );
 
 /// <summary>
@@ -127,5 +130,6 @@ public record GenerationContext(
     int? StudentAge = null,
     string? StudentCountryOfOrigin = null,
     string? StudentCountryOfResidence = null,
-    string? StudentOfficialCefrLevel = null
+    string? StudentOfficialCefrLevel = null,
+    IReadOnlyList<StudentObjectiveContext>? StudentShortTermObjectives = null
 );

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -459,6 +459,22 @@ public class PromptService : IPromptService
             if (reasonForStudying.Length > 0)
                 sb.AppendLine($"- Reason for studying {language}: {reasonForStudying}");
 
+            if (ctx.StudentShortTermObjectives is { Count: > 0 })
+            {
+                sb.AppendLine("- Short-term objectives:");
+                foreach (var obj in ctx.StudentShortTermObjectives)
+                {
+                    var typeLabel = obj.ObjectiveType switch
+                    {
+                        "exam_prep"      => "[Exam prep] ",
+                        "communicative"  => "[Communicative] ",
+                        _                => string.Empty
+                    };
+                    var dateSuffix = obj.TargetDate.HasValue ? $" (by {obj.TargetDate.Value:yyyy-MM-dd})" : string.Empty;
+                    sb.AppendLine($"  - {typeLabel}{InputSanitizer.Sanitize(obj.Text)}{dateSuffix}");
+                }
+            }
+
             sb.AppendLine();
             var motivationSuffix = reasonForStudying.Length > 0
                 ? $", and anchor vocabulary to their stated study motivation: {reasonForStudying}"
@@ -1268,6 +1284,21 @@ public class PromptService : IPromptService
                 sb.AppendLine($"Interests: {string.Join(", ", ctx.StudentInterests.Select(InputSanitizer.Sanitize).Where(s => s.Length > 0))}");
             if (ctx.StudentGoals?.Length > 0)
                 sb.AppendLine($"Goals: {string.Join(", ", ctx.StudentGoals.Select(InputSanitizer.Sanitize).Where(s => s.Length > 0))}");
+            if (ctx.StudentShortTermObjectives is { Count: > 0 })
+            {
+                sb.AppendLine("Short-term objectives:");
+                foreach (var obj in ctx.StudentShortTermObjectives)
+                {
+                    var typeLabel = obj.ObjectiveType switch
+                    {
+                        "exam_prep"     => "[Exam prep] ",
+                        "communicative" => "[Communicative] ",
+                        _               => string.Empty
+                    };
+                    var dateSuffix = obj.TargetDate.HasValue ? $" (by {obj.TargetDate.Value:yyyy-MM-dd})" : string.Empty;
+                    sb.AppendLine($"  - {typeLabel}{InputSanitizer.Sanitize(obj.Text)}{dateSuffix}");
+                }
+            }
             if (ctx.StudentWeaknesses?.Length > 0)
                 sb.AppendLine($"Known weaknesses: {string.Join(", ", ctx.StudentWeaknesses.Select(w => InputSanitizer.Sanitize(w.Description)).Where(s => s.Length > 0))}");
             if (ctx.StudentDifficulties?.Length > 0)

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -464,14 +464,8 @@ public class PromptService : IPromptService
                 sb.AppendLine("- Short-term objectives:");
                 foreach (var obj in ctx.StudentShortTermObjectives)
                 {
-                    var typeLabel = obj.ObjectiveType switch
-                    {
-                        "exam_prep"      => "[Exam prep] ",
-                        "communicative"  => "[Communicative] ",
-                        _                => string.Empty
-                    };
                     var dateSuffix = obj.TargetDate.HasValue ? $" (by {obj.TargetDate.Value:yyyy-MM-dd})" : string.Empty;
-                    sb.AppendLine($"  - {typeLabel}{InputSanitizer.Sanitize(obj.Text)}{dateSuffix}");
+                    sb.AppendLine($"  - {ObjectiveTypeLabel(obj.ObjectiveType)}{InputSanitizer.Sanitize(obj.Text)}{dateSuffix}");
                 }
             }
 
@@ -1289,14 +1283,8 @@ public class PromptService : IPromptService
                 sb.AppendLine("Short-term objectives:");
                 foreach (var obj in ctx.StudentShortTermObjectives)
                 {
-                    var typeLabel = obj.ObjectiveType switch
-                    {
-                        "exam_prep"     => "[Exam prep] ",
-                        "communicative" => "[Communicative] ",
-                        _               => string.Empty
-                    };
                     var dateSuffix = obj.TargetDate.HasValue ? $" (by {obj.TargetDate.Value:yyyy-MM-dd})" : string.Empty;
-                    sb.AppendLine($"  - {typeLabel}{InputSanitizer.Sanitize(obj.Text)}{dateSuffix}");
+                    sb.AppendLine($"  - {ObjectiveTypeLabel(obj.ObjectiveType)}{InputSanitizer.Sanitize(obj.Text)}{dateSuffix}");
                 }
             }
             if (ctx.StudentWeaknesses?.Length > 0)
@@ -1507,6 +1495,13 @@ public class PromptService : IPromptService
     }
 
     private static string CefrCodeToSkillName(string code) => LangTeach.Api.DTOs.CefrSkillCodes.ToSkillName(code);
+
+    private static string ObjectiveTypeLabel(string objectiveType) => objectiveType switch
+    {
+        "exam_prep"     => "[Exam prep] ",
+        "communicative" => "[Communicative] ",
+        _               => string.Empty
+    };
 
     // --- Reflection extraction ---
 

--- a/backend/LangTeach.Api/Controllers/GenerateController.cs
+++ b/backend/LangTeach.Api/Controllers/GenerateController.cs
@@ -204,7 +204,10 @@ public class GenerateController : ControllerBase
             StudentAge: student?.Identity.Age,
             StudentCountryOfOrigin: student?.Identity.CountryOfOrigin,
             StudentCountryOfResidence: student?.Identity.CountryOfResidence,
-            StudentOfficialCefrLevel: student?.Level.OfficialCefrLevel
+            StudentOfficialCefrLevel: student?.Level.OfficialCefrLevel,
+            StudentShortTermObjectives: student?.Profile.ShortTermObjectives
+                .Select(o => new StudentObjectiveContext(o.Text, o.TargetDate, o.ObjectiveType))
+                .ToList()
         );
 
         var claudeRequest = buildPrompt(_promptService, ctx);
@@ -372,7 +375,10 @@ public class GenerateController : ControllerBase
             StudentAge: student?.Identity.Age,
             StudentCountryOfOrigin: student?.Identity.CountryOfOrigin,
             StudentCountryOfResidence: student?.Identity.CountryOfResidence,
-            StudentOfficialCefrLevel: student?.Level.OfficialCefrLevel
+            StudentOfficialCefrLevel: student?.Level.OfficialCefrLevel,
+            StudentShortTermObjectives: student?.Profile.ShortTermObjectives
+                .Select(o => new StudentObjectiveContext(o.Text, o.TargetDate, o.ObjectiveType))
+                .ToList()
         );
 
         var claudeRequest = buildPrompt(ctx);

--- a/backend/LangTeach.Api/DTOs/ShortTermObjectiveDto.cs
+++ b/backend/LangTeach.Api/DTOs/ShortTermObjectiveDto.cs
@@ -1,3 +1,3 @@
 namespace LangTeach.Api.DTOs;
 
-public record ShortTermObjectiveDto(string Id, string Text, DateOnly? TargetDate);
+public record ShortTermObjectiveDto(string Id, string Text, DateOnly? TargetDate, string ObjectiveType = "other");

--- a/backend/LangTeach.Api/Services/CourseService.cs
+++ b/backend/LangTeach.Api/Services/CourseService.cs
@@ -358,7 +358,12 @@ public class CourseService : ICourseService
                     .Where(d => string.Equals(d.Status, "Active", StringComparison.OrdinalIgnoreCase))
                     .ToArray()
                 : null,
-            TeacherNotes: req.TeacherNotes
+            TeacherNotes: req.TeacherNotes,
+            StudentShortTermObjectives: student is not null
+                ? JsonStorageHelper.DeserializeList<ShortTermObjectiveDto>(student.ShortTermObjectives)
+                    .Select(o => new StudentObjectiveContext(o.Text, o.TargetDate, o.ObjectiveType))
+                    .ToList()
+                : null
         );
 
     private static CurriculumEntryDto MapEntryToDto(CurriculumEntry e) =>

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -29,6 +29,9 @@ public class StudentService : IStudentService
     private static readonly HashSet<string> AllowedWeaknessTypes =
         new(StringComparer.OrdinalIgnoreCase) { "grammatical", "lexical", "orthographic" };
 
+    private static readonly HashSet<string> AllowedObjectiveTypes =
+        new(StringComparer.OrdinalIgnoreCase) { "exam_prep", "communicative", "other" };
+
     private static readonly Dictionary<string, string> CanonicalSkillKeys =
         new(StringComparer.OrdinalIgnoreCase)
         {
@@ -318,8 +321,6 @@ public class StudentService : IStudentService
             throw new ValidationException($"BirthYear must be between 1920 and {currentYear}.");
     }
 
-    private static readonly HashSet<string> ValidObjectiveTypes = ["exam_prep", "communicative", "other"];
-
     private static void ValidateShortTermObjectives(List<ShortTermObjectiveDto> objectives)
     {
         if (objectives.Count > 10)
@@ -330,8 +331,8 @@ public class StudentService : IStudentService
                 throw new ValidationException("Each ShortTermObjective must have an Id (max 50 characters).");
             if (string.IsNullOrWhiteSpace(o.Text) || o.Text.Length > 200)
                 throw new ValidationException("Each ShortTermObjective Text must be between 1 and 200 characters.");
-            if (!ValidObjectiveTypes.Contains(o.ObjectiveType))
-                throw new ValidationException($"ShortTermObjective ObjectiveType must be one of: {string.Join(", ", ValidObjectiveTypes)}.");
+            if (!AllowedObjectiveTypes.Contains(o.ObjectiveType))
+                throw new ValidationException($"ShortTermObjective ObjectiveType must be one of: {string.Join(", ", AllowedObjectiveTypes)}.");
         }
     }
 

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -318,6 +318,8 @@ public class StudentService : IStudentService
             throw new ValidationException($"BirthYear must be between 1920 and {currentYear}.");
     }
 
+    private static readonly HashSet<string> ValidObjectiveTypes = ["exam_prep", "communicative", "other"];
+
     private static void ValidateShortTermObjectives(List<ShortTermObjectiveDto> objectives)
     {
         if (objectives.Count > 10)
@@ -328,6 +330,8 @@ public class StudentService : IStudentService
                 throw new ValidationException("Each ShortTermObjective must have an Id (max 50 characters).");
             if (string.IsNullOrWhiteSpace(o.Text) || o.Text.Length > 200)
                 throw new ValidationException("Each ShortTermObjective Text must be between 1 and 200 characters.");
+            if (!ValidObjectiveTypes.Contains(o.ObjectiveType))
+                throw new ValidationException($"ShortTermObjective ObjectiveType must be one of: {string.Join(", ", ValidObjectiveTypes)}.");
         }
     }
 

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -30,7 +30,7 @@ public class StudentService : IStudentService
         new(StringComparer.OrdinalIgnoreCase) { "grammatical", "lexical", "orthographic" };
 
     private static readonly HashSet<string> AllowedObjectiveTypes =
-        new(StringComparer.OrdinalIgnoreCase) { "exam_prep", "communicative", "other" };
+        new(StringComparer.Ordinal) { "exam_prep", "communicative", "other" };
 
     private static readonly Dictionary<string, string> CanonicalSkillKeys =
         new(StringComparer.OrdinalIgnoreCase)

--- a/frontend/src/api/students.ts
+++ b/frontend/src/api/students.ts
@@ -15,10 +15,13 @@ export interface Difficulty {
   status: string
 }
 
+export type ObjectiveType = 'exam_prep' | 'communicative' | 'other'
+
 export interface ShortTermObjective {
   id: string
   text: string
   targetDate: string | null
+  objectiveType: ObjectiveType
 }
 
 export interface LearningGoalItem {

--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -50,7 +50,7 @@ const FULL_STUDENT: Student = {
       { id: 'd1', description: 'Subjuntivo en concesivas', competency: 'Grammar', subcategory: 'subjuntivo', severity: 'high', trend: 'stable', status: 'Active' },
       { id: 'd2', description: 'Registro formal', competency: 'Writing', subcategory: '', severity: 'medium', trend: 'improving', status: 'Covered' },
     ],
-    shortTermObjectives: [{ id: 'obj-1', text: 'Redaccion formal semanal', targetDate: '2026-05-01' }],
+    shortTermObjectives: [{ id: 'obj-1', text: 'Redaccion formal semanal', targetDate: '2026-05-01', objectiveType: 'other' as const }],
     teachingTodos: [
       { id: 'todo-1', text: 'Enviar ejercicios de por/para', createdAt: '2026-01-01T00:00:00Z', sourceSessionLogId: null, status: 'pending', coveredInSessionLogId: null },
       { id: 'todo-2', text: 'Explicar diferencia', createdAt: '2026-01-01T00:00:00Z', sourceSessionLogId: null, status: 'covered', coveredInSessionLogId: 'session-1' },
@@ -414,7 +414,7 @@ describe('StudentProfileTab', () => {
     it('shows OVERDUE label for past-due objective', () => {
       const student = {
         ...FULL_STUDENT,
-        profile: { ...FULL_STUDENT.profile, shortTermObjectives: [{ id: 'obj-1', text: 'Overdue objective', targetDate: dateOffset(-5) }] },
+        profile: { ...FULL_STUDENT.profile, shortTermObjectives: [{ id: 'obj-1', text: 'Overdue objective', targetDate: dateOffset(-5), objectiveType: 'other' as const }] },
       }
       renderProfile(student)
       expect(screen.getByTestId('objective-overdue-label')).toBeInTheDocument()
@@ -423,7 +423,7 @@ describe('StudentProfileTab', () => {
     it('shows Critical label for objective within 3 days', () => {
       const student = {
         ...FULL_STUDENT,
-        profile: { ...FULL_STUDENT.profile, shortTermObjectives: [{ id: 'obj-1', text: 'Critical objective', targetDate: dateOffset(2) }] },
+        profile: { ...FULL_STUDENT.profile, shortTermObjectives: [{ id: 'obj-1', text: 'Critical objective', targetDate: dateOffset(2), objectiveType: 'other' as const }] },
       }
       renderProfile(student)
       expect(screen.getByTestId('objective-critical-label')).toBeInTheDocument()
@@ -432,11 +432,38 @@ describe('StudentProfileTab', () => {
     it('does not show urgency labels for normal objectives', () => {
       const student = {
         ...FULL_STUDENT,
-        profile: { ...FULL_STUDENT.profile, shortTermObjectives: [{ id: 'obj-1', text: 'Normal objective', targetDate: dateOffset(60) }] },
+        profile: { ...FULL_STUDENT.profile, shortTermObjectives: [{ id: 'obj-1', text: 'Normal objective', targetDate: dateOffset(60), objectiveType: 'other' as const }] },
       }
       renderProfile(student)
       expect(screen.queryByTestId('objective-overdue-label')).not.toBeInTheDocument()
       expect(screen.queryByTestId('objective-critical-label')).not.toBeInTheDocument()
+    })
+
+    it('shows exam_prep badge for exam_prep objectives', () => {
+      const student = {
+        ...FULL_STUDENT,
+        profile: { ...FULL_STUDENT.profile, shortTermObjectives: [{ id: 'obj-1', text: 'Pass DELE B2', targetDate: null, objectiveType: 'exam_prep' as const }] },
+      }
+      renderProfile(student)
+      expect(screen.getByTestId('objective-type-badge')).toHaveTextContent('Exam prep')
+    })
+
+    it('shows communicative badge for communicative objectives', () => {
+      const student = {
+        ...FULL_STUDENT,
+        profile: { ...FULL_STUDENT.profile, shortTermObjectives: [{ id: 'obj-1', text: 'Job interview', targetDate: null, objectiveType: 'communicative' as const }] },
+      }
+      renderProfile(student)
+      expect(screen.getByTestId('objective-type-badge')).toHaveTextContent('Communicative')
+    })
+
+    it('shows no type badge for other objectives', () => {
+      const student = {
+        ...FULL_STUDENT,
+        profile: { ...FULL_STUDENT.profile, shortTermObjectives: [{ id: 'obj-1', text: 'General goal', targetDate: null, objectiveType: 'other' as const }] },
+      }
+      renderProfile(student)
+      expect(screen.queryByTestId('objective-type-badge')).not.toBeInTheDocument()
     })
 
     it('shows + button when onSaveShortTermObjective is provided', () => {

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -644,7 +644,19 @@ export function StudentProfileTab({
                           data-testid="objective-row"
                         >
                           <div className="flex items-start justify-between gap-2">
-                            <span className="text-[#1A1B22] font-medium">{obj.text}</span>
+                            <div className="flex items-center gap-1.5 flex-wrap min-w-0">
+                              {obj.objectiveType === 'exam_prep' && (
+                                <span className="shrink-0 text-xs font-semibold px-1.5 py-0.5 rounded bg-indigo-100 text-indigo-700" data-testid="objective-type-badge">
+                                  Exam prep
+                                </span>
+                              )}
+                              {obj.objectiveType === 'communicative' && (
+                                <span className="shrink-0 text-xs font-semibold px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-700" data-testid="objective-type-badge">
+                                  Communicative
+                                </span>
+                              )}
+                              <span className="text-[#1A1B22] font-medium">{obj.text}</span>
+                            </div>
                             {urgency === 'overdue' && (
                               <span className="text-xs font-bold text-red-600 shrink-0 uppercase" data-testid="objective-overdue-label">
                                 OVERDUE

--- a/frontend/src/pages/StudentDetail.test.tsx
+++ b/frontend/src/pages/StudentDetail.test.tsx
@@ -59,7 +59,7 @@ const MOCK_STUDENT: studentsApi.Student = {
     learningGoals: [{ id: '1', text: 'Travel', children: [] }, { id: '2', text: 'DELE B1', children: [] }],
     weaknesses: [],
     difficulties: [],
-    shortTermObjectives: [{ id: 'obj-1', text: 'Complete DELE B1 exam prep', targetDate: '2026-06-01' }],
+    shortTermObjectives: [{ id: 'obj-1', text: 'Complete DELE B1 exam prep', targetDate: '2026-06-01', objectiveType: 'exam_prep' as const }],
     teachingTodos: [{ id: 'todo-1', text: 'Send homework exercises', createdAt: '2026-01-01T00:00:00Z', sourceSessionLogId: null, status: 'Pending', coveredInSessionLogId: null }],
   },
   commercial: { isActive: true, isCorporate: false, rate: '30 EUR/h' },
@@ -393,7 +393,7 @@ describe('StudentDetail - Primary objective in header', () => {
   it('shows days remaining for objective with future date', async () => {
     vi.mocked(studentsApi.getStudent).mockResolvedValue({
       ...MOCK_STUDENT,
-      profile: { ...MOCK_STUDENT.profile, shortTermObjectives: [{ id: 'obj-1', text: 'Future objective', targetDate: '2030-01-01' }] },
+      profile: { ...MOCK_STUDENT.profile, shortTermObjectives: [{ id: 'obj-1', text: 'Future objective', targetDate: '2030-01-01', objectiveType: 'other' as const }] },
     })
     wrapper()
     await screen.findByTestId('primary-objective-card')

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -240,7 +240,7 @@ export default function StudentDetail() {
 
   const { mutateAsync: saveShortTermObjective } = useMutation({
     mutationFn: (text: string) => {
-      const newObj = { id: newId(), text, targetDate: null }
+      const newObj = { id: newId(), text, targetDate: null, objectiveType: 'other' as const }
       return updateStudent(id!, { ...buildStudentPayload(), shortTermObjectives: [...student!.profile.shortTermObjectives, newObj] })
     },
     onSuccess: () => {

--- a/frontend/src/pages/StudentForm.test.tsx
+++ b/frontend/src/pages/StudentForm.test.tsx
@@ -114,7 +114,7 @@ function makeMockStudent(overrides: {
   learningGoals?: { id: string; text: string; children: unknown[] }[];
   weaknesses?: { description: string; weaknessType: string }[];
   difficulties?: { id: string; description: string; competency: string; subcategory: string; severity: string; trend: string; status: string }[];
-  shortTermObjectives?: { id: string; text: string; targetDate?: string }[];
+  shortTermObjectives?: { id: string; text: string; targetDate?: string; objectiveType?: string }[];
   teachingTodos?: { id: string; text: string; status: string; createdAt: string; sourceSessionLogId: null; coveredInSessionLogId: null }[];
   isActive?: boolean; isCorporate?: boolean; rate?: string | null;
   createdAt?: string; updatedAt?: string;

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -109,7 +109,7 @@ function ObjectiveRow({
 }: {
   obj: ShortTermObjective
   autoFocus: boolean
-  onUpdate: (id: string, field: 'text' | 'targetDate', value: string | null) => void
+  onUpdate: (id: string, field: 'text' | 'targetDate' | 'objectiveType', value: string | null) => void
   onRemove: (id: string) => void
 }) {
   const inputRef = useRef<HTMLInputElement>(null)
@@ -133,6 +133,16 @@ function ObjectiveRow({
         data-testid="objective-text-input"
       />
       <div className="flex items-center gap-2">
+        <select
+          value={obj.objectiveType ?? 'other'}
+          onChange={(e) => onUpdate(obj.id, 'objectiveType', e.target.value)}
+          className="h-9 rounded-md border border-zinc-200 bg-white px-2 py-1 text-sm text-[#1A1B22] focus:outline-none focus:ring-2 focus:ring-indigo-300"
+          data-testid="objective-type-select"
+        >
+          <option value="exam_prep">Exam prep</option>
+          <option value="communicative">Communicative</option>
+          <option value="other">Other</option>
+        </select>
         <input
           type="date"
           value={obj.targetDate ?? ''}
@@ -254,7 +264,7 @@ export default function StudentForm() {
       setCountryOfResidence(existing.identity.countryOfResidence ?? '')
       setCityOfResidence(existing.identity.cityOfResidence ?? '')
       setReasonForStudying(existing.identity.reasonForStudying ?? '')
-      setShortTermObjectives(existing.profile.shortTermObjectives ?? [])
+      setShortTermObjectives((existing.profile.shortTermObjectives ?? []).map((o) => ({ ...o, objectiveType: o.objectiveType ?? 'other' })))
       setIsActive(existing.commercial.isActive ?? true)
       setIsCorporate(existing.commercial.isCorporate ?? false)
       setRate(existing.commercial.rate ?? '')
@@ -480,11 +490,11 @@ export default function StudentForm() {
   function addObjective() {
     const id = newId()
     setNewObjectiveId(id)
-    setShortTermObjectives((prev) => [...prev, { id, text: '', targetDate: null }])
+    setShortTermObjectives((prev) => [...prev, { id, text: '', targetDate: null, objectiveType: 'other' as const }])
     if (isEdit) saveNow()
   }
 
-  function updateObjective(objId: string, field: 'text' | 'targetDate', value: string | null) {
+  function updateObjective(objId: string, field: 'text' | 'targetDate' | 'objectiveType', value: string | null) {
     setShortTermObjectives((prev) =>
       prev.map((o) => (o.id === objId ? { ...o, [field]: value } : o))
     )

--- a/frontend/src/pages/Students.test.tsx
+++ b/frontend/src/pages/Students.test.tsx
@@ -450,7 +450,7 @@ describe('Students page', () => {
     vi.mocked(studentsApi.getStudents).mockResolvedValue(
       makeListResponse([makeStudent({
         id: 'abc-123',
-        shortTermObjectives: [{ id: 'obj1', text: 'DELE B2 exam', targetDate }],
+        shortTermObjectives: [{ id: 'obj1', text: 'DELE B2 exam', targetDate, objectiveType: 'exam_prep' as const }],
       })])
     )
     vi.mocked(dashboardApi.getDashboard).mockResolvedValue({

--- a/plan/stabilisation/task857-short-term-objective-type.md
+++ b/plan/stabilisation/task857-short-term-objective-type.md
@@ -1,0 +1,80 @@
+# Task 857 - Add type selector to short-term objective field
+
+## Context
+
+`ShortTermObjective` is stored as a JSON array in `Student.ShortTermObjectives` (nvarchar column). No DB migration needed -- adding a new field with a default in the DTO is backward-compatible: legacy rows deserialize without the field and get `"other"`.
+
+## Changes
+
+### 1. Backend DTO - `ShortTermObjectiveDto.cs`
+Add `string ObjectiveType = "other"` as a positional parameter with default.
+```csharp
+public record ShortTermObjectiveDto(string Id, string Text, DateOnly? TargetDate, string ObjectiveType = "other");
+```
+This is backward-compatible: old JSON without `objectiveType` deserializes to `"other"`.
+
+### 2. Frontend API - `frontend/src/api/students.ts`
+Add `objectiveType: string` to `ShortTermObjective` interface (default "other" handled by transformation in StudentForm).
+
+### 3. Frontend UI - `frontend/src/pages/StudentForm.tsx`
+- Update `ObjectiveRow` component:
+  - Add `'objectiveType'` to the field union type in `onUpdate`
+  - Add a `<select>` with 3 options: `exam_prep` ("Exam prep"), `communicative` ("Communicative"), `other` ("Other")
+  - Style to match existing date input
+- Update `addObjective` to include `objectiveType: 'other'` as default
+- Update `updateObjective` to handle `objectiveType` field  
+- When loading existing student, preserve `objectiveType` (or default to "other" if missing)
+
+### 4. Frontend display - `frontend/src/components/student/StudentProfileTab.tsx`
+Show a small type badge per objective. Use:
+- "Exam Prep" in indigo/blue
+- "Communicative" in green
+- "Other" neutral (omit badge to keep it clean)
+
+### 5. Prompt context - `backend/LangTeach.Api/AI/IPromptService.cs`
+Add a new record and field to both `GenerationContext` and `CurriculumContext`:
+```csharp
+public record StudentObjectiveContext(string Text, DateOnly? TargetDate, string ObjectiveType);
+```
+Add `IReadOnlyList<StudentObjectiveContext>? StudentShortTermObjectives = null` to both contexts.
+
+### 6. Prompt emission - `backend/LangTeach.Api/AI/PromptService.cs`
+In `BuildSystemPrompt` (GenerationContext path) and `CurriculumSystemPrompt`:
+```
+- Short-term objectives:
+  - [Exam prep] Pass DELE B2 by June
+  - [Communicative] Handle a job interview
+```
+Guard with `if (ctx.StudentShortTermObjectives?.Count > 0)`.
+
+### 7. Controller wiring
+- `GenerateController.cs` (x2): pass `StudentShortTermObjectives` to `GenerationContext`
+- `CourseService.cs`: pass to `CurriculumContext`
+
+Map from `student?.Profile.ShortTermObjectives` (already deserialized as `IReadOnlyList<ShortTermObjectiveDto>`).
+
+### 8. Tests
+- `PromptServiceTests.cs`: add tests for objectives emission (with/without type, empty case)
+- `StudentForm.test.tsx`: update test for new type selector rendering
+- `StudentProfileTab.test.tsx`: update fixture to include `objectiveType`
+
+## Files
+
+- `backend/LangTeach.Api/DTOs/ShortTermObjectiveDto.cs` - add ObjectiveType field
+- `backend/LangTeach.Api/AI/IPromptService.cs` - add StudentObjectiveContext, add to GenerationContext + CurriculumContext  
+- `backend/LangTeach.Api/AI/PromptService.cs` - emit objectives with type
+- `backend/LangTeach.Api/Controllers/GenerateController.cs` - wire ShortTermObjectives
+- `backend/LangTeach.Api/Services/CourseService.cs` - wire ShortTermObjectives
+- `backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs` - tests
+- `frontend/src/api/students.ts` - add objectiveType field
+- `frontend/src/pages/StudentForm.tsx` - type selector in ObjectiveRow
+- `frontend/src/components/student/StudentProfileTab.tsx` - display type badge
+- `frontend/src/components/student/StudentProfileTab.test.tsx` - update fixtures
+- `frontend/src/pages/StudentForm.test.tsx` - update for type selector
+
+## Acceptance Criteria Check
+
+- [ ] Type selector with exam_prep / communicative / other in form
+- [ ] Type persisted to backend (via DTO)
+- [ ] Objective type included in AI generation prompt
+- [ ] Existing students default to "other" (DTO default handles this)


### PR DESCRIPTION
## Summary

- Added `objectiveType` field (`exam_prep` | `communicative` | `other`, default `"other"`) to `ShortTermObjectiveDto` — backward-compatible JSON deserialization, existing data defaults to `"other"`
- Backend validation in `StudentService` rejects unknown types via `AllowedObjectiveTypes` set (consistent with existing `AllowedWeaknessTypes` pattern)
- Wired `StudentShortTermObjectives` through `GenerationContext` and `CurriculumContext` — AI prompts now include typed labels (`[Exam prep]`, `[Communicative]`) via a shared `ObjectiveTypeLabel` helper in `PromptService`
- `StudentForm` `ObjectiveRow` has a `<select>` with all three types; defaults new objectives to `"other"`
- `StudentProfileTab` shows color-coded badges (indigo for exam prep, emerald for communicative; no badge for other)

## Test plan

- [ ] `dotnet test` passes (2 new PromptService objective tests)
- [ ] `npm test` passes (3 new StudentProfileTab badge tests, fixture updates)
- [ ] Creating a student with an unknown objectiveType returns 422
- [ ] Existing students without objectiveType field still load correctly (default to `"other"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Students can now categorize short-term objectives as "Exam Prep," "Communicative," or general type
  * Objective type badges display visually in the student profile view
  * Form interface enables selecting objective type when creating or editing objectives
  * Short-term objectives are now included in AI-generated curriculum content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->