### PR TITLE
fix(#940): upgrade QA teacher to Pro tier and enrich Sprint Tester student profile

### DIFF
--- a/.claude/skills/teacher-qa/SKILL.md
+++ b/.claude/skills/teacher-qa/SKILL.md
@@ -104,6 +104,18 @@ docker ps --filter "name=langteachsaas-qa" --format "{{.Names}}"
   done
   ```
 
+### Step 2.5: Ensure QA Teacher is Pro Tier
+
+Run after the stack is healthy (every QA cycle, including after volume resets).
+This prevents the Free tier 50-generation monthly limit from blocking QA runs.
+
+```bash
+source .env.qa && docker compose -f docker-compose.qa.yml --env-file .env.qa exec -T api dotnet LangTeach.Api.dll --qa-seed "$TEACHER_QA_EMAIL"
+```
+
+Expected output: `--qa-seed: teacher <email> set to Pro/approved.`
+If the command fails with "no teacher found", the QA user has not logged in yet — complete the One-Time QA User Onboarding steps above first.
+
 ### Step 3: Run Playwright Personas
 
 For each selected persona, run the corresponding spec:

--- a/.claude/skills/teacher-qa/playwright/helpers/navigation.ts
+++ b/.claude/skills/teacher-qa/playwright/helpers/navigation.ts
@@ -140,6 +140,99 @@ export async function upsertStudent(page: Page, data: StudentData): Promise<stri
   return createStudent(page, data)
 }
 
+/**
+ * Ensures a student has a short-term objective with the given type.
+ * Navigates to the student edit form and adds the objective if none exist.
+ * No-op if the student already has at least one objective.
+ */
+export async function ensureStudentShortTermObjective(
+  page: Page,
+  studentId: string,
+  objective: { text: string; objectiveType: string }
+): Promise<void> {
+  const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5175'
+  await page.goto(`${baseURL}/students/${studentId}/edit`)
+
+  const emptyLocator = page.locator('[data-testid="objectives-empty"]')
+  const rowLocator   = page.locator('[data-testid="objective-row"]').first()
+
+  // Wait until either the empty state or at least one row is visible
+  await Promise.race([
+    emptyLocator.waitFor({ state: 'visible', timeout: 10000 }),
+    rowLocator.waitFor({ state: 'visible', timeout: 10000 }),
+  ]).catch(() => {})
+
+  if (!(await emptyLocator.isVisible())) return
+
+  // Add the objective and wait for the autosave PUT
+  const [putResponse] = await Promise.all([
+    page.waitForResponse(
+      resp =>
+        resp.url().includes('/api/students/') &&
+        resp.request().method() === 'PUT' &&
+        resp.status() === 200,
+      { timeout: 15000 }
+    ),
+    (async () => {
+      await page.click('[data-testid="add-objective"]')
+      await page.fill('[data-testid="objective-text-input"]', objective.text)
+      await page.locator('[data-testid="objective-type-select"]').click()
+      await page.getByRole('option', { name: new RegExp(objective.objectiveType, 'i') }).click()
+      // Blur the text field to trigger autosave
+      await page.locator('[data-testid="objective-text-input"]').blur()
+    })(),
+  ])
+
+  if (!putResponse.ok()) {
+    console.warn(`[teacher-qa] ensureStudentShortTermObjective: PUT /api/students/${studentId} returned ${putResponse.status()}`)
+  }
+}
+
+/**
+ * Ensures a student has at least one confirmed session log.
+ * Navigates to the log-session page and clicks Done if no sessions exist.
+ * No-op if at least one session already exists.
+ */
+export async function ensureStudentHasSessionLog(
+  page: Page,
+  studentId: string
+): Promise<void> {
+  const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5175'
+
+  // Check existing sessions via the summary endpoint
+  const [summaryResponse] = await Promise.all([
+    page.waitForResponse(
+      resp =>
+        resp.url().includes(`/api/students/${studentId}/sessions/summary`) &&
+        resp.status() === 200 &&
+        resp.request().resourceType() === 'xhr',
+      { timeout: 10000 }
+    ),
+    page.goto(`${baseURL}/students/${studentId}?tab=sessions`),
+  ])
+
+  const summary: { totalSessions?: number } = await summaryResponse.json()
+  if ((summary.totalSessions ?? 0) > 0) return
+
+  // No sessions — create a minimal confirmed one via the log-session UI
+  await page.goto(`${baseURL}/students/${studentId}/log-session`)
+  await page.locator('[data-testid="log-session-page"]').waitFor({ state: 'visible', timeout: 15000 })
+
+  // Wait for autosave to create the Draft session before clicking Done
+  await page.waitForResponse(
+    resp =>
+      resp.url().includes(`/api/students/${studentId}/sessions`) &&
+      resp.request().method() === 'POST' &&
+      resp.status() === 201,
+    { timeout: 15000 }
+  )
+
+  await page.click('[data-testid="done-btn"]')
+
+  // Wait until redirected away from the log-session page
+  await page.waitForURL(`${baseURL}/students/${studentId}**`, { timeout: 15000 })
+}
+
 // ---------------------------------------------------------------------------
 // Lessons
 // ---------------------------------------------------------------------------

--- a/.claude/skills/teacher-qa/playwright/tests/sprint-reviewer.spec.ts
+++ b/.claude/skills/teacher-qa/playwright/tests/sprint-reviewer.spec.ts
@@ -21,6 +21,8 @@ import path from 'path'
 import { createQAAuthContext } from '../helpers/auth'
 import {
   upsertStudent,
+  ensureStudentShortTermObjective,
+  ensureStudentHasSessionLog,
   createLesson,
   triggerFullGeneration,
   extractLessonContent,
@@ -70,7 +72,16 @@ test('Sprint Reviewer — integration test for current sprint features', async (
   const page = await context.newPage()
 
   // 1. Ensure student [QA] Sprint Tester exists (create if first run, reuse on subsequent runs)
-  await upsertStudent(page, PERSONA.student)
+  const studentId = await upsertStudent(page, PERSONA.student)
+
+  // 1a. Ensure the student has a short-term objective (type: communicative) for #857 feature
+  await ensureStudentShortTermObjective(page, studentId, {
+    text: 'Hold a natural conversation in Spanish',
+    objectiveType: 'communicative',
+  })
+
+  // 1b. Ensure the student has at least one session log for #858 last-session summary card
+  await ensureStudentHasSessionLog(page, studentId)
 
   // 2. Create lesson with the sprint-specific topic
   const lessonData = { ...PERSONA.lesson, studentName: PERSONA.student.name }

--- a/backend/LangTeach.Api/Program.cs
+++ b/backend/LangTeach.Api/Program.cs
@@ -305,6 +305,39 @@ if (visualSeedIndex >= 0)
     return seeded ? 0 : 1;
 }
 
+// QA seed: dotnet LangTeach.Api.dll --qa-seed <auth0-user-id|email>
+// Idempotent. Ensures the QA teacher is SubscriptionTier=Pro, IsApproved, HasCompletedOnboarding.
+// Run this after each QA stack start (including after volume resets) to prevent Free tier limits.
+var qaSeedIndex = Array.IndexOf(args, "--qa-seed");
+if (qaSeedIndex >= 0)
+{
+    var teacherLookup = (qaSeedIndex + 1 < args.Length ? args[qaSeedIndex + 1] : null)?.Trim();
+    if (string.IsNullOrWhiteSpace(teacherLookup))
+    {
+        Console.Error.WriteLine("Usage: --qa-seed <auth0-user-id|email>");
+        return 1;
+    }
+
+    using var qaSeedScope = app.Services.CreateScope();
+    var qaSeedDb     = qaSeedScope.ServiceProvider.GetRequiredService<AppDbContext>();
+    var qaSeedLogger = qaSeedScope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+    var teacher = teacherLookup.StartsWith("auth0|", StringComparison.OrdinalIgnoreCase)
+        ? await qaSeedDb.Teachers.FirstOrDefaultAsync(t => t.Auth0UserId == teacherLookup)
+        : await qaSeedDb.Teachers.FirstOrDefaultAsync(t => t.Email == teacherLookup);
+    if (teacher is null)
+    {
+        qaSeedLogger.LogError("--qa-seed: no teacher found for '{Lookup}'. Log in at least once before seeding.", teacherLookup);
+        return 1;
+    }
+    teacher.SubscriptionTier       = LangTeach.Api.Data.Models.SubscriptionTier.Pro;
+    teacher.IsApproved              = true;
+    teacher.HasCompletedOnboarding  = true;
+    teacher.UpdatedAt               = DateTime.UtcNow;
+    await qaSeedDb.SaveChangesAsync();
+    qaSeedLogger.LogInformation("--qa-seed: teacher {Email} set to Pro/approved.", teacher.Email);
+    return 0;
+}
+
 app.UseSerilogRequestLogging(options =>
 {
     options.MessageTemplate = "HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000}ms";


### PR DESCRIPTION
Fixes #940

## Summary

- Adds `--qa-seed <email>` CLI command to `Program.cs` that sets `SubscriptionTier=Pro`, `IsApproved=true`, and `HasCompletedOnboarding=true` for the QA teacher. Idempotent. Survives `docker compose down -v` volume resets when run as Step 2.5 each cycle.
- Adds Step 2.5 to teacher-qa `SKILL.md` to run `--qa-seed` after the stack health check, preventing the Free tier 50-generation monthly limit from blocking QA runs.
- Adds `ensureStudentShortTermObjective` and `ensureStudentHasSessionLog` helpers to `navigation.ts` so the Sprint Tester always has the profile data needed to exercise sprint features (#857 objective type selector, #858 last-session summary card, #883 ShortTermObjectives in GenerationContext).
- Updates `sprint-reviewer.spec.ts` to capture `studentId` from `upsertStudent` and call both new helpers before lesson creation.

## Test plan

- [x] `dotnet build` passes with 0 warnings
- [x] `dotnet test` passes
- [x] Frontend vitest passes (1450 tests)
- [x] `npm lint` and `npm build` pass
- [ ] Live QA run with `--qa-seed` after stack start confirms teacher is Pro and generation is unblocked (requires real QA stack)
- [ ] Sprint Reviewer spec run confirms shortTermObjective and session log appear in prompt context (requires real QA stack + Claude API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)