### PR TITLE
fix(#925): Kind filter on dashboard followups + clickable rows

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
@@ -600,26 +600,6 @@ public class DashboardServiceTests : IDisposable
         result.PendingFollowups[0].Text.Should().Be("Op pending");
     }
 
-    [Fact]
-    public async Task GetAsync_PendingFollowups_PedagogicalPendingDoesNotPolluteDashboard()
-    {
-        _db.TeacherFollowups.Add(new TeacherFollowup
-        {
-            Id = Guid.NewGuid(),
-            TeacherId = _teacherId,
-            StudentId = _studentId,
-            Kind = TeacherFollowupKinds.Pedagogical,
-            Text = "Focus on subjunctive",
-            Status = "pending",
-            CreatedAt = DateTime.UtcNow,
-        });
-        _db.SaveChanges();
-
-        var result = await _sut.GetAsync(_teacherId);
-
-        result.PendingFollowups.Should().BeEmpty();
-    }
-
     // GetAsync new field: UpcomingThisWeek
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
@@ -566,6 +566,60 @@ public class DashboardServiceTests : IDisposable
         result.NextSession.LastSessionFollowups.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task GetAsync_PendingFollowups_ExcludesTeachingTodos()
+    {
+        _db.TeacherFollowups.Add(new TeacherFollowup
+        {
+            Id = Guid.NewGuid(),
+            TeacherId = _teacherId,
+            StudentId = _studentId,
+            Kind = TeacherFollowupKinds.Pedagogical,
+            Text = "Teaching todo",
+            Status = "pending",
+            CreatedAt = DateTime.UtcNow,
+        });
+        _db.SaveChanges();
+
+        var result = await _sut.GetAsync(_teacherId);
+
+        result.PendingFollowups.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAsync_PendingFollowups_IncludesOperational()
+    {
+        _db.TeacherFollowups.AddRange(
+            new TeacherFollowup { Id = Guid.NewGuid(), TeacherId = _teacherId, StudentId = _studentId, Kind = TeacherFollowupKinds.Operational, Text = "Op pending", Status = "pending", CreatedAt = DateTime.UtcNow },
+            new TeacherFollowup { Id = Guid.NewGuid(), TeacherId = _teacherId, StudentId = _studentId, Kind = TeacherFollowupKinds.Pedagogical, Text = "Ped pending", Status = "pending", CreatedAt = DateTime.UtcNow });
+        _db.SaveChanges();
+
+        var result = await _sut.GetAsync(_teacherId);
+
+        result.PendingFollowups.Should().HaveCount(1);
+        result.PendingFollowups[0].Text.Should().Be("Op pending");
+    }
+
+    [Fact]
+    public async Task GetAsync_PendingFollowups_PedagogicalPendingDoesNotPolluteDashboard()
+    {
+        _db.TeacherFollowups.Add(new TeacherFollowup
+        {
+            Id = Guid.NewGuid(),
+            TeacherId = _teacherId,
+            StudentId = _studentId,
+            Kind = TeacherFollowupKinds.Pedagogical,
+            Text = "Focus on subjunctive",
+            Status = "pending",
+            CreatedAt = DateTime.UtcNow,
+        });
+        _db.SaveChanges();
+
+        var result = await _sut.GetAsync(_teacherId);
+
+        result.PendingFollowups.Should().BeEmpty();
+    }
+
     // GetAsync new field: UpcomingThisWeek
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/Services/TeacherFollowupServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/TeacherFollowupServiceTests.cs
@@ -162,6 +162,64 @@ public class TeacherFollowupServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetPendingAsync_ExcludesPedagogicalKind()
+    {
+        _db.TeacherFollowups.AddRange(
+            new TeacherFollowup { Id = Guid.NewGuid(), TeacherId = _teacherId, Kind = TeacherFollowupKinds.Operational, Text = "Operational pending", Status = "pending", CreatedAt = DateTime.UtcNow },
+            new TeacherFollowup { Id = Guid.NewGuid(), TeacherId = _teacherId, Kind = TeacherFollowupKinds.Pedagogical, Text = "Pedagogical pending", Status = "pending", CreatedAt = DateTime.UtcNow });
+        _db.SaveChanges();
+
+        var result = await _sut.GetPendingAsync(_teacherId, default);
+
+        result.Should().HaveCount(1);
+        result[0].Text.Should().Be("Operational pending");
+    }
+
+    [Fact]
+    public async Task GetPendingAsync_IncludesOperationalPendingOnly()
+    {
+        _db.TeacherFollowups.AddRange(
+            new TeacherFollowup { Id = Guid.NewGuid(), TeacherId = _teacherId, Kind = TeacherFollowupKinds.Operational, Text = "Op pending", Status = "pending", CreatedAt = DateTime.UtcNow },
+            new TeacherFollowup { Id = Guid.NewGuid(), TeacherId = _teacherId, Kind = TeacherFollowupKinds.Operational, Text = "Op done", Status = "done", CreatedAt = DateTime.UtcNow },
+            new TeacherFollowup { Id = Guid.NewGuid(), TeacherId = _teacherId, Kind = TeacherFollowupKinds.Pedagogical, Text = "Ped pending", Status = "pending", CreatedAt = DateTime.UtcNow },
+            new TeacherFollowup { Id = Guid.NewGuid(), TeacherId = _teacherId, Kind = TeacherFollowupKinds.Pedagogical, Text = "Ped done", Status = "done", CreatedAt = DateTime.UtcNow });
+        _db.SaveChanges();
+
+        var result = await _sut.GetPendingAsync(_teacherId, default);
+
+        result.Should().HaveCount(1);
+        result[0].Text.Should().Be("Op pending");
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ExcludesPedagogicalKind()
+    {
+        _db.TeacherFollowups.AddRange(
+            new TeacherFollowup { Id = Guid.NewGuid(), TeacherId = _teacherId, Kind = TeacherFollowupKinds.Operational, Text = "Operational", Status = "pending", CreatedAt = DateTime.UtcNow },
+            new TeacherFollowup { Id = Guid.NewGuid(), TeacherId = _teacherId, Kind = TeacherFollowupKinds.Pedagogical, Text = "Pedagogical", Status = "pending", CreatedAt = DateTime.UtcNow });
+        _db.SaveChanges();
+
+        var result = await _sut.GetAllAsync(_teacherId, default);
+
+        result.Should().HaveCount(1);
+        result[0].Text.Should().Be("Operational");
+    }
+
+    [Fact]
+    public async Task GetByStudentAsync_ExcludesPedagogicalKind()
+    {
+        _db.TeacherFollowups.AddRange(
+            new TeacherFollowup { Id = Guid.NewGuid(), TeacherId = _teacherId, StudentId = _studentId, Kind = TeacherFollowupKinds.Operational, Text = "Op followup", Status = "pending", CreatedAt = DateTime.UtcNow },
+            new TeacherFollowup { Id = Guid.NewGuid(), TeacherId = _teacherId, StudentId = _studentId, Kind = TeacherFollowupKinds.Pedagogical, Text = "Ped todo", Status = "pending", CreatedAt = DateTime.UtcNow });
+        _db.SaveChanges();
+
+        var result = await _sut.GetByStudentAsync(_teacherId, _studentId, default);
+
+        result.Should().HaveCount(1);
+        result[0].Text.Should().Be("Op followup");
+    }
+
+    [Fact]
     public async Task CreateAsync_WithOtherTeachersStudentId_ThrowsValidationException()
     {
         var otherStudent = Guid.NewGuid();

--- a/backend/LangTeach.Api/Services/TeacherFollowupService.cs
+++ b/backend/LangTeach.Api/Services/TeacherFollowupService.cs
@@ -11,7 +11,7 @@ public class TeacherFollowupService(AppDbContext db) : ITeacherFollowupService
     public async Task<List<TeacherFollowupDto>> GetAllAsync(Guid teacherId, CancellationToken cancellationToken)
     {
         return await db.TeacherFollowups
-            .Where(f => f.TeacherId == teacherId)
+            .Where(f => f.TeacherId == teacherId && f.Kind == TeacherFollowupKinds.Operational)
             .Include(f => f.Student)
             .OrderBy(f => f.CreatedAt)
             .Select(f => ToDto(f, f.Student != null ? f.Student.Name : null))
@@ -21,7 +21,7 @@ public class TeacherFollowupService(AppDbContext db) : ITeacherFollowupService
     public async Task<List<TeacherFollowupDto>> GetPendingAsync(Guid teacherId, CancellationToken cancellationToken)
     {
         return await db.TeacherFollowups
-            .Where(f => f.TeacherId == teacherId && f.Status == "pending")
+            .Where(f => f.TeacherId == teacherId && f.Status == "pending" && f.Kind == TeacherFollowupKinds.Operational)
             .Include(f => f.Student)
             .OrderBy(f => f.CreatedAt)
             .Select(f => ToDto(f, f.Student != null ? f.Student.Name : null))
@@ -31,7 +31,7 @@ public class TeacherFollowupService(AppDbContext db) : ITeacherFollowupService
     public async Task<List<TeacherFollowupDto>> GetByStudentAsync(Guid teacherId, Guid studentId, CancellationToken cancellationToken)
     {
         return await db.TeacherFollowups
-            .Where(f => f.TeacherId == teacherId && f.StudentId == studentId)
+            .Where(f => f.TeacherId == teacherId && f.StudentId == studentId && f.Kind == TeacherFollowupKinds.Operational)
             .OrderBy(f => f.CreatedAt)
             .Select(f => ToDto(f, null))
             .ToListAsync(cancellationToken);

--- a/e2e/tests/followups.spec.ts
+++ b/e2e/tests/followups.spec.ts
@@ -12,6 +12,67 @@ test.beforeAll(async ({ browser }) => {
   await ctx.close()
 })
 
+test('teaching todo does not appear in dashboard pending followups', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    const studentName = `Kind Filter Test ${Date.now()}`
+    await createStudentViaUI(page, { name: studentName, language: 'Spanish', cefrLevel: 'B1', nativeLanguage: 'English' })
+
+    // Add a teaching todo via the TeachingTodosCard on the overview tab
+    const todoText = `Teaching todo ${Date.now()}`
+    await page.getByTestId('ideas-add-header-btn').click()
+    await page.getByTestId('todo-add-input').fill(todoText)
+    await page.getByTestId('todo-add-btn').click()
+
+    // Assert todo IS visible in the teaching-todos-card
+    await expect(page.getByTestId('teaching-todos-card').getByText(todoText)).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // Navigate to dashboard and assert todo does NOT appear in pending followups
+    await page.goto('/')
+    await expect(page.locator('h1')).toHaveText('Dashboard', { timeout: NAV_TIMEOUT })
+    await expect(page.getByTestId('zone2-pending-followups')).toBeVisible({ timeout: UI_TIMEOUT })
+    await expect(page.getByTestId('zone2-pending-followups').getByText(todoText)).not.toBeVisible()
+  } finally {
+    await page.close()
+    await context.close()
+  }
+})
+
+test('clicking followup row text navigates to student overview', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    const studentName = `Click Nav Test ${Date.now()}`
+    await createStudentViaUI(page, { name: studentName, language: 'Spanish', cefrLevel: 'A2', nativeLanguage: 'English' })
+
+    // Add an operational followup via StudentFollowupsCard on the overview tab
+    const followupText = `Clickable followup ${Date.now()}`
+    await expect(page.getByTestId('student-followups-card')).toBeVisible({ timeout: UI_TIMEOUT })
+    await page.getByTestId('followup-input').fill(followupText)
+    await page.getByTestId('followup-add-btn').click()
+    await expect(page.getByTestId('student-followups-card').getByText(followupText)).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // Navigate to dashboard and click the followup text link
+    await page.goto('/')
+    await expect(page.locator('h1')).toHaveText('Dashboard', { timeout: NAV_TIMEOUT })
+    const panel = page.getByTestId('zone2-pending-followups')
+    await expect(panel.getByText(followupText)).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // Click the text link (data-testid starts with followup-text-link-)
+    const textLink = panel.locator('[data-testid^="followup-text-link-"]').filter({ hasText: followupText })
+    await textLink.click()
+
+    // Assert navigated to the student detail page
+    await expect(page).toHaveURL(/\/students\/[^/]+$/, { timeout: NAV_TIMEOUT })
+  } finally {
+    await page.close()
+    await context.close()
+  }
+})
+
 test('followup happy path: create, appear on dashboard, mark done', async ({ browser }) => {
   const context = await createMockAuthContext(browser)
   const page = await context.newPage()

--- a/frontend/src/components/dashboard/PendingFollowups.test.tsx
+++ b/frontend/src/components/dashboard/PendingFollowups.test.tsx
@@ -117,4 +117,21 @@ describe('PendingFollowups', () => {
     wrap(<PendingFollowups followups={followups} />)
     expect(screen.queryByTestId('followups-see-all')).not.toBeInTheDocument()
   })
+
+  it('row click navigates to student overview', () => {
+    wrap(<PendingFollowups followups={[makeFollowup({ id: 'f1', studentId: 'student-1' })]} />)
+    expect(screen.getByTestId('followup-text-link-f1')).toHaveAttribute('href', '/students/student-1')
+  })
+
+  it('row without studentId renders no text link', () => {
+    wrap(<PendingFollowups followups={[makeFollowup({ id: 'f1', studentId: null })]} />)
+    expect(screen.queryByTestId('followup-text-link-f1')).not.toBeInTheDocument()
+  })
+
+  it('dot button is not inside the text link', () => {
+    wrap(<PendingFollowups followups={[makeFollowup({ id: 'f1', studentId: 'student-1' })]} />)
+    const link = screen.getByTestId('followup-text-link-f1')
+    const dot = screen.getByTestId('followup-dot-f1')
+    expect(link).not.toContainElement(dot)
+  })
 })

--- a/frontend/src/components/dashboard/PendingFollowups.tsx
+++ b/frontend/src/components/dashboard/PendingFollowups.tsx
@@ -87,7 +87,7 @@ export function PendingFollowups({ followups }: PendingFollowupsProps) {
                 className="flex items-start gap-3 rounded-lg px-3 py-2.5 hover:bg-[#F4F2FD] transition-colors"
               >
                 <button
-                  onClick={() => handleMarkDone(f.id)}
+                  onClick={(e) => { e.stopPropagation(); handleMarkDone(f.id) }}
                   aria-label="Mark done"
                   title="Mark as done"
                   className={`mt-0.5 shrink-0 w-3.5 h-3.5 rounded-full border-2 ${badge.dotColor} border-transparent hover:opacity-80 hover:scale-125 transition-all`}
@@ -103,7 +103,17 @@ export function PendingFollowups({ followups }: PendingFollowupsProps) {
                       {f.studentName}
                     </Link>
                   )}
-                  <p className="text-sm text-[#1A1B22] font-inter">{f.text}</p>
+                  {f.studentId ? (
+                    <Link
+                      to={`/students/${f.studentId}`}
+                      className="block text-sm text-[#1A1B22] font-inter hover:text-indigo-700 cursor-pointer"
+                      data-testid={`followup-text-link-${f.id}`}
+                    >
+                      {f.text}
+                    </Link>
+                  ) : (
+                    <p className="text-sm text-[#1A1B22] font-inter">{f.text}</p>
+                  )}
                 </div>
                 <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[0.6875rem] font-bold font-inter shrink-0 ${badge.badgeClassName}`} data-testid={`followup-age-${f.id}`}>
                   {badge.label}

--- a/plan/stabilisation/task925-dashboard-followups-kind-filter.md
+++ b/plan/stabilisation/task925-dashboard-followups-kind-filter.md
@@ -1,0 +1,72 @@
+# Task #925 — Dashboard Pending Followups: Kind filter + clickable rows
+
+## Context
+
+`TeacherFollowup` table uses a `Kind` discriminator (`pedagogical` / `operational`) added in task #844.
+The dashboard's Pending Followups tile calls `TeacherFollowupService.GetPendingAsync`, which currently omits the Kind filter, so teaching todos (pedagogical) bleed into the operational followup panel.
+
+## Changes
+
+### 1. Backend — `TeacherFollowupService.cs`
+
+Three methods need the `Kind == operational` guard on teacher-facing surfaces:
+
+- `GetPendingAsync`: add `&& f.Kind == TeacherFollowupKinds.Operational`
+- `GetAllAsync`: add `&& f.Kind == TeacherFollowupKinds.Operational` (feeds the teacher-wide followup inbox via `GET /api/teacher-followups`)
+- `GetByStudentAsync`: add `&& f.Kind == TeacherFollowupKinds.Operational` (feeds the StudentFollowupsCard on the student profile)
+
+Per-student teaching-todo endpoints in `StudentsController` are unaffected (they use a separate service path).
+
+### 2. Frontend — `PendingFollowups.tsx`
+
+Enhancement: wrap the followup text in a clickable `Link` to `/students/{studentId}`:
+
+- Wrap the text `<p>` in a `<Link to={`/students/${f.studentId}`} data-testid={`followup-text-link-${f.id}`}>` when `studentId` is non-null. This is a sibling element to the existing student-name chip `<Link>` (which is conditionally shown above it). Do NOT nest links.
+- Keep the dot `<button>` as a separate action outside the Link; call `e.stopPropagation()` on it to prevent navigation.
+- Rows with `studentId == null`: render the text as a plain `<p>` (no Link, no `cursor-pointer`).
+- Keep the student-name chip unchanged.
+- Link wraps only the text `<p>`; the chip and age badge remain outside the Link.
+
+### 3. Backend tests — `TeacherFollowupServiceTests.cs`
+
+New facts:
+- `GetPendingAsync_ExcludesPedagogicalKind`: seed one operational+pending and one pedagogical+pending; assert only the operational is returned.
+- `GetPendingAsync_IncludesOperationalPendingOnly`: operational+done, pedagogical+pending — assert only the operational+pending is returned.
+- `GetAllAsync_ExcludesPedagogicalKind`: seed one operational and one pedagogical; assert `GetAllAsync` returns only the operational.
+
+### 4. Backend tests — `DashboardServiceTests.cs`
+
+- `GetAsync_PendingFollowups_ExcludesTeachingTodos`: seed a pedagogical+pending row; assert `DashboardDto.PendingFollowups` is empty.
+- `GetAsync_PendingFollowups_IncludesOperational`: seed operational+pending and pedagogical+pending; assert only the operational row is in the response.
+
+### 5. Backend tests — `DashboardServiceTests.cs` (additional)
+
+Move the cross-service test here (DashboardServiceTests already has both TeacherFollowupService and DashboardService wired together):
+
+- `GetAsync_PendingFollowups_NullKind_ExcludedFromDashboard`: seed a `TeacherFollowup` directly with `Kind = TeacherFollowupKinds.Pedagogical` and `Status = "pending"` (simulating what AppendTeachingTodoAsync writes); call `DashboardService.GetAsync`; assert `PendingFollowups` is empty.
+
+### 6. Frontend tests — `PendingFollowups.test.tsx`
+
+- `row click navigates to student overview`: render followup with `studentId`; query by `data-testid="followup-text-link-f1"`; assert it has `href="/students/student-1"`.
+- `dot click does not navigate`: click the dot button (`followup-dot-f1`); assert mark-done handler fires. The dot button is outside the Link element so navigation cannot bubble.
+- `row without studentId is not clickable`: render followup with `studentId: null`; assert `queryByTestId("followup-text-link-f1")` is null (no anchor rendered).
+
+### 7. E2E — new spec in `e2e/tests/followups.spec.ts`
+
+**Test: teaching todo does not appear on dashboard**
+- Login → create student → open student profile → add teaching todo via TeachingTodosCard → assert todo text IS visible in `[data-testid="teaching-todos-card"]` (still on student profile page) → navigate to dashboard → assert todo text is NOT inside `[data-testid="zone2-pending-followups"]`.
+
+**Test: clickable followup row navigates to student**
+- Login → create student → open student profile → add operational followup via student-followups-card → navigate to dashboard → click the followup text link (`data-testid="followup-text-link-{id}"`) → assert URL matches `/students/{studentId}`.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `backend/LangTeach.Api/Services/TeacherFollowupService.cs` | Add Kind filter to 3 methods |
+| `backend/LangTeach.Api.Tests/Services/TeacherFollowupServiceTests.cs` | 3 new tests |
+| `backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs` | 2 new tests |
+| `backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs` | 3 new tests (2 from section 4 + 1 from section 5) |
+| `frontend/src/components/dashboard/PendingFollowups.tsx` | Clickable row enhancement |
+| `frontend/src/components/dashboard/PendingFollowups.test.tsx` | 3 new tests |
+| `e2e/tests/followups.spec.ts` | 2 new test cases |


### PR DESCRIPTION
## Summary

- **Bug fix:** `TeacherFollowupService.GetPendingAsync`, `GetAllAsync`, and `GetByStudentAsync` now filter by `Kind == "operational"`, preventing teaching todos (`Kind = "pedagogical"`) from bleeding into the dashboard tile and teacher followup inbox.
- **Enhancement:** Followup row text in `PendingFollowups.tsx` is now a clickable `Link` to `/students/{id}`. The mark-done dot uses `stopPropagation` so clicking it does not navigate. Rows with `null studentId` remain plain text.

Closes #925.

## Test plan

- [x] Backend: 4 new unit tests (`TeacherFollowupServiceTests` + `DashboardServiceTests`) all pass
- [x] Frontend: 3 new unit tests for clickable row behavior all pass
- [x] E2E: 2 new specs (kind isolation + click-row navigation) in `followups.spec.ts`
- [x] Full build verify: PASS (92 frontend tests, all backend tests green)
- [x] Architecture review: PASS WITH NOTES (minor duplicate test removed)
- [x] UI review: PASS (clickable row affordance correct, dot isolation correct, null-studentId rows non-navigable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pending followups in the dashboard are now separated from teaching todos, displaying only operational followups
  * Pending followup items are now clickable navigation links that take you directly to the corresponding student's detail page
  * Improved interaction handling for action buttons on linked followup items

* **Tests**
  * Added comprehensive unit tests for followup filtering behavior
  * Added end-to-end tests validating dashboard followup separation and student navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->