### PR TITLE
refactor(#869): centralise TeachingTodoDto projection via shared expression

### DIFF
--- a/backend/LangTeach.Api.Tests/DTOs/TeachingTodoDtoProjectionTests.cs
+++ b/backend/LangTeach.Api.Tests/DTOs/TeachingTodoDtoProjectionTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using LangTeach.Api.Data.Models;
+using LangTeach.Api.DTOs;
+
+namespace LangTeach.Api.Tests.DTOs;
+
+public class TeachingTodoDtoProjectionTests
+{
+    private static TeacherFollowup BuildFollowup(Guid? sourceSessionLogId = null, Guid? coveredInSessionLogId = null) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Text = "Work on subjunctive",
+            Status = "pending",
+            CreatedAt = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+            SourceSessionLogId = sourceSessionLogId,
+            CoveredInSessionLogId = coveredInSessionLogId
+        };
+
+    [Fact]
+    public void Compiled_MapsAllFields()
+    {
+        var sourceId = Guid.NewGuid();
+        var followup = BuildFollowup(sourceSessionLogId: sourceId);
+
+        var dto = TeachingTodoDtoProjection.Compiled(followup);
+
+        dto.Id.Should().Be(followup.Id.ToString());
+        dto.Text.Should().Be(followup.Text);
+        dto.CreatedAt.Should().Be(followup.CreatedAt);
+        dto.SourceSessionLogId.Should().Be(sourceId.ToString());
+        dto.Status.Should().Be(followup.Status);
+        dto.CoveredInSessionLogId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Compiled_NullableGuidsMapToNull()
+    {
+        var followup = BuildFollowup();
+
+        var dto = TeachingTodoDtoProjection.Compiled(followup);
+
+        dto.SourceSessionLogId.Should().BeNull();
+        dto.CoveredInSessionLogId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Projection_ExpressionProducesSameResultAsCompiled()
+    {
+        var followup = BuildFollowup(sourceSessionLogId: Guid.NewGuid());
+        var fromCompiled = TeachingTodoDtoProjection.Compiled(followup);
+        var fromExpression = TeachingTodoDtoProjection.Projection.Compile()(followup);
+
+        fromExpression.Should().BeEquivalentTo(fromCompiled);
+    }
+}

--- a/backend/LangTeach.Api/DTOs/TeachingTodoDtoProjection.cs
+++ b/backend/LangTeach.Api/DTOs/TeachingTodoDtoProjection.cs
@@ -1,0 +1,18 @@
+using System.Linq.Expressions;
+using LangTeach.Api.Data.Models;
+
+namespace LangTeach.Api.DTOs;
+
+public static class TeachingTodoDtoProjection
+{
+    public static readonly Expression<Func<TeacherFollowup, TeachingTodoDto>> Projection =
+        f => new TeachingTodoDto(
+            f.Id.ToString(),
+            f.Text,
+            f.CreatedAt,
+            f.SourceSessionLogId != null ? f.SourceSessionLogId.ToString() : null,
+            f.Status,
+            f.CoveredInSessionLogId != null ? f.CoveredInSessionLogId.ToString() : null);
+
+    public static readonly Func<TeacherFollowup, TeachingTodoDto> Compiled = Projection.Compile();
+}

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -230,6 +230,7 @@ public class DashboardService : IDashboardService
                 PendingTodos = s.TeacherFollowups
                     .Where(f => f.Kind == "pedagogical" && f.Status == "pending")
                     .OrderBy(f => f.CreatedAt)
+                    // Projection matches TeachingTodoDtoProjection.Compiled — keep in sync.
                     .Select(f => new TeachingTodoDto(
                         f.Id.ToString(), f.Text, f.CreatedAt,
                         f.SourceSessionLogId != null ? f.SourceSessionLogId.ToString() : null,

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -259,7 +259,7 @@ public class StudentService : IStudentService
                 str => new StudentWeaknessDto(str, "grammatical")),
             JsonStorageHelper.DeserializeList<DifficultyDto>(s.Difficulties),
             JsonStorageHelper.DeserializeList<ShortTermObjectiveDto>(s.ShortTermObjectives),
-            pedagogicalTodos.Select(ToTodo).ToList()
+            pedagogicalTodos.Select(TeachingTodoDtoProjection.Compiled).ToList()
         ),
         new StudentCommercialDto(
             s.IsActive,
@@ -270,13 +270,6 @@ public class StudentService : IStudentService
         s.UpdatedAt
     );
 
-    private static TeachingTodoDto ToTodo(TeacherFollowup f) => new(
-        f.Id.ToString(),
-        f.Text,
-        f.CreatedAt,
-        f.SourceSessionLogId?.ToString(),
-        f.Status,
-        f.CoveredInSessionLogId?.ToString());
 
     private async Task<List<TeacherFollowup>> FetchPedagogicalTodosAsync(Guid studentId, CancellationToken cancellationToken) =>
         await _db.TeacherFollowups

--- a/plan/stabilisation/task869-centralise-teachingtododto-projection.md
+++ b/plan/stabilisation/task869-centralise-teachingtododto-projection.md
@@ -1,0 +1,53 @@
+# Task 869: Centralise TeachingTodoDto Projection
+
+## Problem
+Two independent sites project `TeacherFollowup` to `TeachingTodoDto`:
+- `StudentService.ToTodo()` (static method, LINQ-to-Objects at line 273-279)
+- `DashboardService` inline LINQ (IQueryable, EF Core-translated at lines 233-237)
+
+Both must stay in sync when `TeachingTodoDto` shape changes.
+
+## Approach
+Introduce a single shared `Expression<Func<TeacherFollowup, TeachingTodoDto>>` that:
+- EF Core can translate to SQL (used directly in `IQueryable` chains)
+- Can be compiled to a cached `Func<>` for in-memory (LINQ-to-Objects) use
+
+## Files to Change
+
+### New: `backend/LangTeach.Api/DTOs/TeachingTodoDtoProjection.cs`
+```csharp
+using System.Linq.Expressions;
+using LangTeach.Api.Data.Models;
+
+namespace LangTeach.Api.DTOs;
+
+public static class TeachingTodoDtoProjection
+{
+    public static readonly Expression<Func<TeacherFollowup, TeachingTodoDto>> Projection =
+        f => new TeachingTodoDto(
+            f.Id.ToString(),
+            f.Text,
+            f.CreatedAt,
+            f.SourceSessionLogId != null ? f.SourceSessionLogId.ToString() : null,
+            f.Status,
+            f.CoveredInSessionLogId != null ? f.CoveredInSessionLogId.ToString() : null);
+
+    public static readonly Func<TeacherFollowup, TeachingTodoDto> Compiled = Projection.Compile();
+}
+```
+
+Use explicit null-check (not `?.ToString()`) for EF Core compatibility.
+
+### Modify: `backend/LangTeach.Api/Services/StudentService.cs`
+- Replace `.Select(ToTodo)` with `.Select(TeachingTodoDtoProjection.Compiled)` (line 262)
+- Remove the `private static TeachingTodoDto ToTodo(TeacherFollowup f)` method (lines 273-279)
+
+### Modify: `backend/LangTeach.Api/Services/DashboardService.cs`
+- Replace inline `.Select(f => new TeachingTodoDto(...))` with `.Select(TeachingTodoDtoProjection.Projection)` (lines 233-237)
+
+## Acceptance Criteria Checklist
+- [ ] Single shared projection expression used in both services
+- [ ] No behaviour change; all existing tests pass
+
+## Test Strategy
+Run `dotnet test` in `backend/`. No new tests needed (behaviour unchanged).


### PR DESCRIPTION
## Summary
- Introduces `TeachingTodoDtoProjection` static class in `DTOs/` with a single `Expression<Func<TeacherFollowup, TeachingTodoDto>>` and a cached `Compiled` delegate
- `StudentService.ToTodo()` private static method is removed; replaced with `TeachingTodoDtoProjection.Compiled`
- `DashboardService` keeps its inline EF Core projection (EF Core cannot compose standalone expressions nested inside parent anonymous-type selects) with a cross-reference comment pointing to the canonical class
- 3 unit tests added in `LangTeach.Api.Tests/DTOs/TeachingTodoDtoProjectionTests.cs` to guard against field drift

## Notes
The DashboardService limitation is architectural: the projection is embedded inside a larger anonymous-type `Select` that EF Core translates to SQL. Using LINQKit to force full composition was evaluated and rejected as over-engineering for a P3 refactor (Sophy review).

## Test plan
- [x] `dotnet test` passes (all existing backend tests green)
- [x] 3 new projection unit tests pass
- [x] 3 pre-existing `StudentRoster.test.tsx` frontend failures confirmed pre-existing on sprint branch (not caused by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite verifying teaching todo data mapping, including field conversions, null value handling, and compiled mapper equivalence.

* **Refactor**
  * Unified teaching todo data projection implementation across services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->