### PR TITLE
fix: voice note extraction outputs English when teacher speaks Spanish

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
@@ -698,4 +698,36 @@ public class ReflectionExtractionServiceTests
 
         result.WhatWasCovered.Should().BeNull();
     }
+
+    // Regression guard: prompt must instruct Claude to match the teacher's input language.
+    // Root cause of Jordi's bug: weak "preserve original language" instruction + English sessionTitle
+    // example biased Haiku to generate English titles from Spanish voice notes.
+
+    private static readonly IPromptService RealPrompts = new PromptService(
+        ProfileService,
+        PedagogyService,
+        NullLogger<PromptService>.Instance,
+        NullContentSchemas.Instance);
+
+    [Fact]
+    public void BuildReflectionExtractionPrompt_SystemPrompt_ContainsExplicitLanguageInstruction()
+    {
+        var ctx = new ReflectionExtractionContext(DateOnly.FromDateTime(DateTime.UtcNow), "Hoy practicamos el subjuntivo.", null);
+
+        var request = RealPrompts.BuildReflectionExtractionPrompt(ctx);
+
+        request.SystemPrompt.Should().Contain("same language as the teacher's input text",
+            because: "the prompt must instruct Claude to match the teacher's input language for all generated fields");
+    }
+
+    [Fact]
+    public void BuildReflectionExtractionPrompt_SystemPrompt_SessionTitleExampleIsNotInEnglish()
+    {
+        var ctx = new ReflectionExtractionContext(DateOnly.FromDateTime(DateTime.UtcNow), "Hoy practicamos el subjuntivo.", null);
+
+        var request = RealPrompts.BuildReflectionExtractionPrompt(ctx);
+
+        request.SystemPrompt.Should().NotContain("Subjunctive in time clauses",
+            because: "English examples in sessionTitle bias Haiku to generate English titles from Spanish input");
+    }
 }

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1526,7 +1526,7 @@ public class PromptService : IPromptService
             You are a tool that helps language teachers structure their post-class notes.
             Extract structured information from a teacher's free-form reflection text.
 
-            IMPORTANT: Preserve the original language of the teacher's text. Do not translate any field value into another language.
+            IMPORTANT: All text values in your response MUST be written in the same language as the teacher's input text. If the teacher writes in Spanish, every string value — including sessionTitle, topicTags, teachingTodos, teacherFollowups, and all summaries — must be in Spanish. Never translate or switch to English.
 
             Today is {today.DayOfWeek}, {today:yyyy-MM-dd}.
             {difficultiesSection}
@@ -1554,7 +1554,7 @@ public class PromptService : IPromptService
                 Return null if no next-session ideas are mentioned.
             - sessionDate: string or null — ISO 8601 date (YYYY-MM-DD) of the session being described. Resolve date references using today's date and day of week: "hoy"/"today" = today, "ayer"/"yesterday" = yesterday, "el lunes pasado"/"el pasado lunes" = the most recent Monday before today (not the Monday of this week if today is Monday), "el martes pasado"/"el pasado martes" = the most recent Tuesday before today, and so on for any weekday. Always pick the last occurrence of the named weekday strictly before today. Null if no date is mentioned.
             - sessionStartTime: string or null — 24-hour time (HH:MM) when the session started (e.g. "09:00", "18:30"). Null if not mentioned.
-            - sessionTitle: string or null — a concise title (under 60 chars) for this session derived from what was covered. Examples: "Subjunctive in time clauses", "Pasado compuesto — revisión". Null if no content is mentioned.
+            - sessionTitle: string or null — a concise title (under 60 chars) for this session derived from what was covered, written in the same language as the teacher's input. Examples (Spanish input): "Subjuntivo en cláusulas temporales", "Pasado compuesto — revisión". Null if no content is mentioned.
             - suggestedDifficulties: array of objects (can be empty []) — structured breakdown of the same difficulties mentioned in areasToImprove
             - topicTags: array of objects with "tag" (string) and "category" (string or null) — topics, grammar structures, vocabulary areas covered. Each tag as a concise noun phrase. Empty array if none mentioned.
             - previousHomeworkStatus: "done" | "partial" | "notDone" | null — whether the student completed homework from the previous session. Null if not mentioned.


### PR DESCRIPTION
## Summary

- Strengthened language preservation rule in `BuildReflectionExtractionPrompt`: now explicitly states all string values (including generated fields like `sessionTitle`, `topicTags`, `teachingTodos`) must match the teacher's input language
- Replaced the English `sessionTitle` example ("Subjunctive in time clauses") with a Spanish one ("Subjuntivo en cláusulas temporales") to remove the English bias on Haiku

## Root cause

The original instruction said "Preserve the original language... do not translate." This is correct for *extracted* fields but ambiguous for *synthesized* fields like `sessionTitle` (which is generated, not copied verbatim from the teacher's text). Haiku used the English example as its output template.

## Test plan

- [ ] Record a voice note in Spanish; confirm `sessionTitle`, `topicTags`, and other generated fields come back in Spanish
- [ ] Existing `ReflectionExtractionServiceTests` still pass (no logic change, prompt-only fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language consistency in AI-generated content to ensure all output strings remain in the user's input language without unexpected English translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->