### PR TITLE
fix(#976): autoStart starts recording in React StrictMode dev (cancelled-flag pattern)

### DIFF
--- a/frontend/src/components/audio/AudioRecorder.test.tsx
+++ b/frontend/src/components/audio/AudioRecorder.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { AudioRecorder } from './AudioRecorder'
@@ -165,6 +166,32 @@ describe('AudioRecorder', () => {
     expect(screen.queryByTestId('record-button')).not.toBeInTheDocument()
     expect(screen.queryByTestId('upload-audio-button')).not.toBeInTheDocument()
     expect(screen.queryByTestId('stop-button')).not.toBeInTheDocument()
+  })
+
+  it('still starts recording under React StrictMode (mount, cleanup, re-mount cycle)', async () => {
+    // Regression: React 18 StrictMode runs effects twice in dev (mount,
+    // cleanup, mount again). The previous implementation set autoStartedRef
+    // synchronously inside the effect body, then scheduled setTimeout(0)
+    // for startRecording. StrictMode's cleanup ran clearTimeout, cancelling
+    // the pending call, but autoStartedRef stayed true (refs persist), so
+    // the second mount returned early at the gate. getUserMedia was never
+    // called and the recorder hung in the starting state.
+    //
+    // The fix flips autoStartedRef inside the setTimeout callback (after
+    // the cancelled check), so the first cleanup leaves the gate open for
+    // the re-mount to re-arm.
+    const mockStream = { getTracks: () => [{ stop: vi.fn() }] }
+    mockGetUserMedia.mockResolvedValue(mockStream)
+
+    render(
+      <StrictMode>
+        <AudioRecorder onVoiceNote={vi.fn()} autoStart />
+      </StrictMode>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('stop-button')).toBeInTheDocument()
+    })
   })
 
   it('still starts recording when the parent rerenders with a new onVoiceNote reference', async () => {

--- a/frontend/src/components/audio/AudioRecorder.tsx
+++ b/frontend/src/components/audio/AudioRecorder.tsx
@@ -150,13 +150,23 @@ export function AudioRecorder({
 
   useEffect(() => {
     if (!autoStart || autoStartedRef.current || state !== 'idle' || error) return
-    autoStartedRef.current = true
     // Defer to a microtask so the effect body does not trigger a synchronous
-    // setState cascade. startRecording() awaits getUserMedia before its first
-    // setState anyway, but the deferred call also satisfies the
-    // react-hooks/set-state-in-effect lint rule.
-    const handle = setTimeout(() => { void startRecordingRef.current() }, 0)
-    return () => clearTimeout(handle)
+    // setState cascade. The local cancelled flag + autoStartedRef set inside
+    // the timeout (rather than synchronously) keeps React 18 StrictMode dev
+    // happy: when StrictMode runs the cleanup before the timeout fires, we
+    // cancel cleanly and the re-mount can re-arm. Setting autoStartedRef
+    // synchronously here would gate off the re-mount and recording would
+    // never start in dev.
+    let cancelled = false
+    const handle = setTimeout(() => {
+      if (cancelled) return
+      autoStartedRef.current = true
+      void startRecordingRef.current()
+    }, 0)
+    return () => {
+      cancelled = true
+      clearTimeout(handle)
+    }
   }, [autoStart, state, error])
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {


### PR DESCRIPTION
Closes #976

Third (and hopefully final) fix in the autoStart saga. The previous fix in #975 made the autoStart effect robust to parent rerenders, but a subtler dev-only bug remained.

## Root cause

React 18 StrictMode (enabled in `main.tsx:11`) runs effects twice on mount in dev (mount, cleanup, mount again) to surface bugs. The autoStart effect set `autoStartedRef.current = true` synchronously inside the effect body, BEFORE the deferred `setTimeout(0)` startRecording call fired. Sequence:

1. Mount run 1: `autoStartedRef.current = true`, schedule setTimeout(0).
2. StrictMode cleanup: `clearTimeout(handle)` cancels the pending call. `autoStartedRef.current` stays true (refs persist across StrictMode cycle).
3. Mount run 2: gate fails, return early. No startRecording ever fires.
4. Result: spinner forever, `getUserMedia` never called.

Verified live: `micPermission: \"granted\"`, direct `getUserMedia` resolves in 78ms, but the component is stuck in `idle`.

## Fix

Flip `autoStartedRef.current = true` **inside** the setTimeout callback (after a local `cancelled` flag check), not synchronously in the effect body. When StrictMode cancels the first attempt, the gate is still `false` and the second mount can re-arm. When the timeout actually fires (in either dev StrictMode or prod), it sets the gate and calls startRecording.

```ts
let cancelled = false
const handle = setTimeout(() => {
  if (cancelled) return
  autoStartedRef.current = true
  void startRecordingRef.current()
}, 0)
return () => {
  cancelled = true
  clearTimeout(handle)
}
```

## New regression test

Wraps AudioRecorder in `<StrictMode>` and asserts the Stop button appears. Would have failed before the fix.

## Test plan

- [x] `AudioRecorder.test.tsx` — 16 tests pass (was 15, +1 StrictMode test)
- [x] Frontend test suite — 95 files pass
- [x] `npm lint`, `npm build`, `dotnet build`, `dotnet test`, `bicep build` — all PASS
- [ ] **Manual browser verification (dev mode is where this matters):**
  - In dev with mic permission granted, click \"New student via voice\" → recording UI appears within 1 second
  - Same on student detail page

## The autoStart saga, summarised

- **#964**: introduced autoStart, hid the chooser when active.
- **#971 / PR #972**: added a spinner placeholder for the autoStart pending window. Made the bug visible (was a blank panel).
- **#974 / PR #975**: fixed the parent-rerender variant — held startRecording in a ref, removed it from the effect deps.
- **This PR (#976)**: fixes the dev-StrictMode variant — moved the gate flip inside the setTimeout callback.

Each fix was correct for the bug it addressed, but each surfaced the next layer because the original implementation's testing (mocked promises that resolve synchronously, no parent context, no StrictMode) bypassed all three failure modes. The lesson is in the meta-discussion captured in #973's procedure update: UX-affecting issues need real-browser verification, not just unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)