### PR TITLE
fix(#929): strip null entries from tag arrays at API boundary

### DIFF
--- a/backend/LangTeach.Api.Tests/Helpers/JsonStorageHelperNullFilteringTests.cs
+++ b/backend/LangTeach.Api.Tests/Helpers/JsonStorageHelperNullFilteringTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using LangTeach.Api.Helpers;
+
+namespace LangTeach.Api.Tests.Helpers;
+
+public class JsonStorageHelperNullFilteringTests
+{
+    [Fact]
+    public void DeserializeList_FiltersNullStringEntries()
+    {
+        var json = """["a", null, "b"]""";
+        var result = JsonStorageHelper.DeserializeList<string>(json);
+        result.Should().BeEquivalentTo(["a", "b"]);
+    }
+
+    [Fact]
+    public void DeserializeList_AllNulls_ReturnsEmpty()
+    {
+        var json = "[null, null]";
+        var result = JsonStorageHelper.DeserializeList<string>(json);
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DeserializeList_FiltersNullObjectEntries()
+    {
+        var json = """[{"name":"A"}, null, {"name":"B"}]""";
+        var result = JsonStorageHelper.DeserializeList<SampleDto>(json);
+        result.Should().HaveCount(2);
+        result.Should().NotContainNulls();
+    }
+
+    [Fact]
+    public void DeserializeListNullable_FiltersNullStringEntries()
+    {
+        var json = """["x", null, "y"]""";
+        var result = JsonStorageHelper.DeserializeListNullable<string>(json);
+        result.Should().BeEquivalentTo(["x", "y"]);
+    }
+
+    [Fact]
+    public void DeserializeListNullable_AllNulls_ReturnsEmpty()
+    {
+        var json = "[null]";
+        var result = JsonStorageHelper.DeserializeListNullable<string>(json);
+        result.Should().NotBeNull().And.BeEmpty();
+    }
+
+    private sealed record SampleDto(string Name);
+}

--- a/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/DashboardServiceTests.cs
@@ -504,6 +504,23 @@ public class DashboardServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetAsync_TopicTagsWithNullEntries_StripsNullsFromLastSessionTopicTags()
+    {
+        var past = DateTime.UtcNow.AddDays(-7);
+        var future = DateTime.UtcNow.AddDays(1);
+        var pastSession = MakeSession(_studentId, past);
+        pastSession.TopicTags = "[{\"Tag\":\"Subjuntivo\",\"Category\":null},{\"Tag\":null,\"Category\":null},{\"Tag\":\"Concesivas\",\"Category\":null}]";
+        _db.SessionLogs.Add(pastSession);
+        _db.SessionLogs.Add(MakeSession(_studentId, future));
+        _db.SaveChanges();
+
+        var result = await _sut.GetAsync(_teacherId);
+
+        result.NextSession!.LastSessionTopicTags.Should().Equal("Subjuntivo", "Concesivas");
+        result.NextSession!.LastSessionTopicTags.Should().NotContainNulls();
+    }
+
+    [Fact]
     public async Task GetAsync_FutureSessionWithPastSession_PopulatesLastSessionHomework()
     {
         var past = DateTime.UtcNow.AddDays(-7);

--- a/backend/LangTeach.Api/Helpers/JsonStorageHelper.cs
+++ b/backend/LangTeach.Api/Helpers/JsonStorageHelper.cs
@@ -12,7 +12,7 @@ internal static class JsonStorageHelper
     public static List<T> DeserializeList<T>(string? json)
     {
         if (string.IsNullOrEmpty(json)) return [];
-        try { return JsonSerializer.Deserialize<List<T>>(json, CaseInsensitive) ?? []; }
+        try { return (JsonSerializer.Deserialize<List<T>>(json, CaseInsensitive) ?? []).Where(x => x != null).ToList(); }
         catch (JsonException) { return []; }
     }
 
@@ -22,7 +22,7 @@ internal static class JsonStorageHelper
     public static List<T>? DeserializeListNullable<T>(string? json)
     {
         if (string.IsNullOrEmpty(json)) return null;
-        try { return JsonSerializer.Deserialize<List<T>>(json, CaseInsensitive); }
+        try { return JsonSerializer.Deserialize<List<T>>(json, CaseInsensitive)?.Where(x => x != null).ToList(); }
         catch (JsonException) { return null; }
     }
 

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -64,7 +64,7 @@ public class DashboardService : IDashboardService
             try
             {
                 lastSessionTopicTags = (JsonSerializer.Deserialize<List<TopicTagEntry>>(lastPast.TopicTags) ?? [])
-                    .Select(t => t.Tag).ToList();
+                    .Select(t => t.Tag).Where(t => !string.IsNullOrEmpty(t)).ToList();
             }
             catch (JsonException)
             {

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using LangTeach.Api.Data;
 using LangTeach.Api.Data.Models;
 using LangTeach.Api.DTOs;
@@ -61,15 +60,8 @@ public class DashboardService : IDashboardService
         List<string> lastSessionTopicTags = [];
         if (lastPast is not null)
         {
-            try
-            {
-                lastSessionTopicTags = (JsonSerializer.Deserialize<List<TopicTagEntry>>(lastPast.TopicTags) ?? [])
-                    .Select(t => t.Tag).Where(t => !string.IsNullOrEmpty(t)).ToList();
-            }
-            catch (JsonException)
-            {
-                _logger.LogWarning("Failed to deserialize TopicTags for session {SessionId}", lastPast.Id);
-            }
+            lastSessionTopicTags = JsonStorageHelper.DeserializeList<TopicTagEntry>(lastPast.TopicTags)
+                .Select(t => t.Tag).Where(t => !string.IsNullOrEmpty(t)).ToList();
         }
 
         var lastSessionFollowups = lastPast is not null

--- a/frontend/src/components/dashboard/NextSessionHero.tsx
+++ b/frontend/src/components/dashboard/NextSessionHero.tsx
@@ -81,6 +81,7 @@ export function NextSessionHero({ session }: NextSessionHeroProps) {
   const urgency = getUrgencyBadge(session.sessionDate)
   const hwStatus = getHomeworkStatusInfoSafe(session.previousHomeworkStatus)
 
+  // Belt-and-suspenders: backend strips nulls/empty tags, but guard here too
   const filteredTopicTags = session.lastSessionTopicTags.filter((t) => t != null && t.trim() !== '')
   const hasTopics = filteredTopicTags.length > 0
   const hasResponse = !!session.lastSessionNotes

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -3,6 +3,7 @@
 Out-of-scope observations logged by agents during implementation. Each row is something an agent noticed but did not fix because it was outside the current task's scope. These get batched into future GitHub issues by the PM.
 
 | Source issue | Date | Severity | Observation |
+| #929 | 2026-04-26 | low | `SessionHistoryService.AggregateTopicTags` deserializes `TopicTags` inline (bypassing `JsonStorageHelper`) and guards empty tags via an `if` check but does not benefit from the central null-object filter added in this task. Should be routed through `JsonStorageHelper.DeserializeList<TopicTagEntry>` for consistency. |
 | #945 | 2026-04-26 | low | `activeDifficulties` (LogSession.tsx:265) is computed inline on every render and used in a useEffect deps array -- ESLint react-hooks/exhaustive-deps warns it recreates a new array reference each render. Pre-existing before this PR. Fix: wrap in `useMemo`. |
 | #605 | 2026-04-25 | low | VoiceNote upload API/DTO layer does not validate BlobPath/OriginalFileName/ContentType length at input boundary; EF MaxLength only enforces at DB write, giving a runtime error instead of a clean 400. |
 | #908 | 2026-04-24 | low | Tab bar at 375px clips "Progress" label (shows "Progre") -- pre-existing tab overflow at mobile width, outside StudentDetailHeader scope |


### PR DESCRIPTION
## Summary

- `JsonStorageHelper.DeserializeList<T>` and `DeserializeListNullable<T>` now filter null elements after deserialization, covering all tag/string array fields (Interests, NativeLanguages, SpokenLanguages, etc.)
- `DashboardService` TopicTags deserialization routed through `JsonStorageHelper` (consistent with other services) with an additional `.Where(!string.IsNullOrEmpty)` guard on the projected Tag strings
- `NextSessionHero.tsx` keeps existing null-guard with a belt-and-suspenders comment
- 6 new tests: 5 in `JsonStorageHelperNullFilteringTests` + 1 regression in `DashboardServiceTests`

Closes #929

## Test plan

- [x] `JsonStorageHelperNullFilteringTests` -- DeserializeList/DeserializeListNullable filter nulls from string and object arrays
- [x] `DashboardServiceTests.GetAsync_TopicTagsWithNullEntries_StripsNullsFromLastSessionTopicTags` -- regression covering the crash path
- [x] Full backend test suite: 1188 passed, 0 failed
- [x] Frontend type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of topic tags in session information by filtering out null and empty entries, ensuring the dashboard displays only valid topic tags when viewing the next scheduled session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->