### PR TITLE
fix(#974): autoStart actually starts recording when parent rerenders

### DIFF
--- a/frontend/src/components/audio/AudioRecorder.test.tsx
+++ b/frontend/src/components/audio/AudioRecorder.test.tsx
@@ -167,6 +167,28 @@ describe('AudioRecorder', () => {
     expect(screen.queryByTestId('stop-button')).not.toBeInTheDocument()
   })
 
+  it('still starts recording when the parent rerenders with a new onVoiceNote reference', async () => {
+    // Regression: an unstable onVoiceNote from the parent (no useCallback)
+    // used to cascade into a new startRecording identity, retrigger the
+    // autoStart effect, clearTimeout the pending startRecording call, and
+    // leave autoStartedRef true so it never restarted. Result: spinner
+    // forever, no stop button. This test renders the parent twice in quick
+    // succession (mimicking a React re-render) and asserts recording starts.
+    const mockStream = { getTracks: () => [{ stop: vi.fn() }] }
+    mockGetUserMedia.mockResolvedValue(mockStream)
+
+    const { rerender } = render(
+      <AudioRecorder onVoiceNote={() => {}} autoStart />
+    )
+    // Force a parent rerender BEFORE the queued setTimeout(0) startRecording
+    // fires. A new inline arrow function gives the prop a new identity.
+    rerender(<AudioRecorder onVoiceNote={() => {}} autoStart />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('stop-button')).toBeInTheDocument()
+    })
+  })
+
   it('reveals the chooser when autoStart fails because mic permission is denied', async () => {
     mockGetUserMedia.mockRejectedValue(new Error('Permission denied'))
 

--- a/frontend/src/components/audio/AudioRecorder.tsx
+++ b/frontend/src/components/audio/AudioRecorder.tsx
@@ -138,6 +138,16 @@ export function AudioRecorder({
     }, 1000)
   }, [stopRecording, uploadFile])
 
+  // Hold startRecording in a ref so the autoStart effect does not depend on
+  // its identity. Without this, an unstable onVoiceNote prop from the parent
+  // (a non-memoised handleVoiceNote) cascades into a new startRecording on
+  // every parent render. The cleanup then clearTimeouts the pending call
+  // before it fires, autoStartedRef stays true, and recording never starts.
+  const startRecordingRef = useRef(startRecording)
+  useEffect(() => {
+    startRecordingRef.current = startRecording
+  }, [startRecording])
+
   useEffect(() => {
     if (!autoStart || autoStartedRef.current || state !== 'idle' || error) return
     autoStartedRef.current = true
@@ -145,9 +155,9 @@ export function AudioRecorder({
     // setState cascade. startRecording() awaits getUserMedia before its first
     // setState anyway, but the deferred call also satisfies the
     // react-hooks/set-state-in-effect lint rule.
-    const handle = setTimeout(() => { void startRecording() }, 0)
+    const handle = setTimeout(() => { void startRecordingRef.current() }, 0)
     return () => clearTimeout(handle)
-  }, [autoStart, state, error, startRecording])
+  }, [autoStart, state, error])
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -212,7 +212,9 @@ export default function StudentDetail() {
     },
   })
 
