### PR TITLE
docs(#854): add comment explaining Dashboard skeleton loading pattern

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -31,6 +31,7 @@ export default function Dashboard() {
     )
   }
 
+  // Intentional divergence: skeleton (not spinner) because Dashboard has multiple distinct regions; use this pattern only for similarly complex multi-region pages.
   if (isLoading) {
     return (
       <div className="space-y-5" data-testid="dashboard-skeleton">

--- a/plan/stabilisation/task854-dashboard-skeleton-comment.md
+++ b/plan/stabilisation/task854-dashboard-skeleton-comment.md
@@ -1,0 +1,17 @@
+# Task 854: Document Dashboard skeleton loading pattern
+
+## Issue
+#854 - chore: document or share Dashboard skeleton loading pattern
+
+## Decision
+Option B from issue: add a single comment in Dashboard.tsx above the skeleton JSX block.
+No shared component needed (pattern exists in one place only).
+
+## Change
+Added one comment line above the `if (isLoading)` block in `Dashboard.tsx` explaining:
+- Why Dashboard uses skeleton instead of spinner (multiple distinct layout regions)
+- That this is intentional divergence
+- When to reuse it (similarly complex multi-region pages)
+
+## File changed
+`frontend/src/pages/Dashboard.tsx`


### PR DESCRIPTION
## Summary
- Adds a single comment line above the skeleton loading block in `Dashboard.tsx` explaining why this page uses skeleton instead of spinner, and when to apply the same pattern.

Closes #854

## Test plan
- [ ] Verify comment appears above the `if (isLoading)` block in `Dashboard.tsx`
- [ ] Build passes (`npm build`, `npm lint`, `npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)