### PR TITLE
fix(#904): Skill Imbalance empty state for Diego Seed — seed skill overrides + tests

### DIFF
--- a/backend/LangTeach.Api/Data/DemoSeeder.cs
+++ b/backend/LangTeach.Api/Data/DemoSeeder.cs
@@ -330,8 +330,9 @@ public static class DemoSeeder
             IsActive            = true,
             IsCorporate         = true,
             Rate                = "30 euros",
-            SpokenLanguages     = """["French"]""",
-            ShortTermObjectives = """[{"id":"o1","text":"Complete C1 exam preparation course","targetDate":"2026-09-01"}]""",
+            SpokenLanguages       = """["French"]""",
+            ShortTermObjectives  = """[{"id":"o1","text":"Complete C1 exam preparation course","targetDate":"2026-09-01"}]""",
+            SkillLevelOverrides  = """{"Reading":"B2","Speaking":"B1","Writing":"A2","Listening":"B1"}""",
         }, now);
 
         // Flush all upserted student updates before checking session logs

--- a/backend/LangTeach.Api/Data/DemoSeeder.cs
+++ b/backend/LangTeach.Api/Data/DemoSeeder.cs
@@ -332,7 +332,7 @@ public static class DemoSeeder
             Rate                = "30 euros",
             SpokenLanguages       = """["French"]""",
             ShortTermObjectives  = """[{"id":"o1","text":"Complete C1 exam preparation course","targetDate":"2026-09-01"}]""",
-            SkillLevelOverrides  = """{"Reading":"B2","Speaking":"B1","Writing":"A2","Listening":"B1"}""",
+            SkillLevelOverrides  = DiegoSkillLevelOverrides,
         }, now);
 
         // Flush all upserted student updates before checking session logs
@@ -760,6 +760,7 @@ public static class DemoSeeder
     private const string AnaVisualShortTermObjectives = """[{"id":"o1","text":"Complete B1 grammar review by June 2026","targetDate":"2026-06-01"}]""";
     private const string AnaVisualSkillLevelOverrides = """{"Reading":"B2","Speaking":"B1","Writing":"A2","Listening":"B1"}""";
     private const string AnaVisualSpokenLanguages     = """["English"]""";
+    private const string DiegoSkillLevelOverrides     = """{"Reading":"B2","Speaking":"B1","Writing":"A2","Listening":"B1"}""";
 
     private static async Task EnsureAnaVisualExtrasAsync(AppDbContext db, Guid teacherId, ILogger logger)
     {

--- a/backend/LangTeach.Api/Data/ScenarioSeeder.cs
+++ b/backend/LangTeach.Api/Data/ScenarioSeeder.cs
@@ -10,7 +10,8 @@ namespace LangTeach.Api.Data;
 /// </summary>
 public static class ScenarioSeeder
 {
-    private const string ScenarioTag = "[scenario-seed]";
+    private const string ScenarioTag           = "[scenario-seed]";
+    private const string DiegoSkillLevelOverrides = """{"Reading":"B2","Speaking":"B1","Writing":"A2","Listening":"B1"}""";
 
     // All students whose sessions, followups, and todos are managed by this seeder.
     // Ana Visual, Ana Seed, Marco Seed, Clara Seed, Diego Seed already exist after --visual-seed.
@@ -420,7 +421,7 @@ public static class ScenarioSeeder
         });
 
         // Diego Seed: restore skill overrides (WipeAsync clears them) so Progress tab shows chart
-        diegoSeed.SkillLevelOverrides = """{"Reading":"B2","Speaking":"B1","Writing":"A2","Listening":"B1"}""";
+        diegoSeed.SkillLevelOverrides = DiegoSkillLevelOverrides;
         diegoSeed.UpdatedAt = now;
 
         // Diego Seed: no signal (recent past session + upcoming session, no todos)

--- a/backend/LangTeach.Api/Data/ScenarioSeeder.cs
+++ b/backend/LangTeach.Api/Data/ScenarioSeeder.cs
@@ -419,6 +419,10 @@ public static class ScenarioSeeder
             Status = "pending", Kind = TeacherFollowupKinds.Pedagogical, CreatedAt = now.AddDays(-3),
         });
 
