### PR TITLE
fix(#971): voice trigger shows starting indicator while awaiting mic permission

### DIFF
--- a/frontend/src/components/audio/AudioRecorder.test.tsx
+++ b/frontend/src/components/audio/AudioRecorder.test.tsx
@@ -153,6 +153,20 @@ describe('AudioRecorder', () => {
     expect(screen.queryByTestId('upload-audio-button')).not.toBeInTheDocument()
   })
 
+  it('shows a starting indicator while autoStart is awaiting mic permission', async () => {
+    // getUserMedia stays pending: mimics the user not having decided on the
+    // OS-level permission prompt yet. Without the starting indicator the
+    // panel renders empty and the teacher thinks the feature is broken.
+    mockGetUserMedia.mockReturnValue(new Promise(() => {}))
+
+    render(<AudioRecorder onVoiceNote={vi.fn()} autoStart />)
+
+    expect(await screen.findByTestId('recorder-starting')).toBeInTheDocument()
+    expect(screen.queryByTestId('record-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('upload-audio-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('stop-button')).not.toBeInTheDocument()
+  })
+
   it('reveals the chooser when autoStart fails because mic permission is denied', async () => {
     mockGetUserMedia.mockRejectedValue(new Error('Permission denied'))
 

--- a/frontend/src/components/audio/AudioRecorder.tsx
+++ b/frontend/src/components/audio/AudioRecorder.tsx
@@ -206,6 +206,18 @@ export function AudioRecorder({
         </div>
       )}
 
+      {/* Visible feedback during the autoStart pending window: between mount
+          and getUserMedia resolving, neither the chooser nor the recording UI
+          would otherwise render. Without this branch the panel looks frozen. */}
+      {state === 'idle' && autoStart && !error && (
+        <div className="flex items-center gap-2" data-testid="recorder-starting">
+          <Loader2 className="h-4 w-4 animate-spin text-indigo-500" />
+          <span className="text-sm text-zinc-500">
+            Starting recording... please allow microphone access if prompted.
+          </span>
+        </div>
+      )}
+
       {/* File input lives outside the chooser so the imperative
           switchToFileUpload() handle can trigger it even while the chooser
           is hidden (autoStart mode). It is hidden visually either way. */}


### PR DESCRIPTION
Closes #971

## Summary

Regression patch on #964. The autoStart mode in `AudioRecorder` correctly hid the Record/Upload chooser, but between component mount and `getUserMedia` resolving, no other render branch matched. The voice trigger panel rendered with the section header at the top and a Cancel button at the bottom — and **nothing in between**. Teachers had no signal that the system was engaging the microphone, and on slow permission decisions or dismissed prompts the panel looked frozen.

This patch adds a `recorder-starting` render branch shown whenever `autoStart && state === 'idle' && !error`. It renders a spinner + the message *\"Starting recording... please allow microphone access if prompted.\"*

## Why this slipped through #964

The autoStart tests in #964 mocked `getUserMedia` to either resolve or reject **synchronously**. Both paths bypassed the real-world pending state where the OS permission prompt is open and the promise is unresolved. The new test in this PR uses `mockReturnValue(new Promise(() => {}))` to keep the promise pending and asserts the starting indicator is visible.

## Test plan

- [x] `AudioRecorder.test.tsx` — 15 tests pass (was 14, +1 for the pending state)
- [x] Full frontend test suite — 1507 tests pass
- [x] `npm lint`, `npm build`, `dotnet build`, `dotnet test` — all PASS
- [ ] **Manual browser verification (required by issue, hard to simulate):**
  - In a fresh Chrome profile (mic permission unset), click \"New student via voice\" → see spinner + \"Starting recording...\" message → click Allow → recording UI appears
  - Same on student detail page \"Update via voice\"
  - With mic permission previously denied → chooser + error appear (existing path)
  - With mic permission previously granted → recording UI appears within ~100ms with no flash of empty state

## Notes on review-ui

`review-ui` cannot meaningfully exercise this fix: the pending state only exists while the OS-level mic permission prompt is open and waiting on a real human click. The visible branch is verified by unit test. The fix is narrow (12 lines in one component, behind an existing state guard) so I'm requesting human verification per the issue's checklist instead of a review-ui pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)