### PR TITLE
fix(#980): preserve teacher input language in student profile extraction

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -3301,6 +3301,28 @@ public class PromptServiceTests
         request.SystemPrompt.Should().NotContain("Student's known difficulties");
     }
 
+    // --- BuildStudentProfileExtractionPrompt ---
+
+    [Fact]
+    public void BuildStudentProfileExtractionPrompt_ContainsLanguagePreservationInstruction()
+    {
+        var request = _sut.BuildStudentProfileExtractionPrompt("teacher notes");
+
+        request.SystemPrompt.Should().Contain("same language as the teacher's input");
+        request.SystemPrompt.Should().Contain("Never translate or switch to English");
+    }
+
+    [Fact]
+    public void BuildStudentProfileExtractionPrompt_SetsHaikuModelAndSanitizesUserText()
+    {
+        const string teacherText = "El alumno es B1 y quiere preparar el DELE.";
+
+        var request = _sut.BuildStudentProfileExtractionPrompt(teacherText);
+
+        request.Model.Should().Be(ClaudeModel.Haiku);
+        request.UserPrompt.Should().Contain("DELE");
+    }
+
     // --- BuildReplanSuggestionPrompt ---
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -3313,7 +3313,7 @@ public class PromptServiceTests
     }
 
     [Fact]
-    public void BuildStudentProfileExtractionPrompt_SetsHaikuModelAndSanitizesUserText()
+    public void BuildStudentProfileExtractionPrompt_SetsHaikuModelAndPassesTeacherText()
     {
         const string teacherText = "El alumno es B1 y quiere preparar el DELE.";
 

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1587,6 +1587,8 @@ public class PromptService : IPromptService
             You are a tool that helps language teachers capture student information from free-form voice notes.
             Extract structured student profile fields from a teacher's free-form text.
 
+            IMPORTANT: All text values in your response MUST be written in the same language as the teacher's input text. If the teacher writes in Spanish, every string value (including profession, reasonForStudying, shortTermObjectives.text, difficulties.description, difficulties.subcategory, interests, and teachingTodoTexts) must be in Spanish. Never translate or switch to English.
+
             IMPORTANT: Be conservative. Only extract a field if the teacher stated it clearly and explicitly.
             When ambiguous or uncertain, return null for that field rather than guessing.
             A confirmation drawer full of wrong guesses destroys teacher trust after one use.


### PR DESCRIPTION
## Summary
- Adds the language-preservation clause to `BuildStudentProfileExtractionPrompt` so Haiku no longer translates Spanish input to English on free-form student fields.
- Bug was visible mostly on student **update** because that's where teachers dictate the long free-form fields (`profession`, `reasonForStudying`, objectives, difficulties, interests, todos). Create flows tended to fill only language-neutral factual fields, hiding the issue.
- Mirrors the existing fix in `BuildReflectionExtractionPrompt` (PR #941).
- Adds two unit tests in `PromptServiceTests` (clause present + Haiku model).

Closes #980

## Test plan
- [x] `dotnet test` passes including the two new assertions.
- [x] `task-build-verify` passes (bicep, dotnet build/test, npm lint/build/test).
- [ ] In a real browser: dictate a Spanish update on an existing student covering profession, an objective, two difficulties and an interest. Drawer must show Spanish strings.
- [ ] Repeat with English input. Drawer must show English strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Student profile extraction now maintains language consistency with teacher input, preventing automatic translation to English.

* **Tests**
  * Added coverage for student profile extraction language constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->