-  async function handleVoiceNote(voiceNote: { transcription: string | null }) {
+  // Memoised so the AudioRecorder autoStart effect does not retrigger on every
+  // parent render. See AudioRecorder.tsx for why callback identity matters here.
+  const handleVoiceNote = useCallback(async (voiceNote: { transcription: string | null }) => {
     if (!voiceNote.transcription || !voiceNote.transcription.trim()) {
       setVoiceError('Transcription failed. Please try recording again.')
       setVoiceFlow('idle')
@@ -229,7 +231,7 @@ export default function StudentDetail() {
       setVoiceError('Extraction failed. Please try again.')
       setVoiceFlow('idle')
     }
-  }
+  }, [])
 
   async function handleVoiceSave(patch: VoiceMergePatch) {
     if (!student) return

--- a/frontend/src/pages/Students.tsx
+++ b/frontend/src/pages/Students.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Search, UserPlus, Users, ChevronsUpDown, ChevronDown, Mic, Loader2 } from 'lucide-react'
@@ -318,7 +318,11 @@ export default function Students() {
 
   const currentSortLabel = SORT_OPTIONS.find(o => o.value === sortBy)?.label ?? 'Last Session'
 
-  async function handleVoiceNote(voiceNote: { transcription: string | null }) {
+  // Memoised so the AudioRecorder autoStart effect does not retrigger on every
+  // parent render. An unstable callback cascades into a new startRecording
+  // identity, which causes the autoStart cleanup to clearTimeout the pending
+  // call before it fires (recording never starts). See AudioRecorder.tsx.
+  const handleVoiceNote = useCallback(async (voiceNote: { transcription: string | null }) => {
     if (!voiceNote.transcription || !voiceNote.transcription.trim()) {
       setVoiceError('Transcription failed. Please try recording again.')
       setVoiceFlow('recording')
@@ -335,7 +339,7 @@ export default function Students() {
       setVoiceError('Extraction failed. Please try again.')
       setVoiceFlow('recording')
     }
-  }
+  }, [])
 
   async function handleVoiceCreate(rows: DrawerRow[]) {
     setVoiceFlow('saving')


### PR DESCRIPTION
Closes #974

Followup to the merged #971 (PR #972). The spinner-stuck regression user reported was not just a missing UI placeholder — it was a real broken-recording bug exposed by the spinner.

## Root cause

The autoStart `useEffect` in `AudioRecorder.tsx` depended on the identity of `startRecording`. `startRecording` is a `useCallback` whose deps trace back to the parent's `onVoiceNote` prop. Both `Students.tsx` and `StudentDetail.tsx` defined `handleVoiceNote` as a regular function (no `useCallback`), so every parent rerender produced a new prop reference, which cascaded into a new `startRecording` identity, which retriggered the autoStart effect, whose cleanup `clearTimeout`'d the pending `setTimeout(0)` startRecording call. `autoStartedRef.current` was already `true` so the new effect run returned early without rescheduling. `getUserMedia` was never called. Spinner ran forever.

Verified in browser: `micPermission: \"granted\"`, `isSecureContext: true`, spinner visible, no Stop button, no error. The recorder was just stuck because the autoStart call had been silently cancelled.

The unit tests in #964 and #971 didn't catch this because they render `AudioRecorder` directly with stable mocked props. The bug only surfaces with a real parent that rerenders.

## Fix

Two parts:

1. **`AudioRecorder.tsx`** (the structural fix): hold `startRecording` in a ref kept in sync via a tiny `useEffect`, and remove `startRecording` from the autoStart effect's deps. The autoStart effect now reacts only to `[autoStart, state, error]` — the things it actually cares about. Parent rerenders no longer disturb it.

2. **`Students.tsx` + `StudentDetail.tsx`** (defensive hygiene): wrap `handleVoiceNote` in `useCallback`. Even with the AudioRecorder fix, stable parent callbacks prevent this whole class of bug for any other prop chain.

3. **New regression test**: renders the recorder, forces a rerender with a fresh inline `onVoiceNote`, asserts the Stop button still appears. Would have failed before the fix.

## Test plan

- [x] `AudioRecorder.test.tsx` — 16 tests pass (was 15, +1 regression test)
- [x] Frontend test suite — 95 files pass
- [x] `npm lint`, `npm build`, `dotnet build`, `dotnet test`, `bicep build` — all PASS
- [ ] **Manual browser verification (the original bug only surfaces in a real browser):**
  - Click \"New student via voice\" with mic permission already granted → Stop button + timer appear within 1 second
  - Click \"Update via voice\" on student detail page → same
  - During autoStart, trigger parent rerenders (type in another input that causes state changes) → recording still starts

## Related

- #971 / PR #972 added the spinner placeholder, which made this bug visible (was a blank panel before).
- #964 introduced the autoStart pattern.
- #974 is the issue this PR closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a race condition in audio recording that could leave the recorder unresponsive during interface updates.

* **Tests**
  * Added test coverage to prevent regression of audio recording initialization issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->