### PR TITLE
fix: correct alert windowSize and Log_s field in containerapp bicep

### DIFF
--- a/infra/modules/containerapp.bicep
+++ b/infra/modules/containerapp.bicep
@@ -108,13 +108,11 @@ resource activationFailedAlert 'microsoft.insights/scheduledQueryRules@2022-06-1
     enabled: true
     scopes: [logAnalytics.id]
     evaluationFrequency: 'PT5M'
-    windowSize: 'PT6M'
+    windowSize: 'PT10M'
     criteria: {
       allOf: [
         {
-          // Note: ContainerAppSystemLogs uses Log_s for the free-text message field.
-          // If Azure changes this field name in a future API version, update the query here.
-          query: 'ContainerAppSystemLogs | where Log_s contains "ActivationFailed"'
+          query: 'ContainerAppSystemLogs | where Log contains "ActivationFailed"'
           timeAggregation: 'Count'
           operator: 'GreaterThan'
           threshold: 0

--- a/infra/parameters/dev.bicepparam
+++ b/infra/parameters/dev.bicepparam
@@ -9,3 +9,4 @@ param swaLocation       = 'westeurope'
 param sqlAdminPassword  = readEnvironmentVariable('LANGTEACH_SQL_PASSWORD')
 // Set the env var before deploying: $env:LANGTEACH_SQL_PASSWORD="<from Bitwarden: LangTeach SQL Admin>"
 param alertEmail        = 'robert.freire@gmail.com'
+param allowedOriginSwa  = 'https://white-cliff-02f270f03.4.azurestaticapps.net'


### PR DESCRIPTION
## Summary
Two pre-existing bugs in `infra/modules/containerapp.bicep` that blocked the infra deployment:

- `windowSize: 'PT6M'` is not a supported Azure Monitor granularity — changed to `PT10M`
- `ContainerAppSystemLogs` field `Log_s` no longer exists in the current API — changed to `Log` (confirmed via live workspace schema)
- Added missing `allowedOriginSwa` param to `infra/parameters/dev.bicepparam`

These were discovered and fixed while deploying PR #942. The deployment succeeded after these fixes.

## Test plan
- Infra deployment ran successfully against `rg-langteach-dev` after these changes
- Live Container App confirmed `minReplicas: 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)