### PR TITLE
fix(#911): UI polish sweep — borders, badge colors, session label, progress bar, onboarding

### DIFF
--- a/frontend/src/components/dashboard/NextSessionHero.test.tsx
+++ b/frontend/src/components/dashboard/NextSessionHero.test.tsx
@@ -99,6 +99,17 @@ describe('NextSessionHero', () => {
     expect(subtitle).toHaveTextContent('Session #14')
   })
 
+  it('shows "First Session" for totalSessionCount 1', () => {
+    render(
+      <MemoryRouter>
+        <NextSessionHero session={makeSession({ teachingLanguage: 'Spanish', totalSessionCount: 1 })} />
+      </MemoryRouter>,
+    )
+    const subtitle = screen.getByTestId('hero-identity-subtitle')
+    expect(subtitle).toHaveTextContent('First Session')
+    expect(subtitle).not.toHaveTextContent('Session #')
+  })
+
   it('hides identity subtitle when no language and count is 0', () => {
     render(
       <MemoryRouter>

--- a/frontend/src/components/dashboard/NextSessionHero.tsx
+++ b/frontend/src/components/dashboard/NextSessionHero.tsx
@@ -53,6 +53,7 @@ function formatSessionDay(sessionDate: string): string {
   return d.toLocaleDateString([], { weekday: 'long', month: 'short', day: 'numeric' })
 }
 
+// Canonical format: short month + numeric day ("Mar 28"), matching Sessions list section headers.
 function formatLastSessionDate(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString([], { month: 'short', day: 'numeric' })
 }
@@ -110,7 +111,7 @@ export function NextSessionHero({ session }: NextSessionHeroProps) {
           </h2>
           {(session.teachingLanguage || session.totalSessionCount > 0) && (
             <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mt-0.5" data-testid="hero-identity-subtitle">
-              {[session.teachingLanguage, session.totalSessionCount > 0 ? `Session #${session.totalSessionCount}` : null].filter(Boolean).join(' · ')}
+              {[session.teachingLanguage, session.totalSessionCount === 1 ? 'First Session' : session.totalSessionCount > 1 ? `Session #${session.totalSessionCount}` : null].filter(Boolean).join(' · ')}
             </p>
           )}
         </div>

--- a/frontend/src/components/dashboard/StudentRoster.tsx
+++ b/frontend/src/components/dashboard/StudentRoster.tsx
@@ -43,7 +43,7 @@ function buildRosterSignal(student: ActiveStudent): RosterSignal | null {
     ? Math.floor((now - lastSessionMs) / (1000 * 60 * 60 * 24))
     : null
   if (lastSessionGapDays != null && lastSessionGapDays > 21 && student.nextSessionDate != null) {
-    return { label: 'Returning', className: 'bg-violet-600 text-white' }
+    return { label: 'Returning', className: 'bg-indigo-700 text-white' }
   }
 
   // 4. Homework not done / partial

--- a/frontend/src/components/dashboard/StudentRoster.tsx
+++ b/frontend/src/components/dashboard/StudentRoster.tsx
@@ -20,7 +20,7 @@ interface RosterSignal {
 function buildRosterSignal(student: ActiveStudent): RosterSignal | null {
   // 1. Cancelled 2x (highest priority)
   if (student.cancelledSessionsLast30Days >= 2) {
-    return { label: 'Cancelled 2x', className: 'bg-[#1A1B22] text-white', redDot: true }
+    return { label: 'Cancelled 2x', className: 'bg-red-700 text-white', redDot: true }
   }
 
   const now = Date.now()

--- a/frontend/src/components/settings/TelegramCard.test.tsx
+++ b/frontend/src/components/settings/TelegramCard.test.tsx
@@ -97,6 +97,16 @@ describe('TelegramCard', () => {
     }
   })
 
+  it('copy button has aria-label in pending state', async () => {
+    renderCard()
+    const btn = await screen.findByTestId('telegram-connect-btn')
+    fireEvent.click(btn)
+    await screen.findByTestId('telegram-pending')
+    const copyBtn = screen.getByRole('button', { name: /copy command/i })
+    expect(copyBtn).toBeInTheDocument()
+    expect(copyBtn).toHaveAttribute('aria-label', 'Copy command')
+  })
+
   it('transitions to connected state when query cache is updated to connected', async () => {
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
     renderCard(qc)

--- a/frontend/src/pages/Courses.test.tsx
+++ b/frontend/src/pages/Courses.test.tsx
@@ -52,6 +52,26 @@ describe('Courses list', () => {
     expect(await screen.findByText('No courses yet')).toBeInTheDocument()
   })
 
+  it('progress bar has minWidth 4px when at least 1 lesson created', async () => {
+    vi.mocked(coursesApi.getCourses).mockResolvedValue([{ ...mockCourse, lessonsCreated: 1, sessionCount: 8 }])
+    wrapper(<Courses />)
+
+    await screen.findByText('1/8 sessions')
+    const bar = document.querySelector('.bg-blue-500') as HTMLElement
+    expect(bar).not.toBeNull()
+    expect(bar.style.minWidth).toBe('4px')
+  })
+
+  it('progress bar has no minWidth when lessonsCreated is 0', async () => {
+    vi.mocked(coursesApi.getCourses).mockResolvedValue([{ ...mockCourse, lessonsCreated: 0, sessionCount: 8 }])
+    wrapper(<Courses />)
+
+    await screen.findByText('0/8 sessions')
+    const bar = document.querySelector('.bg-blue-500') as HTMLElement
+    expect(bar).not.toBeNull()
+    expect(bar.style.minWidth).toBe('')
+  })
+
   it('shows delete confirmation dialog on delete click', async () => {
     vi.mocked(coursesApi.getCourses).mockResolvedValue([mockCourse])
     wrapper(<Courses />)

--- a/frontend/src/pages/Courses.tsx
+++ b/frontend/src/pages/Courses.tsx
@@ -112,7 +112,7 @@ export default function Courses() {
                   <div className="w-32 h-1.5 rounded-full bg-zinc-100 overflow-hidden">
                     <div
                       className="h-full bg-blue-500 rounded-full"
-                      style={{ width: `${course.sessionCount > 0 ? (course.lessonsCreated / course.sessionCount) * 100 : 0}%` }}
+                      style={{ width: `${course.sessionCount > 0 ? (course.lessonsCreated / course.sessionCount) * 100 : 0}%`, minWidth: course.lessonsCreated > 0 ? '4px' : undefined }}
                     />
                   </div>
                   <span className="text-xs text-zinc-400">

--- a/frontend/src/pages/LessonEditor.tsx
+++ b/frontend/src/pages/LessonEditor.tsx
@@ -382,7 +382,7 @@ export default function LessonEditor() {
           <Skeleton className="h-8 w-8 rounded-md" />
           <Skeleton className="h-8 w-8 rounded-md" />
         </div>
-        <Card className="bg-white border border-zinc-200">
+        <Card className="bg-white shadow-sm">
           <CardHeader className="py-3 px-6">
             <div className="flex items-center gap-2">
               <Skeleton className="h-5 w-16 rounded-full" />
@@ -394,7 +394,7 @@ export default function LessonEditor() {
         <div className="space-y-4">
           <Skeleton className="h-5 w-32" />
           {[1, 2, 3].map(i => (
-            <Card key={i} className="bg-white border border-zinc-200">
+            <Card key={i} className="bg-white shadow-sm">
               <CardHeader className="py-3 px-6"><Skeleton className="h-4 w-24" /></CardHeader>
               <CardContent className="px-6 pb-4"><Skeleton className="h-24 w-full" /></CardContent>
             </Card>
@@ -647,7 +647,7 @@ export default function LessonEditor() {
 
       {/* Edit details form */}
       {editingMeta && (
-        <Card className="bg-white border border-zinc-200">
+        <Card className="bg-white shadow-sm">
           <CardContent className="px-6 py-4">
             <div className="space-y-4">
               <div className="grid grid-cols-2 gap-4">
@@ -721,7 +721,7 @@ export default function LessonEditor() {
           const canRemove = lesson.sections.length > 1
 
           return (
-            <Card key={type} className="bg-white border border-zinc-200" data-testid={`section-card-${type.toLowerCase()}`}>
+            <Card key={type} className="bg-white shadow-sm" data-testid={`section-card-${type.toLowerCase()}`}>
               <CardHeader className="py-3 px-6 pb-2">
                 <div className="flex items-center justify-between">
                   <CardTitle className="text-sm font-medium text-zinc-700">{SECTION_LABELS[type]}</CardTitle>

--- a/frontend/src/pages/LogSession.test.tsx
+++ b/frontend/src/pages/LogSession.test.tsx
@@ -189,13 +189,21 @@ describe('LogSession', () => {
     expect(screen.getByRole('option', { name: '50 min' })).toBeInTheDocument()
   })
 
-  it('reveals custom duration input when "Other" selected', async () => {
+  it('duration "Other" option includes unit context label "Other (min)"', async () => {
+    const user = userEvent.setup()
+    renderLogSession()
+    await screen.findByTestId('duration-select')
+    await user.click(screen.getByTestId('duration-select'))
+    expect(await screen.findByRole('option', { name: 'Other (min)' })).toBeInTheDocument()
+  })
+
+  it('reveals custom duration input when "Other (min)" selected', async () => {
     const user = userEvent.setup()
     renderLogSession()
     await screen.findByTestId('duration-select')
     expect(screen.queryByTestId('duration-other')).toBeNull()
     await user.click(screen.getByTestId('duration-select'))
-    const option = await screen.findByRole('option', { name: 'Other' })
+    const option = await screen.findByRole('option', { name: 'Other (min)' })
     await user.click(option)
     expect(screen.getByTestId('duration-other')).toBeDefined()
   })

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -38,7 +38,7 @@ const DURATION_OPTIONS = [
   { value: '50', label: '50 min' },
   { value: '60', label: '60 min' },
   { value: '90', label: '90 min' },
-  { value: 'other', label: 'Other' },
+  { value: 'other', label: 'Other (min)' },
 ]
 
 const PREV_HOMEWORK_STATUSES = HOMEWORK_STATUS_PILL_OPTIONS
@@ -790,10 +790,10 @@ export default function LogSession() {
           </PanelSection>
         )}
 
-        {/* Active Difficulties */}
+        {/* Active Difficulties — read-only reference, tinted to distinguish from interactive sections */}
         {activeDifficulties.length > 0 && (
           <PanelSection label="Student Difficulties">
-            <div className="space-y-1.5">
+            <div className="rounded-lg bg-indigo-50 border border-indigo-100 px-3 py-2.5 space-y-1.5">
               {activeDifficulties.map(d => {
                 const key = `${d.competency}|${d.subcategory}`
                 return (

--- a/frontend/src/pages/Students.tsx
+++ b/frontend/src/pages/Students.tsx
@@ -100,7 +100,7 @@ function buildSignals(student: Student, dash: ActiveStudent | undefined): Signal
 
   // Cancelled 2x (highest priority)
   if (dash.cancelledSessionsLast30Days >= 2) {
-    return [{ label: 'Cancelled 2x', className: 'bg-[#1A1B22] text-white', redDot: true }]
+    return [{ label: 'Cancelled 2x', className: 'bg-red-700 text-white', redDot: true }]
   }
 
   // Exam prep: short-term objective with targetDate within 6 weeks
@@ -118,7 +118,7 @@ function buildSignals(student: Student, dash: ActiveStudent | undefined): Signal
   // RETURNING: was inactive 21+ days and now has a scheduled next session
   const isReturning = lastSessionGapDays != null && lastSessionGapDays >= 21 && hasNextSession
   if (isReturning) {
-    return [{ label: 'RETURNING', className: 'bg-[#1A1B22] text-white' }]
+    return [{ label: 'RETURNING', className: 'bg-indigo-700 text-white' }]
   }
 
   // Review pending: has pending teaching todos

--- a/frontend/src/pages/onboarding/OnboardingStep1.tsx
+++ b/frontend/src/pages/onboarding/OnboardingStep1.tsx
@@ -46,13 +46,14 @@ export default function OnboardingStep1({ onNext }: OnboardingStep1Props) {
 
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
+    const nameFromAuth0 = user?.name && !user.name.includes('@') ? user.name : ''
     if (profile) {
-      setDisplayName(profile.displayName || user?.name || '')
+      setDisplayName(profile.displayName || nameFromAuth0)
       setTeachingLanguages(profile.teachingLanguages)
       setCefrLevels(profile.cefrLevels)
       setPreferredStyle(profile.preferredStyle)
-    } else if (user?.name) {
-      setDisplayName(user.name)
+    } else if (nameFromAuth0) {
+      setDisplayName(nameFromAuth0)
     }
   }, [profile, user])
   /* eslint-enable react-hooks/set-state-in-effect */

--- a/plan/stabilisation/task911-ui-polish-sweep.md
+++ b/plan/stabilisation/task911-ui-polish-sweep.md
@@ -1,0 +1,88 @@
+# Task #911: UI Polish Sweep
+
+## Issue
+https://github.com/Robert-Freire/langTeachSaaS/issues/911
+
+## Pre-investigation findings (no code change needed)
+
+- **Item 1 (CEFR badge)**: Students.tsx line 518 already uses `CefrBadge` (rounded-md, square). Test already exists.
+- **Item 3 (Study View max-width)**: StudyView.tsx already has `max-w-2xl mx-auto`.
+- **Item 9 (SavedIndicator)**: Position in the header bar is appropriate for a full-page autosave form. DS §8.2 per-field SavedIndicator applies to inline row edits, not full-page forms.
+- **Item 10 (Telegram aria-label)**: TelegramCard already has `aria-label="Copy command"`.
+
+## Changes to implement
+
+### Item 2: Remove 1px borders from LessonEditor section cards
+**Files:** `frontend/src/pages/LessonEditor.tsx`
+**Change:** Remove `border border-zinc-200` from Card className at lines 385, 397, 650, 724. Cards rely on `bg-white` tonal contrast against `#FBF8FF` main background.
+
+### Item 4: Remap signal badge ad-hoc hex colors to DS tokens
+**Files:** `frontend/src/pages/Students.tsx`
+**Change:** Replace `bg-[#1A1B22]` with DS-token equivalents:
+- "Cancelled 2x": `bg-red-700 text-white` (negative/urgent signal)
+- "RETURNING": `bg-indigo-700 text-white` (uses DS primary color family)
+
+### Item 5: Document canonical date format in NextSessionHero
+**Files:** `frontend/src/components/dashboard/NextSessionHero.tsx`
+**Change:** Add inline comment to `formatLastSessionDate` documenting the chosen format (`{ month: 'short', day: 'numeric' }`) and noting it matches the sessions list section header format.
+
+### Item 6: Onboarding name field — skip email as default
+**Files:** `frontend/src/pages/onboarding/OnboardingStep1.tsx`
+**Change:** Lines 50-55 — two separate branches both set `displayName` from `user?.name`. Patch both to skip if value looks like an email (contains '@'):
+- Line 50: `setDisplayName(profile.displayName || nameFromAuth0)`
+- Line 54-55: replace `else if (user?.name)` branch with the same guard
+
+Where `nameFromAuth0 = user?.name && !user.name.includes('@') ? user.name : ''`.
+
+### Item 7: Dashboard hero "FIRST SESSION" for session #1
+**Files:** `frontend/src/components/dashboard/NextSessionHero.tsx`
+**Change:** Line 113 — if `totalSessionCount === 1`, render "First Session" instead of "Session #1".
+```tsx
+session.totalSessionCount > 0
+  ? (session.totalSessionCount === 1 ? 'First Session' : `Session #${session.totalSessionCount}`)
+  : null
+```
+
+### Item 8: Duration "other" option — add unit context to label
+**Files:** `frontend/src/pages/LogSession.tsx`
+**Change:** Line 41 — change `{ value: 'other', label: 'Other' }` to `{ value: 'other', label: 'Other (min)' }`.
+
+### Item 11: Courses progress bar — enforce minimum visible width
+**Files:** `frontend/src/pages/Courses.tsx`
+**Change:** Add `minWidth` inline style when progress > 0:
+```tsx
+style={{
+  width: `${percent}%`,
+  minWidth: course.lessonsCreated > 0 ? '4px' : undefined,
+}}
+```
+
+### Item 12: "Student Difficulties" read-only visual distinction
+**Files:** `frontend/src/pages/LogSession.tsx`
+**Change:** Wrap the Student Difficulties `PanelSection` content in a `bg-[#F8F7FF]` tinted container, and add a "(reference)" suffix to the section label to signal it is informational.
+
+## Unit tests
+
+| Item | File | Test |
+|------|------|------|
+| 7 | NextSessionHero.test.tsx | Renders "First Session" when totalSessionCount is 1; renders "Session #3" when count is 3 |
+| 8 | LogSession.test.tsx | DURATION_OPTIONS contains "Other (min)" label |
+| 11 | Courses.test.tsx | Progress bar has minWidth 4px when lessonsCreated > 0 |
+| 10 | Settings.test.tsx | Telegram copy button has aria-label (verify existing) |
+
+## Files changed
+- `frontend/src/pages/LessonEditor.tsx`
+- `frontend/src/pages/Students.tsx`
+- `frontend/src/components/dashboard/NextSessionHero.tsx`
+- `frontend/src/pages/onboarding/OnboardingStep1.tsx`
+- `frontend/src/pages/LogSession.tsx`
+- `frontend/src/pages/Courses.tsx`
+- `frontend/src/components/dashboard/NextSessionHero.test.tsx`
+- `frontend/src/pages/Courses.test.tsx`
+- `frontend/src/pages/Settings.test.tsx`
+
+## Out of scope
+- Redesigning signals or adding new signal types
+- Adding new color tokens
+- Redesigning study view beyond max-width (already fixed)
+- Changing SessionHistoryTab or AppShell


### PR DESCRIPTION
## Summary

Batch of 8 UI polish fixes from the 2026-04-24 UI detection sweep. Items 1, 3, 9, 10 were confirmed already resolved in prior work.

| Item | What was fixed |
|------|---------------|
| 2 | LessonEditor section Cards: `border border-zinc-200` → `shadow-sm` (DS No-Line Rule) |
| 4 | Students list + Dashboard roster signal badges: `bg-[#1A1B22]` → `bg-red-700` (Cancelled 2x) / `bg-indigo-700` (RETURNING) |
| 5 | Dashboard hero date format: inline comment documenting canonical format |
| 6 | Onboarding name field: guard prevents Auth0 email being used as display name |
| 7 | Dashboard hero: renders "First Session" when `totalSessionCount === 1` instead of "Session #1" |
| 8 | LogSession duration select: "Other" → "Other (min)" for unit clarity |
| 11 | Courses progress bar: `minWidth: 4px` when any lesson created (prevents invisible bar) |
| 12 | LogSession Student Difficulties: `bg-indigo-50 border border-indigo-100` tint signals read-only reference |

## Test plan

- [ ] Unit: NextSessionHero — "First Session" for count=1, "Session #N" for N>1
- [ ] Unit: Courses — progress bar minWidth 4px when lessonsCreated>0, none when 0
- [ ] Unit: TelegramCard — copy button has `aria-label="Copy command"`
- [ ] Unit: LogSession — duration dropdown has "Other (min)" option; reveals custom input on select
- [ ] Grep: no `bg-[#1A1B22]` in Students.tsx or StudentRoster.tsx
- [ ] Grep: no `border border-zinc-200` on section Cards in LessonEditor.tsx (remaining borders are a button chip and a toolbar, not section cards)

Fixes #911

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Session hero now displays "First Session" instead of "Session #1" for initial sessions
  * Progress bars now display with minimum width for improved visibility on low progress
  * Improved Auth0 name validation to exclude email addresses from display names

* **Style**
  * Updated signal and badge colors for better visual distinction across dashboards
  * Refined card and section styling for improved visual consistency

* **Tests**
  * Added test coverage for session labels, progress bar rendering, and accessibility features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->