### PR TITLE
feat(#1006): DS token/button fixes — ghost hover, secondary tonal bg, AudioRecorder pairing

### DIFF
--- a/frontend/src/components/audio/AudioRecorder.tsx
+++ b/frontend/src/components/audio/AudioRecorder.tsx
@@ -214,7 +214,7 @@ export function AudioRecorder({
           </Button>
           <Button
             type="button"
-            variant="outline"
+            variant="secondary"
             size="sm"
             onClick={() => fileInputRef.current?.click()}
             disabled={isDisabled}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
-          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+          "hover:bg-surface-container-low hover:text-foreground aria-expanded:bg-surface-container-low aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:
           "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
         link: "text-primary underline-offset-4 hover:underline",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -28,8 +28,9 @@
     /* indigo-800 primary */
     --primary: oklch(0.398 0.195 277.366);
     --primary-foreground: oklch(0.985 0 0);
-    --secondary: oklch(0.97 0 0);
+    --secondary: #F4F2FD;
     --secondary-foreground: oklch(0.205 0 0);
+    --surface-container-low: #F4F2FD;
     --muted: oklch(0.97 0 0);
     --muted-foreground: oklch(0.556 0 0);
     --accent: oklch(0.97 0 0);
@@ -110,6 +111,7 @@
     --color-destructive: var(--destructive);
     --color-accent-foreground: var(--accent-foreground);
     --color-accent: var(--accent);
+    --color-surface-container-low: var(--surface-container-low);
     --color-muted-foreground: var(--muted-foreground);
     --color-muted: var(--muted);
     --color-secondary-foreground: var(--secondary-foreground);


### PR DESCRIPTION
Closes #1006

## Summary

- **Ghost button hover:** Replace `hover:bg-muted` (near-white) with new `--surface-container-low: #F4F2FD` (lavender). Matches DS §5 spec and `docs/design-system.md` line 228. Fixes all 20+ ghost button instances in one token change.
- **Secondary tonal background:** `--secondary` updated from `oklch(0.97 0 0)` (near-white, visually ghost) to `#F4F2FD` (lavender). Fixes "New student via voice" button DS §5 violation — now reads as a visible secondary alongside the gradient primary "Add Student" CTA.
- **AudioRecorder button pairing:** Upload button `variant="outline"` → `variant="secondary"` in idle state. Record (filled primary) + Upload (secondary/lavender) now belong to the same visual family per DS §5.

## Test plan

- [ ] Students list: confirm "New student via voice" has visible lavender background next to "Add Student" gradient primary
- [ ] Student detail: open voice recorder panel, confirm Record + Upload read as a primary+secondary pair
- [ ] Any screen with ghost buttons: hover should show lavender, not near-white
- [ ] Confirm no regressions in outline/muted/badge surfaces (Badge overrides with explicit className are unaffected)

## Review findings summary

| Reviewer | Finding | Action |
|---|---|---|
| qa-verify | Criterion 3 unconfirmed from diff alone | Dismissed — `Students.tsx:419` already uses `variant="secondary"`, confirmed pre-implementation |
| Code review | Hex vs oklch format for `--surface-container-low` | Dismissed — keeping hex `#F4F2FD` preserves the explicit DS spec reference from `design-system.md` |
| review-ui | All 3 criteria visually confirmed (PASS) | Fixed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button styling for improved visual consistency across the interface
  * Refined theme color palette for a refreshed appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->