### PR TITLE
feat(#856): add mark-done and hide-completed to teaching todos

### DIFF
--- a/e2e/tests/students.spec.ts
+++ b/e2e/tests/students.spec.ts
@@ -794,14 +794,18 @@ test('teaching todos: add, toggle covered, verify ordering on overview tab', asy
 
   await page.getByTestId(`todo-toggle-${todoId}`).click()
 
-  // Wait for covered state (strikethrough)
+  // Done item disappears from default view; reveal it via the toggle
+  await expect(page.getByTestId('todo-show-completed-toggle')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
+  await page.getByTestId('todo-show-completed-toggle').click()
+
+  // Wait for done state (strikethrough)
   await expect(page.getByTestId(`todo-text-${todoId}`)).toHaveClass(/line-through/, { timeout: FEEDBACK_TIMEOUT })
 
-  // Verify ordering: pending todo should appear before covered
+  // Verify ordering: pending todo should appear before done
   const reorderedItems = page.getByTestId('teaching-todo-item')
   const firstText = await reorderedItems.first().getByTestId(/^todo-text-/).textContent()
   const lastText = await reorderedItems.last().getByTestId(/^todo-text-/).textContent()
-  expect(firstText).not.toEqual(todoText) // the one we covered should now be last
+  expect(firstText).not.toEqual(todoText) // the one we marked done should now be last
   expect(lastText).toEqual(todoText)
 
   // Cleanup: delete the student
@@ -862,24 +866,30 @@ test('teaching todos: toggle persists after reload and can be toggled back to pe
   const toggleTestId = await toggleBtn.getAttribute('data-testid')
   const todoId = toggleTestId!.replace('todo-toggle-', '')
 
-  // Toggle to covered — this previously returned 400
+  // Toggle to done
   const coverDone = waitForTodoWrite()
   await toggleBtn.click()
   await coverDone
+
+  // Done item is hidden by default; reveal it to verify strikethrough
+  await expect(page.getByTestId('todo-show-completed-toggle')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
+  await page.getByTestId('todo-show-completed-toggle').click()
   await expect(page.getByTestId(`todo-text-${todoId}`)).toHaveClass(/line-through/, { timeout: FEEDBACK_TIMEOUT })
 
-  // Reload and verify persistence
+  // Reload and verify persistence — reveal completed again after reload
   await page.reload()
   await expect(page.getByTestId('teaching-todos-card')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
+  await expect(page.getByTestId('todo-show-completed-toggle')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
+  await page.getByTestId('todo-show-completed-toggle').click()
   await expect(page.getByTestId(`todo-text-${todoId}`)).toHaveClass(/line-through/, { timeout: FEEDBACK_TIMEOUT })
 
-  // Toggle back to pending
+  // Toggle back to pending (toggle button now visible since completed are shown)
   const pendingDone = waitForTodoWrite()
   await page.getByTestId(`todo-toggle-${todoId}`).click()
   await pendingDone
   await expect(page.getByTestId(`todo-text-${todoId}`)).not.toHaveClass(/line-through/, { timeout: FEEDBACK_TIMEOUT })
 
-  // Reload again and verify pending state persists
+  // Reload again and verify pending state persists (item visible by default, no completed toggle)
   await page.reload()
   await expect(page.getByTestId('teaching-todos-card')).toBeVisible({ timeout: FEEDBACK_TIMEOUT })
   await expect(page.getByTestId(`todo-text-${todoId}`)).not.toHaveClass(/line-through/, { timeout: FEEDBACK_TIMEOUT })

--- a/frontend/src/components/student/TeachingTodosCard.test.tsx
+++ b/frontend/src/components/student/TeachingTodosCard.test.tsx
@@ -31,6 +31,14 @@ const COVERED_TODO: TeachingTodo = {
   status: 'covered',
   coveredInSessionLogId: 'session-1',
 }
+const DONE_TODO: TeachingTodo = {
+  id: '3',
+  text: 'Pronunciation drills',
+  createdAt: new Date(Date.now() - 259200000).toISOString(), // 3 days ago
+  sourceSessionLogId: null,
+  status: 'done',
+  coveredInSessionLogId: null,
+}
 
 function makeStudent(todos: TeachingTodo[]) {
   return { teachingTodos: todos } as unknown as import('@/api/students').Student
@@ -59,14 +67,54 @@ describe('TeachingTodosCard', () => {
     expect(screen.getByTestId('todo-add-input')).toBeInTheDocument()
   })
 
-  it('renders list of todos', () => {
+  it('renders only pending todos by default (hides completed)', () => {
     render(<TeachingTodosCard {...defaultProps} />, { wrapper })
     expect(screen.getByTestId('teaching-todos-list')).toBeInTheDocument()
-    expect(screen.getAllByTestId('teaching-todo-item')).toHaveLength(2)
+    // Only PENDING_TODO visible by default; COVERED_TODO is hidden
+    expect(screen.getAllByTestId('teaching-todo-item')).toHaveLength(1)
+    expect(screen.getByTestId(`todo-text-${PENDING_TODO.id}`)).toBeInTheDocument()
+    expect(screen.queryByTestId(`todo-text-${COVERED_TODO.id}`)).not.toBeInTheDocument()
   })
 
-  it('sorts pending todos before covered ones', () => {
-    // Pass covered first to verify sorting
+  it('shows "Show N completed" toggle when completed todos exist', () => {
+    render(<TeachingTodosCard {...defaultProps} />, { wrapper })
+    expect(screen.getByTestId('todo-show-completed-toggle')).toHaveTextContent('Show 1 completed')
+  })
+
+  it('does not show completed toggle when no completed todos exist', () => {
+    render(<TeachingTodosCard todos={[PENDING_TODO]} studentId="s1" onStudentChange={vi.fn()} />, { wrapper })
+    expect(screen.queryByTestId('todo-show-completed-toggle')).not.toBeInTheDocument()
+  })
+
+  it('reveals completed todos when toggle is clicked', () => {
+    render(<TeachingTodosCard {...defaultProps} />, { wrapper })
+    fireEvent.click(screen.getByTestId('todo-show-completed-toggle'))
+    expect(screen.getAllByTestId('teaching-todo-item')).toHaveLength(2)
+    expect(screen.getByTestId(`todo-text-${COVERED_TODO.id}`)).toBeInTheDocument()
+  })
+
+  it('changes toggle label to "Hide completed" when expanded', () => {
+    render(<TeachingTodosCard {...defaultProps} />, { wrapper })
+    fireEvent.click(screen.getByTestId('todo-show-completed-toggle'))
+    expect(screen.getByTestId('todo-show-completed-toggle')).toHaveTextContent('Hide completed (1)')
+  })
+
+  it('hides completed todos again when toggle is clicked a second time', () => {
+    render(<TeachingTodosCard {...defaultProps} />, { wrapper })
+    fireEvent.click(screen.getByTestId('todo-show-completed-toggle'))
+    fireEvent.click(screen.getByTestId('todo-show-completed-toggle'))
+    expect(screen.getAllByTestId('teaching-todo-item')).toHaveLength(1)
+  })
+
+  it('shows "Show 2 completed" when both done and covered todos exist', () => {
+    render(
+      <TeachingTodosCard todos={[PENDING_TODO, COVERED_TODO, DONE_TODO]} studentId="s1" onStudentChange={vi.fn()} />,
+      { wrapper }
+    )
+    expect(screen.getByTestId('todo-show-completed-toggle')).toHaveTextContent('Show 2 completed')
+  })
+
+  it('sorts pending todos before completed ones when expanded', () => {
     render(
       <TeachingTodosCard
         todos={[COVERED_TODO, PENDING_TODO]}
@@ -75,20 +123,22 @@ describe('TeachingTodosCard', () => {
       />,
       { wrapper }
     )
+    fireEvent.click(screen.getByTestId('todo-show-completed-toggle'))
     const items = screen.getAllByTestId('teaching-todo-item')
     expect(items[0]).toHaveTextContent('Explain subjunctive') // pending first
     expect(items[1]).toHaveTextContent('Past tense review')   // covered second
   })
 
-  it('applies strikethrough to covered todos', () => {
+  it('applies strikethrough to completed todos when visible', () => {
     render(<TeachingTodosCard {...defaultProps} />, { wrapper })
+    fireEvent.click(screen.getByTestId('todo-show-completed-toggle'))
     const coveredText = screen.getByTestId(`todo-text-${COVERED_TODO.id}`)
     expect(coveredText.className).toContain('line-through')
   })
 
-  it('shows relative time for each todo', () => {
-    render(<TeachingTodosCard {...defaultProps} />, { wrapper })
-    expect(screen.getAllByText(/ago/)).toHaveLength(2)
+  it('shows relative time for each visible todo', () => {
+    render(<TeachingTodosCard todos={[PENDING_TODO]} studentId="s1" onStudentChange={vi.fn()} />, { wrapper })
+    expect(screen.getAllByText(/ago/)).toHaveLength(1)
   })
 
   it('calls appendTeachingTodo on add and updates list optimistically', async () => {
@@ -108,16 +158,32 @@ describe('TeachingTodosCard', () => {
     await waitFor(() => expect(onStudentChange).toHaveBeenCalled())
   })
 
-  it('calls updateTeachingTodo on toggle', async () => {
+  it('calls updateTeachingTodo with status "done" on toggle', async () => {
     vi.mocked(studentsApi.updateTeachingTodo).mockResolvedValue(makeStudent([
-      { ...PENDING_TODO, status: 'covered' },
+      { ...PENDING_TODO, status: 'done' },
       COVERED_TODO,
     ]))
     render(<TeachingTodosCard {...defaultProps} onStudentChange={vi.fn()} />, { wrapper })
 
     fireEvent.click(screen.getByTestId(`todo-toggle-${PENDING_TODO.id}`))
     await waitFor(() =>
-      expect(studentsApi.updateTeachingTodo).toHaveBeenCalledWith('student-1', PENDING_TODO.id, { status: 'covered' })
+      expect(studentsApi.updateTeachingTodo).toHaveBeenCalledWith('student-1', PENDING_TODO.id, { status: 'done' })
+    )
+  })
+
+  it('calls updateTeachingTodo with status "pending" when toggling a done todo', async () => {
+    vi.mocked(studentsApi.updateTeachingTodo).mockResolvedValue(makeStudent([
+      { ...DONE_TODO, status: 'pending' },
+    ]))
+    render(
+      <TeachingTodosCard todos={[DONE_TODO]} studentId="s1" onStudentChange={vi.fn()} />,
+      { wrapper }
+    )
+    // Reveal completed todos first
+    fireEvent.click(screen.getByTestId('todo-show-completed-toggle'))
+    fireEvent.click(screen.getByTestId(`todo-toggle-${DONE_TODO.id}`))
+    await waitFor(() =>
+      expect(studentsApi.updateTeachingTodo).toHaveBeenCalledWith('s1', DONE_TODO.id, { status: 'pending' })
     )
   })
 

--- a/frontend/src/components/student/TeachingTodosCard.tsx
+++ b/frontend/src/components/student/TeachingTodosCard.tsx
@@ -15,6 +15,8 @@ interface TeachingTodosCardProps {
   onAddFormClose?: () => void
 }
 
+const COMPLETED_STATUSES = new Set(['done', 'covered', 'dismissed'])
+
 function relativeTime(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime()
   const mins = Math.floor(diff / 60000)
@@ -46,13 +48,14 @@ export function TeachingTodosCard({ todos, studentId, onStudentChange, allowEdit
   const [optimisticAdds, setOptimisticAdds] = useState<OptimisticAdd[]>([])
   const [pendingUpdates, setPendingUpdates] = useState<Map<string, PendingUpdate>>(() => new Map())
   const [deletedIds, setDeletedIds] = useState<Set<string>>(() => new Set())
+  const [showCompleted, setShowCompleted] = useState(false)
 
   const [newText, setNewText] = useState('')
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editText, setEditText] = useState('')
 
-  // Derive displayed list from server state + optimistic overlays
-  const displayedTodos = useMemo(() => {
+  // Derive all merged todos from server state + optimistic overlays
+  const allMergedTodos = useMemo(() => {
     const serverMerged = todos
       .filter(t => !deletedIds.has(t.id))
       .map(t => {
@@ -61,6 +64,16 @@ export function TeachingTodosCard({ todos, studentId, onStudentChange, allowEdit
       })
     return sortTodos([...serverMerged, ...optimisticAdds])
   }, [todos, deletedIds, pendingUpdates, optimisticAdds])
+
+  const completedCount = useMemo(
+    () => allMergedTodos.filter(t => COMPLETED_STATUSES.has(t.status)).length,
+    [allMergedTodos]
+  )
+
+  const displayedTodos = useMemo(
+    () => showCompleted ? allMergedTodos : allMergedTodos.filter(t => !COMPLETED_STATUSES.has(t.status)),
+    [allMergedTodos, showCompleted]
+  )
 
   const addMutation = useMutation({
     mutationFn: (text: string) => appendTeachingTodo(studentId, text),
@@ -141,7 +154,7 @@ export function TeachingTodosCard({ todos, studentId, onStudentChange, allowEdit
 
   function handleToggle(todo: TeachingTodo) {
     if (toggleMutation.isPending) return
-    const next = todo.status === 'pending' ? 'covered' : 'pending'
+    const next = todo.status === 'pending' ? 'done' : 'pending'
     toggleMutation.mutate({ todoId: todo.id, status: next })
   }
 
@@ -153,7 +166,7 @@ export function TeachingTodosCard({ todos, studentId, onStudentChange, allowEdit
   function commitEdit(todoId: string, currentStatus: string) {
     const text = editText.trim()
     setEditingId(null)
-    const originalTodo = todos.find(t => t.id === todoId) ?? displayedTodos.find(t => t.id === todoId)
+    const originalTodo = todos.find(t => t.id === todoId) ?? allMergedTodos.find(t => t.id === todoId)
     if (text && text !== originalTodo?.text) {
       editMutation.mutate({ todoId, text, status: currentStatus })
     }
@@ -161,91 +174,105 @@ export function TeachingTodosCard({ todos, studentId, onStudentChange, allowEdit
 
   return (
     <div data-testid="teaching-todos-card">
-      {displayedTodos.length === 0 ? (
+      {allMergedTodos.length === 0 ? (
         <p className="text-sm text-zinc-400 italic mb-3" data-testid="teaching-todos-empty">
           No ideas yet. Add one below.
         </p>
       ) : (
-        <ul className="space-y-2 mb-3" data-testid="teaching-todos-list">
-          {displayedTodos.map((todo) => {
-            const isCovered = todo.status === 'covered'
-            const isDismissed = todo.status === 'dismissed'
-            const isInactive = isCovered || isDismissed
-            const isEditing = editingId === todo.id
-            const isOptimistic = '_temp' in todo
+        <>
+          {displayedTodos.length > 0 && (
+            <ul className="space-y-2 mb-3" data-testid="teaching-todos-list">
+              {displayedTodos.map((todo) => {
+                const isDone = todo.status === 'done'
+                const isCovered = todo.status === 'covered'
+                const isDismissed = todo.status === 'dismissed'
+                const isCompleted = isDone || isCovered || isDismissed
+                const isEditing = editingId === todo.id
+                const isOptimistic = '_temp' in todo
 
-            return (
-              <li
-                key={todo.id}
-                className="flex items-start gap-2 group"
-                data-testid="teaching-todo-item"
-              >
-                {/* Checkbox / status toggle */}
-                <button
-                  type="button"
-                  onClick={() => !isOptimistic && handleToggle(todo)}
-                  aria-label={isCovered ? 'Mark pending' : 'Mark covered'}
-                  data-testid={`todo-toggle-${todo.id}`}
-                  className={`mt-0.5 shrink-0 w-4 h-4 rounded border-2 flex items-center justify-center transition-colors ${
-                    isCovered
-                      ? 'bg-green-500 border-green-500'
-                      : isDismissed
-                        ? 'border-zinc-300 bg-zinc-100'
-                        : 'border-indigo-400 hover:border-indigo-600'
-                  }`}
-                >
-                  {isCovered && <Check className="h-2.5 w-2.5 text-white" strokeWidth={3} />}
-                </button>
-
-                {/* Text / edit */}
-                <div className="flex-1 min-w-0">
-                  {isEditing ? (
-                    <input
-                      autoFocus
-                      type="text"
-                      value={editText}
-                      onChange={e => setEditText(e.target.value)}
-                      onBlur={() => commitEdit(todo.id, todo.status)}
-                      onKeyDown={e => {
-                        if (e.key === 'Enter') commitEdit(todo.id, todo.status)
-                        if (e.key === 'Escape') setEditingId(null)
-                      }}
-                      maxLength={500}
-                      className="w-full text-sm border-b border-indigo-300 bg-transparent outline-none text-[#1A1B22] py-0.5"
-                      data-testid={`todo-edit-input-${todo.id}`}
-                    />
-                  ) : (
-                    <span
-                      className={`text-sm leading-snug ${
-                        isInactive ? 'line-through text-zinc-400' : 'text-[#1A1B22]'
-                      } ${allowEdit && !isOptimistic ? 'cursor-text hover:text-indigo-700' : ''}`}
-                      onClick={() => allowEdit && !isOptimistic && startEdit(todo)}
-                      data-testid={`todo-text-${todo.id}`}
-                    >
-                      {todo.text}
-                    </span>
-                  )}
-                  <span className="block text-[0.6875rem] text-zinc-400 mt-0.5" data-testid={`todo-time-${todo.id}`}>
-                    {relativeTime(todo.createdAt)}
-                  </span>
-                </div>
-
-                {/* Delete button (allowEdit only, not for provisional optimistic items) */}
-                {allowEdit && !isEditing && !isOptimistic && (
-                  <button
-                    type="button"
-                    onClick={() => deleteMutation.mutate(todo.id)}
-                    aria-label="Delete todo"
-                    data-testid={`todo-delete-${todo.id}`}
-                    className="shrink-0 text-zinc-300 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100 mt-0.5"
+                return (
+                  <li
+                    key={todo.id}
+                    className="flex items-start gap-2 group"
+                    data-testid="teaching-todo-item"
                   >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </button>
-                )}
-              </li>
-            )
-          })}
-        </ul>
+                    {/* Checkbox / status toggle */}
+                    <button
+                      type="button"
+                      onClick={() => !isOptimistic && handleToggle(todo)}
+                      aria-label={isCompleted ? 'Mark pending' : 'Mark done'}
+                      data-testid={`todo-toggle-${todo.id}`}
+                      className={`mt-0.5 shrink-0 w-4 h-4 rounded border-2 flex items-center justify-center transition-colors ${
+                        isCompleted
+                          ? 'bg-green-500 border-green-500'
+                          : 'border-indigo-400 hover:border-indigo-600'
+                      }`}
+                    >
+                      {isCompleted && <Check className="h-2.5 w-2.5 text-white" strokeWidth={3} />}
+                    </button>
+
+                    {/* Text / edit */}
+                    <div className="flex-1 min-w-0">
+                      {isEditing ? (
+                        <input
+                          autoFocus
+                          type="text"
+                          value={editText}
+                          onChange={e => setEditText(e.target.value)}
+                          onBlur={() => commitEdit(todo.id, todo.status)}
+                          onKeyDown={e => {
+                            if (e.key === 'Enter') commitEdit(todo.id, todo.status)
+                            if (e.key === 'Escape') setEditingId(null)
+                          }}
+                          maxLength={500}
+                          className="w-full text-sm border-b border-indigo-300 bg-transparent outline-none text-[#1A1B22] py-0.5"
+                          data-testid={`todo-edit-input-${todo.id}`}
+                        />
+                      ) : (
+                        <span
+                          className={`text-sm leading-snug ${
+                            isCompleted ? 'line-through text-zinc-400' : 'text-[#1A1B22]'
+                          } ${allowEdit && !isOptimistic ? 'cursor-text hover:text-indigo-700' : ''}`}
+                          onClick={() => allowEdit && !isOptimistic && startEdit(todo)}
+                          data-testid={`todo-text-${todo.id}`}
+                        >
+                          {todo.text}
+                        </span>
+                      )}
+                      <span className="block text-[0.6875rem] text-zinc-400 mt-0.5" data-testid={`todo-time-${todo.id}`}>
+                        {relativeTime(todo.createdAt)}
+                      </span>
+                    </div>
+
+                    {/* Delete button (allowEdit only, not for provisional optimistic items) */}
+                    {allowEdit && !isEditing && !isOptimistic && (
+                      <button
+                        type="button"
+                        onClick={() => deleteMutation.mutate(todo.id)}
+                        aria-label="Delete todo"
+                        data-testid={`todo-delete-${todo.id}`}
+                        className="shrink-0 text-zinc-300 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100 mt-0.5"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+
+          {completedCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowCompleted(v => !v)}
+              data-testid="todo-show-completed-toggle"
+              className="mb-3 text-xs text-zinc-400 hover:text-zinc-600 transition-colors"
+            >
+              {showCompleted ? `Hide completed (${completedCount})` : `Show ${completedCount} completed`}
+            </button>
+          )}
+        </>
       )}
 
       {/* Add input — always visible in uncontrolled mode; visible only when showAddForm=true in controlled mode */}

--- a/plan/stabilisation/task856-teaching-todo-mark-done.md
+++ b/plan/stabilisation/task856-teaching-todo-mark-done.md
@@ -1,0 +1,32 @@
+# Task 856 — Add timestamp and mark-done to "ideas para próximas clases"
+
+## Summary
+Add hide-by-default and "show N completed" toggle to TeachingTodosCard. Backend already has all required fields (CreatedAt, Status with done/covered/dismissed). Frontend already renders timestamps.
+
+## What's already done
+- `TeachingTodoDto` has `CreatedAt` and `Status` (accepts `done`)
+- `TeachingTodosCard` renders relative timestamps
+- Toggle exists but uses `covered` (session-auto) — change to `done` for manual marking
+
+## Changes
+
+### Frontend only
+
+**`TeachingTodosCard.tsx`**
+- Change `handleToggle`: pending → done, done/covered → pending
+- Add `showCompleted` state (default false)
+- Filter displayedTodos: hide done/covered/dismissed when !showCompleted
+- Compute completedCount from all todos (server + optimistic)
+- Render "Show N completed" button below list when completedCount > 0
+
+**`TeachingTodosCard.test.tsx`**
+- Update toggle test: expect `{ status: 'done' }` not `{ status: 'covered' }`
+- Add DONE_TODO fixture
+- Add tests: completed hidden by default, toggle shows them, count label
+
+## Acceptance criteria mapping
+- [x] Timestamp visible — already done
+- [ ] Mark done toggle → done status, pending hidden → done, done → pending
+- [ ] Done hidden by default
+- [ ] "show N completed" toggle
+- [x] New ideas default to pending

--- a/plan/ui-review-backlog.md
+++ b/plan/ui-review-backlog.md
@@ -5,3 +5,9 @@ Non-blocking findings from review-ui runs. Periodically review this file and bat
 ---
 
 *Cleared 2026-04-22 during UI Redesign & Student Profile Polish sprint close. Seeder coverage gaps batched into #834. UX polish items (combobox summary, Focus Areas description) batched into #840. Remaining entries deleted (intentional per Stitch spec, covered by unit tests, or pre-existing infrastructure).*
+
+## #856 (2026-04-23)
+
+| Screen | Finding | Severity |
+|--------|---------|---------|
+| Student overview > TeachingTodosCard | "Show N completed / Hide completed (N)" toggle is plain muted text with no explicit button shape. Hover changes color but no background/border affordance. DS ghost-button treatment may be more appropriate for list-level expand/collapse actions. | Minor |


### PR DESCRIPTION
## Summary

- Completed todos (done/covered/dismissed) hidden by default in "ideas para próximas clases"
- Toggle checkbox now marks pending → `done` (manual completion), not `covered` (session-auto)
- "Show N completed" / "Hide completed (N)" button appears when completed todos exist
- Timestamps were already rendered; all 5 acceptance criteria now satisfied
- 22 unit tests + 2 updated e2e tests cover new behaviour

Closes #856

## Test plan

- [ ] Add 2 teaching ideas to a student; both appear as pending
- [ ] Check one idea -- it disappears from default view
- [ ] "Show 1 completed" toggle appears; click reveals it with strikethrough
- [ ] Click "Hide completed (1)" hides it again
- [ ] Reload -- state persists; checked item still hidden by default
- [ ] Click "Show 1 completed", uncheck -- item returns to pending view
- [ ] New idea added via input defaults to pending (visible by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)