### PR TITLE
feat(#1008): Atelier Assistant panel shell

### DIFF
--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -266,6 +266,25 @@ describe('AppShell', () => {
     expect(screen.getByTestId('assistant-panel')).toBeInTheDocument()
   })
 
+  it('assistant empty state shows generic prompt on /students/new (not student-specific)', async () => {
+    const user = userEvent.setup()
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const { unmount } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/students/new']}>
+          <AppShell />
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+    const aside = document.querySelector('aside')
+    const openBtn = aside?.querySelector('[data-testid="open-assistant-btn"]') as HTMLElement
+    await user.click(openBtn)
+    // Should show generic prompt, not "What did you cover with new today?"
+    expect(screen.queryByText(/What did you cover with/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/What would you like to cover today/i)).toBeInTheDocument()
+    unmount()
+  })
+
   it('Escape with transcription shows inline discard confirm instead of closing', async () => {
     const user = userEvent.setup()
     renderShell()

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -266,6 +266,21 @@ describe('AppShell', () => {
     expect(screen.getByTestId('assistant-panel')).toBeInTheDocument()
   })
 
+  it('Escape with transcription shows inline discard confirm instead of closing', async () => {
+    const user = userEvent.setup()
+    renderShell()
+    const aside = document.querySelector('aside')
+    const openBtn = aside?.querySelector('[data-testid="open-assistant-btn"]') as HTMLElement
+    await user.click(openBtn)
+    const input = screen.getByTestId('assistant-input')
+    await user.type(input, 'Hoy hemos trabajado el subjuntivo')
+    await user.click(screen.getByTestId('assistant-send-btn'))
+    // Now there is a transcription — Escape should show confirm, not close
+    await user.keyboard('{Escape}')
+    expect(screen.getByTestId('assistant-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('discard-confirm')).toBeInTheDocument()
+  })
+
   it('Open Assistant button shows active state class when panel is open', async () => {
     const user = userEvent.setup()
     renderShell()

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -139,7 +139,8 @@ const STUDENT_ID_RE = /^\/students\/([^/]+)/
 
 function extractStudentId(pathname: string): string | null {
   const match = pathname.match(STUDENT_ID_RE)
-  return match ? match[1] : null
+  if (!match) return null
+  return match[1] === 'new' ? null : match[1]
 }
 
 export default function AppShell() {
@@ -156,7 +157,6 @@ export default function AppShell() {
     queryFn: () => getStudent(studentId!),
     enabled: studentId !== null,
     select: (s) => s.name,
-    staleTime: 5 * 60 * 1000,
   })
 
   // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,12 +1,15 @@
 import { useState, useEffect, type ElementType } from 'react'
 import { Link, Outlet, useLocation } from 'react-router-dom'
 import { useAuth0 } from '@auth0/auth0-react'
-import { LayoutDashboard, Users, CalendarDays, BookOpen, GraduationCap, Settings, LogOut, Menu, Sparkles, HelpCircle, X } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+import { LayoutDashboard, Users, CalendarDays, BookOpen, GraduationCap, Settings, LogOut, Menu, Sparkles, HelpCircle } from 'lucide-react'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { cn } from '@/lib/utils'
 import LangTeachLogo from '@/components/LangTeachLogo'
-import { Sheet, SheetClose, SheetContent } from '@/components/ui/sheet'
+import { Sheet, SheetContent } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
+import AtelierAssistantPanel from '@/components/AtelierAssistantPanel'
+import { getStudent } from '@/api/students'
 
 const mainNavItems = [
   { to: '/', label: 'Dashboard', icon: LayoutDashboard },
@@ -132,11 +135,29 @@ function SidebarContent({ user, initials, logout, location, assistantOpen, onTog
   )
 }
 
+const STUDENT_ID_RE = /^\/students\/([^/]+)/
+
+function extractStudentId(pathname: string): string | null {
+  const match = pathname.match(STUDENT_ID_RE)
+  return match ? match[1] : null
+}
+
 export default function AppShell() {
   const { user, logout } = useAuth0()
   const location = useLocation()
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [assistantOpen, setAssistantOpen] = useState(false)
+  const [transcription, setTranscription] = useState<string | null>(null)
+
+  const studentId = extractStudentId(location.pathname)
+
+  const { data: studentData } = useQuery({
+    queryKey: ['student', studentId],
+    queryFn: () => getStudent(studentId!),
+    enabled: studentId !== null,
+    select: (s) => s.name,
+    staleTime: 5 * 60 * 1000,
+  })
 
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { setDrawerOpen(false) }, [location.pathname])
@@ -229,34 +250,15 @@ export default function AppShell() {
         </main>
       </div>
 
-      {/* Assistant stub panel */}
-      <Sheet open={assistantOpen} onOpenChange={setAssistantOpen}>
-        <SheetContent
-          data-testid="assistant-panel"
-          className="right-0 left-auto w-[360px] max-w-full flex flex-col p-0 shadow-[0_8px_40px_0_rgb(26_27_34_/_0.12)] data-open:slide-in-from-right data-closed:slide-out-to-right"
-        >
-          <div className="flex items-center justify-between px-5 py-4">
-            <div className="flex items-center gap-2">
-              <div className="h-7 w-7 rounded-full bg-[linear-gradient(135deg,var(--color-primary),#4F46E5)] flex items-center justify-center">
-                <Sparkles className="h-3.5 w-3.5 text-white" />
-              </div>
-              <span className="font-semibold font-inter text-sm text-zinc-900">Atelier Assistant</span>
-            </div>
-            <SheetClose
-              aria-label="Close Assistant"
-              className="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 transition-colors"
-            >
-              <X className="h-4 w-4" />
-            </SheetClose>
-          </div>
-          <div className="flex-1 flex items-center justify-center px-6 text-center">
-            <div className="space-y-2">
-              <Sparkles className="h-8 w-8 text-zinc-200 mx-auto" />
-              <p className="text-sm text-zinc-400 font-inter">Voice and chat assistant coming soon.</p>
-            </div>
-          </div>
-        </SheetContent>
-      </Sheet>
+      {/* Atelier Assistant panel */}
+      <AtelierAssistantPanel
+        open={assistantOpen}
+        onClose={() => setAssistantOpen(false)}
+        onCloseDiscarding={() => { setAssistantOpen(false); setTranscription(null) }}
+        studentName={studentData}
+        transcription={transcription}
+        onSubmit={(text) => setTranscription(text)}
+      />
     </div>
   )
 }

--- a/frontend/src/components/AtelierAssistantPanel.test.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import AtelierAssistantPanel from './AtelierAssistantPanel'
+
+function renderPanel(overrides: Partial<Parameters<typeof AtelierAssistantPanel>[0]> = {}) {
+  const props = {
+    open: true,
+    onClose: vi.fn(),
+    onCloseDiscarding: vi.fn(),
+    studentName: undefined,
+    transcription: null,
+    onSubmit: vi.fn(),
+    ...overrides,
+  }
+  return { ...render(<AtelierAssistantPanel {...props} />), props }
+}
+
+describe('AtelierAssistantPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders header: title, status indicator, and close button', () => {
+    renderPanel()
+    expect(screen.getByText('Atelier Assistant')).toBeInTheDocument()
+    expect(screen.getByText('Ready')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /close assistant/i })).toBeInTheDocument()
+  })
+
+  it('renders empty state with generic prompt when no student name', () => {
+    renderPanel({ transcription: null, studentName: undefined })
+    expect(screen.getByTestId('assistant-empty-state')).toBeInTheDocument()
+    expect(screen.getByText(/What would you like to cover today/i)).toBeInTheDocument()
+  })
+
+  it('renders empty state with student name when provided', () => {
+    renderPanel({ transcription: null, studentName: 'Ana' })
+    expect(screen.getByText(/What did you cover with Ana today/i)).toBeInTheDocument()
+  })
+
+  it('renders text input and send button', () => {
+    renderPanel()
+    expect(screen.getByTestId('assistant-input')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /send message/i })).toBeInTheDocument()
+  })
+
+  it('calls onSubmit and clears input on Enter', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    renderPanel({ onSubmit })
+    const input = screen.getByTestId('assistant-input')
+    await user.type(input, 'Worked on the subjunctive')
+    await user.keyboard('{Enter}')
+    expect(onSubmit).toHaveBeenCalledWith('Worked on the subjunctive')
+    expect(input).toHaveValue('')
+  })
+
+  it('calls onSubmit and clears input on send button click', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    renderPanel({ onSubmit })
+    const input = screen.getByTestId('assistant-input')
+    await user.type(input, 'Vocabulary review')
+    await user.click(screen.getByTestId('assistant-send-btn'))
+    expect(onSubmit).toHaveBeenCalledWith('Vocabulary review')
+    expect(input).toHaveValue('')
+  })
+
+  it('send button is disabled when input is empty', () => {
+    renderPanel()
+    expect(screen.getByRole('button', { name: /send message/i })).toBeDisabled()
+  })
+
+  it('shows transcription block and proposals stub after submission', () => {
+    renderPanel({ transcription: 'Worked on present perfect.' })
+    expect(screen.getByTestId('transcription-block')).toBeInTheDocument()
+    expect(screen.getByText('Worked on present perfect.')).toBeInTheDocument()
+    expect(screen.getByText('Proposed Updates')).toBeInTheDocument()
+    expect(screen.getByText('(coming soon)')).toBeInTheDocument()
+  })
+
+  it('shows transcription in italic blockquote style', () => {
+    renderPanel({ transcription: 'Some text here.' })
+    const block = screen.getByTestId('transcription-block')
+    expect(block.tagName.toLowerCase()).toBe('blockquote')
+    expect(block.className).toContain('italic')
+  })
+
+  it('calls onClose immediately on X click when no transcription', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    renderPanel({ transcription: null, onClose })
+    await user.click(screen.getByRole('button', { name: /close assistant/i }))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('shows inline discard confirm on X click when transcription exists', async () => {
+    const user = userEvent.setup()
+    renderPanel({ transcription: 'Some content.' })
+    await user.click(screen.getByRole('button', { name: /close assistant/i }))
+    expect(screen.getByTestId('discard-confirm')).toBeInTheDocument()
+  })
+
+  it('calls onCloseDiscarding and hides confirm when Discard pressed', async () => {
+    const user = userEvent.setup()
+    const onCloseDiscarding = vi.fn()
+    renderPanel({ transcription: 'Some content.', onCloseDiscarding })
+    await user.click(screen.getByRole('button', { name: /close assistant/i }))
+    await user.click(screen.getByTestId('discard-confirm-yes'))
+    expect(onCloseDiscarding).toHaveBeenCalled()
+  })
+
+  it('hides confirm and keeps panel open when Keep editing pressed', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    renderPanel({ transcription: 'Some content.', onClose })
+    await user.click(screen.getByRole('button', { name: /close assistant/i }))
+    expect(screen.getByTestId('discard-confirm')).toBeInTheDocument()
+    await user.click(screen.getByTestId('discard-confirm-cancel'))
+    expect(screen.queryByTestId('discard-confirm')).not.toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not render when open is false', () => {
+    renderPanel({ open: false })
+    expect(screen.queryByTestId('assistant-panel')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Sparkles, X, Send } from 'lucide-react'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
 import { Input } from '@/components/ui/input'
@@ -22,6 +22,12 @@ export default function AtelierAssistantPanel({
 }: Props) {
   const [inputValue, setInputValue] = useState('')
   const [pendingClose, setPendingClose] = useState(false)
+
+  useEffect(() => {
+    if (!open || transcription === null) {
+      setPendingClose(false)
+    }
+  }, [open, transcription])
 
   function handleCloseAttempt() {
     if (transcription !== null) {

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -1,0 +1,163 @@
+import { useState } from 'react'
+import { Sparkles, X, Send } from 'lucide-react'
+import { Sheet, SheetContent } from '@/components/ui/sheet'
+import { Input } from '@/components/ui/input'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  onCloseDiscarding: () => void
+  studentName?: string
+  transcription: string | null
+  onSubmit: (text: string) => void
+}
+
+export default function AtelierAssistantPanel({
+  open,
+  onClose,
+  onCloseDiscarding,
+  studentName,
+  transcription,
+  onSubmit,
+}: Props) {
+  const [inputValue, setInputValue] = useState('')
+  const [pendingClose, setPendingClose] = useState(false)
+
+  function handleCloseAttempt() {
+    if (transcription !== null) {
+      setPendingClose(true)
+    } else {
+      onClose()
+    }
+  }
+
+  function handleSheetOpenChange(newOpen: boolean) {
+    if (!newOpen) handleCloseAttempt()
+  }
+
+  function handleSubmit() {
+    const text = inputValue.trim()
+    if (!text) return
+    onSubmit(text)
+    setInputValue('')
+    setPendingClose(false)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      handleSubmit()
+    }
+  }
+
+  const emptyPrompt = studentName
+    ? `What did you cover with ${studentName} today?`
+    : 'What would you like to cover today?'
+
+  return (
+    <Sheet open={open} onOpenChange={handleSheetOpenChange}>
+      <SheetContent
+        data-testid="assistant-panel"
+        className="right-0 left-auto w-[380px] max-w-full flex flex-col p-0 backdrop-blur-[12px] bg-white/80 shadow-[0_8px_40px_0_rgb(26_27_34_/_0.12)] data-open:slide-in-from-right data-closed:slide-out-to-right"
+      >
+        {/* Header */}
+        <div className="flex items-center px-5 py-4 gap-2 shrink-0">
+          <div className="h-7 w-7 rounded-full bg-[linear-gradient(135deg,var(--color-primary),#4F46E5)] flex items-center justify-center shrink-0">
+            <Sparkles className="h-3.5 w-3.5 text-white" aria-hidden="true" />
+          </div>
+          <span className="font-semibold font-inter text-sm text-[#1A1B22] flex-1">Atelier Assistant</span>
+          <div className="flex items-center gap-1.5 mr-3" role="status" aria-label="Status: Ready">
+            <span className="h-2 w-2 rounded-full bg-emerald-500 shrink-0" aria-hidden="true" />
+            <span className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter">Ready</span>
+          </div>
+          <button
+            onClick={handleCloseAttempt}
+            aria-label="Close Assistant"
+            className="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Discard confirm (inline, no browser dialog) */}
+        {pendingClose && (
+          <div
+            className="mx-4 mb-3 px-4 py-3 rounded-xl bg-amber-50 flex items-center justify-between gap-3 shrink-0"
+            data-testid="discard-confirm"
+          >
+            <span className="text-sm font-inter text-zinc-700 flex-1">Close and discard?</span>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => { setPendingClose(false); onCloseDiscarding() }}
+                data-testid="discard-confirm-yes"
+                className="text-sm font-inter font-medium text-red-600 hover:text-red-700 transition-colors px-2 py-1 rounded-lg hover:bg-red-50"
+              >
+                Discard
+              </button>
+              <button
+                onClick={() => setPendingClose(false)}
+                data-testid="discard-confirm-cancel"
+                className="text-sm font-inter font-medium text-indigo-600 hover:text-indigo-700 transition-colors px-2 py-1 rounded-lg hover:bg-indigo-50"
+              >
+                Keep editing
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          {transcription === null ? (
+            <div className="flex flex-col items-center justify-center h-full text-center gap-3" data-testid="assistant-empty-state">
+              <Sparkles className="h-8 w-8 text-zinc-200" aria-hidden="true" />
+              <p className="text-sm font-inter text-zinc-400">{emptyPrompt}</p>
+            </div>
+          ) : (
+            <div className="space-y-5" data-testid="assistant-transcription-view">
+              <div>
+                <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mb-2">
+                  Transcription
+                </p>
+                <blockquote
+                  className="border-l-2 border-indigo-300 pl-3 italic text-sm font-inter text-zinc-700"
+                  data-testid="transcription-block"
+                >
+                  {transcription}
+                </blockquote>
+              </div>
+              <div>
+                <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mb-2">
+                  Proposed Updates
+                </p>
+                <p className="text-sm font-inter text-zinc-400">(coming soon)</p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer: text input */}
+        <div className="px-4 pb-4 pt-2 shrink-0">
+          <div className="flex items-center gap-2">
+            <Input
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="What did you cover today?"
+              className="flex-1 bg-[#F4F2FD] border-0 focus-visible:ring-0 rounded-xl h-10 px-4 text-sm font-inter"
+              data-testid="assistant-input"
+            />
+            <button
+              onClick={handleSubmit}
+              disabled={!inputValue.trim()}
+              aria-label="Send message"
+              className="h-10 w-10 flex items-center justify-center rounded-xl bg-[linear-gradient(135deg,var(--color-primary),#4F46E5)] text-white disabled:opacity-40 transition-opacity shrink-0"
+              data-testid="assistant-send-btn"
+            >
+              <Send className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { Sparkles, X, Send } from 'lucide-react'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
 import { Input } from '@/components/ui/input'
@@ -23,12 +23,6 @@ export default function AtelierAssistantPanel({
   const [inputValue, setInputValue] = useState('')
   const [pendingClose, setPendingClose] = useState(false)
 
-  useEffect(() => {
-    if (!open || transcription === null) {
-      setPendingClose(false)
-    }
-  }, [open, transcription])
-
   function handleCloseAttempt() {
     if (transcription !== null) {
       setPendingClose(true)
@@ -38,7 +32,11 @@ export default function AtelierAssistantPanel({
   }
 
   function handleSheetOpenChange(newOpen: boolean) {
-    if (!newOpen) handleCloseAttempt()
+    if (newOpen) {
+      setPendingClose(false)
+    } else {
+      handleCloseAttempt()
+    }
   }
 
   function handleSubmit() {

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -7,3 +7,7 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 *Cleared 2026-04-22 during UI Redesign & Student Profile Polish sprint close. Actionable entries batched into #833 (bug batch: todo validation + countdown + difficulty feedback), #837 (deduplication: getInitials/formatRelativeDate/CEFR_ORDER). Remaining entries deleted (verified safe, intentional per spec, already tracked in #737/#707/#644/#714/#715/#716/#683/#741/#742/#756/#809/#657, or consistent with existing patterns).*
 
 *Cleared 2026-04-27 during Student Profile Voice Input sprint close. Actionable entries batched into #989 (DS component polish), #990 (code hardening), #992 (navigation UX). Dismissed and cosmetic entries deleted (#927 dismissed, #947 rename too cosmetic).*
+
+## #1008 (2026-04-28)
+
+- **AppShell transcription state lift** (arch-reviewer): `transcription: string | null` for the Atelier Assistant lives in AppShell. This works for part 1 but deviates from the pattern of sub-panel state living local or in a dedicated context (compare `VoiceUpdateDrawer` state in `StudentDetail.tsx`). If parts 2/3 add more cross-cutting assistant state (proposals, selection, apply flow), refactor to a dedicated `AtelierAssistantContext` provider. Deferred — assess at #1009.

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -4,6 +4,7 @@ Out-of-scope observations logged by agents during implementation. Each row is so
 
 | Source issue | Date | Severity | Observation |
 | #1002 | 2026-04-28 | low | Keyboard shortcut hint (⌘K label-sm text below sidebar CTA) is an undocumented pattern in the design system. Needs Vera sign-off before it becomes a reusable convention. |
+| #1002 | 2026-04-28 | medium | AppShell sidebar links to `/help` (added by #1002) but no route exists in App.tsx. Clicking Help navigates to an unmatched screen. Needs a Help page or the link removed. |
 
 *Cleared 2026-04-22 during UI Redesign & Student Profile Polish sprint close. Actionable entries batched into: #833 (bug batch), #834 (seeder gaps), #835 (e2e session-log rewrite), #836 (ScenarioSeeder Hans B1), #837 (deduplication), #838 (session title from web UI), #839 (debug log privacy), #840 (Edit Student UX), #841 (stale closure + LogSession pre-populate). Already-tracked entries removed (referenced #737/#707/#644/#714/#715/#716/#683/#741/#742/#756/#809/#657). Dismissed entries removed (defensive-only, intentional, or resolved).*
 

--- a/plan/ui-review-backlog.md
+++ b/plan/ui-review-backlog.md
@@ -7,3 +7,10 @@ Non-blocking findings from review-ui runs. Periodically review this file and bat
 *Cleared 2026-04-22 during UI Redesign & Student Profile Polish sprint close. Seeder coverage gaps batched into #834. UX polish items (combobox summary, Focus Areas description) batched into #840. Remaining entries deleted (intentional per Stitch spec, covered by unit tests, or pre-existing infrastructure).*
 
 *Cleared 2026-04-27 during Student Profile Voice Input sprint close. DS/component findings batched into #989 (DS component polish batch). Seeder coverage gap (#904) batched into #991 (e2e test fixes). Environment-only entry (#906) deleted. Navigation findings batched into #992.*
+
+## #1008 (2026-04-28) — Atelier Assistant panel (new patterns, not violations)
+
+- [1] Inline discard confirm (amber-50 bg, "Close and discard?" + Discard/Keep editing): new pattern for inline confirmation inside a Sheet panel — not covered in design-system.md. Works visually, needs Vera review before it becomes a repeated pattern.
+- [2] Transcription blockquote display (`border-l-2 border-indigo-300 italic`): new pattern for AI-returned verbatim content — not covered in design-system.md. Looks correct but no spec for content display blocks.
+- [3] "READY" status indicator (green dot + all-caps Label-SM in panel header): new pattern for live panel status — not covered in design-system.md.
+- [4] "PROPOSED UPDATES / (coming soon)" placeholder section: new pattern for pending-feature sections — acceptable for part 1 stub, will be replaced in #1009.


### PR DESCRIPTION
Closes #1008

Builds on top of #1015 (Open Assistant CTA). Replaces the stub panel with the full shell.

## Summary

- New `AtelierAssistantPanel` component: slides in from the right (~380px desktop, full-screen mobile), glassmorphism surface (`bg-white/80 + backdrop-blur-[12px]`), no 1px borders
- **Header**: indigo sparkle gradient circle + "Atelier Assistant" title + green dot + "READY" status indicator + X close button
- **Empty state**: "What did you cover with [student] today?" when on a student route (name fetched from shared `['student', id]` cache), generic prompt otherwise
- **Text input** pinned at footer: placeholder "What did you cover today?", submits on Enter or send button
- **TRANSCRIPTION block**: submitted text appears verbatim in italic blockquote above "Proposed Updates" + "(coming soon)" stub
- **Inline discard confirm**: pressing X or Escape while transcription exists shows an amber-50 banner with Discard / Keep editing — no browser dialog
- **Persistence**: transcription state lives in `AppShell` alongside `assistantOpen`, so it survives in-app navigation
- No LLM call (part 1 of 3)

## Context detection

`extractStudentId(pathname)` regex extracts the student ID from `/students/:id/*` routes. Student name fetched via `useQuery(['student', id])` (shares cache with `StudentDetail`).

## Test plan

- [x] 40 unit tests (15 panel + 25 AppShell), all pass
- [x] TypeScript clean
- [x] Build verify: all checks pass (96 tests)
- [x] QA verify: PASS (added Escape-with-transcription integration test)
- [x] Architecture review: PASS WITH NOTES (removed `staleTime` mismatch; transcription-in-AppShell tradeoff logged to code-review-backlog for #1009)
- [x] UI review: PASS (4 new-pattern gaps logged to ui-review-backlog, no violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Atelier Assistant panel with a message input, transcription display, and a discard-confirm flow when closing with unsaved transcription.
  * Empty-state prompt now adapts to student context when viewing a student profile.

* **Tests**
  * New tests covering panel rendering, submission (Enter/button), transcription behavior, discard-confirm handling, and student-aware empty-state copy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->