### PR TITLE
fix: wire teachingTodos + teacherFollowups from voice extraction

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceIntegrationTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceIntegrationTests.cs
@@ -167,4 +167,22 @@ public class PromptServiceIntegrationTests
         sections.TryGetProperty("warmUp", out _).Should().BeTrue();
         sections.TryGetProperty("production", out _).Should().BeTrue();
     }
+
+    [SkipIfNoClaudeApiKey]
+    public async Task ReflectionExtraction_AñadeFollowUp_ExtractsTeacherFollowup()
+    {
+        using var tc = BuildClients();
+
+        var pedagogyService = new PedagogyConfigService(NullLogger<PedagogyConfigService>.Instance,
+            new SectionProfileService(NullLogger<SectionProfileService>.Instance));
+        var sut = new ReflectionExtractionService(tc.Client, tc.Prompts, pedagogyService,
+            NullLogger<ReflectionExtractionService>.Instance);
+
+        var result = await sut.ExtractAsync("añade follow up tengo que preparar ejercicios");
+
+        result.TeacherFollowups.Should().NotBeEmpty(
+            "expected 'añade follow up tengo que preparar ejercicios' to produce a teacherFollowups entry");
+        result.TeacherFollowups[0].Should().ContainAny("ejercicio", "preparar",
+            "expected the extracted followup to mention preparing exercises");
+    }
 }

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1558,8 +1558,8 @@ public class PromptService : IPromptService
             - suggestedDifficulties: array of objects (can be empty []) — structured breakdown of the same difficulties mentioned in areasToImprove
             - topicTags: array of objects with "tag" (string) and "category" (string or null) — topics, grammar structures, vocabulary areas covered. Each tag as a concise noun phrase. Empty array if none mentioned.
             - previousHomeworkStatus: "done" | "partial" | "notDone" | null — whether the student completed homework from the previous session. Null if not mentioned.
-            - teachingTodos: array of strings — pedagogical ideas for future sessions (grammar points to revisit, vocabulary to practise, skills to develop; e.g. "hay que practicar el subjuntivo"). Empty array if none.
-            - teacherFollowups: array of strings — operational actions owed by the teacher (send materials, book a test, contact a school; e.g. "le tengo que mandar ejercicios"). Empty array if none.
+            - teachingTodos: array of strings — pedagogical ideas for future sessions (grammar points to revisit, vocabulary to practise, skills to develop; e.g. "hay que practicar el subjuntivo"). Also triggered by imperative phrases like "apunta como teaching todo [X]", "añade como idea [X]". Empty array if none.
+            - teacherFollowups: array of strings — operational actions owed by the teacher (send materials, book a test, contact a school; e.g. "le tengo que mandar ejercicios", "tengo que preparar ejercicios"). Also triggered by imperative phrases like "añade follow up [X]", "apunta follow up [X]", "añade como follow up [X]" — extract the action after the trigger phrase. Empty array if none.
             - levelReassessment: CEFR level string (e.g. "B1", "B2+") or null — if the teacher mentions reassessing or updating the student's level. Null if not mentioned.
             - durationMinutes: integer or null — session duration in minutes. Null if not mentioned.
             - isCancelled: true | false | null — true only if the session was cancelled or the student did not show up. Null if not mentioned.

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -1176,6 +1176,12 @@ export default function LogSession() {
                       extracted.topicTags && extracted.topicTags.length > 0 &&
                       extracted.topicTags.some(t => !snapshot.topicTags.some(s => s.tag.toLowerCase() === t.tag.toLowerCase()))
                     ) changed.add('topicTags')
+
+                    if (extracted.teachingTodos && extracted.teachingTodos.length > 0)
+                      setNewTodos(prev => [...prev, ...extracted.teachingTodos!.filter(t => !prev.includes(t))])
+                    if (extracted.teacherFollowups && extracted.teacherFollowups.length > 0)
+                      setNewFollowups(prev => [...prev, ...extracted.teacherFollowups!.filter(f => !prev.includes(f))])
+
                     if (changed.size > 0) {
                       setPulsingFields(changed)
                       setExtractedFields(changed)

--- a/plan/ui-review-backlog.md
+++ b/plan/ui-review-backlog.md
@@ -25,6 +25,13 @@ Non-blocking findings from review-ui runs. Periodically review this file and bat
 | AudioRecorder component (voice recording panel) | "Upload audio" button uses ghost/outline style next to filled Primary "Record" button. DS section 5 forbids ghost + Primary pairing. Pre-existing from #944, not introduced by #947. | Minor |
 | AudioRecorder component | Record + Upload audio two-button layout is a new pattern not defined in the design system. Pre-existing from #944. | Minor |
 
+## #944 (2026-04-26)
+
+| Screen | Finding | Severity |
+|--------|---------|---------|
+| VoiceUpdateDrawer footer | Ghost Cancel + filled Primary Save on same row inside a drawer/modal footer. DS §5 forbids this pairing for screen-level buttons; rule is ambiguous for modal footers. Needs explicit drawer footer spec in design-system.md. | Minor |
+| VoiceUpdateDrawer inline row edit | Per-row edit uses raw `<input>` (not shadcn `<Input>`). DS §11.1 targets List-Add controls; inline transient edit within a drawer row is not covered. Needs design decision. | Minor |
+
 ## #856 (2026-04-23)
 
 | Screen | Finding | Severity |


### PR DESCRIPTION
## Summary
- Voice extraction returned `teachingTodos` and `teacherFollowups` from the AI but `LogSession.tsx` never read those fields — they were silently dropped after every recording
- Fixed by appending extracted items into the existing "New Teaching Todos" and "New Followups" panels (dedup guard so re-recording doesn't add duplicates)
- Prompt enriched with the `"añade follow up [X]"` / `"apunta follow up [X]"` imperative pattern + added `"tengo que preparar ejercicios"` as an example so Haiku recognises these triggers reliably

## Test plan
- [ ] Record "añade follow up tengo que preparar ejercicios" — item appears in New Followups panel
- [ ] Record a teaching idea — item appears in New Teaching Todos panel
- [ ] Re-recording the same phrase doesn't duplicate the entry
- [ ] Integration test `ReflectionExtraction_AñadeFollowUp_ExtractsTeacherFollowup` passes with `AI_INTEGRATION_TESTS=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)