### PR TITLE
feat(#944): voice recording with confirmation drawer on student profile

### DIFF
--- a/frontend/src/api/studentExtraction.test.ts
+++ b/frontend/src/api/studentExtraction.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { extractStudentProfile } from './studentExtraction'
+import { apiClient } from '../lib/apiClient'
+
+vi.mock('../lib/apiClient', () => ({
+  apiClient: { post: vi.fn() },
+}))
+
+const mockPost = vi.mocked(apiClient.post)
+
+describe('extractStudentProfile', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('posts to extract-profile and returns result', async () => {
+    const response = { cefrLevel: 'B1', profession: null, nativeLanguages: [], spokenLanguages: [], interests: [], shortTermObjectives: [], difficulties: [], teachingTodoTexts: [], name: null, birthYear: null, countryOfResidence: null, cityOfResidence: null, reasonForStudying: null, officialCefrLevel: null }
+    mockPost.mockResolvedValue({ data: response })
+
+    const result = await extractStudentProfile('Student is a B1 level teacher.')
+    expect(mockPost).toHaveBeenCalledWith('/api/students/extract-profile', { text: 'Student is a B1 level teacher.' })
+    expect(result).toEqual(response)
+  })
+})

--- a/frontend/src/api/studentExtraction.ts
+++ b/frontend/src/api/studentExtraction.ts
@@ -1,0 +1,34 @@
+import { apiClient } from '../lib/apiClient'
+
+export interface ExtractedObjective {
+  text: string
+  targetDate: string | null
+}
+
+export interface ExtractedDifficulty {
+  description: string
+  competency: string
+  subcategory: string
+}
+
+export interface ExtractedStudentProfile {
+  name: string | null
+  birthYear: number | null
+  profession: string | null
+  countryOfResidence: string | null
+  cityOfResidence: string | null
+  reasonForStudying: string | null
+  nativeLanguages: string[]
+  spokenLanguages: string[]
+  cefrLevel: string | null
+  officialCefrLevel: string | null
+  shortTermObjectives: ExtractedObjective[]
+  difficulties: ExtractedDifficulty[]
+  teachingTodoTexts: string[]
+  interests: string[]
+}
+
+export async function extractStudentProfile(text: string): Promise<ExtractedStudentProfile> {
+  const res = await apiClient.post<ExtractedStudentProfile>('/api/students/extract-profile', { text })
+  return res.data
+}

--- a/frontend/src/components/audio/AudioRecorder.tsx
+++ b/frontend/src/components/audio/AudioRecorder.tsx
@@ -33,6 +33,16 @@ export function AudioRecorder({ onVoiceNote, disabled }: AudioRecorderProps) {
 
   useEffect(() => () => stopInterval(), [stopInterval])
 
+  useEffect(() => {
+    return () => {
+      const recorder = mediaRecorderRef.current
+      if (recorder && recorder.state !== 'inactive') {
+        recorder.stream?.getTracks().forEach((t) => t.stop())
+        recorder.stop()
+      }
+    }
+  }, [])
+
   async function uploadFile(file: File) {
     setState('uploading')
     setError(null)

--- a/frontend/src/components/student/StudentDetailHeader.test.tsx
+++ b/frontend/src/components/student/StudentDetailHeader.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { StudentDetailHeader } from './StudentDetailHeader'
 import type { Student } from '@/api/students'
@@ -176,5 +176,39 @@ describe('StudentDetailHeader', () => {
     expect(screen.getByTestId('primary-objective-card')).toBeInTheDocument()
     expect(screen.getByTestId('edit-profile-link')).toBeInTheDocument()
     expect(screen.getByTestId('log-session-button')).toBeInTheDocument()
+  })
+
+  it('does not render voice update button when onVoiceUpdateClick is not provided', () => {
+    renderHeader()
+    expect(screen.queryByTestId('voice-update-button')).not.toBeInTheDocument()
+  })
+
+  it('renders voice update button when onVoiceUpdateClick is provided', () => {
+    render(
+      <MemoryRouter>
+        <StudentDetailHeader
+          student={BASE_STUDENT}
+          nextSession={null}
+          sessionFrequency={null}
+          onVoiceUpdateClick={vi.fn()}
+        />
+      </MemoryRouter>
+    )
+    expect(screen.getByTestId('voice-update-button')).toBeInTheDocument()
+  })
+
+  it('disables voice update button when voiceFlowActive is true', () => {
+    render(
+      <MemoryRouter>
+        <StudentDetailHeader
+          student={BASE_STUDENT}
+          nextSession={null}
+          sessionFrequency={null}
+          onVoiceUpdateClick={vi.fn()}
+          voiceFlowActive={true}
+        />
+      </MemoryRouter>
+    )
+    expect(screen.getByTestId('voice-update-button')).toBeDisabled()
   })
 })