+        // Diego Seed: restore skill overrides (WipeAsync clears them) so Progress tab shows chart
+        diegoSeed.SkillLevelOverrides = """{"Reading":"B2","Speaking":"B1","Writing":"A2","Listening":"B1"}""";
+        diegoSeed.UpdatedAt = now;
+
         // Diego Seed: no signal (recent past session + upcoming session, no todos)
         db.SessionLogs.AddRange(
             new SessionLog

--- a/e2e/tests/student-detail.spec.ts
+++ b/e2e/tests/student-detail.spec.ts
@@ -270,6 +270,31 @@ test('student detail profile tab: inline-add short-term objective', async ({ bro
   }
 })
 
+test('student detail progress tab: skill imbalance chart renders when skill overrides exist', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    await page.goto('/students')
+    await expect(page.locator('h1')).toHaveText('Students', { timeout: NAV_TIMEOUT })
+
+    const diegoSeed = page.getByText('Diego Seed').first()
+    await expect(diegoSeed).toBeVisible({ timeout: UI_TIMEOUT })
+    await diegoSeed.click()
+
+    await expect(page).toHaveURL(/\/students\/(?!new$)[^/]+$/, { timeout: NAV_TIMEOUT })
+    await page.getByTestId('tab-progress').click()
+    await expect(page.getByTestId('progress-tab-content')).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // Chart renders — skill bars are present, empty state is not shown
+    await expect(page.getByTestId('skill-bar-reading')).toBeVisible({ timeout: UI_TIMEOUT })
+    await expect(page.getByTestId('skill-bar-writing')).toBeVisible({ timeout: UI_TIMEOUT })
+    await expect(page.getByText('No skill assessments recorded yet.')).not.toBeVisible()
+  } finally {
+    await context.close()
+  }
+})
+
 test('student detail progress tab: renders without errors', async ({ browser }) => {
   const context = await createMockAuthContext(browser)
   const page = await context.newPage()

--- a/e2e/tests/visual/student-detail.visual.spec.ts
+++ b/e2e/tests/visual/student-detail.visual.spec.ts
@@ -123,6 +123,24 @@ test('@visual student detail sessions tab - expanded row with editable fields', 
   await context.close()
 })
 
+test('@visual student detail progress tab - skill bars', async ({ browser }) => {
+  fs.mkdirSync('screenshots', { recursive: true })
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  const consoleErrors: string[] = []
+  page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()) })
+
+  await page.goto(`/students/${studentWithSessionsId}`)
+  await expect(page.getByTestId('student-detail-name')).toBeVisible({ timeout: NAV_TIMEOUT })
+  await page.getByTestId('tab-progress').click()
+  await expect(page.getByTestId('progress-tab-content')).toBeVisible({ timeout: UI_TIMEOUT })
+  await expect(page.getByTestId('skill-bar-reading')).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.screenshot({ path: 'screenshots/progress-dashboard.png', fullPage: true })
+
+  expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)
+  await context.close()
+})
+
 test('@visual student detail overview tab - with sessions', async ({ browser }) => {
   fs.mkdirSync('screenshots', { recursive: true })
   const context = await createMockAuthContext(browser)

--- a/frontend/src/components/student/ProgressDashboard.test.tsx
+++ b/frontend/src/components/student/ProgressDashboard.test.tsx
@@ -116,6 +116,19 @@ describe('ProgressDashboard', () => {
     expect(screen.getByText('No skill assessments recorded yet.')).toBeInTheDocument()
   })
 
+  it('renders chart with partial skill overrides and omits bars for missing skills', () => {
+    const student = {
+      ...baseStudent,
+      level: { ...baseStudent.level, skillLevelOverrides: { Reading: 'B2', Writing: 'A2' } },
+    }
+    renderProgress(student)
+    expect(screen.queryByText('No skill assessments recorded yet.')).not.toBeInTheDocument()
+    expect(screen.getByTestId('skill-bar-reading')).toBeInTheDocument()
+    expect(screen.getByTestId('skill-bar-writing')).toBeInTheDocument()
+    expect(screen.queryByTestId('skill-bar-speaking')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('skill-bar-listening')).not.toBeInTheDocument()
+  })
+
   it('renders pacing section', () => {
     renderProgress(baseStudent, [baseSession])
     expect(screen.getByTestId('pacing-section')).toBeInTheDocument()

--- a/plan/stabilisation/task904-skill-imbalance-empty-state.md
+++ b/plan/stabilisation/task904-skill-imbalance-empty-state.md
@@ -1,0 +1,55 @@
+# Task 904 — Skill Imbalance: empty state shown even when student has skill-level overrides
+
+## Problem
+
+The Skill Imbalance Analysis card on the Progress tab shows "No skill assessments recorded yet." for Diego Seed even though the sweep report observed skill overrides on other tabs.
+
+## Root Cause
+
+`DemoSeeder.SeedScenarioStudentsAsync` creates Diego Seed WITHOUT `SkillLevelOverrides`. The field defaults to `"{}"`. `ProgressDashboard` checks `Object.keys(skillOverrides).length > 0` — correct behavior, but no data is ever present.
+
+The frontend logic is correct. Both Overview and Progress tabs read from `student.level.skillLevelOverrides`. The bug is in the seed data.
+
+Additionally, `ScenarioSeeder.WipeAsync` resets `SkillLevelOverrides = "{}"` for all scenario students (including Diego) and Scenario 5 never restores Diego's overrides.
+
+## Changes
+
+### Backend
+
+1. **DemoSeeder.cs** (line ~325): Add `SkillLevelOverrides` to Diego Seed:
+   ```
+   SkillLevelOverrides = """{"Reading":"B2","Speaking":"B1","Writing":"A2","Listening":"B1"}"""
+   ```
+   Diego is B2. Writing A2 (2 levels below) gets a Gap badge; Speaking and Listening B1 (1 below) get the subdued color.
+
+2. **ScenarioSeeder.cs** (SeedScenario5Async, after Diego session inserts): Restore Diego's overrides after WipeAsync resets them:
+   ```
+   diegoSeed.SkillLevelOverrides = """{"Reading":"B2","Speaking":"B1","Writing":"A2","Listening":"B1"}""";
+   diegoSeed.UpdatedAt = now;
+   ```
+
+### Frontend tests
+
+3. **ProgressDashboard.test.tsx**: Add "some skills set" test:
+   - `skillLevelOverrides: { Reading: 'B2', Writing: 'A2' }` (2 of 4 skills)
+   - Assert chart renders (no empty state text)
+   - Assert Reading and Writing bars present
+   - Assert Speaking and Listening bars absent
+
+4. **e2e/tests/student-detail.spec.ts**: Add e2e test navigating to Diego's Progress tab and asserting skill bars visible (not empty state).
+
+5. **e2e/tests/visual/student-detail.visual.spec.ts**: Add `@visual progress tab - skill bars` screenshot spec using `studentWithSessionsId` (Diego).
+
+## No frontend component changes required
+
+`ProgressDashboard.tsx` is already correct. The `hasSkillData` check and conditional rendering are fine.
+
+## AC coverage
+
+| AC | How covered |
+|----|-------------|
+| Reads same source as Overview tab | Already true (both use `student.level.skillLevelOverrides`) |
+| Chart renders when any skill non-null | Unit tests: "all skills set" (existing) + "some skills set" (new) |
+| Empty state only when all null | Unit test: "no skills set" (existing) |
+| Unit tests: all/some/no skills | Done |
+| Visual spec for student with skill overrides | Visual spec added |

--- a/plan/ui-review-backlog.md
+++ b/plan/ui-review-backlog.md
@@ -6,6 +6,12 @@ Non-blocking findings from review-ui runs. Periodically review this file and bat
 
 *Cleared 2026-04-22 during UI Redesign & Student Profile Polish sprint close. Seeder coverage gaps batched into #834. UX polish items (combobox summary, Focus Areas description) batched into #840. Remaining entries deleted (intentional per Stitch spec, covered by unit tests, or pre-existing infrastructure).*
 
+## #904 (2026-04-24)
+
+| Screen | Finding | Severity |
+|--------|---------|---------|
+| Progress tab > Skill Imbalance Analysis | Visual spec only covers Diego Seed (has overrides). Consider adding an empty-state visual test using Clara Seed (no overrides) for regression coverage. | Minor |
+
 ## #856 (2026-04-23)
 
 | Screen | Finding | Severity |


### PR DESCRIPTION
## Summary

- **Root cause**: `DemoSeeder.SeedScenarioStudentsAsync` created Diego Seed without `SkillLevelOverrides` (defaults to `"{}"`), so the Skill Imbalance Analysis card always showed the empty state. The `ProgressDashboard` component logic was already correct.
- **DemoSeeder**: Added `SkillLevelOverrides` to Diego Seed (`Reading B2, Speaking B1, Writing A2, Listening B1`), extracted as a named constant matching the existing `AnaVisualSkillLevelOverrides` pattern.
- **ScenarioSeeder**: Scenario 5 now restores Diego's skill overrides after `WipeAsync` resets them, using the same constant.
- **Tests**: Added "some skills set" unit test to `ProgressDashboard.test.tsx` (2 of 4 skills), new e2e test for Progress tab skill bars (Diego Seed), and a `@visual progress tab - skill bars` screenshot spec.

## Test plan

- [ ] All unit tests pass (`npm test`: 89 test files, 1384 tests)
- [ ] All dotnet tests pass
- [ ] Build verify PASS
- [ ] qa-verify: PASS
- [ ] architecture-reviewer: PASS
- [ ] Sophy: APPROVE (deduplication nit addressed)
- [ ] review-ui: PASS (skill bars visible for Diego, empty state for Clara)
- [ ] No merge conflicts with sprint/stabilisation

🤖 Generated with [Claude Code](https://claude.com/claude-code)