### PR TITLE
fix(#994): ExtractProfile UpsertTeacherAsync + competency taxonomy + birthYear anchor

### DIFF
--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1625,7 +1625,9 @@ public class PromptService : IPromptService
 
     public ClaudeRequest BuildStudentProfileExtractionPrompt(string text)
     {
-        const string system = """
+        var currentYear = DateTime.UtcNow.Year;
+        var competencies = string.Join(", ", _pedagogy.GetValidDifficultyCompetencies().OrderBy(x => x));
+        var system = $"""
             You are a tool that helps language teachers capture student information from free-form voice notes.
             Extract structured student profile fields from a teacher's free-form text.
 
@@ -1638,7 +1640,7 @@ public class PromptService : IPromptService
 
             Respond ONLY with a valid JSON object using these exact keys:
             - name: string or null — student's full name. Null if not clearly stated.
-            - birthYear: integer or null — student's year of birth (e.g. 1990). Null if not clearly stated or only an age is mentioned without a computable birth year.
+            - birthYear: integer or null — student's year of birth (e.g. 1990). If the teacher states an age rather than a year, compute the birth year as {currentYear} minus the stated age. Null if neither a birth year nor an age is mentioned.
             - profession: string or null — student's job or occupation. Null if not mentioned.
             - countryOfResidence: string or null — country where the student currently lives. Null if not mentioned.
             - cityOfResidence: string or null — city where the student currently lives. Null if not mentioned.
@@ -1653,7 +1655,7 @@ public class PromptService : IPromptService
               Empty array [] if no objectives mentioned.
             - difficulties: array of objects — student weaknesses or trouble areas explicitly mentioned. Each object has:
                 - description: string — full description of the difficulty
-                - competency: string — broad area (e.g. "Grammar", "Vocabulary", "Pronunciation", "Listening", "Speaking", "Reading", "Writing")
+                - competency: string — must be one of: {competencies}
                 - subcategory: string — specific item (e.g. "ser/estar", "subjunctive", "past tense"), free text
               Empty array [] if no difficulties mentioned.
             - teachingTodoTexts: array of strings — pedagogical ideas or reminders for the teacher regarding this student. Empty array [] if none.
@@ -1661,7 +1663,6 @@ public class PromptService : IPromptService
 
             Use null for scalar fields that cannot be clearly inferred from the text.
             Keep each value concise.
-            Respond with JSON only, no markdown, no explanation.
             """;
 
         return new ClaudeRequest(SystemPrompt: system, UserPrompt: InputSanitizer.Sanitize(text), Model: ClaudeModel.Haiku, MaxTokens: 1024);

--- a/backend/LangTeach.Api/Controllers/StudentsController.cs
+++ b/backend/LangTeach.Api/Controllers/StudentsController.cs
@@ -196,7 +196,8 @@ public class StudentsController : ControllerBase
         if (Auth0Id is null) return Unauthorized();
         if (!ModelState.IsValid) return BadRequest(ModelState);
 
-        _logger.LogInformation("POST /api/students/extract-profile. Auth0Id={Auth0Id} TextLength={TextLength}", Auth0Id, request.Text.Length);
+        var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
+        _logger.LogInformation("POST /api/students/extract-profile. TeacherId={TeacherId} TextLength={TextLength}", teacherId, request.Text.Length);
         var extracted = await _extractionService.ExtractAsync(request.Text, cancellationToken);
         return Ok(extracted);
     }


### PR DESCRIPTION
Closes #994

## Summary

Three critical findings from Stage 1b branch review, all in two files.

- **AR-1:** `ExtractProfile` in `StudentsController` now calls `UpsertTeacherAsync` before doing work, consistent with every other write endpoint in the controller.
- **PH-1:** `BuildStudentProfileExtractionPrompt` now injects the live competency list from `_pedagogy.GetValidDifficultyCompetencies()` instead of hardcoded macro-skills (`Listening/Speaking/Reading/Writing`) that fail `StudentService.ValidateDifficulties()` at save time.
- **PH-2:** `birthYear` instruction now injects `DateTime.UtcNow.Year` so the model can compute birth year from age with a real anchor instead of hallucinating from its training distribution.
- **PH-3:** Removed duplicate trailing "Respond with JSON only" line (already stated at top of same prompt).

## Test plan

- [ ] `dotnet test` — 340 passed, 0 failed
- [ ] `npm test` — 95 passed, 0 failed
- [ ] Record a voice note mentioning a student difficulty with a canonical competency (e.g. "tiene problemas con gramática"). Confirm drawer shows it without save error.
- [ ] Record a voice note mentioning only an age ("tiene 34 años"). Confirm birthYear is computed as current year minus age, not hallucinated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Profile extraction now correctly computes birth year from stated age.
  * Competency validation uses dynamically configured difficulty levels for greater accuracy.
  * Enhanced logging for improved system monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->