--- a/frontend/src/components/student/StudentDetailHeader.tsx
+++ b/frontend/src/components/student/StudentDetailHeader.tsx
@@ -188,7 +188,7 @@ export function StudentDetailHeader({ student, nextSession, sessionFrequency, on
             <button
               onClick={onVoiceUpdateClick}
               disabled={voiceFlowActive}
-              className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium bg-indigo-50 text-indigo-600 hover:bg-indigo-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium bg-indigo-50 text-indigo-600 hover:bg-indigo-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
               data-testid="voice-update-button"
             >
               <Mic className="h-3.5 w-3.5" />

--- a/frontend/src/components/student/StudentDetailHeader.tsx
+++ b/frontend/src/components/student/StudentDetailHeader.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate } from 'react-router-dom'
-import { ArrowLeft, NotebookPen, Pencil, CalendarClock } from 'lucide-react'
+import { ArrowLeft, NotebookPen, Pencil, CalendarClock, Mic } from 'lucide-react'
 import type { Student } from '@/api/students'
 import type { SessionLog } from '@/api/sessionLogs'
 import { formatDateShort } from '@/utils/formatDate'
@@ -71,12 +71,14 @@ function HeaderObjective({ student }: { student: Student }) {
 }
 
 interface StudentDetailHeaderProps {
+  onVoiceUpdateClick?: () => void
+  voiceFlowActive?: boolean
   student: Student
   nextSession: SessionLog | null
   sessionFrequency: string | null
 }
 
-export function StudentDetailHeader({ student, nextSession, sessionFrequency }: StudentDetailHeaderProps) {
+export function StudentDetailHeader({ student, nextSession, sessionFrequency, onVoiceUpdateClick, voiceFlowActive }: StudentDetailHeaderProps) {
   const navigate = useNavigate()
   const identitySubtitle = buildIdentitySubtitle(student)
 
@@ -182,6 +184,17 @@ export function StudentDetailHeader({ student, nextSession, sessionFrequency }: 
 
         {/* Actions */}
         <div className="flex items-center gap-2 shrink-0 md:self-start">
+          {onVoiceUpdateClick && (
+            <button
+              onClick={onVoiceUpdateClick}
+              disabled={voiceFlowActive}
+              className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium bg-indigo-50 text-indigo-600 hover:bg-indigo-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              data-testid="voice-update-button"
+            >
+              <Mic className="h-3.5 w-3.5" />
+              Update via voice
+            </button>
+          )}
           <Link
             to={`/students/${student.id}/edit`}
             className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium bg-indigo-50 text-indigo-600 hover:bg-indigo-100 transition-colors"

--- a/frontend/src/components/student/VoiceUpdateDrawer.test.tsx
+++ b/frontend/src/components/student/VoiceUpdateDrawer.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { VoiceUpdateDrawer } from './VoiceUpdateDrawer'
+import { mergeExtractedIntoStudent } from '@/lib/voiceUpdateMerge'
+import type { Student } from '@/api/students'
+import type { ExtractedStudentProfile } from '@/api/studentExtraction'
+
+const BASE_STUDENT: Student = {
+  id: 's1',
+  name: 'Ana',
+  learningLanguage: 'Spanish',
+  level: { cefrLevel: 'A2', officialCefrLevel: null, skillLevelOverrides: {} },
+  languages: { nativeLanguages: ['English'], spokenLanguages: [] },
+  identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null },
+  profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
+  commercial: { isActive: true, isCorporate: false, rate: null },
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+}
+
+const EMPTY_EXTRACTED: ExtractedStudentProfile = {
+  name: null, birthYear: null, profession: null, countryOfResidence: null, cityOfResidence: null,
+  reasonForStudying: null, nativeLanguages: [], spokenLanguages: [], cefrLevel: null,
+  officialCefrLevel: null, shortTermObjectives: [], difficulties: [], teachingTodoTexts: [], interests: [],
+}
+
+function renderDrawer(extracted: Partial<ExtractedStudentProfile> = {}, student: Student = BASE_STUDENT) {
+  const onSave = vi.fn()
+  const onClose = vi.fn()
+  render(
+    <VoiceUpdateDrawer
+      student={student}
+      extracted={{ ...EMPTY_EXTRACTED, ...extracted }}
+      saving={false}
+      onSave={onSave}
+      onClose={onClose}
+    />
+  )
+  return { onSave, onClose }
+}
+
+describe('VoiceUpdateDrawer', () => {
+  it('shows empty state when nothing is extracted', () => {
+    renderDrawer()
+    expect(screen.getByTestId('empty-extraction')).toBeInTheDocument()
+    expect(screen.queryByTestId('drawer-save')).not.toBeInTheDocument()
+  })
+
+  it('renders CHANGED badge when scalar field has different existing value', () => {
+    renderDrawer({ cefrLevel: 'B1' })
+    expect(screen.getByTestId('badge-CHANGED')).toBeInTheDocument()
+  })
+
+  it('renders NEW badge when scalar field is currently null', () => {
+    renderDrawer({ profession: 'Teacher' })
+    expect(screen.getByTestId('badge-NEW')).toBeInTheDocument()
+  })
+
+  it('renders ADDED badge for list items', () => {
+    renderDrawer({ interests: ['Cooking'] })
+    expect(screen.getByTestId('badge-ADDED')).toBeInTheDocument()
+  })
+
+  it('remove icon drops a row and updates save count', () => {
+    renderDrawer({ profession: 'Teacher', interests: ['Cooking'] })
+    const removeButtons = screen.getAllByLabelText('Remove')
+    expect(screen.getByTestId('drawer-save')).toHaveTextContent('Save 2 changes')
+    fireEvent.click(removeButtons[0])
+    expect(screen.getByTestId('drawer-save')).toHaveTextContent('Save 1 change')
+  })
+
+  it('save button is disabled when all rows removed', () => {
+    renderDrawer({ profession: 'Teacher' })
+    fireEvent.click(screen.getByLabelText('Remove'))
+    expect(screen.getByTestId('drawer-save')).toBeDisabled()
+  })
+
+  it('inline edit updates row value', () => {
+    renderDrawer({ profession: 'Teacher' })
+    fireEvent.click(screen.getByLabelText('Edit'))
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'Engineer' } })
+    fireEvent.blur(input)
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+  })
+
+  it('cancel calls onClose without calling onSave', () => {
+    const { onSave, onClose } = renderDrawer({ profession: 'Teacher' })
+    fireEvent.click(screen.getByTestId('drawer-cancel'))
+    expect(onClose).toHaveBeenCalled()
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('save calls onSave with merged patch', () => {
+    const { onSave } = renderDrawer({ profession: 'Teacher' })
+    fireEvent.click(screen.getByTestId('drawer-save'))
+    expect(onSave).toHaveBeenCalledTimes(1)
+    const patch = onSave.mock.calls[0][0]
+    expect(patch.profession).toBe('Teacher')
+  })
+
+  it('backdrop click calls onClose', () => {
+    const { onClose } = renderDrawer({ profession: 'Teacher' })
+    fireEvent.click(screen.getByTestId('drawer-backdrop'))
+    expect(onClose).toHaveBeenCalled()
+  })
+})
+
+describe('mergeExtractedIntoStudent', () => {
+  function makeRow(fieldKey: string, value: string, badge: 'CHANGED' | 'NEW' | 'ADDED' = 'NEW') {
+    return { id: 'r1', fieldKey, label: fieldKey, badge, currentValue: null, value }
+  }
+
+  it('replaces scalar field', () => {
+    const rows = [makeRow('cefrLevel', 'B2', 'CHANGED')]
+    const patch = mergeExtractedIntoStudent(rows, EMPTY_EXTRACTED, BASE_STUDENT)
+    expect(patch.cefrLevel).toBe('B2')
+  })
+
+  it('deduplicates interests case-insensitively', () => {
+    const student: Student = { ...BASE_STUDENT, profile: { ...BASE_STUDENT.profile, interests: ['cooking'] } }
+    const rows = [makeRow('interests', 'Cooking', 'ADDED')]
+    const patch = mergeExtractedIntoStudent(rows, EMPTY_EXTRACTED, student)
+    expect((patch as { interests: string[] }).interests).toEqual(['cooking'])
+  })
+
+  it('appends unique interest', () => {
+    const rows = [makeRow('interests', 'Travel', 'ADDED')]
+    const patch = mergeExtractedIntoStudent(rows, EMPTY_EXTRACTED, BASE_STUDENT)
+    expect((patch as { interests: string[] }).interests).toContain('Travel')
+  })
+
+  it('always appends teachingTodos without dedup', () => {
+    const existing = [{ id: 'e1', text: 'Practice vocab', createdAt: '2026-01-01T00:00:00Z', sourceSessionLogId: null, status: 'Pending', coveredInSessionLogId: null }]
+    const student: Student = { ...BASE_STUDENT, profile: { ...BASE_STUDENT.profile, teachingTodos: existing } }
+    const rows = [makeRow('teachingTodos', 'Practice vocab', 'ADDED')]
+    const patch = mergeExtractedIntoStudent(rows, EMPTY_EXTRACTED, student)
+    expect((patch as { teachingTodos: unknown[] }).teachingTodos).toHaveLength(2)
+  })
+
+  it('deduplicates native languages case-insensitively', () => {
+    const rows = [makeRow('nativeLanguages', 'english', 'ADDED')]
+    const patch = mergeExtractedIntoStudent(rows, EMPTY_EXTRACTED, BASE_STUDENT)
+    expect((patch as { nativeLanguages: string[] }).nativeLanguages).toEqual(['English'])
+  })
+
+  it('returns empty patch when no rows', () => {
+    const patch = mergeExtractedIntoStudent([], EMPTY_EXTRACTED, BASE_STUDENT)
+    expect(Object.keys(patch)).toHaveLength(0)
+  })
+})

--- a/frontend/src/components/student/VoiceUpdateDrawer.test.tsx
+++ b/frontend/src/components/student/VoiceUpdateDrawer.test.tsx
@@ -113,20 +113,20 @@ describe('mergeExtractedIntoStudent', () => {
 
   it('replaces scalar field', () => {
     const rows = [makeRow('cefrLevel', 'B2', 'CHANGED')]
-    const patch = mergeExtractedIntoStudent(rows, EMPTY_EXTRACTED, BASE_STUDENT)
+    const patch = mergeExtractedIntoStudent(rows, BASE_STUDENT)
     expect(patch.cefrLevel).toBe('B2')
   })
 
   it('deduplicates interests case-insensitively', () => {
     const student: Student = { ...BASE_STUDENT, profile: { ...BASE_STUDENT.profile, interests: ['cooking'] } }
     const rows = [makeRow('interests', 'Cooking', 'ADDED')]
-    const patch = mergeExtractedIntoStudent(rows, EMPTY_EXTRACTED, student)
+    const patch = mergeExtractedIntoStudent(rows, student)
     expect((patch as { interests: string[] }).interests).toEqual(['cooking'])
   })
 
   it('appends unique interest', () => {
     const rows = [makeRow('interests', 'Travel', 'ADDED')]
-    const patch = mergeExtractedIntoStudent(rows, EMPTY_EXTRACTED, BASE_STUDENT)
+    const patch = mergeExtractedIntoStudent(rows, BASE_STUDENT)
     expect((patch as { interests: string[] }).interests).toContain('Travel')
   })
 
@@ -134,18 +134,18 @@ describe('mergeExtractedIntoStudent', () => {
     const existing = [{ id: 'e1', text: 'Practice vocab', createdAt: '2026-01-01T00:00:00Z', sourceSessionLogId: null, status: 'pending', coveredInSessionLogId: null }]
     const student: Student = { ...BASE_STUDENT, profile: { ...BASE_STUDENT.profile, teachingTodos: existing } }
     const rows = [makeRow('teachingTodos', 'Practice vocab', 'ADDED')]
-    const patch = mergeExtractedIntoStudent(rows, EMPTY_EXTRACTED, student)
+    const patch = mergeExtractedIntoStudent(rows, student)
     expect((patch as { teachingTodos: unknown[] }).teachingTodos).toHaveLength(2)
   })
 
   it('deduplicates native languages case-insensitively', () => {
     const rows = [makeRow('nativeLanguages', 'english', 'ADDED')]
-    const patch = mergeExtractedIntoStudent(rows, EMPTY_EXTRACTED, BASE_STUDENT)
+    const patch = mergeExtractedIntoStudent(rows, BASE_STUDENT)
     expect((patch as { nativeLanguages: string[] }).nativeLanguages).toEqual(['English'])
   })
 
   it('returns empty patch when no rows', () => {
-    const patch = mergeExtractedIntoStudent([], EMPTY_EXTRACTED, BASE_STUDENT)
+    const patch = mergeExtractedIntoStudent([], BASE_STUDENT)
     expect(Object.keys(patch)).toHaveLength(0)
   })
 })

--- a/frontend/src/components/student/VoiceUpdateDrawer.test.tsx
+++ b/frontend/src/components/student/VoiceUpdateDrawer.test.tsx
@@ -131,7 +131,7 @@ describe('mergeExtractedIntoStudent', () => {
   })
 
   it('always appends teachingTodos without dedup', () => {
-    const existing = [{ id: 'e1', text: 'Practice vocab', createdAt: '2026-01-01T00:00:00Z', sourceSessionLogId: null, status: 'Pending', coveredInSessionLogId: null }]
+    const existing = [{ id: 'e1', text: 'Practice vocab', createdAt: '2026-01-01T00:00:00Z', sourceSessionLogId: null, status: 'pending', coveredInSessionLogId: null }]
     const student: Student = { ...BASE_STUDENT, profile: { ...BASE_STUDENT.profile, teachingTodos: existing } }
     const rows = [makeRow('teachingTodos', 'Practice vocab', 'ADDED')]
     const patch = mergeExtractedIntoStudent(rows, EMPTY_EXTRACTED, student)

--- a/frontend/src/components/student/VoiceUpdateDrawer.tsx
+++ b/frontend/src/components/student/VoiceUpdateDrawer.tsx
@@ -1,0 +1,191 @@
+import { useState } from 'react'
+import { Pencil, X, ChevronRight, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { Student } from '@/api/students'
+import type { ExtractedStudentProfile } from '@/api/studentExtraction'
+import { buildDrawerRows, mergeExtractedIntoStudent } from '@/lib/voiceUpdateMerge'
+import type { DrawerRow, VoiceMergePatch } from '@/lib/voiceUpdateMerge'
+
+type RowBadge = DrawerRow['badge']
+
+const BADGE_STYLES: Record<RowBadge, string> = {
+  CHANGED: 'bg-amber-50 text-amber-700',
+  ADDED: 'bg-indigo-50 text-indigo-600',
+  NEW: 'bg-emerald-50 text-emerald-700',
+}
+
+function isEmptyExtraction(extracted: ExtractedStudentProfile): boolean {
+  return (
+    !extracted.cefrLevel && !extracted.officialCefrLevel && !extracted.profession &&
+    !extracted.reasonForStudying && !extracted.birthYear && !extracted.countryOfResidence &&
+    !extracted.cityOfResidence && extracted.nativeLanguages.length === 0 &&
+    extracted.spokenLanguages.length === 0 && extracted.interests.length === 0 &&
+    extracted.shortTermObjectives.length === 0 && extracted.difficulties.length === 0 &&
+    extracted.teachingTodoTexts.length === 0
+  )
+}
+
+interface VoiceUpdateDrawerProps {
+  student: Student
+  extracted: ExtractedStudentProfile
+  saving: boolean
+  onSave: (patch: VoiceMergePatch) => void
+  onClose: () => void
+}
+
+export function VoiceUpdateDrawer({ student, extracted, saving, onSave, onClose }: VoiceUpdateDrawerProps) {
+  const [rows, setRows] = useState<DrawerRow[]>(() => buildDrawerRows(extracted, student))
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editValue, setEditValue] = useState('')
+
+  const isEmpty = isEmptyExtraction(extracted)
+
+  function removeRow(id: string) {
+    setRows((prev) => prev.filter((r) => r.id !== id))
+    if (editingId === id) setEditingId(null)
+  }
+
+  function startEdit(row: DrawerRow) {
+    setEditingId(row.id)
+    setEditValue(row.value)
+  }
+
+  function commitEdit(id: string) {
+    setRows((prev) => prev.map((r) => r.id === id ? { ...r, value: editValue } : r))
+    setEditingId(null)
+  }
+
+  function handleSave() {
+    onSave(mergeExtractedIntoStudent(rows, extracted, student))
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end" data-testid="voice-update-drawer">
+      <div
+        className="absolute inset-0 bg-black/20"
+        onClick={onClose}
+        data-testid="drawer-backdrop"
+      />
+      <div
+        className="relative flex flex-col w-full sm:w-[480px] h-full overflow-hidden"
+        style={{
+          background: 'rgba(255,255,255,0.80)',
+          backdropFilter: 'blur(12px)',
+          WebkitBackdropFilter: 'blur(12px)',
+        }}
+        data-testid="drawer-panel"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 bg-white/60">
+          <h2 className="text-base font-semibold text-gray-900">Review extracted data</h2>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+            data-testid="drawer-close"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-2">
+          {isEmpty ? (
+            <div className="flex flex-col items-center justify-center h-full text-center gap-3 py-12" data-testid="empty-extraction">
+              <p className="text-sm text-gray-500">
+                Nothing was extracted. Try speaking more clearly about the student.
+              </p>
+              <Button variant="ghost" size="sm" onClick={onClose}>
+                Dismiss
+              </Button>
+            </div>
+          ) : (
+            rows.map((row) => (
+              <div
+                key={row.id}
+                className="flex items-start gap-3 rounded-xl px-4 py-3 bg-white/70"
+                data-testid={`drawer-row-${row.fieldKey}`}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="text-[10px] font-semibold tracking-widest uppercase text-gray-400">
+                      {row.label}
+                    </span>
+                    <span
+                      className={`text-[10px] font-bold tracking-widest uppercase px-1.5 py-0.5 rounded-md ${BADGE_STYLES[row.badge]}`}
+                      data-testid={`badge-${row.badge}`}
+                    >
+                      {row.badge}
+                    </span>
+                  </div>
+                  {row.badge === 'CHANGED' && row.currentValue && (
+                    <div className="flex items-center gap-1.5 mb-0.5">
+                      <span className="text-sm text-gray-400 line-through">{row.currentValue}</span>
+                      <ChevronRight className="h-3 w-3 text-gray-300 shrink-0" />
+                    </div>
+                  )}
+                  {editingId === row.id ? (
+                    <input
+                      autoFocus
+                      className="w-full text-sm text-indigo-700 font-medium bg-indigo-50 rounded-lg px-2 py-1 outline-none"
+                      value={editValue}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      onBlur={() => commitEdit(row.id)}
+                      onKeyDown={(e) => { if (e.key === 'Enter') commitEdit(row.id) }}
+                      data-testid={`edit-input-${row.id}`}
+                    />
+                  ) : (
+                    <span className="text-sm text-indigo-700 font-medium" data-testid={`row-value-${row.id}`}>
+                      {row.value}
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center gap-1 shrink-0 mt-0.5">
+                  <button
+                    onClick={() => startEdit(row)}
+                    className="rounded-lg p-1 text-gray-400 hover:text-indigo-600 hover:bg-indigo-50 transition-colors"
+                    data-testid={`edit-row-${row.id}`}
+                    aria-label="Edit"
+                  >
+                    <Pencil className="h-3.5 w-3.5" />
+                  </button>
+                  <button
+                    onClick={() => removeRow(row.id)}
+                    className="rounded-lg p-1 text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors"
+                    data-testid={`remove-row-${row.id}`}
+                    aria-label="Remove"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* Footer */}
+        {!isEmpty && (
+          <div className="flex items-center justify-end gap-3 px-6 py-4 bg-white/60">
+            <Button variant="ghost" size="sm" onClick={onClose} disabled={saving} data-testid="drawer-cancel">
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={saving || rows.length === 0}
+              className="text-white min-w-[120px]"
+              style={{ background: 'linear-gradient(135deg, #3525CD, #4F46E5)' }}
+              data-testid="drawer-save"
+            >
+              {saving ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                `Save ${rows.length} change${rows.length === 1 ? '' : 's'}`
+              )}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/student/VoiceUpdateDrawer.tsx
+++ b/frontend/src/components/student/VoiceUpdateDrawer.tsx
@@ -29,11 +29,12 @@ interface VoiceUpdateDrawerProps {
   student: Student
   extracted: ExtractedStudentProfile
   saving: boolean
+  saveError?: string | null
   onSave: (patch: VoiceMergePatch) => void
   onClose: () => void
 }
 
-export function VoiceUpdateDrawer({ student, extracted, saving, onSave, onClose }: VoiceUpdateDrawerProps) {
+export function VoiceUpdateDrawer({ student, extracted, saving, saveError, onSave, onClose }: VoiceUpdateDrawerProps) {
   const [rows, setRows] = useState<DrawerRow[]>(() => buildDrawerRows(extracted, student))
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editValue, setEditValue] = useState('')
@@ -56,7 +57,7 @@ export function VoiceUpdateDrawer({ student, extracted, saving, onSave, onClose 
   }
 
   function handleSave() {
-    onSave(mergeExtractedIntoStudent(rows, extracted, student))
+    onSave(mergeExtractedIntoStudent(rows, student))
   }
 
   return (
@@ -165,7 +166,9 @@ export function VoiceUpdateDrawer({ student, extracted, saving, onSave, onClose 
 
         {/* Footer */}
         {!isEmpty && (
-          <div className="flex items-center justify-end gap-3 px-6 py-4 bg-white/60">
+          <div className="flex flex-col gap-2 px-6 py-4 bg-white/60">
+            {saveError && <p className="text-sm text-red-500 text-right" data-testid="save-error">{saveError}</p>}
+          <div className="flex items-center justify-end gap-3">
             <Button variant="ghost" size="sm" onClick={onClose} disabled={saving} data-testid="drawer-cancel">
               Cancel
             </Button>
@@ -183,6 +186,7 @@ export function VoiceUpdateDrawer({ student, extracted, saving, onSave, onClose 
                 `Save ${rows.length} change${rows.length === 1 ? '' : 's'}`
               )}
             </Button>
+          </div>
           </div>
         )}
       </div>

--- a/frontend/src/lib/voiceUpdateMerge.ts
+++ b/frontend/src/lib/voiceUpdateMerge.ts
@@ -176,7 +176,7 @@ export function mergeExtractedIntoStudent(
       text: row.value,
       createdAt: new Date().toISOString(),
       sourceSessionLogId: null,
-      status: 'Pending',
+      status: 'pending',
       coveredInSessionLogId: null,
     }))
     patch.teachingTodos = [...existing, ...toAdd]

--- a/frontend/src/lib/voiceUpdateMerge.ts
+++ b/frontend/src/lib/voiceUpdateMerge.ts
@@ -1,6 +1,6 @@
 import { newId } from '@/lib/newId'
 import type { Student, Difficulty, ShortTermObjective, TeachingTodo } from '@/api/students'
-import type { ExtractedStudentProfile } from '@/api/studentExtraction'
+import type { ExtractedStudentProfile, ExtractedObjective, ExtractedDifficulty } from '@/api/studentExtraction'
 
 export interface DrawerRow {
   id: string
@@ -9,6 +9,9 @@ export interface DrawerRow {
   badge: 'CHANGED' | 'ADDED' | 'NEW'
   currentValue: string | null
   value: string
+  /** Original extracted metadata — preserved so edits to value don't lose targetDate/competency/subcategory */
+  extractedObjective?: ExtractedObjective
+  extractedDifficulty?: ExtractedDifficulty
 }
 
 export type VoiceMergePatch = {
@@ -68,10 +71,26 @@ export function buildDrawerRows(extracted: ExtractedStudentProfile, student: Stu
     rows.push({ id: newId(), fieldKey: 'interests', label: 'Interest', badge: 'ADDED', currentValue: null, value: interest })
   }
   for (const obj of extracted.shortTermObjectives) {
-    rows.push({ id: newId(), fieldKey: 'shortTermObjectives', label: 'Short-term Objective', badge: 'ADDED', currentValue: null, value: obj.targetDate ? `${obj.text} (by ${obj.targetDate})` : obj.text })
+    rows.push({
+      id: newId(),
+      fieldKey: 'shortTermObjectives',
+      label: 'Short-term Objective',
+      badge: 'ADDED',
+      currentValue: null,
+      value: obj.targetDate ? `${obj.text} (by ${obj.targetDate})` : obj.text,
+      extractedObjective: obj,
+    })
   }
   for (const diff of extracted.difficulties) {
-    rows.push({ id: newId(), fieldKey: 'difficulties', label: 'Difficulty', badge: 'ADDED', currentValue: null, value: diff.description })
+    rows.push({
+      id: newId(),
+      fieldKey: 'difficulties',
+      label: 'Difficulty',
+      badge: 'ADDED',
+      currentValue: null,
+      value: diff.description,
+      extractedDifficulty: diff,
+    })
   }
   for (const todo of extracted.teachingTodoTexts) {
     rows.push({ id: newId(), fieldKey: 'teachingTodos', label: 'Idea for Next Class', badge: 'ADDED', currentValue: null, value: todo })
@@ -82,7 +101,6 @@ export function buildDrawerRows(extracted: ExtractedStudentProfile, student: Stu
 
 export function mergeExtractedIntoStudent(
   confirmedRows: DrawerRow[],
-  extracted: ExtractedStudentProfile,
   student: Student
 ): VoiceMergePatch {
   const patch: VoiceMergePatch = {}
@@ -97,8 +115,9 @@ export function mergeExtractedIntoStudent(
   if (has('countryOfResidence')) patch.countryOfResidence = rowValue('countryOfResidence')
   if (has('cityOfResidence')) patch.cityOfResidence = rowValue('cityOfResidence')
   if (has('birthYear')) {
-    const v = rowValue('birthYear')
-    patch.birthYear = v ? parseInt(v, 10) : null
+    const v = rowValue('birthYear')?.trim() ?? ''
+    const parsed = parseInt(v, 10)
+    patch.birthYear = /^\d{4}$/.test(v) && Number.isFinite(parsed) ? parsed : null
   }
 
   const confirmedNativeLangs = confirmedRows.filter((r) => r.fieldKey === 'nativeLanguages').map((r) => r.value)
@@ -134,13 +153,15 @@ export function mergeExtractedIntoStudent(
   const confirmedObjectives = confirmedRows.filter((r) => r.fieldKey === 'shortTermObjectives')
   if (confirmedObjectives.length > 0) {
     const existing = student.profile.shortTermObjectives
-    const extractedObjMap = new Map(extracted.shortTermObjectives.map((o) => [o.text, o]))
     const toAdd: ShortTermObjective[] = []
     for (const row of confirmedObjectives) {
-      const rawText = row.value.replace(/ \(by [^)]+\)$/, '')
-      const orig = extractedObjMap.get(rawText)
-      if (!existing.some((e) => e.text.toLowerCase() === rawText.toLowerCase())) {
-        toAdd.push({ id: newId(), text: rawText, targetDate: orig?.targetDate ?? null, objectiveType: 'other' })
+      if (!existing.some((e) => e.text.toLowerCase() === row.value.toLowerCase())) {
+        toAdd.push({
+          id: newId(),
+          text: row.value,
+          targetDate: row.extractedObjective?.targetDate ?? null,
+          objectiveType: 'other',
+        })
       }
     }
     patch.shortTermObjectives = [...existing, ...toAdd]
@@ -149,16 +170,14 @@ export function mergeExtractedIntoStudent(
   const confirmedDifficulties = confirmedRows.filter((r) => r.fieldKey === 'difficulties')
   if (confirmedDifficulties.length > 0) {
     const existing = student.profile.difficulties
-    const extractedDiffMap = new Map(extracted.difficulties.map((d) => [d.description, d]))
     const toAdd: Difficulty[] = []
     for (const row of confirmedDifficulties) {
-      const orig = extractedDiffMap.get(row.value)
       if (!existing.some((e) => e.description.toLowerCase() === row.value.toLowerCase())) {
         toAdd.push({
           id: newId(),
           description: row.value,
-          competency: orig?.competency ?? 'general',
-          subcategory: orig?.subcategory ?? 'general',
+          competency: row.extractedDifficulty?.competency ?? 'general',
+          subcategory: row.extractedDifficulty?.subcategory ?? 'general',
           severity: 'medium',
           trend: 'stable',
           status: 'Active',

--- a/frontend/src/lib/voiceUpdateMerge.ts
+++ b/frontend/src/lib/voiceUpdateMerge.ts
@@ -1,0 +1,186 @@
+import { newId } from '@/lib/newId'
+import type { Student, Difficulty, ShortTermObjective, TeachingTodo } from '@/api/students'
+import type { ExtractedStudentProfile } from '@/api/studentExtraction'
+
+export interface DrawerRow {
+  id: string
+  fieldKey: string
+  label: string
+  badge: 'CHANGED' | 'ADDED' | 'NEW'
+  currentValue: string | null
+  value: string
+}
+
+export type VoiceMergePatch = {
+  cefrLevel?: string
+  officialCefrLevel?: string | null
+  profession?: string | null
+  reasonForStudying?: string | null
+  birthYear?: number | null
+  countryOfResidence?: string | null
+  cityOfResidence?: string | null
+  nativeLanguages?: string[]
+  spokenLanguages?: string[]
+  interests?: string[]
+  shortTermObjectives?: ShortTermObjective[]
+  difficulties?: Difficulty[]
+  teachingTodos?: TeachingTodo[]
+}
+
+export function buildDrawerRows(extracted: ExtractedStudentProfile, student: Student): DrawerRow[] {
+  const rows: DrawerRow[] = []
+
+  function addScalar(
+    fieldKey: string,
+    label: string,
+    extractedVal: string | number | null | undefined,
+    currentVal: string | number | null | undefined
+  ) {
+    if (extractedVal == null || extractedVal === '') return
+    const extStr = String(extractedVal)
+    const currStr = currentVal != null ? String(currentVal) : null
+    if (currStr !== null && currStr.toLowerCase() === extStr.toLowerCase()) return
+    rows.push({
+      id: newId(),
+      fieldKey,
+      label,
+      badge: currStr != null ? 'CHANGED' : 'NEW',
+      currentValue: currStr,
+      value: extStr,
+    })
+  }
+
+  addScalar('cefrLevel', 'CEFR Level', extracted.cefrLevel, student.level.cefrLevel)
+  addScalar('officialCefrLevel', 'Official CEFR', extracted.officialCefrLevel, student.level.officialCefrLevel)
+  addScalar('profession', 'Profession', extracted.profession, student.identity.profession)
+  addScalar('reasonForStudying', 'Reason for Studying', extracted.reasonForStudying, student.profile.reasonForStudying)
+  addScalar('birthYear', 'Birth Year', extracted.birthYear, student.identity.birthYear)
+  addScalar('countryOfResidence', 'Country of Residence', extracted.countryOfResidence, student.identity.countryOfResidence)
+  addScalar('cityOfResidence', 'City of Residence', extracted.cityOfResidence, student.identity.cityOfResidence)
+
+  for (const lang of extracted.nativeLanguages) {
+    rows.push({ id: newId(), fieldKey: 'nativeLanguages', label: 'Native Language', badge: 'ADDED', currentValue: null, value: lang })
+  }
+  for (const lang of extracted.spokenLanguages) {
+    rows.push({ id: newId(), fieldKey: 'spokenLanguages', label: 'Spoken Language', badge: 'ADDED', currentValue: null, value: lang })
+  }
+  for (const interest of extracted.interests) {
+    rows.push({ id: newId(), fieldKey: 'interests', label: 'Interest', badge: 'ADDED', currentValue: null, value: interest })
+  }
+  for (const obj of extracted.shortTermObjectives) {
+    rows.push({ id: newId(), fieldKey: 'shortTermObjectives', label: 'Short-term Objective', badge: 'ADDED', currentValue: null, value: obj.targetDate ? `${obj.text} (by ${obj.targetDate})` : obj.text })
+  }
+  for (const diff of extracted.difficulties) {
+    rows.push({ id: newId(), fieldKey: 'difficulties', label: 'Difficulty', badge: 'ADDED', currentValue: null, value: diff.description })
+  }
+  for (const todo of extracted.teachingTodoTexts) {
+    rows.push({ id: newId(), fieldKey: 'teachingTodos', label: 'Idea for Next Class', badge: 'ADDED', currentValue: null, value: todo })
+  }
+
+  return rows
+}
+
+export function mergeExtractedIntoStudent(
+  confirmedRows: DrawerRow[],
+  extracted: ExtractedStudentProfile,
+  student: Student
+): VoiceMergePatch {
+  const patch: VoiceMergePatch = {}
+
+  const has = (fieldKey: string) => confirmedRows.some((r) => r.fieldKey === fieldKey)
+  const rowValue = (fieldKey: string) => confirmedRows.find((r) => r.fieldKey === fieldKey)?.value ?? null
+
+  if (has('cefrLevel')) patch.cefrLevel = rowValue('cefrLevel')!
+  if (has('officialCefrLevel')) patch.officialCefrLevel = rowValue('officialCefrLevel')
+  if (has('profession')) patch.profession = rowValue('profession')
+  if (has('reasonForStudying')) patch.reasonForStudying = rowValue('reasonForStudying')
+  if (has('countryOfResidence')) patch.countryOfResidence = rowValue('countryOfResidence')
+  if (has('cityOfResidence')) patch.cityOfResidence = rowValue('cityOfResidence')
+  if (has('birthYear')) {
+    const v = rowValue('birthYear')
+    patch.birthYear = v ? parseInt(v, 10) : null
+  }
+
+  const confirmedNativeLangs = confirmedRows.filter((r) => r.fieldKey === 'nativeLanguages').map((r) => r.value)
+  if (confirmedNativeLangs.length > 0) {
+    const existing = student.languages.nativeLanguages
+    const deduped = [...existing]
+    for (const lang of confirmedNativeLangs) {
+      if (!deduped.some((l) => l.toLowerCase() === lang.toLowerCase())) deduped.push(lang)
+    }
+    patch.nativeLanguages = deduped
+  }
+
+  const confirmedSpokenLangs = confirmedRows.filter((r) => r.fieldKey === 'spokenLanguages').map((r) => r.value)
+  if (confirmedSpokenLangs.length > 0) {
+    const existing = student.languages.spokenLanguages
+    const deduped = [...existing]
+    for (const lang of confirmedSpokenLangs) {
+      if (!deduped.some((l) => l.toLowerCase() === lang.toLowerCase())) deduped.push(lang)
+    }
+    patch.spokenLanguages = deduped
+  }
+
+  const confirmedInterests = confirmedRows.filter((r) => r.fieldKey === 'interests').map((r) => r.value)
+  if (confirmedInterests.length > 0) {
+    const existing = student.profile.interests
+    const deduped = [...existing]
+    for (const item of confirmedInterests) {
+      if (!deduped.some((i) => i.toLowerCase() === item.toLowerCase())) deduped.push(item)
+    }
+    patch.interests = deduped
+  }
+
+  const confirmedObjectives = confirmedRows.filter((r) => r.fieldKey === 'shortTermObjectives')
+  if (confirmedObjectives.length > 0) {
+    const existing = student.profile.shortTermObjectives
+    const extractedObjMap = new Map(extracted.shortTermObjectives.map((o) => [o.text, o]))
+    const toAdd: ShortTermObjective[] = []
+    for (const row of confirmedObjectives) {
+      const rawText = row.value.replace(/ \(by [^)]+\)$/, '')
+      const orig = extractedObjMap.get(rawText)
+      if (!existing.some((e) => e.text.toLowerCase() === rawText.toLowerCase())) {
+        toAdd.push({ id: newId(), text: rawText, targetDate: orig?.targetDate ?? null, objectiveType: 'other' })
+      }
+    }
+    patch.shortTermObjectives = [...existing, ...toAdd]
+  }
+
+  const confirmedDifficulties = confirmedRows.filter((r) => r.fieldKey === 'difficulties')
+  if (confirmedDifficulties.length > 0) {
+    const existing = student.profile.difficulties
+    const extractedDiffMap = new Map(extracted.difficulties.map((d) => [d.description, d]))
+    const toAdd: Difficulty[] = []
+    for (const row of confirmedDifficulties) {
+      const orig = extractedDiffMap.get(row.value)
+      if (!existing.some((e) => e.description.toLowerCase() === row.value.toLowerCase())) {
+        toAdd.push({
+          id: newId(),
+          description: row.value,
+          competency: orig?.competency ?? 'general',
+          subcategory: orig?.subcategory ?? 'general',
+          severity: 'medium',
+          trend: 'stable',
+          status: 'Active',
+        })
+      }
+    }
+    patch.difficulties = [...existing, ...toAdd]
+  }
+
+  const confirmedTodos = confirmedRows.filter((r) => r.fieldKey === 'teachingTodos')
+  if (confirmedTodos.length > 0) {
+    const existing = student.profile.teachingTodos
+    const toAdd: TeachingTodo[] = confirmedTodos.map((row) => ({
+      id: newId(),
+      text: row.value,
+      createdAt: new Date().toISOString(),
+      sourceSessionLogId: null,
+      status: 'Pending',
+      coveredInSessionLogId: null,
+    }))
+    patch.teachingTodos = [...existing, ...toAdd]
+  }
+
+  return patch
+}

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from 'react'
+import { Loader2 } from 'lucide-react'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getStudent, updateStudent } from '../api/students'
@@ -295,7 +296,7 @@ export default function StudentDetail() {
 
       {voiceFlow === 'extracting' && (
         <div className="rounded-2xl bg-white p-4 flex items-center gap-2 text-sm text-gray-500" data-testid="extracting-indicator">
-          <span className="inline-block h-4 w-4 rounded-full border-2 border-indigo-500 border-t-transparent animate-spin" />
+          <Loader2 className="h-4 w-4 animate-spin text-indigo-500" />
           Analysing recording...
         </div>
       )}

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -14,6 +14,11 @@ import { StudentProfileTab } from '@/components/student/StudentProfileTab'
 import { StudentOverviewTab } from '@/components/student/StudentOverviewTab'
 import { SessionHistoryTab } from '@/components/session/SessionHistoryTab'
 import { ProgressDashboard } from '@/components/student/ProgressDashboard'
+import { AudioRecorder } from '@/components/audio/AudioRecorder'
+import { VoiceUpdateDrawer } from '@/components/student/VoiceUpdateDrawer'
+import type { VoiceMergePatch } from '@/lib/voiceUpdateMerge'
+import { extractStudentProfile } from '@/api/studentExtraction'
+import type { ExtractedStudentProfile } from '@/api/studentExtraction'
 
 function calcSessionFrequency(sessions: SessionLog[]): string | null {
   const past = sessions
@@ -39,6 +44,11 @@ export default function StudentDetail() {
   const activeTab = searchParams.get('tab') ?? 'overview'
   const [difficultyToggleError, setDifficultyToggleError] = useState<string | null>(null)
   const difficultyToggleAttemptRef = useRef(0)
+
+  type VoiceFlow = 'idle' | 'recording' | 'extracting' | 'confirming' | 'saving'
+  const [voiceFlow, setVoiceFlow] = useState<VoiceFlow>('idle')
+  const [extractedProfile, setExtractedProfile] = useState<ExtractedStudentProfile | null>(null)
+  const [voiceError, setVoiceError] = useState<string | null>(null)
 
   const { data: student, isLoading, isError } = useQuery({
     queryKey: ['student', id],
@@ -195,6 +205,39 @@ export default function StudentDetail() {
     },
   })
 
+  async function handleVoiceNote(voiceNote: { transcription: string | null }) {
+    if (!voiceNote.transcription || !voiceNote.transcription.trim()) {
+      setVoiceError('Transcription failed. Please try recording again.')
+      setVoiceFlow('idle')
+      return
+    }
+    setVoiceFlow('extracting')
+    setVoiceError(null)
+    try {
+      const result = await extractStudentProfile(voiceNote.transcription)
+      setExtractedProfile(result)
+      setVoiceFlow('confirming')
+    } catch (err) {
+      logger.error('StudentDetail', 'Voice extraction failed', err)
+      setVoiceError('Extraction failed. Please try again.')
+      setVoiceFlow('idle')
+    }
+  }
+
+  async function handleVoiceSave(patch: VoiceMergePatch) {
+    if (!student) return
+    setVoiceFlow('saving')
+    try {
+      await updateStudent(id!, { ...buildStudentPayload(), ...patch })
+      queryClient.invalidateQueries({ queryKey: ['student', id] })
+      setVoiceFlow('idle')
+      setExtractedProfile(null)
+    } catch (err) {
+      logger.error('StudentDetail', 'Voice save failed', err)
+      setVoiceFlow('confirming')
+    }
+  }
+
   if (isLoading) {
     return (
       <div className="space-y-6">
@@ -235,7 +278,37 @@ export default function StudentDetail() {
         student={student}
         nextSession={nextSession}
         sessionFrequency={sessionFrequency}
+        onVoiceUpdateClick={() => setVoiceFlow('recording')}
+        voiceFlowActive={voiceFlow !== 'idle'}
       />
+
+      {voiceFlow === 'recording' && (
+        <div className="rounded-2xl bg-white p-4 flex flex-col gap-2" data-testid="voice-recorder-panel">
+          <p className="text-xs font-semibold tracking-widest uppercase text-gray-400">Update via voice</p>
+          <AudioRecorder onVoiceNote={handleVoiceNote} />
+          {voiceError && <p className="text-sm text-red-500">{voiceError}</p>}
+          <Button variant="ghost" size="sm" className="self-start" onClick={() => { setVoiceFlow('idle'); setVoiceError(null) }}>
+            Cancel
+          </Button>
+        </div>
+      )}
+
+      {voiceFlow === 'extracting' && (
+        <div className="rounded-2xl bg-white p-4 flex items-center gap-2 text-sm text-gray-500" data-testid="extracting-indicator">
+          <span className="inline-block h-4 w-4 rounded-full border-2 border-indigo-500 border-t-transparent animate-spin" />
+          Analysing recording...
+        </div>
+      )}
+
+      {(voiceFlow === 'confirming' || voiceFlow === 'saving') && extractedProfile && (
+        <VoiceUpdateDrawer
+          student={student}
+          extracted={extractedProfile}
+          saving={voiceFlow === 'saving'}
+          onSave={(patch: VoiceMergePatch) => handleVoiceSave(patch)}
+          onClose={() => { setVoiceFlow('idle'); setExtractedProfile(null) }}
+        />
+      )}
 
       {/* Tab bar */}
       <div className="flex gap-1" role="tablist">

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -235,6 +235,7 @@ export default function StudentDetail() {
       setExtractedProfile(null)
     } catch (err) {
       logger.error('StudentDetail', 'Voice save failed', err)
+      setVoiceError('Save failed. Please try again.')
       setVoiceFlow('confirming')
     }
   }
@@ -306,8 +307,9 @@ export default function StudentDetail() {
           student={student}
           extracted={extractedProfile}
           saving={voiceFlow === 'saving'}
+          saveError={voiceError}
           onSave={(patch: VoiceMergePatch) => handleVoiceSave(patch)}
-          onClose={() => { setVoiceFlow('idle'); setExtractedProfile(null) }}
+          onClose={() => { setVoiceFlow('idle'); setExtractedProfile(null); setVoiceError(null) }}
         />
       )}
 


### PR DESCRIPTION
## Summary

- Adds "Update via voice" button to student detail page header
- After recording, transcription is sent to `POST /api/students/extract-profile`; a glassmorphism confirmation drawer slides in showing extracted fields
- Each row shows CHANGED / ADDED / NEW badge; teachers can edit inline or remove rows before saving
- Save merges confirmed fields into the student via the existing PUT endpoint — scalar replace, list append-with-dedup, teachingTodos always appended

## Design

- Drawer: `rgba(255,255,255,0.80)` + `backdrop-blur: 12px` per Academic Atelier spec
- No borders anywhere in the drawer (tonal layering only)
- Full-width on mobile, 480px on sm+
- Null transcription guard: shows error instead of calling the extract endpoint

## Test plan

- [ ] `VoiceUpdateDrawer.test.tsx` — badges, remove, inline edit, cancel, save, merge logic, dedup
- [ ] `studentExtraction.test.ts` — API module
- [ ] `StudentDetailHeader.test.tsx` — voice button visibility and disabled state
- [ ] Merge logic unit tests: scalar replace, list dedup, teachingTodo always-append

Closes #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled voice-driven student profile updates with automatic extraction of profile information from voice input
  * Added a confirmation interface to review and apply extracted changes before saving

* **Tests**
  * Added comprehensive test coverage for voice update and extraction features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->