### PR TITLE
feat: style 'Open full session' as ghost button on expanded session row (#928)

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -221,7 +221,7 @@ Sessions are edited inline in their expanded row. No modal, no separate edit pag
 
 > **Overflow fields:** The full-page session editor (`/sessions/:id/edit`) remains accessible for fields not yet inline-editable (topic tags, homework assigned, level reassessment, session status, voice notes, teaching todos, followups). A link to it may appear at the bottom of the expanded row. When the link covers only 1-3 specific fields, its label should name them ("Edit topic tags & homework"). When the editor covers many fields, a general label ("Open full session") is acceptable. The label must never imply the inline edit is partial or incomplete. As fields migrate inline, the link scope shrinks and is eventually removed.
 >
-> **Escape-hatch styling:** Style this link as a ghost button (transparent background, `text-indigo-600`, `border-indigo-200`, hover `#F4F2FD`). This is intentional and does not conflict with §8.3 — the ghost button is a low-prominence secondary affordance that makes the full editor discoverable without competing with the inline-edit fields.
+> **Escape-hatch styling:** Style this link as a ghost button (transparent background, `text-indigo-600`, hover `#F4F2FD`). This is intentional and does not conflict with §8.3 — the ghost button is a low-prominence secondary affordance that makes the full editor discoverable without competing with the inline-edit fields.
 
 ---
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -219,7 +219,9 @@ Sessions are edited inline in their expanded row. No modal, no separate edit pag
 - Delete is accessible via a destructive icon in the expanded state or a confirmation prompt — never the primary affordance.
 - Double-click to edit is not permitted (too hidden for a professional tool).
 
-> **Overflow fields:** The full-page session editor (`/sessions/:id/edit`) remains accessible for fields not yet inline-editable (topic tags, homework assigned, level reassessment, session status). A link to it may appear at the bottom of the expanded row. Its label must describe what is there ("Edit topic tags, homework & more"), not imply that the inline edit is partial or incomplete. As fields migrate inline, the link should shrink in scope and eventually be removed.
+> **Overflow fields:** The full-page session editor (`/sessions/:id/edit`) remains accessible for fields not yet inline-editable (topic tags, homework assigned, level reassessment, session status, voice notes, teaching todos, followups). A link to it may appear at the bottom of the expanded row. When the link covers only 1-3 specific fields, its label should name them ("Edit topic tags & homework"). When the editor covers many fields, a general label ("Open full session") is acceptable. The label must never imply the inline edit is partial or incomplete. As fields migrate inline, the link scope shrinks and is eventually removed.
+>
+> **Escape-hatch styling:** Style this link as a ghost button (transparent background, `text-indigo-600`, `border-indigo-200`, hover `#F4F2FD`). This is intentional and does not conflict with §8.3 — the ghost button is a low-prominence secondary affordance that makes the full editor discoverable without competing with the inline-edit fields.
 
 ---
 

--- a/frontend/src/components/session/SessionHistoryTab.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.tsx
@@ -511,7 +511,7 @@ function SessionEntry({
             <div className="mt-6 pt-4 border-t border-[#C7C4D8]/10 flex items-center gap-3">
               <Link
                 to={`/students/${studentId}/sessions/${session.id}/edit`}
-                className="inline-flex items-center gap-1.5 text-xs text-indigo-600 bg-transparent border border-indigo-200 hover:bg-[#F4F2FD] transition-colors px-3 py-1.5 rounded"
+                className="inline-flex items-center gap-1.5 text-xs text-indigo-600 bg-transparent hover:bg-[#F4F2FD] transition-colors px-3 py-1.5 rounded"
                 data-testid="edit-full-session-link"
               >
                 <Pencil className="h-3 w-3" />

--- a/frontend/src/components/session/SessionHistoryTab.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.tsx
@@ -511,11 +511,11 @@ function SessionEntry({
             <div className="mt-6 pt-4 border-t border-[#C7C4D8]/10 flex items-center gap-3">
               <Link
                 to={`/students/${studentId}/sessions/${session.id}/edit`}
-                className="inline-flex items-center gap-1.5 text-sm text-indigo-600 hover:text-indigo-700 transition-colors px-2 py-1 rounded hover:bg-indigo-50"
+                className="inline-flex items-center gap-1.5 text-xs text-indigo-600 bg-transparent border border-indigo-200 hover:bg-[#F4F2FD] transition-colors px-3 py-1.5 rounded"
                 data-testid="edit-full-session-link"
               >
-                <Pencil className="h-3.5 w-3.5" />
-                Edit full session
+                <Pencil className="h-3 w-3" />
+                Open full session
               </Link>
               <button
                 type="button"

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -5,3 +5,9 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 ---
 
 *Cleared 2026-04-22 during UI Redesign & Student Profile Polish sprint close. Actionable entries batched into #833 (bug batch: todo validation + countdown + difficulty feedback), #837 (deduplication: getInitials/formatRelativeDate/CEFR_ORDER). Remaining entries deleted (verified safe, intentional per spec, already tracked in #737/#707/#644/#714/#715/#716/#683/#741/#742/#756/#809/#657, or consistent with existing patterns).*
+
+## Sprint: Student Profile Voice Input
+
+| Issue | Date | Finding | Severity |
+|-------|------|---------|----------|
+| #928 | 2026-04-25 | `Button variant="ghost"` uses `hover:bg-muted` (near-white gray) while the app's surface-container-low hover color `#F4F2FD` (lavender) is hardcoded in 10+ places. Pre-existing divergence between the shared Button component and app-level ghost-style links. Consider aligning `--muted` token to `#F4F2FD` or introducing a `surface-container-low` CSS variable. | Low |


### PR DESCRIPTION
Closes #928

## Summary
- Restyled the "Edit full session" link in the expanded session row as a pure ghost button (`bg-transparent hover:bg-[#F4F2FD] text-indigo-600`) per Vera's design decision
- Renamed label from "Edit full session" to "Open full session"
- Updated `docs/design-system.md` §8.3 to document the escape-hatch pattern as intentional, and reconciled the label-naming rule for multi-field overflow links

## Test plan
- [ ] Open student profile, expand a session row, verify "Open full session" ghost button appears below the 4 inline-editable fields
- [ ] Hover the button: background shifts to `#F4F2FD` lavender
- [ ] Click navigates to the full LogSession edit page
- [ ] All existing SessionHistoryTab tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)