### PR TITLE
fix: add MaxLength to VoiceNote blob columns and guard AudioRecorder double-upload (#605)

### DIFF
--- a/backend/LangTeach.Api/Data/AppDbContext.cs
+++ b/backend/LangTeach.Api/Data/AppDbContext.cs
@@ -220,6 +220,9 @@ public class AppDbContext : DbContext
              .WithMany()
              .HasForeignKey(v => v.TeacherId)
              .OnDelete(DeleteBehavior.Cascade);
+            e.Property(v => v.BlobPath).HasMaxLength(500);
+            e.Property(v => v.OriginalFileName).HasMaxLength(255);
+            e.Property(v => v.ContentType).HasMaxLength(100);
             // TranscribedAt: null = not transcribed, non-null = transcription complete (timestamp provides timing)
         });
 

--- a/backend/LangTeach.Api/Migrations/20260425191721_AddVoiceNoteColumnMaxLengths.Designer.cs
+++ b/backend/LangTeach.Api/Migrations/20260425191721_AddVoiceNoteColumnMaxLengths.Designer.cs
@@ -4,6 +4,7 @@ using LangTeach.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LangTeach.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260425191721_AddVoiceNoteColumnMaxLengths")]
+    partial class AddVoiceNoteColumnMaxLengths
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/LangTeach.Api/Migrations/20260425191721_AddVoiceNoteColumnMaxLengths.cs
+++ b/backend/LangTeach.Api/Migrations/20260425191721_AddVoiceNoteColumnMaxLengths.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LangTeach.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddVoiceNoteColumnMaxLengths : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "OriginalFileName",
+                table: "VoiceNotes",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ContentType",
+                table: "VoiceNotes",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "BlobPath",
+                table: "VoiceNotes",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "OriginalFileName",
+                table: "VoiceNotes",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ContentType",
+                table: "VoiceNotes",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "BlobPath",
+                table: "VoiceNotes",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(500)",
+                oldMaxLength: 500);
+        }
+    }
+}

--- a/frontend/src/components/audio/AudioRecorder.test.tsx
+++ b/frontend/src/components/audio/AudioRecorder.test.tsx
@@ -139,4 +139,31 @@ describe('AudioRecorder', () => {
     expect(screen.getByTestId('record-button')).toBeDisabled()
     expect(screen.getByTestId('upload-audio-button')).toBeDisabled()
   })
+
+  it('does not trigger a second upload if handleFileChange fires twice in quick succession', async () => {
+    let resolveUpload: (v: VoiceNote) => void
+    vi.mocked(voiceNotesApi.uploadVoiceNote).mockReturnValue(
+      new Promise((r) => { resolveUpload = r })
+    )
+
+    render(<AudioRecorder onVoiceNote={vi.fn()} />)
+
+    const input = screen.getByTestId('audio-file-input')
+    const file = new File(['data'], 'audio.webm', { type: 'audio/webm' })
+
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } })
+    })
+
+    // Second fire while upload is still in progress — uploadVoiceNote should only be called once
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } })
+    })
+
+    resolveUpload!(SAMPLE_NOTE)
+
+    await waitFor(() => {
+      expect(voiceNotesApi.uploadVoiceNote).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/frontend/src/components/audio/AudioRecorder.tsx
+++ b/frontend/src/components/audio/AudioRecorder.tsx
@@ -107,7 +107,7 @@ export function AudioRecorder({ onVoiceNote, disabled }: AudioRecorderProps) {
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
-    if (!file) return
+    if (!file || state !== 'idle') return
     e.target.value = ''
 
     if (!ALLOWED_UPLOAD_TYPES.includes(file.type)) {

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -3,6 +3,7 @@
 Out-of-scope observations logged by agents during implementation. Each row is something an agent noticed but did not fix because it was outside the current task's scope. These get batched into future GitHub issues by the PM.
 
 | Source issue | Date | Severity | Observation |
+| #605 | 2026-04-25 | low | VoiceNote upload API/DTO layer does not validate BlobPath/OriginalFileName/ContentType length at input boundary; EF MaxLength only enforces at DB write, giving a runtime error instead of a clean 400. |
 | #908 | 2026-04-24 | low | Tab bar at 375px clips "Progress" label (shows "Progre") -- pre-existing tab overflow at mobile width, outside StudentDetailHeader scope |
 | #834 | 2026-04-22 | low | EnsureAnaVisualExtrasAsync.UpdatedAt uses DateTime.UtcNow inline instead of caller's now (pre-existing inconsistency, not introduced by this task) |
 | #809 | 2026-04-22 | low | languages.json has duplicate concepts: "Mandarin" and "Chinese (Mandarin)" - requires data migration to consolidate; filed #874 |


### PR DESCRIPTION
## Summary
- Add `HasMaxLength(500/255/100)` to `VoiceNote.BlobPath`, `OriginalFileName`, `ContentType` in `AppDbContext` (fluent API, matches project convention). Previously these were `nvarchar(max)`.
- Generate migration `AddVoiceNoteColumnMaxLengths` to apply the schema change.
- Guard `AudioRecorder.handleFileChange` with `state !== 'idle'` check to prevent a second concurrent upload if the file input change event fires twice.

## Test plan
- [ ] All existing AudioRecorder tests pass (8/8)
- [ ] New test: double-fire of file input change while upload in progress calls `uploadVoiceNote` exactly once
- [ ] `dotnet build` and `dotnet test` pass
- [ ] Full `npm test` (92 test files) pass

## Ops note
Before applying the migration in prod, verify no existing `BlobPath` values exceed 500 chars, no `OriginalFileName` values exceed 255 chars, and no `ContentType` values exceed 100 chars (all extremely unlikely in practice).

Closes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)