### PR TITLE
feat: student profile extraction service and endpoint (#946)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/CurriculumGenerationServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/CurriculumGenerationServiceTests.cs
@@ -33,6 +33,7 @@ internal sealed class FakePromptService : IPromptService
     }
 
     public ClaudeRequest BuildReflectionExtractionPrompt(ReflectionExtractionContext ctx) => Dummy();
+    public ClaudeRequest BuildStudentProfileExtractionPrompt(string text) => Dummy();
     public ClaudeRequest BuildReplanSuggestionPrompt(ReplanSuggestionContext ctx) => Dummy();
     public ClaudeRequest BuildCurriculumValidationPrompt(CurriculumValidationContext ctx) => Dummy();
 

--- a/backend/LangTeach.Api.Tests/Services/StudentProfileExtractionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/StudentProfileExtractionServiceTests.cs
@@ -246,6 +246,42 @@ public class StudentProfileExtractionServiceTests
     }
 
     [Fact]
+    public async Task ExtractAsync_WhenClaudeReturnsValidJson_ReturnsPopulatedDto()
+    {
+        var validJson = """
+            {
+              "name": "Ana López",
+              "birthYear": 1988,
+              "profession": "Doctor",
+              "countryOfResidence": "Mexico",
+              "cityOfResidence": "Ciudad de México",
+              "reasonForStudying": "Move to Spain",
+              "nativeLanguages": ["Spanish"],
+              "spokenLanguages": ["English"],
+              "cefrLevel": "B1",
+              "officialCefrLevel": null,
+              "shortTermObjectives": [{"text": "Improve writing", "targetDate": null}],
+              "difficulties": [{"description": "Struggles with subjunctive", "competency": "Grammar", "subcategory": "subjunctive"}],
+              "teachingTodoTexts": ["Send grammar exercises"],
+              "interests": ["Cinema", "Photography"]
+            }
+            """;
+        var sut = CreateSut(validJson);
+
+        var result = await sut.ExtractAsync("Ana López es médica, nació en 1988...");
+
+        result.Name.Should().Be("Ana López");
+        result.BirthYear.Should().Be(1988);
+        result.Profession.Should().Be("Doctor");
+        result.CefrLevel.Should().Be("B1");
+        result.NativeLanguages.Should().BeEquivalentTo(["Spanish"]);
+        result.Difficulties.Should().HaveCount(1);
+        result.ShortTermObjectives.Should().HaveCount(1);
+        result.TeachingTodoTexts.Should().BeEquivalentTo(["Send grammar exercises"]);
+        result.Interests.Should().BeEquivalentTo(["Cinema", "Photography"]);
+    }
+
+    [Fact]
     public async Task ExtractAsync_CallsClaudeWithHaikuModel()
     {
         ClaudeRequest? captured = null;

--- a/backend/LangTeach.Api.Tests/Services/StudentProfileExtractionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/StudentProfileExtractionServiceTests.cs
@@ -1,0 +1,274 @@
+using FluentAssertions;
+using LangTeach.Api.AI;
+using LangTeach.Api.DTOs;
+using LangTeach.Api.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace LangTeach.Api.Tests.Services;
+
+// FakePromptService is defined in CurriculumGenerationServiceTests.cs (internal scope)
+
+file sealed class ProfileExtractionClaudeClient : IClaudeClient
+{
+    private readonly Func<ClaudeRequest, ClaudeResponse>? _handler;
+    private readonly Exception? _exception;
+    private readonly string? _fixedJson;
+    public ClaudeRequest? LastRequest { get; private set; }
+
+    public ProfileExtractionClaudeClient(string fixedJson) => _fixedJson = fixedJson;
+    public ProfileExtractionClaudeClient(Exception exception) => _exception = exception;
+    public ProfileExtractionClaudeClient(Func<ClaudeRequest, ClaudeResponse> handler) => _handler = handler;
+
+    public Task<ClaudeResponse> CompleteAsync(ClaudeRequest request, CancellationToken ct = default)
+    {
+        LastRequest = request;
+        if (_exception is not null) throw _exception;
+        if (_fixedJson is not null)
+            return Task.FromResult(new ClaudeResponse(_fixedJson, "claude-haiku", 10, 20));
+        return Task.FromResult(_handler!(request));
+    }
+
+    public async IAsyncEnumerable<string> StreamAsync(ClaudeRequest request, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await Task.Yield();
+        yield return "{}";
+    }
+}
+
+public class StudentProfileExtractionServiceTests
+{
+    private static readonly IPromptService FakePrompts = new FakePromptService();
+
+    private static StudentProfileExtractionService CreateSut(string fixedJson) =>
+        new(new ProfileExtractionClaudeClient(fixedJson), FakePrompts, NullLogger<StudentProfileExtractionService>.Instance);
+
+    [Fact]
+    public void ParseResponse_ExtractsAllScalarFields()
+    {
+        var sut = CreateSut("{}");
+        var json = """
+            {
+              "name": "María García",
+              "birthYear": 1990,
+              "profession": "Engineer",
+              "countryOfResidence": "Spain",
+              "cityOfResidence": "Madrid",
+              "reasonForStudying": "Work promotion",
+              "nativeLanguages": ["Spanish"],
+              "spokenLanguages": ["English", "French"],
+              "cefrLevel": "B2",
+              "officialCefrLevel": "B1",
+              "shortTermObjectives": [],
+              "difficulties": [],
+              "teachingTodoTexts": [],
+              "interests": ["Travel", "Cooking"]
+            }
+            """;
+
+        var result = sut.ParseResponse(json);
+
+        result.Name.Should().Be("María García");
+        result.BirthYear.Should().Be(1990);
+        result.Profession.Should().Be("Engineer");
+        result.CountryOfResidence.Should().Be("Spain");
+        result.CityOfResidence.Should().Be("Madrid");
+        result.ReasonForStudying.Should().Be("Work promotion");
+        result.NativeLanguages.Should().BeEquivalentTo(["Spanish"]);
+        result.SpokenLanguages.Should().BeEquivalentTo(["English", "French"]);
+        result.CefrLevel.Should().Be("B2");
+        result.OfficialCefrLevel.Should().Be("B1");
+        result.Interests.Should().BeEquivalentTo(["Travel", "Cooking"]);
+    }
+
+    [Fact]
+    public void ParseResponse_ExtractsShortTermObjectives()
+    {
+        var sut = CreateSut("{}");
+        var json = """
+            {
+              "shortTermObjectives": [
+                {"text": "Pass B2 exam", "targetDate": "2026-06-30"},
+                {"text": "Improve speaking fluency", "targetDate": null}
+              ],
+              "difficulties": [], "nativeLanguages": [], "spokenLanguages": [],
+              "teachingTodoTexts": [], "interests": []
+            }
+            """;
+
+        var result = sut.ParseResponse(json);
+
+        result.ShortTermObjectives.Should().HaveCount(2);
+        result.ShortTermObjectives[0].Text.Should().Be("Pass B2 exam");
+        result.ShortTermObjectives[0].TargetDate.Should().Be("2026-06-30");
+        result.ShortTermObjectives[1].Text.Should().Be("Improve speaking fluency");
+        result.ShortTermObjectives[1].TargetDate.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseResponse_ExtractsDifficulties()
+    {
+        var sut = CreateSut("{}");
+        var json = """
+            {
+              "difficulties": [
+                {"description": "Confuses ser and estar", "competency": "Grammar", "subcategory": "ser/estar"}
+              ],
+              "shortTermObjectives": [], "nativeLanguages": [], "spokenLanguages": [],
+              "teachingTodoTexts": [], "interests": []
+            }
+            """;
+
+        var result = sut.ParseResponse(json);
+
+        result.Difficulties.Should().HaveCount(1);
+        result.Difficulties[0].Description.Should().Be("Confuses ser and estar");
+        result.Difficulties[0].Competency.Should().Be("Grammar");
+        result.Difficulties[0].Subcategory.Should().Be("ser/estar");
+    }
+
+    [Fact]
+    public void ParseResponse_ReturnsAllNullsAndEmptyLists_WhenJsonIsEmpty()
+    {
+        var sut = CreateSut("{}");
+
+        var result = sut.ParseResponse("{}");
+
+        result.Name.Should().BeNull();
+        result.BirthYear.Should().BeNull();
+        result.Profession.Should().BeNull();
+        result.CefrLevel.Should().BeNull();
+        result.NativeLanguages.Should().BeEmpty();
+        result.SpokenLanguages.Should().BeEmpty();
+        result.ShortTermObjectives.Should().BeEmpty();
+        result.Difficulties.Should().BeEmpty();
+        result.TeachingTodoTexts.Should().BeEmpty();
+        result.Interests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseResponse_HandlesInvalidJson_ReturnsEmpty()
+    {
+        var sut = CreateSut("{}");
+
+        var result = sut.ParseResponse("this is not json");
+
+        result.Name.Should().BeNull();
+        result.NativeLanguages.Should().BeEmpty();
+        result.Difficulties.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseResponse_StripsFencesBeforeParsing()
+    {
+        var sut = CreateSut("{}");
+        var fenced = "```json\n{\"name\":\"Ana\"}\n```";
+
+        var result = sut.ParseResponse(fenced);
+
+        result.Name.Should().Be("Ana");
+    }
+
+    [Theory]
+    [InlineData("B1", "B1")]
+    [InlineData("A2+", "A2+")]
+    [InlineData("C1", "C1")]
+    [InlineData("Intermediate", null)]
+    [InlineData("B3", null)]
+    public void ParseResponse_ValidatesCefrLevel(string input, string? expected)
+    {
+        var sut = CreateSut("{}");
+        var json = $$"""{"cefrLevel":"{{input}}","nativeLanguages":[],"spokenLanguages":[],"shortTermObjectives":[],"difficulties":[],"teachingTodoTexts":[],"interests":[]}""";
+
+        var result = sut.ParseResponse(json);
+
+        result.CefrLevel.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ParseResponse_ObjectiveDateIsNullWhenNotIsoFormat()
+    {
+        var sut = CreateSut("{}");
+        var json = """
+            {
+              "shortTermObjectives": [{"text": "Get a job", "targetDate": "next summer"}],
+              "difficulties": [], "nativeLanguages": [], "spokenLanguages": [],
+              "teachingTodoTexts": [], "interests": []
+            }
+            """;
+
+        var result = sut.ParseResponse(json);
+
+        result.ShortTermObjectives[0].TargetDate.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseResponse_SkipsDifficultyMissingRequiredFields()
+    {
+        var sut = CreateSut("{}");
+        var json = """
+            {
+              "difficulties": [
+                {"description": "Valid entry", "competency": "Grammar", "subcategory": "ser/estar"},
+                {"competency": "Vocabulary"}
+              ],
+              "shortTermObjectives": [], "nativeLanguages": [], "spokenLanguages": [],
+              "teachingTodoTexts": [], "interests": []
+            }
+            """;
+
+        var result = sut.ParseResponse(json);
+
+        result.Difficulties.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_WhenClaudeFails_ReturnsEmpty_NoException()
+    {
+        var client = new ProfileExtractionClaudeClient(new HttpRequestException("network error"));
+        var sut = new StudentProfileExtractionService(client, FakePrompts, NullLogger<StudentProfileExtractionService>.Instance);
+
+        var result = await sut.ExtractAsync("some teacher notes");
+
+        result.Name.Should().BeNull();
+        result.NativeLanguages.Should().BeEmpty();
+        result.Difficulties.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_WhenClaudeReturnsMalformedJson_ReturnsEmpty_NoException()
+    {
+        var sut = CreateSut("definitely not json {{{{");
+
+        var result = await sut.ExtractAsync("some teacher notes");
+
+        result.Name.Should().BeNull();
+        result.NativeLanguages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_CallsClaudeWithHaikuModel()
+    {
+        ClaudeRequest? captured = null;
+        var client = new ProfileExtractionClaudeClient(req =>
+        {
+            captured = req;
+            return new ClaudeResponse("""{"nativeLanguages":[],"spokenLanguages":[],"shortTermObjectives":[],"difficulties":[],"teachingTodoTexts":[],"interests":[]}""", "claude-haiku", 10, 20);
+        });
+        var realPrompts = new PromptService(
+            new SectionProfileService(NullLogger<SectionProfileService>.Instance),
+            new PedagogyConfigService(NullLogger<PedagogyConfigService>.Instance, new SectionProfileService(NullLogger<SectionProfileService>.Instance)),
+            NullLogger<PromptService>.Instance,
+            new NullContentSchemas());
+        var sut = new StudentProfileExtractionService(client, realPrompts, NullLogger<StudentProfileExtractionService>.Instance);
+
+        await sut.ExtractAsync("María estudia español para trabajar en Madrid.");
+
+        captured.Should().NotBeNull();
+        captured!.Model.Should().Be(ClaudeModel.Haiku);
+    }
+}
+
+file sealed class NullContentSchemas : IContentSchemaService
+{
+    public string? GetSchema(string contentType) => null;
+}

--- a/backend/LangTeach.Api/AI/IPromptService.cs
+++ b/backend/LangTeach.Api/AI/IPromptService.cs
@@ -26,6 +26,7 @@ public interface IPromptService
     ClaudeRequest BuildNoticingTaskPrompt(GenerationContext ctx);
     ClaudeRequest BuildCurriculumPrompt(CurriculumContext ctx);
     ClaudeRequest BuildReflectionExtractionPrompt(ReflectionExtractionContext ctx);
+    ClaudeRequest BuildStudentProfileExtractionPrompt(string text);
     ClaudeRequest BuildReplanSuggestionPrompt(ReplanSuggestionContext ctx);
     ClaudeRequest BuildCurriculumValidationPrompt(CurriculumValidationContext ctx);
 }

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1579,6 +1579,50 @@ public class PromptService : IPromptService
         return new ClaudeRequest(SystemPrompt: system, UserPrompt: teacherText, Model: ClaudeModel.Haiku, MaxTokens: 2048);
     }
 
+    // --- Student profile extraction ---
+
+    public ClaudeRequest BuildStudentProfileExtractionPrompt(string text)
+    {
+        const string system = """
+            You are a tool that helps language teachers capture student information from free-form voice notes.
+            Extract structured student profile fields from a teacher's free-form text.
+
+            IMPORTANT: Be conservative. Only extract a field if the teacher stated it clearly and explicitly.
+            When ambiguous or uncertain, return null for that field rather than guessing.
+            A confirmation drawer full of wrong guesses destroys teacher trust after one use.
+            It is better to extract 3 accurate fields than 10 speculative ones.
+
+            Respond ONLY with a valid JSON object using these exact keys:
+            - name: string or null — student's full name. Null if not clearly stated.
+            - birthYear: integer or null — student's year of birth (e.g. 1990). Null if not clearly stated or only an age is mentioned without a computable birth year.
+            - profession: string or null — student's job or occupation. Null if not mentioned.
+            - countryOfResidence: string or null — country where the student currently lives. Null if not mentioned.
+            - cityOfResidence: string or null — city where the student currently lives. Null if not mentioned.
+            - reasonForStudying: string or null — why the student is learning the language. Null if not mentioned.
+            - nativeLanguages: array of strings — student's native or mother tongue(s). Empty array [] if not mentioned.
+            - spokenLanguages: array of strings — other languages the student speaks (not the target language being taught, not the native language). Empty array [] if not mentioned.
+            - cefrLevel: string or null — teacher's own CEFR assessment of the student (e.g. "B1", "B2+"). Null if not mentioned.
+            - officialCefrLevel: string or null — official/exam-certified CEFR level (e.g. from a DELE, DELF certificate). Null if not mentioned.
+            - shortTermObjectives: array of objects — near-term learning goals mentioned by the teacher. Each object has:
+                - text: string — description of the objective
+                - targetDate: string or null — ISO 8601 date (YYYY-MM-DD) if a date is mentioned, otherwise null
+              Empty array [] if no objectives mentioned.
+            - difficulties: array of objects — student weaknesses or trouble areas explicitly mentioned. Each object has:
+                - description: string — full description of the difficulty
+                - competency: string — broad area (e.g. "Grammar", "Vocabulary", "Pronunciation", "Listening", "Speaking", "Reading", "Writing")
+                - subcategory: string — specific item (e.g. "ser/estar", "subjunctive", "past tense"), free text
+              Empty array [] if no difficulties mentioned.
+            - teachingTodoTexts: array of strings — pedagogical ideas or reminders for the teacher regarding this student. Empty array [] if none.
+            - interests: array of strings — personal interests, hobbies, or topics the student enjoys. Empty array [] if not mentioned.
+
+            Use null for scalar fields that cannot be clearly inferred from the text.
+            Keep each value concise.
+            Respond with JSON only, no markdown, no explanation.
+            """;
+
+        return new ClaudeRequest(SystemPrompt: system, UserPrompt: InputSanitizer.Sanitize(text), Model: ClaudeModel.Haiku, MaxTokens: 1024);
+    }
+
     // --- Replan suggestion ---
 
     public ClaudeRequest BuildReplanSuggestionPrompt(ReplanSuggestionContext ctx)

--- a/backend/LangTeach.Api/Controllers/StudentsController.cs
+++ b/backend/LangTeach.Api/Controllers/StudentsController.cs
@@ -15,17 +15,20 @@ public class StudentsController : ControllerBase
     private readonly IStudentService _studentService;
     private readonly ILessonNoteService _lessonNoteService;
     private readonly IProfileService _profileService;
+    private readonly IStudentProfileExtractionService _extractionService;
     private readonly ILogger<StudentsController> _logger;
 
     public StudentsController(
         IStudentService studentService,
         ILessonNoteService lessonNoteService,
         IProfileService profileService,
+        IStudentProfileExtractionService extractionService,
         ILogger<StudentsController> logger)
     {
         _studentService = studentService;
         _lessonNoteService = lessonNoteService;
         _profileService = profileService;
+        _extractionService = extractionService;
         _logger = logger;
     }
 
@@ -185,6 +188,17 @@ public class StudentsController : ControllerBase
             return NotFound();
         }
         return Ok(student);
+    }
+
+    [HttpPost("extract-profile")]
+    public async Task<IActionResult> ExtractProfile([FromBody] ExtractStudentProfileRequest request, CancellationToken cancellationToken)
+    {
+        if (Auth0Id is null) return Unauthorized();
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        _logger.LogInformation("POST /api/students/extract-profile. Auth0Id={Auth0Id} TextLength={TextLength}", Auth0Id, request.Text.Length);
+        var extracted = await _extractionService.ExtractAsync(request.Text, cancellationToken);
+        return Ok(extracted);
     }
 
     [HttpDelete("{id:guid}")]

--- a/backend/LangTeach.Api/DTOs/StudentProfileExtractionDtos.cs
+++ b/backend/LangTeach.Api/DTOs/StudentProfileExtractionDtos.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LangTeach.Api.DTOs;
+
+public class ExtractStudentProfileRequest
+{
+    [Required, MaxLength(10000)]
+    public string Text { get; set; } = string.Empty;
+}
+
+// All fields nullable/empty by design — extraction is best-effort.
+public record ExtractedStudentProfileDto(
+    string? Name,
+    int? BirthYear,
+    string? Profession,
+    string? CountryOfResidence,
+    string? CityOfResidence,
+    string? ReasonForStudying,
+    List<string> NativeLanguages,
+    List<string> SpokenLanguages,
+    string? CefrLevel,
+    string? OfficialCefrLevel,
+    List<ExtractedObjectiveDto> ShortTermObjectives,
+    List<ExtractedDifficultyDto> Difficulties,
+    List<string> TeachingTodoTexts,
+    List<string> Interests
+);
+
+public record ExtractedObjectiveDto(string Text, string? TargetDate);
+
+public record ExtractedDifficultyDto(string Description, string Competency, string Subcategory);

--- a/backend/LangTeach.Api/Program.cs
+++ b/backend/LangTeach.Api/Program.cs
@@ -178,6 +178,10 @@ if (builder.Environment.IsEnvironment("E2ETesting") || builder.Environment.IsEnv
 else
     builder.Services.AddScoped<IReflectionExtractionService, ReflectionExtractionService>();
 if (builder.Environment.IsEnvironment("E2ETesting") || builder.Environment.IsEnvironment("Testing"))
+    builder.Services.AddScoped<IStudentProfileExtractionService, StubStudentProfileExtractionService>();
+else
+    builder.Services.AddScoped<IStudentProfileExtractionService, StudentProfileExtractionService>();
+if (builder.Environment.IsEnvironment("E2ETesting") || builder.Environment.IsEnvironment("Testing"))
     builder.Services.AddScoped<IReplanSuggestionService, StubReplanSuggestionService>();
 else
     builder.Services.AddScoped<IReplanSuggestionService, ReplanSuggestionService>();

--- a/backend/LangTeach.Api/Services/IStudentProfileExtractionService.cs
+++ b/backend/LangTeach.Api/Services/IStudentProfileExtractionService.cs
@@ -1,0 +1,8 @@
+using LangTeach.Api.DTOs;
+
+namespace LangTeach.Api.Services;
+
+public interface IStudentProfileExtractionService
+{
+    Task<ExtractedStudentProfileDto> ExtractAsync(string text, CancellationToken ct = default);
+}

--- a/backend/LangTeach.Api/Services/StubStudentProfileExtractionService.cs
+++ b/backend/LangTeach.Api/Services/StubStudentProfileExtractionService.cs
@@ -1,0 +1,34 @@
+using LangTeach.Api.DTOs;
+
+namespace LangTeach.Api.Services;
+
+public class StubStudentProfileExtractionService : IStudentProfileExtractionService
+{
+    private readonly ILogger<StubStudentProfileExtractionService> _logger;
+
+    public StubStudentProfileExtractionService(ILogger<StubStudentProfileExtractionService> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task<ExtractedStudentProfileDto> ExtractAsync(string text, CancellationToken ct = default)
+    {
+        _logger.LogInformation("StubStudentProfileExtractionService.ExtractAsync called with {Length} chars", text.Length);
+        return Task.FromResult(new ExtractedStudentProfileDto(
+            Name: "[Extracted] María García",
+            BirthYear: 1990,
+            Profession: "[Extracted] Engineer",
+            CountryOfResidence: "[Extracted] Spain",
+            CityOfResidence: "[Extracted] Madrid",
+            ReasonForStudying: "[Extracted] Work promotion",
+            NativeLanguages: ["Spanish"],
+            SpokenLanguages: ["English"],
+            CefrLevel: "B2",
+            OfficialCefrLevel: null,
+            ShortTermObjectives: [new ExtractedObjectiveDto("[Extracted] Pass B2 exam", "2026-06-30")],
+            Difficulties: [new ExtractedDifficultyDto("[Extracted] Subjunctive usage", "Grammar", "subjunctive")],
+            TeachingTodoTexts: ["[Extracted] Send subjunctive exercises"],
+            Interests: ["[Extracted] Travel", "[Extracted] Cooking"]
+        ));
+    }
+}

--- a/backend/LangTeach.Api/Services/StudentProfileExtractionService.cs
+++ b/backend/LangTeach.Api/Services/StudentProfileExtractionService.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using LangTeach.Api.AI;
 using LangTeach.Api.DTOs;
 using LangTeach.Api.Helpers;
@@ -7,6 +9,9 @@ namespace LangTeach.Api.Services;
 
 public class StudentProfileExtractionService : IStudentProfileExtractionService
 {
+    private static readonly Regex CefrLevelRegex =
+        new(@"^[ABC][12]\+?$", RegexOptions.Compiled);
+
     private readonly IClaudeClient _claude;
     private readonly IPromptService _prompts;
     private readonly ILogger<StudentProfileExtractionService> _logger;
@@ -67,6 +72,7 @@ public class StudentProfileExtractionService : IStudentProfileExtractionService
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to parse student profile extraction JSON (length: {Length})", json?.Length ?? 0);
+            _logger.LogDebug("Unparseable Claude response: {Preview}...", json is null ? null : json[..Math.Min(200, json.Length)]);
             return Empty();
         }
     }
@@ -107,9 +113,6 @@ public class StudentProfileExtractionService : IStudentProfileExtractionService
         }
         return result;
     }
-
-    private static readonly System.Text.RegularExpressions.Regex CefrLevelRegex =
-        new(@"^[ABC][12]\+?$", System.Text.RegularExpressions.RegexOptions.Compiled);
 
     private static string? ParseCefrLevel(JsonElement root, string key)
     {
@@ -156,9 +159,9 @@ public class StudentProfileExtractionService : IStudentProfileExtractionService
     {
         var raw = GetStringOrNull(root, key);
         if (raw is null) return null;
-        return DateOnly.TryParseExact(raw, "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture,
-            System.Globalization.DateTimeStyles.None, out var parsed)
-            ? parsed.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture)
+        return DateOnly.TryParseExact(raw, "yyyy-MM-dd", CultureInfo.InvariantCulture,
+            DateTimeStyles.None, out var parsed)
+            ? parsed.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)
             : null;
     }
 }

--- a/backend/LangTeach.Api/Services/StudentProfileExtractionService.cs
+++ b/backend/LangTeach.Api/Services/StudentProfileExtractionService.cs
@@ -1,0 +1,164 @@
+using System.Text.Json;
+using LangTeach.Api.AI;
+using LangTeach.Api.DTOs;
+using LangTeach.Api.Helpers;
+
+namespace LangTeach.Api.Services;
+
+public class StudentProfileExtractionService : IStudentProfileExtractionService
+{
+    private readonly IClaudeClient _claude;
+    private readonly IPromptService _prompts;
+    private readonly ILogger<StudentProfileExtractionService> _logger;
+
+    public StudentProfileExtractionService(
+        IClaudeClient claude,
+        IPromptService prompts,
+        ILogger<StudentProfileExtractionService> logger)
+    {
+        _claude = claude;
+        _prompts = prompts;
+        _logger = logger;
+    }
+
+    public async Task<ExtractedStudentProfileDto> ExtractAsync(string text, CancellationToken ct = default)
+    {
+        var request = _prompts.BuildStudentProfileExtractionPrompt(text);
+
+        ClaudeResponse response;
+        try
+        {
+            response = await _claude.CompleteAsync(request, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Claude API call failed during student profile extraction");
+            return Empty();
+        }
+
+        return ParseResponse(response.Content);
+    }
+
+    internal ExtractedStudentProfileDto ParseResponse(string json)
+    {
+        try
+        {
+            var cleaned = ContentJsonHelper.StripFences(json) ?? string.Empty;
+            using var doc = JsonDocument.Parse(cleaned);
+            var root = doc.RootElement;
+
+            return new ExtractedStudentProfileDto(
+                Name: GetStringOrNull(root, "name"),
+                BirthYear: GetIntOrNull(root, "birthYear"),
+                Profession: GetStringOrNull(root, "profession"),
+                CountryOfResidence: GetStringOrNull(root, "countryOfResidence"),
+                CityOfResidence: GetStringOrNull(root, "cityOfResidence"),
+                ReasonForStudying: GetStringOrNull(root, "reasonForStudying"),
+                NativeLanguages: ParseStringArray(root, "nativeLanguages"),
+                SpokenLanguages: ParseStringArray(root, "spokenLanguages"),
+                CefrLevel: ParseCefrLevel(root, "cefrLevel"),
+                OfficialCefrLevel: ParseCefrLevel(root, "officialCefrLevel"),
+                ShortTermObjectives: ParseObjectives(root),
+                Difficulties: ParseDifficulties(root),
+                TeachingTodoTexts: ParseStringArray(root, "teachingTodoTexts"),
+                Interests: ParseStringArray(root, "interests")
+            );
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse student profile extraction JSON (length: {Length})", json?.Length ?? 0);
+            return Empty();
+        }
+    }
+
+    private static ExtractedStudentProfileDto Empty() =>
+        new(null, null, null, null, null, null, [], [], null, null, [], [], [], []);
+
+    private static string? GetStringOrNull(JsonElement root, string key)
+    {
+        if (root.TryGetProperty(key, out var prop) && prop.ValueKind == JsonValueKind.String)
+        {
+            var value = prop.GetString();
+            return string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+        return null;
+    }
+
+    private static int? GetIntOrNull(JsonElement root, string key)
+    {
+        if (!root.TryGetProperty(key, out var prop)) return null;
+        return prop.ValueKind == JsonValueKind.Number && prop.TryGetInt32(out var v) ? v : null;
+    }
+
+    private static List<string> ParseStringArray(JsonElement root, string key)
+    {
+        var result = new List<string>();
+        if (!root.TryGetProperty(key, out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return result;
+
+        foreach (var item in arr.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String)
+            {
+                var s = item.GetString();
+                if (!string.IsNullOrWhiteSpace(s))
+                    result.Add(s);
+            }
+        }
+        return result;
+    }
+
+    private static readonly System.Text.RegularExpressions.Regex CefrLevelRegex =
+        new(@"^[ABC][12]\+?$", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    private static string? ParseCefrLevel(JsonElement root, string key)
+    {
+        var raw = GetStringOrNull(root, key);
+        return raw is not null && CefrLevelRegex.IsMatch(raw) ? raw : null;
+    }
+
+    private static List<ExtractedObjectiveDto> ParseObjectives(JsonElement root)
+    {
+        var result = new List<ExtractedObjectiveDto>();
+        if (!root.TryGetProperty("shortTermObjectives", out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return result;
+
+        foreach (var item in arr.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object) continue;
+            var text = GetStringOrNull(item, "text");
+            if (string.IsNullOrWhiteSpace(text)) continue;
+            var targetDate = GetIsoDateOrNull(item, "targetDate");
+            result.Add(new ExtractedObjectiveDto(text, targetDate));
+        }
+        return result;
+    }
+
+    private static List<ExtractedDifficultyDto> ParseDifficulties(JsonElement root)
+    {
+        var result = new List<ExtractedDifficultyDto>();
+        if (!root.TryGetProperty("difficulties", out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return result;
+
+        foreach (var item in arr.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object) continue;
+            var description = GetStringOrNull(item, "description")?.Trim();
+            var competency = GetStringOrNull(item, "competency")?.Trim();
+            var subcategory = GetStringOrNull(item, "subcategory")?.Trim() ?? string.Empty;
+            if (description is null || competency is null) continue;
+            result.Add(new ExtractedDifficultyDto(description, competency, subcategory));
+        }
+        return result;
+    }
+
+    private static string? GetIsoDateOrNull(JsonElement root, string key)
+    {
+        var raw = GetStringOrNull(root, key);
+        if (raw is null) return null;
+        return DateOnly.TryParseExact(raw, "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.None, out var parsed)
+            ? parsed.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture)
+            : null;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `POST /api/students/extract-profile` — a stateless endpoint that extracts student profile fields from free-form teacher text using Claude Haiku
- Implements `IStudentProfileExtractionService` + `StudentProfileExtractionService` following the same pattern as `ReflectionExtractionService`
- `StubStudentProfileExtractionService` registered for E2ETesting/Testing environments
- Conservative extraction prompt: returns null for ambiguous fields rather than guessing; gracefully returns empty DTO on Claude failure (no 500)

## Test plan

- [x] 17 unit tests: successful extraction, Claude failure fallback, malformed JSON, CEFR validation, objective date parsing, difficulty filtering, round-trip ExtractAsync happy path
- [x] All 1170 backend tests pass
- [x] All 1440 frontend tests pass
- [x] `dotnet build` clean (0 warnings, 0 errors)
- [x] `bicep build` clean
- [x] `npm build` and `npm lint` clean

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/api/students/extract-profile` endpoint to automatically extract and structure student profile information from text input, including name, profession, location, languages, proficiency levels, learning objectives, and challenges.

* **Tests**
  * Added comprehensive test suite validating profile extraction accuracy, error handling, and response formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->