### PR TITLE
fix(#991): e2e spec fixes — CS1998 warning + midnight UTC flaky test

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/TelegramControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/TelegramControllerTests.cs
@@ -125,11 +125,11 @@ public class TelegramControllerTests
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
-    private async Task<Guid> GetTeacherIdAsync(string auth0Id)
+    private Task<Guid> GetTeacherIdAsync(string auth0Id)
     {
         using var scope = _factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
         var teacher = db.Teachers.First(t => t.Auth0UserId == auth0Id);
-        return teacher.Id;
+        return Task.FromResult(teacher.Id);
     }
 }

--- a/e2e/tests/visual/student-detail.visual.spec.ts
+++ b/e2e/tests/visual/student-detail.visual.spec.ts
@@ -116,7 +116,7 @@ test('@visual student detail sessions tab - expanded row with editable fields', 
   await expect(page.getByTestId('session-history-list')).toBeVisible({ timeout: UI_TIMEOUT })
   await page.getByTestId('session-entry-toggle').first().click()
   await expect(page.getByTestId('session-entry-detail').first()).toBeVisible({ timeout: UI_TIMEOUT })
-  await expect(page.getByTestId('log-session-title-input').first()).toBeVisible({ timeout: UI_TIMEOUT })
+  await expect(page.getByTestId('session-title-input').first()).toBeVisible({ timeout: UI_TIMEOUT })
   await page.screenshot({ path: 'screenshots/student-detail-session-expanded.png', fullPage: true })
 
   expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)

--- a/e2e/tests/visual/student-detail.visual.spec.ts
+++ b/e2e/tests/visual/student-detail.visual.spec.ts
@@ -116,7 +116,7 @@ test('@visual student detail sessions tab - expanded row with editable fields', 
   await expect(page.getByTestId('session-history-list')).toBeVisible({ timeout: UI_TIMEOUT })
   await page.getByTestId('session-entry-toggle').first().click()
   await expect(page.getByTestId('session-entry-detail').first()).toBeVisible({ timeout: UI_TIMEOUT })
-  await expect(page.getByTestId('session-title-input').first()).toBeVisible({ timeout: UI_TIMEOUT })
+  await expect(page.getByTestId('log-session-title-input').first()).toBeVisible({ timeout: UI_TIMEOUT })
   await page.screenshot({ path: 'screenshots/student-detail-session-expanded.png', fullPage: true })
 
   expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)

--- a/frontend/src/pages/LogSession.test.tsx
+++ b/frontend/src/pages/LogSession.test.tsx
@@ -170,7 +170,8 @@ describe('LogSession', () => {
   it('date defaults to today', async () => {
     renderLogSession()
     await screen.findByTestId('session-date')
-    const today = new Date().toISOString().split('T')[0]
+    const d = new Date()
+    const today = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
     expect(screen.getByTestId('session-date')).toHaveValue(today)
   })
 


### PR DESCRIPTION
## Summary

- Removes `async` from `TelegramControllerTests.GetTeacherIdAsync` (CS1998: async method without await since #545). Returns `Task.FromResult(teacher.Id)`.
- Fixes `LogSession.test.tsx` "date defaults to today" flaky failure at midnight UTC: replaces `new Date().toISOString().split('T')[0]` (UTC) with `getFullYear/getMonth/getDate` (local time), matching how `LogSession.tsx` builds its default via `todayLocalDateStr()`.
- Note: `session-log-voice.spec.ts` old modal refs were already gone in HEAD. `student-detail.visual.spec.ts` `session-title-input` testid is correct for the `SessionHistoryTab` component (architecture review confirmed, revert committed).

All changes are test-only; no production code touched.

Closes #991

## Test plan

- [ ] `dotnet test` passes (CS1998 warning gone)
- [ ] `npm test` passes (LogSession "date defaults to today" is timezone-safe)
- [ ] No regressions in other specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)