### PR TITLE
fix(#912): translate 'Ideas para Clases' section header to English

### DIFF
--- a/frontend/src/components/student/StudentOverviewTab.test.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.test.tsx
@@ -319,6 +319,11 @@ describe('StudentOverviewTab - card order and conditional styling', () => {
     expect(wrapper.className).toContain('FFF9F2')
   })
 
+  it('Ideas card section heading reads "Teaching Ideas"', () => {
+    renderOverview(BASE_STUDENT)
+    expect(screen.getByText('Teaching Ideas')).toBeInTheDocument()
+  })
+
   it('Ideas card has muted background when no todos', () => {
     renderOverview({ ...BASE_STUDENT, profile: { ...BASE_STUDENT.profile, teachingTodos: [] } })
     const wrapper = screen.getByTestId('ideas-card-wrapper')

--- a/frontend/src/components/student/StudentOverviewTab.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.tsx
@@ -465,7 +465,7 @@ export function StudentOverviewTab({
         {/* Card 2: Pedagogical Profile */}
         <PedagogicalProfileCard student={student} />
 
-        {/* Card 3: Ideas para Clases */}
+        {/* Card 3: Teaching Ideas */}
         <div
           className={`rounded-2xl p-6 transition-colors ${
             pendingTodosCount > 0 ? 'bg-white' : 'bg-[#F4F2FD]'
@@ -474,7 +474,7 @@ export function StudentOverviewTab({
           data-testid="ideas-card-wrapper"
         >
           <div className="flex items-center justify-between mb-1">
-            <SectionHeader>Ideas para Clases</SectionHeader>
+            <SectionHeader>Teaching Ideas</SectionHeader>
             <button
               type="button"
               onClick={() => setShowIdeasAdd(true)}

--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -595,9 +595,9 @@ describe('StudentProfileTab', () => {
       expect(screen.getByText('Enviar ejercicios de por/para')).toBeInTheDocument()
     })
 
-    it('displays section heading as "Ideas para Clases"', () => {
+    it('displays section heading as "Teaching Ideas"', () => {
       renderProfile(FULL_STUDENT)
-      expect(screen.getByText('Ideas para Clases')).toBeInTheDocument()
+      expect(screen.getByText('Teaching Ideas')).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/components/student/StudentProfileTab.tsx
+++ b/frontend/src/components/student/StudentProfileTab.tsx
@@ -989,9 +989,9 @@ export function StudentProfileTab({
             </div>
           </section>
 
-          {/* 5. Ideas para Clases */}
+          {/* 5. Teaching Ideas */}
           <section data-testid="profile-teaching-todos">
-            <SectionHeader>Ideas para Clases</SectionHeader>
+            <SectionHeader>Teaching Ideas</SectionHeader>
             <TeachingTodosCard
               todos={student.profile.teachingTodos}
               studentId={student.id}

--- a/plan/stabilisation/task912-translate-ideas-para-clases.md
+++ b/plan/stabilisation/task912-translate-ideas-para-clases.md
@@ -1,0 +1,12 @@
+# Task 912: Translate "IDEAS PARA CLASES" to English
+
+## Problem
+The "Ideas para Clases" section heading appeared in Spanish on an English UI (Student Detail Overview tab and Profile tab).
+
+## Change
+- `StudentOverviewTab.tsx`: `<SectionHeader>Ideas para Clases</SectionHeader>` → `<SectionHeader>Teaching Ideas</SectionHeader>`
+- `StudentProfileTab.tsx`: same heading in the profile tab section
+- `StudentProfileTab.test.tsx`: updated matching test description and assertion
+
+## Grep confirmation
+No remaining user-facing Spanish strings in `frontend/src/components/student/` or `frontend/src/pages/StudentDetail.tsx`.


### PR DESCRIPTION
## Summary
- Replace Spanish heading `Ideas para Clases` with `Teaching Ideas` on the Student Detail Overview tab (`StudentOverviewTab.tsx`)
- Same fix on the Profile tab (`StudentProfileTab.tsx`)
- Update matching unit test in `StudentProfileTab.test.tsx` and add heading assertion to `StudentOverviewTab.test.tsx`

Closes #912

## Test plan
- [x] `npx vitest run` -- 109 tests pass across StudentOverviewTab and StudentProfileTab suites
- [x] Grep confirms no remaining user-facing Spanish strings in `frontend/src/components/student/` or `frontend/src/pages/StudentDetail.tsx`
- [x] UI review PASS -- "TEACHING IDEAS" heading renders consistently with adjacent headings (same uppercase label-SM style)
- [x] Code review PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)