### PR TITLE
fix(#902): filter empty topic tags in NextSessionHero to prevent bare comma

### DIFF
--- a/frontend/src/components/dashboard/NextSessionHero.test.tsx
+++ b/frontend/src/components/dashboard/NextSessionHero.test.tsx
@@ -184,6 +184,53 @@ describe('NextSessionHero', () => {
     expect(screen.queryByText('Promises made')).not.toBeInTheDocument()
   })
 
+  describe('topic tag filtering', () => {
+    it('hides TOPICS row when lastSessionTopicTags is an empty array', () => {
+      render(
+        <MemoryRouter>
+          <NextSessionHero session={makeSession({ lastSessionTopicTags: [] })} />
+        </MemoryRouter>,
+      )
+      expect(screen.queryByText('Topics')).not.toBeInTheDocument()
+    })
+
+    it('hides TOPICS row when lastSessionTopicTags contains a single empty string', () => {
+      render(
+        <MemoryRouter>
+          <NextSessionHero session={makeSession({ lastSessionTopicTags: [''] })} />
+        </MemoryRouter>,
+      )
+      expect(screen.queryByText('Topics')).not.toBeInTheDocument()
+    })
+
+    it('hides TOPICS row when lastSessionTopicTags contains only whitespace strings', () => {
+      render(
+        <MemoryRouter>
+          <NextSessionHero session={makeSession({ lastSessionTopicTags: ['   ', '\t'] })} />
+        </MemoryRouter>,
+      )
+      expect(screen.queryByText('Topics')).not.toBeInTheDocument()
+    })
+
+    it('shows only real tags when mixed with empty strings', () => {
+      render(
+        <MemoryRouter>
+          <NextSessionHero session={makeSession({ lastSessionTopicTags: ['', 'Subjuntivo', '  ', 'Concesivas'] })} />
+        </MemoryRouter>,
+      )
+      expect(screen.getByText('Subjuntivo, Concesivas')).toBeInTheDocument()
+    })
+
+    it('shows all real tags when none are empty', () => {
+      render(
+        <MemoryRouter>
+          <NextSessionHero session={makeSession({ lastSessionTopicTags: ['Pretérito', 'Imperfecto'] })} />
+        </MemoryRouter>,
+      )
+      expect(screen.getByText('Pretérito, Imperfecto')).toBeInTheDocument()
+    })
+  })
+
   it('refreshes countdown badge after 60 seconds', async () => {
     vi.useFakeTimers()
     // Session is 45 minutes away — renders as "IN 45 MIN"

--- a/frontend/src/components/dashboard/NextSessionHero.tsx
+++ b/frontend/src/components/dashboard/NextSessionHero.tsx
@@ -86,7 +86,8 @@ export function NextSessionHero({ session }: NextSessionHeroProps) {
   const urgency = getUrgencyBadge(session.sessionDate)
   const hwStatus = homeworkStatusLabel(session.previousHomeworkStatus)
 
-  const hasTopics = session.lastSessionTopicTags.length > 0
+  const filteredTopicTags = session.lastSessionTopicTags.filter((t) => t.trim() !== '')
+  const hasTopics = filteredTopicTags.length > 0
   const hasResponse = !!session.lastSessionNotes
   const hasLastHomework = !!session.lastSessionHomework
   const hasPromises = session.lastSessionFollowups.length > 0
@@ -160,7 +161,7 @@ export function NextSessionHero({ session }: NextSessionHeroProps) {
               {hasTopics && (
                 <div>
                   <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mb-0.5">Topics</p>
-                  <p className="text-sm text-[#1A1B22] font-inter">{session.lastSessionTopicTags.join(', ')}</p>
+                  <p className="text-sm text-[#1A1B22] font-inter">{filteredTopicTags.join(', ')}</p>
                 </div>
               )}
               {hasResponse && (

--- a/plan/stabilisation/task902-dashboard-topics-empty-string.md
+++ b/plan/stabilisation/task902-dashboard-topics-empty-string.md
@@ -1,0 +1,21 @@
+# Task 902: Dashboard TOPICS bare comma fix
+
+## Problem
+`NextSessionHero` renders a bare comma when `lastSessionTopicTags` is `[""]` because
+`hasTopics = session.lastSessionTopicTags.length > 0` evaluates to true and
+`.join(', ')` produces `", "`.
+
+## Fix
+- Derive `filteredTopicTags` by filtering `.trim() !== ''` before the `hasTopics` check.
+- Use `filteredTopicTags` in the join expression.
+- No backend change needed.
+
+## Files changed
+- `frontend/src/components/dashboard/NextSessionHero.tsx` — filter logic + join fix
+- `frontend/src/components/dashboard/NextSessionHero.test.tsx` — 5 new unit tests in `topic tag filtering` describe block
+
+## Acceptance criteria
+- [x] Filter applied before `hasTopics` and before `.join`
+- [x] TOPICS row hidden when filtered list is empty
+- [x] Unit tests: empty array, single empty string, whitespace-only, mixed, all-real
+- [x] Audit of `frontend/src/api/dashboard.ts` — no join there, data passes through as-is


### PR DESCRIPTION
## Summary

- Derives `filteredTopicTags` from `lastSessionTopicTags` by filtering out empty and whitespace-only strings before the `hasTopics` check and the `.join(', ')` render
- TOPICS row is now hidden entirely when the filtered list is empty
- Adds 5 unit tests in the `topic tag filtering` describe block: empty array, single empty string, whitespace-only, mixed empty+real, all-real

Closes #902

## Test plan

- [x] `NextSessionHero.test.tsx` -- 21 tests pass (16 existing + 5 new)
- [x] Full frontend test suite passes (1383 tests)
- [x] Build verify PASS (bicep, dotnet build, dotnet test, lint, npm build, npm test)
- [x] QA verify PASS
- [x] Architecture review PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)