### PR TITLE
fix(#871): align ValidationException handling in StudentsController and CoursesController

### DIFF
--- a/backend/LangTeach.Api/Controllers/CoursesController.cs
+++ b/backend/LangTeach.Api/Controllers/CoursesController.cs
@@ -56,7 +56,8 @@ public class CoursesController : ControllerBase
         }
         catch (ValidationException ex)
         {
-            return BadRequest(ex.Message);
+            ModelState.AddModelError(string.Empty, ex.Message);
+            return BadRequest(ModelState);
         }
         catch (CurriculumGenerationException ex)
         {

--- a/backend/LangTeach.Api/Controllers/StudentsController.cs
+++ b/backend/LangTeach.Api/Controllers/StudentsController.cs
@@ -63,7 +63,8 @@ public class StudentsController : ControllerBase
         }
         catch (ValidationException ex)
         {
-            return ValidationProblem(ex.Message);
+            ModelState.AddModelError(string.Empty, ex.Message);
+            return BadRequest(ModelState);
         }
     }
 
@@ -111,7 +112,8 @@ public class StudentsController : ControllerBase
         }
         catch (ValidationException ex)
         {
-            return ValidationProblem(ex.Message);
+            ModelState.AddModelError(string.Empty, ex.Message);
+            return BadRequest(ModelState);
         }
     }
 
@@ -144,7 +146,8 @@ public class StudentsController : ControllerBase
         }
         catch (System.ComponentModel.DataAnnotations.ValidationException ex)
         {
-            return ValidationProblem(ex.Message);
+            ModelState.AddModelError(string.Empty, ex.Message);
+            return BadRequest(ModelState);
         }
     }
 
@@ -165,7 +168,8 @@ public class StudentsController : ControllerBase
         }
         catch (System.ComponentModel.DataAnnotations.ValidationException ex)
         {
-            return ValidationProblem(ex.Message);
+            ModelState.AddModelError(string.Empty, ex.Message);
+            return BadRequest(ModelState);
         }
     }
 

--- a/plan/stabilisation/task871-validation-exception-alignment.md
+++ b/plan/stabilisation/task871-validation-exception-alignment.md
@@ -1,0 +1,19 @@
+# Task 871: Align ValidationException error handling in StudentsController and CoursesController
+
+## Issue
+#871 — follow-up to #852.
+
+## Changes
+
+**StudentsController** (4 occurrences):
+- `Create` (line ~66): `ValidationProblem(ex.Message)` → `ModelState.AddModelError + BadRequest(ModelState)`
+- `Update` (line ~114): same
+- `AppendTeachingTodo` (line ~147): same (fully-qualified `System.ComponentModel.DataAnnotations.ValidationException`)
+- `UpdateTeachingTodo` (line ~168): same
+
+**CoursesController** (1 occurrence):
+- `Create` (line ~59): raw `BadRequest(ex.Message)` → `ModelState.AddModelError + BadRequest(ModelState)`
+
+## Testing
+- `dotnet build`: 0 errors, 0 warnings
+- `dotnet test`: 1141 passed, 0 failed


### PR DESCRIPTION
## Summary

- Replace `ValidationProblem(ex.Message)` with `ModelState.AddModelError + BadRequest(ModelState)` in 4 catch blocks in `StudentsController`
- Replace raw `BadRequest(ex.Message)` with `ModelState.AddModelError + BadRequest(ModelState)` in `CoursesController`
- All five API controllers handling `ValidationException` now return consistent `BadRequest(ModelState)` responses

Follow-up to #852.

## Test plan

- [x] `dotnet build` passes (0 errors, 0 warnings)
- [x] `dotnet test` passes (1141 passed, 0 failed)
- [x] `npm lint` + `npm build` + `npm test` pass
- [x] Architecture review: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)