### PR TITLE
feat(#1001): apply 135deg gradient to primary CTAs

### DIFF
--- a/frontend/src/components/audio/AudioRecorder.tsx
+++ b/frontend/src/components/audio/AudioRecorder.tsx
@@ -206,7 +206,6 @@ export function AudioRecorder({
             size="sm"
             onClick={startRecording}
             disabled={isDisabled}
-            className="bg-primary hover:bg-primary/90 text-white"
             data-testid="record-button"
           >
             <Mic className="h-4 w-4 mr-1" />

--- a/frontend/src/components/lesson/FullLessonGenerateButton.tsx
+++ b/frontend/src/components/lesson/FullLessonGenerateButton.tsx
@@ -290,7 +290,6 @@ export function FullLessonGenerateButton({
                 <AlertDialogCancel onClick={handleCancel}>Cancel</AlertDialogCancel>
                 <AlertDialogAction
                   onClick={handleConfirm}
-                  className="bg-primary hover:bg-primary/90 text-white"
                   data-testid="confirm-generate-full-lesson"
                 >
                   Generate

--- a/frontend/src/components/lesson/GeneratePanel.tsx
+++ b/frontend/src/components/lesson/GeneratePanel.tsx
@@ -416,7 +416,7 @@ export function GeneratePanel({
             size="sm"
             onClick={handleGenerate}
             disabled={isQuotaExhausted || quotaExceeded || allowedTypes.length === 0}
-            className="bg-primary hover:bg-primary/90 text-white text-xs"
+            className="text-xs"
             data-testid="generate-btn"
           >
             {isError && !quotaExceeded ? 'Retry' : 'Generate'}
@@ -438,7 +438,7 @@ export function GeneratePanel({
               size="sm"
               onClick={handleInsertOrReplace}
               disabled={inserting}
-              className="bg-primary hover:bg-primary/90 text-white text-xs"
+              className="text-xs"
               data-testid="insert-btn"
             >
               {inserting

--- a/frontend/src/components/settings/TelegramCard.tsx
+++ b/frontend/src/components/settings/TelegramCard.tsx
@@ -176,7 +176,6 @@ export function TelegramCard() {
         size="sm"
         onClick={() => generate.mutate()}
         disabled={generate.isPending}
-        className="bg-primary hover:bg-primary/90"
         data-testid="telegram-connect-btn"
       >
         {generate.isPending ? 'Generating...' : 'Connect Telegram'}

--- a/frontend/src/components/student/StudentDetailHeader.tsx
+++ b/frontend/src/components/student/StudentDetailHeader.tsx
@@ -205,8 +205,7 @@ export function StudentDetailHeader({ student, nextSession, sessionFrequency, on
           </Link>
           <Button
             onClick={() => navigate(`/students/${student.id}/log-session`)}
-            className="rounded-xl text-white text-sm font-medium"
-            style={{ background: 'linear-gradient(135deg, #3525CD, #4F46E5)' }}
+            className="rounded-xl text-sm font-medium"
             size="sm"
             data-testid="log-session-button"
           >

--- a/frontend/src/components/student/StudentOverviewTab.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.tsx
@@ -383,7 +383,7 @@ function TeachingNotesPanel({
               {onSaveTeachingNotes && (
                 <button
                   onClick={handleEdit}
-                  className="rounded-xl lt-gradient-primary bg-primary text-white hover:shadow-md active:brightness-90 px-5 py-2 text-sm font-bold transition-all"
+                  className="rounded-xl lt-gradient-primary bg-primary text-white hover:shadow-md active:brightness-90 disabled:[background-image:none] disabled:opacity-50 px-5 py-2 text-sm font-bold transition-all"
                   data-testid="add-memory-btn"
                 >
                   Add Memory

--- a/frontend/src/components/student/StudentOverviewTab.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.tsx
@@ -352,7 +352,7 @@ function TeachingNotesPanel({
                 <button
                   onClick={handleSave}
                   disabled={saving}
-                  className="rounded-xl bg-primary hover:bg-primary/90 px-4 py-1.5 text-sm font-bold transition-all disabled:opacity-50"
+                  className="rounded-xl lt-gradient-primary bg-primary text-white hover:shadow-md active:brightness-90 disabled:[background-image:none] disabled:opacity-50 px-4 py-1.5 text-sm font-bold transition-all"
                   data-testid="teaching-notes-save-btn"
                 >
                   Save
@@ -383,7 +383,7 @@ function TeachingNotesPanel({
               {onSaveTeachingNotes && (
                 <button
                   onClick={handleEdit}
-                  className="rounded-xl bg-primary hover:bg-primary/90 px-5 py-2 text-sm font-bold transition-all"
+                  className="rounded-xl lt-gradient-primary bg-primary text-white hover:shadow-md active:brightness-90 px-5 py-2 text-sm font-bold transition-all"
                   data-testid="add-memory-btn"
                 >
                   Add Memory

--- a/frontend/src/components/student/StudentOverviewTab.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Button } from '@/components/ui/button'
 import { Link } from 'react-router-dom'
 import { ArrowRight, Brain, Plus, BookOpen } from 'lucide-react'
 import type { Student } from '@/api/students'
@@ -349,14 +350,14 @@ function TeachingNotesPanel({
               />
               {saveError && <p className="text-sm text-red-300">{saveError}</p>}
               <div className="flex gap-2">
-                <button
+                <Button
                   onClick={handleSave}
                   disabled={saving}
-                  className="rounded-xl lt-gradient-primary bg-primary text-white hover:shadow-md active:brightness-90 disabled:[background-image:none] disabled:opacity-50 px-4 py-1.5 text-sm font-bold transition-all"
+                  className="rounded-xl px-4 py-1.5 font-bold"
                   data-testid="teaching-notes-save-btn"
                 >
                   Save
-                </button>
+                </Button>
                 <button
                   onClick={() => setEditing(false)}
                   className="rounded-xl bg-white/10 hover:bg-white/20 px-4 py-1.5 text-sm font-medium transition-all"
@@ -381,13 +382,13 @@ function TeachingNotesPanel({
                 </p>
               )}
               {onSaveTeachingNotes && (
-                <button
+                <Button
                   onClick={handleEdit}
-                  className="rounded-xl lt-gradient-primary bg-primary text-white hover:shadow-md active:brightness-90 disabled:[background-image:none] disabled:opacity-50 px-5 py-2 text-sm font-bold transition-all"
+                  className="rounded-xl px-5 py-2 font-bold"
                   data-testid="add-memory-btn"
                 >
                   Add Memory
-                </button>
+                </Button>
               )}
             </>
           )}

--- a/frontend/src/components/student/VoiceUpdateDrawer.tsx
+++ b/frontend/src/components/student/VoiceUpdateDrawer.tsx
@@ -212,8 +212,7 @@ export function VoiceUpdateDrawer(props: VoiceUpdateDrawerProps) {
                 size="sm"
                 onClick={handleSave}
                 disabled={saveDisabled}
-                className="text-white min-w-[120px]"
-                style={{ background: 'linear-gradient(135deg, #3525CD, #4F46E5)' }}
+                className="min-w-[120px]"
                 data-testid="drawer-save"
               >
                 {saving ? (

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default: "lt-gradient-primary bg-primary text-primary-foreground hover:shadow-md active:brightness-90 disabled:[background-image:none]",
         outline:
           "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -133,6 +133,10 @@
     --radius-4xl: calc(var(--radius) * 2.6);
 }
 
+@utility lt-gradient-primary {
+  background-image: linear-gradient(135deg, #3525CD 0%, #4F46E5 50%, #6366f1 100%);
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/frontend/src/pages/LessonEditor.tsx
+++ b/frontend/src/pages/LessonEditor.tsx
@@ -568,7 +568,7 @@ export default function LessonEditor() {
               data-testid="inline-schedule-input"
             />
             <div className="flex items-center gap-2 shrink-0">
-              <Button size="sm" onClick={handleQuickSchedule} disabled={!inlineScheduleDate} className="bg-primary hover:bg-primary/90 text-white">Save</Button>
+              <Button size="sm" onClick={handleQuickSchedule} disabled={!inlineScheduleDate}>Save</Button>
               <Button variant="ghost" size="sm" onClick={() => { setSchedulingInline(false); setInlineScheduleDate('') }}>Cancel</Button>
             </div>
           </div>
@@ -691,7 +691,7 @@ export default function LessonEditor() {
               </div>
               <div className="flex gap-2 justify-end">
                 <Button variant="outline" size="sm" onClick={() => setEditingMeta(false)}>Cancel</Button>
-                <Button size="sm" onClick={handleMetaSave} className="bg-primary hover:bg-primary/90 text-white">Save</Button>
+                <Button size="sm" onClick={handleMetaSave}>Save</Button>
               </div>
             </div>
           </CardContent>
@@ -926,7 +926,6 @@ export default function LessonEditor() {
             <AlertDialogAction
               onClick={handleLinkStudent}
               disabled={!linkStudentId}
-              className="bg-primary hover:bg-primary/90 text-white"
             >
               Link Student
             </AlertDialogAction>

--- a/frontend/src/pages/LessonNew.tsx
+++ b/frontend/src/pages/LessonNew.tsx
@@ -327,7 +327,6 @@ export default function LessonNew() {
             <Button
               onClick={() => doCreate()}
               disabled={!isFormValid || isPending}
-              className="bg-primary hover:bg-primary/90 text-white"
               data-testid="submit-lesson"
             >
               {isPending ? 'Creating...' : 'Create Lesson'}

--- a/frontend/src/pages/Lessons.tsx
+++ b/frontend/src/pages/Lessons.tsx
@@ -152,7 +152,7 @@ export default function Lessons() {
         actions={
           <Link
             to="/lessons/new"
-            className={cn(buttonVariants(), 'bg-primary hover:bg-primary/90 text-white')}
+            className={cn(buttonVariants())}
             data-testid="new-lesson-btn"
           >
             <PlusCircle className="h-4 w-4 mr-1.5" />
@@ -219,7 +219,7 @@ export default function Lessons() {
           <p className="text-sm text-zinc-500 mb-6">Create your first lesson to get started.</p>
           <Link
             to="/lessons/new"
-            className={cn(buttonVariants(), 'bg-primary hover:bg-primary/90 text-white')}
+            className={cn(buttonVariants())}
           >
             Create your first lesson
           </Link>

--- a/frontend/src/pages/LogSession.tsx
+++ b/frontend/src/pages/LogSession.tsx
@@ -1482,7 +1482,7 @@ export default function LogSession() {
                         setNewDifficulty({ description: '', competency: '', subcategory: '' })
                         markChangedAndSaveNow({ suggestedDifficulties: next })
                       }}
-                      className="bg-primary hover:bg-primary/90 text-white shrink-0 disabled:opacity-50"
+                      className="shrink-0"
                       data-testid="add-difficulty-btn"
                     >
                       <Plus className="h-4 w-4" />
@@ -1549,7 +1549,7 @@ export default function LogSession() {
                       className="text-sm bg-white flex-1"
                       data-testid="new-todo-input"
                     />
-                    <Button type="button" size="sm" onClick={addTodo} className="bg-primary hover:bg-primary/90 text-white">
+                    <Button type="button" size="sm" onClick={addTodo}>
                       <Plus className="h-4 w-4" />
                     </Button>
                   </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -110,7 +110,7 @@ export default function Settings() {
             {!validationError && isError && (
               <span className="text-sm text-red-600 font-medium">Save failed. Please try again.</span>
             )}
-            <Button type="submit" form="profile-form" disabled={isPending} className="bg-primary hover:bg-primary/90">
+            <Button type="submit" form="profile-form" disabled={isPending}>
               {isPending ? 'Saving...' : 'Done'}
             </Button>
           </div>

--- a/frontend/src/pages/Students.tsx
+++ b/frontend/src/pages/Students.tsx
@@ -554,7 +554,7 @@ export default function Students() {
           <p className="text-sm text-zinc-500 mb-6">Add your first student to get started.</p>
           <Link
             to="/students/new"
-            className={cn(buttonVariants(), 'bg-primary hover:bg-primary/90 text-white')}
+            className={cn(buttonVariants())}
           >
             Add your first student
           </Link>

--- a/frontend/src/pages/onboarding/OnboardingStep1.tsx
+++ b/frontend/src/pages/onboarding/OnboardingStep1.tsx
@@ -124,7 +124,7 @@ export default function OnboardingStep1({ onNext }: OnboardingStep1Props) {
       {error && <p className="text-sm text-red-600" data-testid="step1-error">{error}</p>}
 
       <div className="flex justify-end">
-        <Button type="submit" disabled={isPending} className="bg-primary hover:bg-primary/90" data-testid="onboarding-next">
+        <Button type="submit" disabled={isPending} data-testid="onboarding-next">
           {isPending ? 'Saving...' : 'Next'}
         </Button>
       </div>

--- a/frontend/src/pages/onboarding/OnboardingStep2.tsx
+++ b/frontend/src/pages/onboarding/OnboardingStep2.tsx
@@ -148,7 +148,7 @@ export default function OnboardingStep2({ onNext, onBack, onSkip }: OnboardingSt
               Skip, I'll do this later
             </button>
           )}
-          <Button type="submit" disabled={isPending} className="bg-primary hover:bg-primary/90" data-testid="onboarding-next">
+          <Button type="submit" disabled={isPending} data-testid="onboarding-next">
             {isPending ? 'Creating...' : 'Next'}
           </Button>
         </div>

--- a/frontend/src/pages/onboarding/OnboardingStep3.tsx
+++ b/frontend/src/pages/onboarding/OnboardingStep3.tsx
@@ -114,7 +114,7 @@ export default function OnboardingStep3({ student, onBack, onSkip }: OnboardingS
               Skip, I'll do this later
             </button>
           )}
-          <Button type="submit" disabled={isPending} className="bg-primary hover:bg-primary/90" data-testid="onboarding-next">
+          <Button type="submit" disabled={isPending} data-testid="onboarding-next">
             {isPending ? 'Creating...' : 'Finish & Open Lesson'}
           </Button>
         </div>


### PR DESCRIPTION
Closes #1001

## Summary

- Added `@utility lt-gradient-primary` to `index.css` with the design-system signature gradient: `linear-gradient(135deg, #3525CD 0%, #4F46E5 50%, #6366f1 100%)`
- Updated `Button` default variant: gradient + `hover:shadow-md` (shadow lift) + `active:brightness-90` (dim on press) + `disabled:[background-image:none]` (strip gradient when disabled)
- Removed `bg-primary hover:bg-primary/90` className overrides from 13 `<Button>` callsites (tailwind-merge was fighting the gradient)
- Removed inline `style={{ background: 'linear-gradient(...)' }}` from `VoiceUpdateDrawer` and `StudentDetailHeader` (inline styles override classes; 2-stop versions now replaced by the 3-stop utility via the default variant)
- Converted two raw `<button>` CTAs in `StudentOverviewTab` (Save, Add Memory) to `<Button>` component so gradient is not duplicated in className strings
- Fixed `cn(buttonVariants(), 'bg-primary ...')` calls in `Lessons.tsx` and `Students.tsx`
- Icon-only buttons (`TeachingTodosCard`, `StudentProfileTab` save icons) left as flat primary per DESIGN.md: "no gradient on icon buttons unless primary screen action"
- Secondary, ghost, outline, link, destructive variants: untouched

## Test plan

- [x] `npm run build` clean (no TS/Vite errors)
- [x] `npm test` 95/95 test files, 1514 tests pass
- [x] UI review (review-ui agent): PASS on Dashboard, Students, Student Detail, Lessons, Settings, Onboarding
- [x] Gradient visible on primary CTAs (lighter top-left, deeper bottom-right indigo)
- [x] Secondary/ghost/icon buttons confirmed gradient-free
- [x] No gradient on cards, badges, or non-button surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)