### PR TITLE
fix(#951): remove line-clamp from LastSessionCard, add View session link

### DIFF
--- a/frontend/src/components/student/LastSessionCard.test.tsx
+++ b/frontend/src/components/student/LastSessionCard.test.tsx
@@ -147,6 +147,21 @@ describe('LastSessionCard', () => {
     expect(screen.getByTestId('last-session-title')).toHaveTextContent('Most recent')
   })
 
+  it('renders View session link with correct href', () => {
+    renderCard(makeSession())
+    const link = screen.getByTestId('last-session-view-link')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/students/student-1/sessions/sess-x/edit')
+    expect(link).toHaveTextContent('View session')
+  })
+
+  it('renders View session link even when actualContent is null', () => {
+    renderCard(makeSession({ actualContent: null }))
+    expect(screen.queryByTestId('last-session-content')).not.toBeInTheDocument()
+    const link = screen.getByTestId('last-session-view-link')
+    expect(link).toHaveAttribute('href', '/students/student-1/sessions/sess-x/edit')
+  })
+
   it('does not render an edit control (read-only)', () => {
     renderCard(makeSession())
     const card = screen.getByTestId('last-session-card')

--- a/frontend/src/components/student/LastSessionCard.tsx
+++ b/frontend/src/components/student/LastSessionCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { BookOpen, NotebookPen } from 'lucide-react'
+import { BookOpen, ExternalLink, NotebookPen } from 'lucide-react'
 import type { SessionLog } from '@/api/sessionLogs'
 import { parseTopicTags } from '@/api/sessionLogs'
 import { getDisplayTitle } from '@/lib/sessionUtils'
@@ -91,7 +91,7 @@ export function LastSessionCard({ session, studentId }: Props) {
 
           {actual && (
             <p
-              className="text-sm text-zinc-700 mt-2 line-clamp-4 whitespace-pre-wrap"
+              className="text-sm text-zinc-700 mt-2 whitespace-pre-wrap"
               data-testid="last-session-content"
             >
               {actual}
@@ -123,6 +123,16 @@ export function LastSessionCard({ session, studentId }: Props) {
               </p>
             </div>
           )}
+          <div className="mt-4">
+            <Link
+              to={`/students/${studentId}/sessions/${session.id}/edit`}
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-800"
+              data-testid="last-session-view-link"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              View session
+            </Link>
+          </div>
         </div>
       </div>
     </section>

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -11,3 +11,4 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 | Issue | Date | Finding | Severity |
 |-------|------|---------|----------|
 | #928 | 2026-04-25 | `Button variant="ghost"` uses `hover:bg-muted` (near-white gray) while the app's surface-container-low hover color `#F4F2FD` (lavender) is hardcoded in 10+ places. Pre-existing divergence between the shared Button component and app-level ghost-style links. Consider aligning `--muted` token to `#F4F2FD` or introducing a `surface-container-low` CSS variable. | Low |
+| #951 | 2026-04-26 | Indigo inline-link hover treatment inconsistent across student cards: `LastSessionCard` uses `hover:text-indigo-800` only (per issue AC), `LessonHistoryCard` adds `hover:underline`. Consider standardising to one pattern (add `hover:underline` everywhere, or drop it everywhere). | Low |


### PR DESCRIPTION
Closes #951

## Summary
- Removes `line-clamp-4` from the `actualContent` paragraph in `LastSessionCard` so teacher-written session notes render in full without truncation
- Adds a "View session" link at the bottom of the card navigating to `/students/{studentId}/sessions/{session.id}/edit`, matching the visual style of the existing "Log session" link
- Two new unit tests covering the link href and the null-actualContent case

## Test plan
- [ ] Last Session card shows full session content (no clipping) when notes are long
- [ ] "View session" link appears at the bottom of a populated card and navigates correctly
- [ ] Empty state (no session) still shows "Log session" link only, unchanged
- [ ] Card renders correctly when `actualContent` is null

🤖 Generated with [Claude Code](https://claude.com/claude-code)