### PR TITLE
fix(#978): language pill heights match (inline-block + items-center)

### DIFF
--- a/frontend/src/components/student/StudentOverviewTab.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.tsx
@@ -129,20 +129,20 @@ function PedagogicalProfileCard({ student }: { student: Student }) {
       </div>
 
       {/* Language tags — always rendered; target language always present */}
-      <div className="mt-5 pt-4 border-t border-white/50 flex flex-wrap gap-2" data-testid="language-tags">
+      <div className="mt-5 pt-4 border-t border-white/50 flex flex-wrap items-center gap-2" data-testid="language-tags">
         {student.languages.nativeLanguages.map((lang) => (
           <span
             key={`L-${lang}`}
-            className="bg-[#E2DFFF] text-[#3323CC] rounded-md px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide"
+            className="inline-block bg-[#E2DFFF] text-[#3323CC] rounded-md px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide"
             data-testid="native-language-tag"
           >
             L-{lang.toUpperCase()}
           </span>
         ))}
         <Tooltip>
-          <TooltipTrigger render={<span />}>
+          <TooltipTrigger render={<span className="inline-flex items-center" />}>
             <span
-              className="bg-[#D0F4DE] text-[#1A6636] rounded-md px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide cursor-default"
+              className="inline-block bg-[#D0F4DE] text-[#1A6636] rounded-md px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide cursor-default"
               data-testid="target-language-tag"
             >
               T-{student.learningLanguage.toUpperCase()}


### PR DESCRIPTION
Closes #978

## Summary

L-OTHER and T-SPANISH pills sat side by side at different heights and baselines because the T-SPANISH pill is wrapped inside `TooltipTrigger`'s `<span />`. The inner styled span rendered as `display: inline` (no padding contribution to height) and inherited the body's 24px line-box from the wrapper, while L-OTHER (direct flex child) was blockified with full padding contribution at 24px.

Three small changes that compose to pixel-perfect alignment:
- **`inline-block`** on both pills so padding always contributes to height regardless of nesting depth.
- **`items-center`** on the parent flex so flex items align to a common cross-axis center.
- **`inline-flex items-center`** on the TooltipTrigger wrapper so the inner pill is centered within the wrapper instead of sitting on the wrapper's inherited 24px text baseline.

## Verification

Verified live in browser at `/students/{id}` Overview tab. Both pills now report:
- `y: 433.02` (identical top)
- `height: 18.99` (identical)
- `bottom: 452.01` (identical)
- `yDelta: 0`, `hDelta: 0`

## Test plan

- [x] `npm test` — 1508 tests pass
- [x] `npm lint`, `npm build`, `dotnet build`, `dotnet test`, `bicep build` — all PASS
- [x] Manual browser verification — pills render identical
- [ ] Tooltip on T-SPANISH still works (Vera verified visually pre-PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)