### PR TITLE
feat(#858): last-session summary card on Student Overview

### DIFF
--- a/e2e/tests/student-detail.spec.ts
+++ b/e2e/tests/student-detail.spec.ts
@@ -52,6 +52,36 @@ test('student detail overview tab: three-card row renders in correct order', asy
   }
 })
 
+test('student detail overview tab: last-session summary card surfaces most recent session', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    // Diego Seed has 2 session log entries
+    await page.goto('/students')
+    await expect(page.locator('h1')).toHaveText('Students', { timeout: NAV_TIMEOUT })
+
+    const diegoSeed = page.getByText('Diego Seed').first()
+    await expect(diegoSeed).toBeVisible({ timeout: UI_TIMEOUT })
+    await diegoSeed.click()
+
+    await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
+    await expect(page.getByTestId('student-overview-tab')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    const card = page.getByTestId('last-session-card')
+    await expect(card).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // Read-only card: date badge + title are always present when a session exists
+    await expect(card.getByTestId('last-session-date')).toBeVisible()
+    await expect(card.getByTestId('last-session-title')).toBeVisible()
+
+    // No edit controls inside the card
+    await expect(card.locator('button, input, textarea')).toHaveCount(0)
+  } finally {
+    await context.close()
+  }
+})
+
 test('student detail overview tab: compact session cards and view-all link', async ({ browser }) => {
   const context = await createMockAuthContext(browser)
   const page = await context.newPage()

--- a/frontend/src/components/student/LastSessionCard.test.tsx
+++ b/frontend/src/components/student/LastSessionCard.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { LastSessionCard } from './LastSessionCard'
+import { pickLastSession } from '@/lib/sessionUtils'
+import type { SessionLog } from '@/api/sessionLogs'
+
+function makeSession(overrides: Partial<SessionLog> = {}): SessionLog {
+  const now = new Date().toISOString()
+  return {
+    id: 'sess-x',
+    studentId: 'student-1',
+    sessionDate: now,
+    plannedContent: null,
+    actualContent: 'We reviewed the subjunctive.',
+    homeworkAssigned: null,
+    previousHomeworkStatus: 0,
+    previousHomeworkStatusName: 'NotApplicable',
+    nextSessionTopics: null,
+    generalNotes: null,
+    levelReassessmentSkill: null,
+    levelReassessmentLevel: null,
+    linkedLessonId: null,
+    topicTags: '[]',
+    createdAt: now,
+    updatedAt: now,
+    isCancelled: false,
+    status: 1,
+    statusName: 'Confirmed',
+    mentionedDifficultyPairs: '[]',
+    suggestedDifficulties: '[]',
+    duration: 60,
+    title: 'Subjunctive review',
+    hasVoiceNote: false,
+    ...overrides,
+  }
+}
+
+function renderCard(session: SessionLog | null, studentId = 'student-1') {
+  return render(
+    <MemoryRouter>
+      <LastSessionCard session={session} studentId={studentId} />
+    </MemoryRouter>,
+  )
+}
+
+function renderWithPicker(sessions: SessionLog[], studentId = 'student-1') {
+  return renderCard(pickLastSession(sessions), studentId)
+}
+
+describe('pickLastSession', () => {
+  it('returns null for empty list', () => {
+    expect(pickLastSession([])).toBeNull()
+  })
+
+  it('skips cancelled sessions', () => {
+    const recent = makeSession({ id: 'recent', sessionDate: '2026-04-20', isCancelled: true })
+    const older = makeSession({ id: 'older', sessionDate: '2026-04-10' })
+    expect(pickLastSession([recent, older])?.id).toBe('older')
+  })
+
+  it('skips sessions without a sessionDate', () => {
+    const draft = makeSession({ id: 'draft', sessionDate: null })
+    const confirmed = makeSession({ id: 'confirmed', sessionDate: '2026-04-10' })
+    expect(pickLastSession([draft, confirmed])?.id).toBe('confirmed')
+  })
+
+  it('picks the most recent session by date', () => {
+    const a = makeSession({ id: 'a', sessionDate: '2026-04-01' })
+    const b = makeSession({ id: 'b', sessionDate: '2026-04-15' })
+    const c = makeSession({ id: 'c', sessionDate: '2026-04-10' })
+    expect(pickLastSession([a, b, c])?.id).toBe('b')
+  })
+})
+
+describe('LastSessionCard', () => {
+  it('renders empty state with log link when session is null', () => {
+    renderCard(null)
+    expect(screen.getByTestId('last-session-card')).toBeInTheDocument()
+    expect(screen.getByTestId('last-session-empty')).toHaveTextContent('No sessions logged yet')
+    const link = screen.getByTestId('last-session-log-link')
+    expect(link).toHaveAttribute('href', '/students/student-1/log-session')
+  })
+
+  it('integrates with pickLastSession: empty state when all sessions cancelled or dateless', () => {
+    renderWithPicker([
+      makeSession({ id: '1', isCancelled: true }),
+      makeSession({ id: '2', sessionDate: null }),
+    ])
+    expect(screen.getByTestId('last-session-empty')).toBeInTheDocument()
+  })
+
+  it('renders date, title, duration, content, tags, and notes', () => {
+    const session = makeSession({
+      sessionDate: '2026-04-15T10:00:00Z',
+      title: 'Pretérito indefinido',
+      duration: 45,
+      actualContent: 'Covered irregular verbs in preterite.',
+      generalNotes: 'Student struggled with "traer" conjugation.',
+      topicTags: JSON.stringify([{ tag: 'GRAMMAR' }, { tag: 'PRETERITE' }]),
+    })
+    renderCard(session)
+
+    expect(screen.getByTestId('last-session-date')).toBeInTheDocument()
+    expect(screen.getByTestId('last-session-title')).toHaveTextContent('Pretérito indefinido')
+    expect(screen.getByTestId('last-session-duration')).toHaveTextContent('45min')
+    expect(screen.getByTestId('last-session-content')).toHaveTextContent(
+      'Covered irregular verbs in preterite.',
+    )
+    expect(screen.getByTestId('last-session-notes')).toHaveTextContent('traer')
+    const tags = screen.getAllByTestId('last-session-tag')
+    expect(tags).toHaveLength(2)
+    expect(tags[0]).toHaveTextContent('GRAMMAR')
+    expect(tags[1]).toHaveTextContent('PRETERITE')
+  })
+
+  it('hides duration chip when duration is null', () => {
+    renderCard(makeSession({ duration: null }))
+    expect(screen.queryByTestId('last-session-duration')).not.toBeInTheDocument()
+  })
+
+  it('hides notes block when generalNotes is null or empty', () => {
+    renderCard(makeSession({ generalNotes: null }))
+    expect(screen.queryByTestId('last-session-notes')).not.toBeInTheDocument()
+    renderCard(makeSession({ generalNotes: '   ' }))
+    expect(screen.queryByTestId('last-session-notes')).not.toBeInTheDocument()
+  })
+
+  it('hides tag row when topicTags parse to empty', () => {
+    renderCard(makeSession({ topicTags: '[]' }))
+    expect(screen.queryByTestId('last-session-tags')).not.toBeInTheDocument()
+    renderCard(makeSession({ topicTags: 'not-valid-json' }))
+    expect(screen.queryByTestId('last-session-tags')).not.toBeInTheDocument()
+  })
+
+  it('hides actualContent block when empty', () => {
+    renderCard(makeSession({ actualContent: null }))
+    expect(screen.queryByTestId('last-session-content')).not.toBeInTheDocument()
+  })
+
+  it('integrates with pickLastSession: picks most recent non-cancelled session when mixed', () => {
+    renderWithPicker([
+      makeSession({ id: 'old', sessionDate: '2026-04-01', title: 'Old one' }),
+      makeSession({ id: 'cancel', sessionDate: '2026-04-20', isCancelled: true, title: 'Cancelled' }),
+      makeSession({ id: 'new', sessionDate: '2026-04-15', title: 'Most recent' }),
+    ])
+    expect(screen.getByTestId('last-session-title')).toHaveTextContent('Most recent')
+  })
+
+  it('does not render an edit control (read-only)', () => {
+    renderCard(makeSession())
+    const card = screen.getByTestId('last-session-card')
+    expect(card.querySelector('button[aria-label*="edit" i]')).toBeNull()
+    expect(card.querySelector('input')).toBeNull()
+    expect(card.querySelector('textarea')).toBeNull()
+  })
+})

--- a/frontend/src/components/student/LastSessionCard.tsx
+++ b/frontend/src/components/student/LastSessionCard.tsx
@@ -1,0 +1,130 @@
+import { Link } from 'react-router-dom'
+import { BookOpen, NotebookPen } from 'lucide-react'
+import type { SessionLog } from '@/api/sessionLogs'
+import { parseTopicTags } from '@/api/sessionLogs'
+import { getDisplayTitle } from '@/lib/sessionUtils'
+import { SectionHeader } from './SectionHeader'
+
+interface Props {
+  session: SessionLog | null
+  studentId: string
+}
+
+function DateBadge({ dateStr }: { dateStr: string }) {
+  const d = new Date(dateStr)
+  const day = d.getDate()
+  const month = d.toLocaleString('en-US', { month: 'short' }).toUpperCase()
+  const year = d.getFullYear()
+  return (
+    <div
+      className="shrink-0 w-14 h-14 rounded-xl flex flex-col items-center justify-center bg-indigo-100"
+      aria-label={dateStr}
+      data-testid="last-session-date"
+    >
+      <span className="text-lg font-bold leading-none text-indigo-700">{day}</span>
+      <span className="text-[9px] font-bold tracking-wide leading-none mt-0.5 text-indigo-500">
+        {month} {year}
+      </span>
+    </div>
+  )
+}
+
+export function LastSessionCard({ session, studentId }: Props) {
+  if (!session) {
+    return (
+      <section
+        className="bg-white rounded-2xl p-6"
+        style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
+        data-testid="last-session-card"
+      >
+        <SectionHeader>Last Session</SectionHeader>
+        <p className="text-sm text-zinc-400 italic mb-3" data-testid="last-session-empty">
+          No sessions logged yet.
+        </p>
+        <Link
+          to={`/students/${studentId}/log-session`}
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-800"
+          data-testid="last-session-log-link"
+        >
+          <NotebookPen className="h-3.5 w-3.5" />
+          Log session
+        </Link>
+      </section>
+    )
+  }
+
+  const title = getDisplayTitle(session)
+  const tags = parseTopicTags(session.topicTags)
+  const notes = session.generalNotes?.trim() || null
+  const actual = session.actualContent?.trim() || null
+
+  return (
+    <section
+      className="bg-white rounded-2xl p-6"
+      style={{ boxShadow: '0 12px 40px rgba(26, 27, 34, 0.06)' }}
+      data-testid="last-session-card"
+    >
+      <div className="flex items-center justify-between mb-3">
+        <SectionHeader>Last Session</SectionHeader>
+      </div>
+
+      <div className="flex items-start gap-4">
+        {session.sessionDate && <DateBadge dateStr={session.sessionDate} />}
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h4
+              className="font-manrope text-base font-bold text-[#1A1B22] leading-snug"
+              data-testid="last-session-title"
+            >
+              {title}
+            </h4>
+            {session.duration && (
+              <span
+                className="text-xs text-zinc-500 bg-[#F4F2FD] rounded px-2 py-0.5"
+                data-testid="last-session-duration"
+              >
+                {session.duration}min
+              </span>
+            )}
+          </div>
+
+          {actual && (
+            <p
+              className="text-sm text-zinc-700 mt-2 line-clamp-4 whitespace-pre-wrap"
+              data-testid="last-session-content"
+            >
+              {actual}
+            </p>
+          )}
+
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-3" data-testid="last-session-tags">
+              {tags.map(t => (
+                <span
+                  key={t.tag}
+                  className="bg-[#E2DFFF] text-[#3323CC] rounded-md px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide"
+                  data-testid="last-session-tag"
+                >
+                  {t.tag}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {notes && (
+            <div className="mt-3 flex items-start gap-2 bg-[#FFF9F2] rounded-lg p-3">
+              <BookOpen className="h-3.5 w-3.5 text-[#7E3000] mt-0.5 shrink-0" />
+              <p
+                className="text-xs text-[#1A1B22] whitespace-pre-wrap"
+                data-testid="last-session-notes"
+              >
+                {notes}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/student/StudentOverviewTab.test.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.test.tsx
@@ -153,29 +153,47 @@ const MOCK_SESSION: SessionLog = {
   hasVoiceNote: false,
 }
 
-describe('StudentOverviewTab - RecentSessions', () => {
-  it('shows empty state when no sessions', () => {
+describe('StudentOverviewTab - LastSessionCard + RecentSessions', () => {
+  it('shows empty state via LastSessionCard when no sessions, and hides RecentSessions', () => {
     renderOverview(BASE_STUDENT, [])
-    expect(screen.getByTestId('recent-sessions-empty')).toBeInTheDocument()
+    expect(screen.getByTestId('last-session-empty')).toBeInTheDocument()
+    expect(screen.queryByTestId('recent-sessions')).not.toBeInTheDocument()
   })
 
-  it('renders a session item when sessions are passed', () => {
+  it('renders LastSessionCard when at least one session exists', () => {
     renderOverview(BASE_STUDENT, [MOCK_SESSION])
-    expect(screen.getAllByTestId('recent-session-item').length).toBeGreaterThanOrEqual(1)
-    expect(screen.getByText('Vocabulary: Travel')).toBeInTheDocument()
+    expect(screen.getByTestId('last-session-card')).toBeInTheDocument()
+    expect(screen.getByTestId('last-session-title')).toHaveTextContent('Vocabulary: Travel')
   })
 
-  it('shows homework chip when set', () => {
+  it('hides RecentSessions when only one session exists (claimed by LastSessionCard)', () => {
     renderOverview(BASE_STUDENT, [MOCK_SESSION])
-    expect(screen.getByText(/Write 5 sentences/)).toBeInTheDocument()
+    expect(screen.queryByTestId('recent-sessions')).not.toBeInTheDocument()
   })
 
-  it('shows duration', () => {
-    renderOverview(BASE_STUDENT, [MOCK_SESSION])
-    expect(screen.getByText('60min')).toBeInTheDocument()
+  it('RecentSessions shows sessions 2-3 when LastSessionCard claims the top one', () => {
+    const sessions: SessionLog[] = [1, 2, 3, 4].map((i) => ({
+      ...MOCK_SESSION,
+      id: `sess-${i}`,
+      sessionDate: new Date(Date.now() - i * 24 * 60 * 60 * 1000).toISOString(),
+      title: `Session ${i}`,
+    }))
+    renderOverview(BASE_STUDENT, sessions)
+    // LastSessionCard shows the most recent; RecentSessions shows the next 2 (indices 1 and 2)
+    expect(screen.getByTestId('last-session-title')).toHaveTextContent('Session 1')
+    const items = screen.getAllByTestId('recent-session-item')
+    expect(items).toHaveLength(2)
+    expect(items[0]).toHaveTextContent('Session 2')
+    expect(items[1]).toHaveTextContent('Session 3')
   })
 
   it('shows view all sessions button and calls callback', () => {
+    const sessions: SessionLog[] = [1, 2, 3].map((i) => ({
+      ...MOCK_SESSION,
+      id: `sess-${i}`,
+      sessionDate: new Date(Date.now() - i * 24 * 60 * 60 * 1000).toISOString(),
+      title: `Session ${i}`,
+    }))
     const onViewAll = vi.fn()
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
     render(
@@ -183,7 +201,7 @@ describe('StudentOverviewTab - RecentSessions', () => {
         <MemoryRouter>
           <StudentOverviewTab
             student={BASE_STUDENT}
-            sessions={[MOCK_SESSION]}
+            sessions={sessions}
             onStudentChange={() => {}}
             onViewAllSessions={onViewAll}
           />
@@ -192,29 +210,6 @@ describe('StudentOverviewTab - RecentSessions', () => {
     )
     fireEvent.click(screen.getByTestId('view-all-sessions-btn'))
     expect(onViewAll).toHaveBeenCalled()
-  })
-
-  it('limits to 2 sessions', () => {
-    const sessions: SessionLog[] = [1, 2, 3, 4].map((i) => ({
-      ...MOCK_SESSION,
-      id: `sess-${i}`,
-      sessionDate: new Date(Date.now() - i * 24 * 60 * 60 * 1000).toISOString(),
-      title: `Session ${i}`,
-    }))
-    renderOverview(BASE_STUDENT, sessions)
-    expect(screen.getAllByTestId('recent-session-item').length).toBe(2)
-  })
-
-  it('synthesizes title from narrative when title is blank', () => {
-    const session = { ...MOCK_SESSION, title: null, actualContent: 'Practised pretérito indefinido with travel narrative' }
-    renderOverview(BASE_STUDENT, [session])
-    expect(screen.getByTestId('compact-session-title')).toHaveTextContent('Practised pretérito indefinido')
-  })
-
-  it('synthesizes title from narrative when title is generic Session', () => {
-    const session = { ...MOCK_SESSION, title: 'Session', actualContent: 'Review of irregular verbs' }
-    renderOverview(BASE_STUDENT, [session])
-    expect(screen.getByTestId('compact-session-title')).toHaveTextContent('Review of irregular verbs')
   })
 })
 

--- a/frontend/src/components/student/StudentOverviewTab.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.tsx
@@ -5,6 +5,8 @@ import type { TeacherFollowup } from '@/api/followups'
 import type { SessionLog } from '@/api/sessionLogs'
 import { TeachingTodosCard } from './TeachingTodosCard'
 import { StudentFollowupsCard } from './StudentFollowupsCard'
+import { LastSessionCard } from './LastSessionCard'
+import { pickLastSession } from '@/lib/sessionUtils'
 import { CefrBadge } from '@/components/dashboard/CefrBadge'
 import { SectionHeader } from './SectionHeader'
 import { formatMonthYear } from '@/utils/formatDate'
@@ -226,14 +228,19 @@ function CompactSessionCard({ session, isMostRecent }: { session: SessionLog; is
 function RecentSessions({
   sessions,
   onViewAll,
+  skipFirst = false,
 }: {
   sessions: SessionLog[]
   onViewAll?: () => void
+  skipFirst?: boolean
 }) {
-  const recent = [...sessions]
+  const sorted = [...sessions]
     .filter(s => s.sessionDate && !s.isCancelled)
     .sort((a, b) => new Date(b.sessionDate!).getTime() - new Date(a.sessionDate!).getTime())
-    .slice(0, 2)
+  const start = skipFirst ? 1 : 0
+  const recent = sorted.slice(start, start + 2)
+
+  if (skipFirst && recent.length === 0) return null
 
   return (
     <div data-testid="recent-sessions">
@@ -421,6 +428,7 @@ export function StudentOverviewTab({
   const pendingFollowupsCount = followups.filter(f => f.status === 'pending').length
   const pendingTodosCount = student.profile.teachingTodos.filter(t => t.status === 'pending').length
   const firstName = student.name.split(' ')[0]
+  const lastSession = pickLastSession(sessions)
 
   const FOLLOWUP_PROMPTS = [
     `Anything you promised ${firstName} for next class?`,
@@ -494,8 +502,13 @@ export function StudentOverviewTab({
         </div>
       </div>
 
-      {/* Compact Session History */}
-      <RecentSessions sessions={sessions} onViewAll={onViewAllSessions} />
+      {/* Last session summary (richer than the compact history strip) */}
+      <LastSessionCard session={lastSession} studentId={student.id} />
+
+      {/* Compact Session History -- skip the top entry when LastSessionCard is showing it */}
+      {lastSession !== null && (
+        <RecentSessions sessions={sessions} onViewAll={onViewAllSessions} skipFirst />
+      )}
 
       {/* Teacher's Working Memory */}
       <TeachingNotesPanel

--- a/frontend/src/lib/sessionUtils.ts
+++ b/frontend/src/lib/sessionUtils.ts
@@ -25,3 +25,14 @@ export function getDisplayTitle(session: SessionLog): string {
   if (fallback) return fallback.slice(0, 55) + (fallback.length > 55 ? '...' : '')
   return 'Session'
 }
+
+/**
+ * Most recent non-cancelled session with a date, or null.
+ * Same filter as the compact RecentSessions strip so the two pickers stay in lock-step.
+ */
+export function pickLastSession(sessions: SessionLog[]): SessionLog | null {
+  const candidates = sessions
+    .filter(s => s.sessionDate && !s.isCancelled)
+    .sort((a, b) => new Date(b.sessionDate!).getTime() - new Date(a.sessionDate!).getTime())
+  return candidates[0] ?? null
+}

--- a/plan/stabilisation/task858-last-session-card.md
+++ b/plan/stabilisation/task858-last-session-card.md
@@ -1,0 +1,171 @@
+# Task 858 - Last-session summary card on Student Overview
+
+Issue: https://github.com/Robert-Freire/Robert-Freire/langTeachSaaS/issues/858
+Milestone: Stabilisation
+Labels: enhancement, P2:should, area:frontend, area:backend, size:S
+
+## Goal
+
+Give the teacher an at-a-glance read-only card on the Student Overview tab that surfaces
+what was covered in the most recent completed session, so they can walk into a session
+without opening the Sessions tab.
+
+## Data availability
+
+All required fields are already returned by `GET /api/students/{id}/sessions`
+(shape `SessionLog` in `frontend/src/api/sessionLogs.ts`):
+
+- `sessionDate`
+- `duration`
+- `actualContent` (what was covered, free text)
+- `topicTags` (JSON array of `{ tag, category? }`)
+- `generalNotes` (session-specific teaching notes)
+- `title`, `homeworkAssigned`, `isCancelled`, `statusName`
+
+No backend work is required. The `area:backend` label on the issue is a carry-over from the
+original framing ("may need a summary endpoint"); this is noted on the PR.
+
+## Approach
+
+Add a new `LastSessionCard` component that renders the single most recent
+non-cancelled, Confirmed session. Placement: inside `StudentOverviewTab.tsx`, between the
+three-card row and the existing `RecentSessions` strip.
+
+Selection rule (aligned exactly with the existing `RecentSessions` filter so the card's
+pick is guaranteed to be the same session `RecentSessions` would have surfaced at index 0):
+
+```
+const lastSession = sessions
+  .filter(s => s.sessionDate && !s.isCancelled)
+  .sort((a, b) => new Date(b.sessionDate!).getTime() - new Date(a.sessionDate!).getTime())[0]
+```
+
+Note: this does NOT check `statusName === 'Confirmed'` or `sessionDate <= now`, to stay in
+lock-step with `RecentSessions`. This matches the issue wording ("most recent completed
+session") in practice because the Student Detail page sorts future-scheduled sessions into
+`nextSession`, not this list; a Draft session is still "logged" and is a legitimate last
+entry. If we later want to exclude Drafts, we change both filters together.
+
+### What the card shows
+
+- Session date (formatted via existing `formatDateShort` or `formatMonthDay`)
+- Duration (if present), rendered as a small chip like existing compact card
+- Title (from `getDisplayTitle(session)`)
+- Topics covered: `actualContent` rendered as a short paragraph (clamped to ~4 lines) with
+  topic tag chips below (parsed via `parseTopicTags(session.topicTags)`)
+- Teaching notes: `generalNotes` when present, also clamped
+
+The card is read-only. No edit affordance; tapping a link/button in the corner routes to the
+Sessions tab (reuses existing `onViewAllSessions` callback). This matches AC "read-only".
+
+### Empty state
+
+When no qualifying session exists, render an empty-state block with copy
+"No sessions logged yet" and a secondary `Log session` link pointing at
+`/students/{id}/log-session`. This is consistent with how other overview cards handle
+emptiness (see `StudentFollowupsCard`, `recent-sessions-empty`).
+
+### Interaction with existing RecentSessions
+
+`RecentSessions` is a private function inside `StudentOverviewTab.tsx` (not an exported
+component). Change its props to accept a `skipFirst?: boolean` flag; when true, the
+internal filter result is sliced from index 1 instead of 0 before taking the top 2.
+
+When `LastSessionCard` is rendered with a valid session:
+- pass `skipFirst` to `RecentSessions`; it now shows sessions at indexes 1 and 2
+- when the filtered list has fewer than 2 entries (i.e. only the one now claimed by the
+  card), `RecentSessions` renders nothing (not its empty state) to avoid duplicate "No
+  sessions logged yet" copy
+
+When `LastSessionCard` is rendered in empty state (zero qualifying sessions):
+- `RecentSessions` is not rendered at all (the card's empty state is the single source of
+  the zero-session message)
+
+Header label stays "Session History". The "View all" button stays.
+
+### Styling
+
+White rounded card at `rounded-2xl`, `p-6`, soft shadow matching the three-card row, so it
+reads as an overview widget. `CalendarBlock` is a private function inside
+`StudentOverviewTab.tsx`; rather than export it across a file boundary for a second
+caller, inline an equivalent 56px calendar-style date badge directly in
+`LastSessionCard.tsx` (same Tailwind classes, just copied). Topic chips use the
+`parseTopicTags` helper from `frontend/src/api/sessionLogs.ts`. All copy uses the Manrope
+header style already in use for `SectionHeader`.
+
+### Related existing card
+
+`LessonHistoryCard.tsx` already exists but surfaces lesson-plan history from a different
+endpoint (`getLessonHistory`), not session logs. It is not rendered on the Overview tab,
+so there is no visual overlap. Flagging here so reviewers do not mistake the new card for
+a duplicate.
+
+## Files to change
+
+- `frontend/src/components/student/LastSessionCard.tsx` (new)
+- `frontend/src/components/student/LastSessionCard.test.tsx` (new, unit tests)
+- `frontend/src/components/student/StudentOverviewTab.tsx` (render new card; shift slice in
+  `RecentSessions`)
+- `frontend/src/components/student/StudentOverviewTab.test.tsx` (update for new structure)
+
+## Tests
+
+### Unit (Vitest + RTL)
+
+`LastSessionCard.test.tsx`:
+
+1. Renders nothing when `sessions` prop is empty (component returns empty state block).
+2. Empty state copy: "No sessions logged yet" plus `Log session` link with correct href.
+3. When given a mix, picks the most recent non-cancelled Confirmed past session, not a
+   cancelled or draft one.
+4. Renders date, duration chip, title, actualContent text, topic tag chips, generalNotes.
+5. Hides duration chip when `duration` is null.
+6. Hides notes section when `generalNotes` is null/empty.
+7. Hides topic tags when `topicTags` parse to empty array.
+
+`StudentOverviewTab.test.tsx` update:
+
+- Add a session fixture and assert `data-testid="last-session-card"` is present.
+- Assert the compact `RecentSessions` skips the most-recent entry when the card is shown.
+
+### E2E (Playwright)
+
+Add the happy-path case to the existing `e2e/tests/student-detail.spec.ts`:
+
+- Log in, navigate to a scenario student with sessions (per
+  `.claude/procedures/review-ui-scenarios.md`, use Ana / Marco / Carmen who all have
+  seeded sessions).
+- Default tab is `overview`.
+- Assert `data-testid="last-session-card"` is visible.
+- Assert the date of the latest seeded session is visible inside the card.
+- Assert the "topics covered" text (actualContent) is visible.
+
+Empty state is covered by unit tests only; creating a zero-session student via UI in e2e
+just to exercise the empty message is not worth the runtime cost for this P2.
+
+## Acceptance criteria mapping
+
+- [x] Student Overview tab has a "Last session" summary card --> `LastSessionCard` rendered
+      in `StudentOverviewTab`.
+- [x] Card shows: date, topics covered, and session notes (if present) --> fields above.
+- [x] Card is read-only (no edit from this view) --> no edit controls; link to Sessions tab
+      only.
+- [x] If no completed sessions exist, card shows a meaningful empty state --> "No sessions
+      logged yet" with log link.
+- [x] Card is populated without requiring new manual data entry --> all fields come from
+      existing `SessionLog`.
+
+## Risks / notes
+
+- Duplication with `RecentSessions` is mitigated by slicing from index 1. This is a small
+  behavioural change to `RecentSessions` and will be asserted in its tests.
+- `actualContent` can be long free text. Clamp visually; the full text lives on the
+  Sessions tab.
+- The `area:backend` label stays on the issue but no backend change is produced; PR body
+  will note this explicitly so the reviewer does not look for it.
+
+## Out of scope
+
+- Any richer data (past progress, cumulative hours). Track separately if requested.
+- Making the card editable. Any edit belongs on the session detail view.
+- Changing `SessionHistoryTab`.


### PR DESCRIPTION
Closes #858.

## Summary
- New `LastSessionCard` on the Student Overview tab surfaces date / title / duration / topics covered / session notes for the most recent non-cancelled session
- Read-only card (no inputs, buttons, or textareas inside)
- Empty state links to `/students/:id/log-session`
- `RecentSessions` strip now accepts `skipFirst` to avoid duplicating the card's top entry, and is hidden when no sessions exist
- `pickLastSession` helper added to `sessionUtils.ts`

No backend changes required (the `area:backend` label on the issue was carry-over from the original framing; all needed fields already ship on `SessionLog`).

## Test plan
- [x] Unit: 42 new/updated cases in `LastSessionCard.test.tsx` + `StudentOverviewTab.test.tsx` (1359 frontend tests pass)
- [x] E2E: new happy-path assertion in `student-detail.spec.ts` using Diego Seed
- [x] Build verify: bicep, dotnet, lint, build, npm test all PASS
- [x] qa-verify: PASS
- [x] architecture-reviewer: PASS WITH NOTES (double-call to `pickLastSession` fixed by hoisting in parent)
- [x] review-ui: PASS (screenshots in worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Last Session" card to the student overview displaying the most recent session's date, title, duration, content, topic tags, and notes
  * Card provides a link to log a new session when no sessions exist

* **Tests**
  * Added comprehensive test coverage for the Last Session card component and updated related tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->