### PR TITLE
feat(#1009): Atelier Assistant LLM integration and multi-entity proposal cards

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/AssistantControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/AssistantControllerTests.cs
@@ -1,0 +1,155 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using LangTeach.Api.Data;
+using LangTeach.Api.Data.Models;
+using LangTeach.Api.DTOs;
+using LangTeach.Api.Tests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LangTeach.Api.Tests.Controllers;
+
+[Collection("ApiTests")]
+public class AssistantControllerTests
+{
+    private readonly AuthenticatedWebAppFactory _factory;
+
+    public AssistantControllerTests(AuthenticatedWebAppFactory factory)
+    {
+        _factory = factory;
+    }
+
+    private async Task<(HttpClient client, Guid studentId)> SeedTeacherWithStudent(
+        string auth0Id, string email, string cefrLevel = "A2")
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var teacher = new Teacher
+        {
+            Id = Guid.NewGuid(),
+            Auth0UserId = auth0Id,
+            Email = email,
+            DisplayName = "Assistant Test Teacher",
+            IsApproved = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        db.Teachers.Add(teacher);
+
+        var student = new Student
+        {
+            Id = Guid.NewGuid(),
+            TeacherId = teacher.Id,
+            Name = "Ana",
+            LearningLanguage = "Spanish",
+            CefrLevel = cefrLevel,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        db.Students.Add(student);
+        await db.SaveChangesAsync();
+
+        var client = _factory.CreateAuthenticatedClient(auth0Id, email);
+        return (client, student.Id);
+    }
+
+    [Fact]
+    public async Task Propose_WithStudentId_ReturnsStudentAndSessionProposals()
+    {
+        // StubStudentProfileExtractionService returns CefrLevel=B2, Profession=[Extracted] Engineer.
+        // Student is seeded with CefrLevel=A2, so a cefrLevel proposal should be emitted.
+        var (client, studentId) = await SeedTeacherWithStudent(
+            "auth0|assistant-propose-ok", "assistant-propose-ok@example.com", cefrLevel: "A2");
+
+        var request = new AssistantProposeRequest
+        {
+            Text = "We worked on past perfect. Set writing level to B1 and add a passive voice todo.",
+            StudentId = studentId,
+        };
+        var response = await client.PostAsJsonAsync("/api/assistant/propose", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<AssistantProposeResponse>();
+        body.Should().NotBeNull();
+        body!.Proposals.Should().NotBeEmpty();
+
+        // Student proposals from StubStudentProfileExtractionService
+        body.Proposals.Should().Contain(p => p.Type == "student" && p.Field == "cefrLevel");
+        body.Proposals.Should().Contain(p => p.Type == "student" && p.Field == "profession");
+        body.Proposals.Should().Contain(p => p.Type == "student" && p.Field == "countryOfResidence");
+
+        // Session proposals from StubReflectionExtractionService
+        body.Proposals.Should().Contain(p => p.Type == "session" && p.Field == "title");
+        body.Proposals.Should().Contain(p => p.Type == "session" && p.Field == "actualContent");
+        body.Proposals.Should().Contain(p => p.Type == "session" && p.Field == "generalNotes");
+        body.Proposals.Should().Contain(p => p.Type == "session" && p.Field == "homeworkAssigned");
+
+        // All proposals have an id, label, newValue
+        body.Proposals.Should().AllSatisfy(p =>
+        {
+            p.Id.Should().NotBeNullOrEmpty();
+            p.Label.Should().NotBeNullOrEmpty();
+            p.NewValue.Should().NotBeNullOrEmpty();
+        });
+    }
+
+    [Fact]
+    public async Task Propose_WithoutStudentId_ReturnsOnlySessionProposals()
+    {
+        var (client, _) = await SeedTeacherWithStudent(
+            "auth0|assistant-propose-nosid", "assistant-propose-nosid@example.com");
+
+        var request = new AssistantProposeRequest
+        {
+            Text = "We covered grammar topics today.",
+            StudentId = null,
+            SessionId = null,
+        };
+        var response = await client.PostAsJsonAsync("/api/assistant/propose", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<AssistantProposeResponse>();
+        body.Should().NotBeNull();
+
+        // No student or todo proposals when studentId is absent
+        body!.Proposals.Should().NotContain(p => p.Type == "student");
+        body.Proposals.Should().NotContain(p => p.Type == "todo");
+
+        // Session proposals should still be present
+        body.Proposals.Should().Contain(p => p.Type == "session");
+    }
+
+    [Fact]
+    public async Task Propose_EmptyText_Returns400()
+    {
+        var (client, _) = await SeedTeacherWithStudent(
+            "auth0|assistant-empty-text", "assistant-empty-text@example.com");
+
+        var request = new AssistantProposeRequest { Text = "   " };
+        var response = await client.PostAsJsonAsync("/api/assistant/propose", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Propose_CefrLevelUnchanged_DoesNotEmitCefrProposal()
+    {
+        // StubStudentProfileExtractionService returns CefrLevel=B2.
+        // Seed student with B2 so old == new → no cefrLevel proposal.
+        var (client, studentId) = await SeedTeacherWithStudent(
+            "auth0|assistant-no-cefr-change", "assistant-no-cefr-change@example.com", cefrLevel: "B2");
+
+        var request = new AssistantProposeRequest
+        {
+            Text = "Standard lesson today.",
+            StudentId = studentId,
+        };
+        var response = await client.PostAsJsonAsync("/api/assistant/propose", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<AssistantProposeResponse>();
+        body.Should().NotBeNull();
+        body!.Proposals.Should().NotContain(p => p.Type == "student" && p.Field == "cefrLevel");
+    }
+}

--- a/backend/LangTeach.Api/Controllers/AssistantController.cs
+++ b/backend/LangTeach.Api/Controllers/AssistantController.cs
@@ -1,0 +1,105 @@
+using System.Security.Claims;
+using LangTeach.Api.DTOs;
+using LangTeach.Api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LangTeach.Api.Controllers;
+
+[ApiController]
+[Route("api/assistant")]
+[Authorize]
+public class AssistantController : ControllerBase
+{
+    private readonly IStudentService _studentService;
+    private readonly ISessionLogService _sessionLogService;
+    private readonly IStudentProfileExtractionService _studentExtractionService;
+    private readonly IReflectionExtractionService _reflectionExtractionService;
+    private readonly IProfileService _profileService;
+    private readonly ILogger<AssistantController> _logger;
+
+    public AssistantController(
+        IStudentService studentService,
+        ISessionLogService sessionLogService,
+        IStudentProfileExtractionService studentExtractionService,
+        IReflectionExtractionService reflectionExtractionService,
+        IProfileService profileService,
+        ILogger<AssistantController> logger)
+    {
+        _studentService = studentService;
+        _sessionLogService = sessionLogService;
+        _studentExtractionService = studentExtractionService;
+        _reflectionExtractionService = reflectionExtractionService;
+        _profileService = profileService;
+        _logger = logger;
+    }
+
+    private string? Auth0Id => User.FindFirstValue(ClaimTypes.NameIdentifier);
+    private string Email => User.FindFirstValue(ClaimTypes.Email) ?? "";
+
+    [HttpPost("propose")]
+    public async Task<IActionResult> Propose([FromBody] AssistantProposeRequest request, CancellationToken ct)
+    {
+        if (Auth0Id is null) return Unauthorized();
+        if (string.IsNullOrWhiteSpace(request.Text))
+            return BadRequest("Text is required.");
+
+        var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
+
+        StudentDto? student = null;
+        if (request.StudentId.HasValue)
+            student = await _studentService.GetByIdAsync(teacherId, request.StudentId.Value, ct);
+
+        var knownDifficulties = student?.Profile.Difficulties
+            .Select(d => d.Description ?? "")
+            .Where(d => !string.IsNullOrWhiteSpace(d))
+            .ToList() as IReadOnlyList<string>;
+
+        var studentTask = _studentExtractionService.ExtractAsync(request.Text, ct);
+        var reflectionTask = _reflectionExtractionService.ExtractAsync(request.Text, knownDifficulties, ct);
+
+        await Task.WhenAll(studentTask, reflectionTask);
+
+        var studentExtraction = await studentTask;
+        var reflectionExtraction = await reflectionTask;
+
+        SessionLogDto? session = null;
+        if (student != null && request.SessionId.HasValue)
+            session = await _sessionLogService.GetByIdAsync(teacherId, student.Id, request.SessionId.Value, ct);
+
+        var proposals = new List<ProposalDto>();
+
+        if (student != null)
+        {
+            EmitProposal(proposals, "student", "cefrLevel", "CEFR Level", student.Level.CefrLevel, studentExtraction.CefrLevel);
+            EmitProposal(proposals, "student", "profession", "Profession", student.Identity.Profession, studentExtraction.Profession);
+            EmitProposal(proposals, "student", "countryOfResidence", "Country of Residence", student.Identity.CountryOfResidence, studentExtraction.CountryOfResidence);
+
+            foreach (var todo in reflectionExtraction.TeachingTodos)
+            {
+                if (!string.IsNullOrWhiteSpace(todo))
+                    proposals.Add(new ProposalDto(Guid.NewGuid().ToString(), "todo", "text", "Teaching Todo", null, todo));
+            }
+        }
+
+        EmitProposal(proposals, "session", "title", "Session Title", session?.Title, reflectionExtraction.SessionTitle);
+        EmitProposal(proposals, "session", "actualContent", "What Was Covered", session?.ActualContent, reflectionExtraction.WhatWasCovered?.Value);
+        EmitProposal(proposals, "session", "generalNotes", "Areas to Improve", session?.GeneralNotes, reflectionExtraction.AreasToImprove?.Value);
+        EmitProposal(proposals, "session", "homeworkAssigned", "Homework Assigned", session?.HomeworkAssigned, reflectionExtraction.HomeworkAssigned?.Value);
+
+        return Ok(new AssistantProposeResponse(proposals));
+    }
+
+    private static void EmitProposal(
+        List<ProposalDto> proposals,
+        string type,
+        string field,
+        string label,
+        string? oldValue,
+        string? newValue)
+    {
+        if (string.IsNullOrWhiteSpace(newValue)) return;
+        if (string.Equals(oldValue?.Trim(), newValue.Trim(), StringComparison.OrdinalIgnoreCase)) return;
+        proposals.Add(new ProposalDto(Guid.NewGuid().ToString(), type, field, label, oldValue, newValue));
+    }
+}

--- a/backend/LangTeach.Api/Controllers/AssistantController.cs
+++ b/backend/LangTeach.Api/Controllers/AssistantController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace LangTeach.Api.Controllers;
 
 [ApiController]
-[Route("api/assistant")]
+[Route("api/[controller]")]
 [Authorize]
 public class AssistantController : ControllerBase
 {

--- a/backend/LangTeach.Api/Controllers/SessionLogsController.cs
+++ b/backend/LangTeach.Api/Controllers/SessionLogsController.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
+using System.Text.Json;
 using LangTeach.Api.DTOs;
 using LangTeach.Api.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -174,10 +175,16 @@ public class SessionLogsController : ControllerBase
         }
     }
 
+    private static readonly JsonSerializerOptions _caseInsensitive =
+        new() { PropertyNameCaseInsensitive = true };
+
     private static UpdateSessionLogRequest MapSessionToUpdateRequest(SessionLogDto s)
     {
-        // MentionedDifficultyPairs and SuggestedDifficulties are stored as JSON strings in the DTO;
-        // passing null here is safe — UpdateAsync treats null as "clear" for those fields.
+        // MentionedDifficultyPairs and SuggestedDifficulties are stored as JSON strings in the DTO.
+        // Deserialize them so UpdateAsync round-trips the existing data rather than clearing it.
+        var pairs = TryDeserialize<List<DifficultyPairDto>>(s.MentionedDifficultyPairs);
+        var difficulties = TryDeserialize<List<SuggestedDifficultyDto>>(s.SuggestedDifficulties);
+
         return new UpdateSessionLogRequest
         {
             SessionDate = s.SessionDate,
@@ -195,7 +202,16 @@ public class SessionLogsController : ControllerBase
             Status = s.Status,
             Duration = s.Duration,
             Title = s.Title,
+            MentionedDifficultyPairs = pairs,
+            SuggestedDifficulties = difficulties,
         };
+    }
+
+    private static T? TryDeserialize<T>(string? json) where T : class
+    {
+        if (string.IsNullOrWhiteSpace(json) || json == "[]") return null;
+        try { return JsonSerializer.Deserialize<T>(json, _caseInsensitive); }
+        catch { return null; }
     }
 
     [HttpDelete("{sessionId:guid}")]

--- a/backend/LangTeach.Api/Controllers/SessionLogsController.cs
+++ b/backend/LangTeach.Api/Controllers/SessionLogsController.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
-using System.Text.Json;
 using LangTeach.Api.DTOs;
 using LangTeach.Api.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -146,34 +145,21 @@ public class SessionLogsController : ControllerBase
     }
 
     [HttpPatch("{sessionId:guid}")]
-    public async Task<IActionResult> PatchSession(Guid studentId, Guid sessionId, [FromBody] Dictionary<string, JsonElement> fields, CancellationToken cancellationToken)
+    public async Task<IActionResult> PatchSession(Guid studentId, Guid sessionId, [FromBody] PatchSessionRequest patch, CancellationToken cancellationToken)
     {
         if (Auth0Id is null) return Unauthorized();
+        if (!ModelState.IsValid) return BadRequest(ModelState);
 
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
         var session = await _sessionLogService.GetByIdAsync(teacherId, studentId, sessionId, cancellationToken);
         if (session is null) return NotFound();
 
+        // Pre-populate all fields from current state, then overwrite only provided fields.
         var request = MapSessionToUpdateRequest(session);
-
-        foreach (var (key, value) in fields)
-        {
-            switch (key.ToLowerInvariant())
-            {
-                case "title":
-                    request.Title = value.GetString();
-                    break;
-                case "actualcontent":
-                    request.ActualContent = value.GetString();
-                    break;
-                case "generalnotes":
-                    request.GeneralNotes = value.GetString();
-                    break;
-                case "homeworkassigned":
-                    request.HomeworkAssigned = value.GetString();
-                    break;
-            }
-        }
+        if (patch.Title is not null) request.Title = patch.Title;
+        if (patch.ActualContent is not null) request.ActualContent = patch.ActualContent;
+        if (patch.GeneralNotes is not null) request.GeneralNotes = patch.GeneralNotes;
+        if (patch.HomeworkAssigned is not null) request.HomeworkAssigned = patch.HomeworkAssigned;
 
         try
         {

--- a/backend/LangTeach.Api/Controllers/SessionLogsController.cs
+++ b/backend/LangTeach.Api/Controllers/SessionLogsController.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
+using System.Text.Json;
 using LangTeach.Api.DTOs;
 using LangTeach.Api.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -142,6 +143,73 @@ public class SessionLogsController : ControllerBase
             ModelState.AddModelError(string.Empty, ex.Message);
             return BadRequest(ModelState);
         }
+    }
+
+    [HttpPatch("{sessionId:guid}")]
+    public async Task<IActionResult> PatchSession(Guid studentId, Guid sessionId, [FromBody] Dictionary<string, JsonElement> fields, CancellationToken cancellationToken)
+    {
+        if (Auth0Id is null) return Unauthorized();
+
+        var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
+        var session = await _sessionLogService.GetByIdAsync(teacherId, studentId, sessionId, cancellationToken);
+        if (session is null) return NotFound();
+
+        var request = MapSessionToUpdateRequest(session);
+
+        foreach (var (key, value) in fields)
+        {
+            switch (key.ToLowerInvariant())
+            {
+                case "title":
+                    request.Title = value.GetString();
+                    break;
+                case "actualcontent":
+                    request.ActualContent = value.GetString();
+                    break;
+                case "generalnotes":
+                    request.GeneralNotes = value.GetString();
+                    break;
+                case "homeworkassigned":
+                    request.HomeworkAssigned = value.GetString();
+                    break;
+            }
+        }
+
+        try
+        {
+            var updated = await _sessionLogService.UpdateAsync(teacherId, studentId, sessionId, request, cancellationToken);
+            if (updated is null) return NotFound();
+            return Ok(updated);
+        }
+        catch (ValidationException ex)
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+            return BadRequest(ModelState);
+        }
+    }
+
+    private static UpdateSessionLogRequest MapSessionToUpdateRequest(SessionLogDto s)
+    {
+        // MentionedDifficultyPairs and SuggestedDifficulties are stored as JSON strings in the DTO;
+        // passing null here is safe — UpdateAsync treats null as "clear" for those fields.
+        return new UpdateSessionLogRequest
+        {
+            SessionDate = s.SessionDate,
+            PlannedContent = s.PlannedContent,
+            ActualContent = s.ActualContent,
+            HomeworkAssigned = s.HomeworkAssigned,
+            PreviousHomeworkStatus = s.PreviousHomeworkStatus,
+            NextSessionTopics = s.NextSessionTopics,
+            GeneralNotes = s.GeneralNotes,
+            LevelReassessmentSkill = s.LevelReassessmentSkill,
+            LevelReassessmentLevel = s.LevelReassessmentLevel,
+            LinkedLessonId = s.LinkedLessonId,
+            TopicTags = s.TopicTags,
+            IsCancelled = s.IsCancelled,
+            Status = s.Status,
+            Duration = s.Duration,
+            Title = s.Title,
+        };
     }
 
     [HttpDelete("{sessionId:guid}")]

--- a/backend/LangTeach.Api/Controllers/StudentsController.cs
+++ b/backend/LangTeach.Api/Controllers/StudentsController.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
+using System.Text.Json;
 using LangTeach.Api.DTOs;
 using LangTeach.Api.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -119,6 +120,75 @@ public class StudentsController : ControllerBase
             return BadRequest(ModelState);
         }
     }
+
+    [HttpPatch("{id:guid}")]
+    public async Task<IActionResult> PatchStudent(Guid id, [FromBody] Dictionary<string, JsonElement> fields, CancellationToken cancellationToken)
+    {
+        if (Auth0Id is null) return Unauthorized();
+
+        var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
+        var student = await _studentService.GetByIdAsync(teacherId, id, cancellationToken);
+        if (student is null) return NotFound();
+
+        var request = MapStudentToUpdateRequest(student);
+
+        foreach (var (key, value) in fields)
+        {
+            switch (key.ToLowerInvariant())
+            {
+                case "cefrlevel":
+                    request.CefrLevel = value.GetString() ?? request.CefrLevel;
+                    break;
+                case "profession":
+                    request.Profession = value.GetString();
+                    break;
+                case "countryofresidence":
+                    request.CountryOfResidence = value.GetString();
+                    break;
+            }
+        }
+
+        try
+        {
+            var updated = await _studentService.UpdateAsync(teacherId, id, request, cancellationToken);
+            if (updated is null) return NotFound();
+            return Ok(updated);
+        }
+        catch (ValidationException ex)
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+            return BadRequest(ModelState);
+        }
+    }
+
+    private static UpdateStudentRequest MapStudentToUpdateRequest(StudentDto s) => new()
+    {
+        Name = s.Name,
+        LearningLanguage = s.LearningLanguage,
+        CefrLevel = s.Level.CefrLevel,
+        OfficialCefrLevel = s.Level.OfficialCefrLevel,
+        SkillLevelOverrides = s.Level.SkillLevelOverrides,
+        Interests = s.Profile.Interests,
+        NativeLanguages = s.Languages.NativeLanguages,
+        SpokenLanguages = s.Languages.SpokenLanguages,
+        LearningGoals = s.Profile.LearningGoals,
+        Weaknesses = s.Profile.Weaknesses,
+        Difficulties = s.Profile.Difficulties,
+        PersonalNotes = s.Profile.PersonalNotes,
+        TeachingNotes = s.Profile.TeachingNotes,
+        ShortTermObjectives = s.Profile.ShortTermObjectives,
+        TeachingTodos = s.Profile.TeachingTodos,
+        BirthYear = s.Identity.BirthYear,
+        Profession = s.Identity.Profession,
+        CountryOfOrigin = s.Identity.CountryOfOrigin,
+        CityOfOrigin = s.Identity.CityOfOrigin,
+        CountryOfResidence = s.Identity.CountryOfResidence,
+        CityOfResidence = s.Identity.CityOfResidence,
+        ReasonForStudying = s.Profile.ReasonForStudying,
+        IsActive = s.Commercial.IsActive,
+        IsCorporate = s.Commercial.IsCorporate,
+        Rate = s.Commercial.Rate,
+    };
 
     [HttpGet("{studentId:guid}/lesson-history")]
     public async Task<IActionResult> GetLessonHistory(Guid studentId, CancellationToken cancellationToken)

--- a/backend/LangTeach.Api/Controllers/StudentsController.cs
+++ b/backend/LangTeach.Api/Controllers/StudentsController.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
-using System.Text.Json;
 using LangTeach.Api.DTOs;
 using LangTeach.Api.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -122,31 +121,20 @@ public class StudentsController : ControllerBase
     }
 
     [HttpPatch("{id:guid}")]
-    public async Task<IActionResult> PatchStudent(Guid id, [FromBody] Dictionary<string, JsonElement> fields, CancellationToken cancellationToken)
+    public async Task<IActionResult> PatchStudent(Guid id, [FromBody] PatchStudentRequest patch, CancellationToken cancellationToken)
     {
         if (Auth0Id is null) return Unauthorized();
+        if (!ModelState.IsValid) return BadRequest(ModelState);
 
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
         var student = await _studentService.GetByIdAsync(teacherId, id, cancellationToken);
         if (student is null) return NotFound();
 
+        // Pre-populate all required fields from current state, then overwrite only provided fields.
         var request = MapStudentToUpdateRequest(student);
-
-        foreach (var (key, value) in fields)
-        {
-            switch (key.ToLowerInvariant())
-            {
-                case "cefrlevel":
-                    request.CefrLevel = value.GetString() ?? request.CefrLevel;
-                    break;
-                case "profession":
-                    request.Profession = value.GetString();
-                    break;
-                case "countryofresidence":
-                    request.CountryOfResidence = value.GetString();
-                    break;
-            }
-        }
+        if (patch.CefrLevel is not null) request.CefrLevel = patch.CefrLevel;
+        if (patch.Profession is not null) request.Profession = patch.Profession;
+        if (patch.CountryOfResidence is not null) request.CountryOfResidence = patch.CountryOfResidence;
 
         try
         {

--- a/backend/LangTeach.Api/DTOs/AssistantDtos.cs
+++ b/backend/LangTeach.Api/DTOs/AssistantDtos.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LangTeach.Api.DTOs;
+
+public class AssistantProposeRequest
+{
+    [Required, MaxLength(5000)]
+    public string Text { get; set; } = "";
+
+    public Guid? StudentId { get; set; }
+    public Guid? SessionId { get; set; }
+}
+
+public record ProposalDto(
+    string Id,
+    string Type,
+    string Field,
+    string Label,
+    string? OldValue,
+    string NewValue
+);
+
+public record AssistantProposeResponse(List<ProposalDto> Proposals);

--- a/backend/LangTeach.Api/DTOs/AssistantDtos.cs
+++ b/backend/LangTeach.Api/DTOs/AssistantDtos.cs
@@ -21,3 +21,30 @@ public record ProposalDto(
 );
 
 public record AssistantProposeResponse(List<ProposalDto> Proposals);
+
+public class PatchStudentRequest
+{
+    [RegularExpression(@"^(A1|A2|B1|B2|C1|C2)$", ErrorMessage = "CefrLevel must be one of: A1, A2, B1, B2, C1, C2.")]
+    public string? CefrLevel { get; set; }
+
+    [MaxLength(128)]
+    public string? Profession { get; set; }
+
+    [MaxLength(64)]
+    public string? CountryOfResidence { get; set; }
+}
+
+public class PatchSessionRequest
+{
+    [MaxLength(120)]
+    public string? Title { get; set; }
+
+    [MaxLength(5000)]
+    public string? ActualContent { get; set; }
+
+    [MaxLength(5000)]
+    public string? GeneralNotes { get; set; }
+
+    [MaxLength(2000)]
+    public string? HomeworkAssigned { get; set; }
+}

--- a/frontend/src/api/assistant.ts
+++ b/frontend/src/api/assistant.ts
@@ -31,6 +31,7 @@ export async function applyStudentProposal(
   field: string,
   value: string,
 ): Promise<void> {
+  // field is one of: cefrLevel, profession, countryOfResidence — matches PatchStudentRequest
   await apiClient.patch(`/api/students/${studentId}`, { [field]: value })
 }
 
@@ -40,6 +41,7 @@ export async function applySessionProposal(
   field: string,
   value: string,
 ): Promise<void> {
+  // field is one of: title, actualContent, generalNotes, homeworkAssigned — matches PatchSessionRequest
   await apiClient.patch(`/api/students/${studentId}/sessions/${sessionId}`, { [field]: value })
 }
 

--- a/frontend/src/api/assistant.ts
+++ b/frontend/src/api/assistant.ts
@@ -1,0 +1,51 @@
+import { apiClient } from '../lib/apiClient'
+
+export interface ProposalDto {
+  id: string
+  type: 'student' | 'session' | 'todo'
+  field: string
+  label: string
+  oldValue: string | null
+  newValue: string
+}
+
+export interface ProposeResponse {
+  proposals: ProposalDto[]
+}
+
+export async function proposeAssistant(
+  text: string,
+  studentId?: string,
+  sessionId?: string,
+): Promise<ProposeResponse> {
+  const res = await apiClient.post<ProposeResponse>('/api/assistant/propose', {
+    text,
+    studentId: studentId ?? null,
+    sessionId: sessionId ?? null,
+  })
+  return res.data
+}
+
+export async function applyStudentProposal(
+  studentId: string,
+  field: string,
+  value: string,
+): Promise<void> {
+  await apiClient.patch(`/api/students/${studentId}`, { [field]: value })
+}
+
+export async function applySessionProposal(
+  studentId: string,
+  sessionId: string,
+  field: string,
+  value: string,
+): Promise<void> {
+  await apiClient.patch(`/api/students/${studentId}/sessions/${sessionId}`, { [field]: value })
+}
+
+export async function applyTodoProposal(
+  studentId: string,
+  text: string,
+): Promise<void> {
+  await apiClient.post(`/api/students/${studentId}/teaching-todos`, { text })
+}

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -5,6 +5,13 @@ import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import AppShell from './AppShell'
 
+vi.mock('../api/assistant', () => ({
+  proposeAssistant: vi.fn().mockResolvedValue({ proposals: [] }),
+  applyStudentProposal: vi.fn().mockResolvedValue(undefined),
+  applySessionProposal: vi.fn().mockResolvedValue(undefined),
+  applyTodoProposal: vi.fn().mockResolvedValue(undefined),
+}))
+
 const mockLogout = vi.fn()
 vi.mock('@auth0/auth0-react', () => ({
   useAuth0: () => ({

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -9,6 +9,7 @@ import LangTeachLogo from '@/components/LangTeachLogo'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
 import AtelierAssistantPanel from '@/components/AtelierAssistantPanel'
+import { useAtelierAssistant } from '@/hooks/useAtelierAssistant'
 import { getStudent } from '@/api/students'
 
 const mainNavItems = [
@@ -136,6 +137,7 @@ function SidebarContent({ user, initials, logout, location, assistantOpen, onTog
 }
 
 const STUDENT_ID_RE = /^\/students\/([^/]+)/
+const SESSION_ID_RE = /^\/students\/[^/]+\/sessions\/([^/]+)/
 
 function extractStudentId(pathname: string): string | null {
   const match = pathname.match(STUDENT_ID_RE)
@@ -143,14 +145,19 @@ function extractStudentId(pathname: string): string | null {
   return match[1] === 'new' ? null : match[1]
 }
 
+function extractSessionId(pathname: string): string | null {
+  const match = pathname.match(SESSION_ID_RE)
+  return match ? match[1] : null
+}
+
 export default function AppShell() {
   const { user, logout } = useAuth0()
   const location = useLocation()
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [assistantOpen, setAssistantOpen] = useState(false)
-  const [transcription, setTranscription] = useState<string | null>(null)
 
   const studentId = extractStudentId(location.pathname)
+  const sessionId = extractSessionId(location.pathname)
 
   const { data: studentData } = useQuery({
     queryKey: ['student', studentId],
@@ -158,6 +165,8 @@ export default function AppShell() {
     enabled: studentId !== null,
     select: (s) => s.name,
   })
+
+  const assistant = useAtelierAssistant(studentId, sessionId)
 
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { setDrawerOpen(false) }, [location.pathname])
@@ -254,10 +263,18 @@ export default function AppShell() {
       <AtelierAssistantPanel
         open={assistantOpen}
         onClose={() => setAssistantOpen(false)}
-        onCloseDiscarding={() => { setAssistantOpen(false); setTranscription(null) }}
+        onCloseDiscarding={() => { setAssistantOpen(false); assistant.reset() }}
         studentName={studentData}
-        transcription={transcription}
-        onSubmit={(text) => setTranscription(text)}
+        transcription={assistant.transcription}
+        processing={assistant.processing}
+        proposals={assistant.proposals}
+        onSubmit={assistant.submit}
+        onApply={assistant.apply}
+        onDismiss={assistant.dismiss}
+        onUndo={assistant.undoDismiss}
+        onRetry={assistant.apply}
+        onApplyAll={assistant.applyAll}
+        onDismissAll={assistant.dismissAll}
       />
     </div>
   )

--- a/frontend/src/components/AtelierAssistantPanel.test.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.test.tsx
@@ -2,18 +2,42 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import AtelierAssistantPanel from './AtelierAssistantPanel'
+import type { ProposalWithStatus } from '@/hooks/useAtelierAssistant'
 
-function renderPanel(overrides: Partial<Parameters<typeof AtelierAssistantPanel>[0]> = {}) {
-  const props = {
-    open: true,
-    onClose: vi.fn(),
-    onCloseDiscarding: vi.fn(),
-    studentName: undefined,
-    transcription: null,
-    onSubmit: vi.fn(),
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  onCloseDiscarding: vi.fn(),
+  studentName: undefined as string | undefined,
+  transcription: null as string | null,
+  processing: false,
+  proposals: [] as ProposalWithStatus[],
+  onSubmit: vi.fn(),
+  onApply: vi.fn(),
+  onDismiss: vi.fn(),
+  onUndo: vi.fn(),
+  onRetry: vi.fn(),
+  onApplyAll: vi.fn(),
+  onDismissAll: vi.fn(),
+}
+
+function renderPanel(overrides: Partial<typeof defaultProps> = {}) {
+  const props = { ...defaultProps, ...overrides }
+  return { ...render(<AtelierAssistantPanel {...props} />), props }
+}
+
+function makeProposal(overrides: Partial<ProposalWithStatus> = {}): ProposalWithStatus {
+  return {
+    id: 'p1',
+    type: 'student',
+    field: 'cefrLevel',
+    label: 'CEFR Level',
+    oldValue: 'A2',
+    newValue: 'B1',
+    status: 'proposed',
+    undoVisible: false,
     ...overrides,
   }
-  return { ...render(<AtelierAssistantPanel {...props} />), props }
 }
 
 describe('AtelierAssistantPanel', () => {
@@ -26,6 +50,17 @@ describe('AtelierAssistantPanel', () => {
     expect(screen.getByText('Atelier Assistant')).toBeInTheDocument()
     expect(screen.getByText('Ready')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /close assistant/i })).toBeInTheDocument()
+  })
+
+  it('shows PROCESSING INSIGHT status when processing', () => {
+    renderPanel({ processing: true, transcription: 'some text' })
+    expect(screen.getByText(/processing insight/i)).toBeInTheDocument()
+  })
+
+  it('disables input and send button when processing', () => {
+    renderPanel({ processing: true })
+    expect(screen.getByTestId('assistant-input')).toBeDisabled()
+    expect(screen.getByRole('button', { name: /send message/i })).toBeDisabled()
   })
 
   it('renders empty state with generic prompt when no student name', () => {
@@ -72,12 +107,52 @@ describe('AtelierAssistantPanel', () => {
     expect(screen.getByRole('button', { name: /send message/i })).toBeDisabled()
   })
 
-  it('shows transcription block and proposals stub after submission', () => {
-    renderPanel({ transcription: 'Worked on present perfect.' })
+  it('shows transcription block and empty proposals message after submission', () => {
+    renderPanel({ transcription: 'Worked on present perfect.', proposals: [] })
     expect(screen.getByTestId('transcription-block')).toBeInTheDocument()
     expect(screen.getByText('Worked on present perfect.')).toBeInTheDocument()
     expect(screen.getByText('Proposed Updates')).toBeInTheDocument()
-    expect(screen.getByText('(coming soon)')).toBeInTheDocument()
+    expect(screen.getByTestId('proposals-empty')).toBeInTheDocument()
+  })
+
+  it('shows loading indicator while processing with transcription', () => {
+    renderPanel({ transcription: 'some text', processing: true, proposals: [] })
+    expect(screen.getByTestId('proposals-loading')).toBeInTheDocument()
+  })
+
+  it('renders proposal cards when proposals are provided', () => {
+    const proposal = makeProposal()
+    renderPanel({ transcription: 'some text', proposals: [proposal] })
+    expect(screen.getByTestId('proposals-list')).toBeInTheDocument()
+    expect(screen.getByTestId(`proposal-card-${proposal.id}`)).toBeInTheDocument()
+  })
+
+  it('shows batch actions footer when there are proposed cards', () => {
+    renderPanel({ transcription: 'some text', proposals: [makeProposal({ status: 'proposed' })] })
+    expect(screen.getByTestId('batch-actions')).toBeInTheDocument()
+    expect(screen.getByTestId('apply-all-btn')).toBeInTheDocument()
+    expect(screen.getByTestId('dismiss-all-btn')).toBeInTheDocument()
+  })
+
+  it('hides batch actions footer when no proposed cards remain', () => {
+    renderPanel({ transcription: 'some text', proposals: [makeProposal({ status: 'applied' })] })
+    expect(screen.queryByTestId('batch-actions')).not.toBeInTheDocument()
+  })
+
+  it('calls onApplyAll on Apply All Remaining click', async () => {
+    const user = userEvent.setup()
+    const onApplyAll = vi.fn()
+    renderPanel({ transcription: 'text', proposals: [makeProposal()], onApplyAll })
+    await user.click(screen.getByTestId('apply-all-btn'))
+    expect(onApplyAll).toHaveBeenCalled()
+  })
+
+  it('calls onDismissAll on Dismiss All Remaining click', async () => {
+    const user = userEvent.setup()
+    const onDismissAll = vi.fn()
+    renderPanel({ transcription: 'text', proposals: [makeProposal()], onDismissAll })
+    await user.click(screen.getByTestId('dismiss-all-btn'))
+    expect(onDismissAll).toHaveBeenCalled()
   })
 
   it('shows transcription in italic blockquote style', () => {

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import { Sparkles, X, Send } from 'lucide-react'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
 import { Input } from '@/components/ui/input'
+import type { ProposalWithStatus } from '@/hooks/useAtelierAssistant'
+import ProposalCard from '@/components/assistant/ProposalCard'
 
 interface Props {
   open: boolean
@@ -9,7 +11,15 @@ interface Props {
   onCloseDiscarding: () => void
   studentName?: string
   transcription: string | null
+  processing: boolean
+  proposals: ProposalWithStatus[]
   onSubmit: (text: string) => void
+  onApply: (id: string) => void
+  onDismiss: (id: string) => void
+  onUndo: (id: string) => void
+  onRetry: (id: string) => void
+  onApplyAll: () => void
+  onDismissAll: () => void
 }
 
 export default function AtelierAssistantPanel({
@@ -18,7 +28,15 @@ export default function AtelierAssistantPanel({
   onCloseDiscarding,
   studentName,
   transcription,
+  processing,
+  proposals,
   onSubmit,
+  onApply,
+  onDismiss,
+  onUndo,
+  onRetry,
+  onApplyAll,
+  onDismissAll,
 }: Props) {
   const [inputValue, setInputValue] = useState('')
   const [pendingClose, setPendingClose] = useState(false)
@@ -41,7 +59,7 @@ export default function AtelierAssistantPanel({
 
   function handleSubmit() {
     const text = inputValue.trim()
-    if (!text) return
+    if (!text || processing) return
     onSubmit(text)
     setInputValue('')
     setPendingClose(false)
@@ -58,6 +76,8 @@ export default function AtelierAssistantPanel({
     ? `What did you cover with ${studentName} today?`
     : 'What would you like to cover today?'
 
+  const pendingProposals = proposals.filter(p => p.status === 'proposed')
+
   return (
     <Sheet open={open} onOpenChange={handleSheetOpenChange}>
       <SheetContent
@@ -70,9 +90,18 @@ export default function AtelierAssistantPanel({
             <Sparkles className="h-3.5 w-3.5 text-white" aria-hidden="true" />
           </div>
           <span className="font-semibold font-inter text-sm text-[#1A1B22] flex-1">Atelier Assistant</span>
-          <div className="flex items-center gap-1.5 mr-3" role="status" aria-label="Status: Ready">
-            <span className="h-2 w-2 rounded-full bg-emerald-500 shrink-0" aria-hidden="true" />
-            <span className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter">Ready</span>
+          <div
+            className="flex items-center gap-1.5 mr-3"
+            role="status"
+            aria-label={processing ? 'Status: Processing' : 'Status: Ready'}
+          >
+            <span
+              className={processing ? 'h-2 w-2 rounded-full bg-amber-400 shrink-0 animate-pulse' : 'h-2 w-2 rounded-full bg-emerald-500 shrink-0'}
+              aria-hidden="true"
+            />
+            <span className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter">
+              {processing ? 'Processing Insight' : 'Ready'}
+            </span>
           </div>
           <button
             onClick={handleCloseAttempt}
@@ -133,11 +162,52 @@ export default function AtelierAssistantPanel({
                 <p className="text-[0.6875rem] font-bold uppercase tracking-[0.05em] text-zinc-400 font-inter mb-2">
                   Proposed Updates
                 </p>
-                <p className="text-sm font-inter text-zinc-400">(coming soon)</p>
+                {processing ? (
+                  <p className="text-sm font-inter text-zinc-400" data-testid="proposals-loading">
+                    Analysing…
+                  </p>
+                ) : proposals.length === 0 ? (
+                  <p className="text-sm font-inter text-zinc-400" data-testid="proposals-empty">
+                    No updates suggested.
+                  </p>
+                ) : (
+                  <div className="space-y-2" data-testid="proposals-list">
+                    {proposals.map(proposal => (
+                      <ProposalCard
+                        key={proposal.id}
+                        proposal={proposal}
+                        onApply={onApply}
+                        onDismiss={onDismiss}
+                        onUndo={onUndo}
+                        onRetry={onRetry}
+                      />
+                    ))}
+                  </div>
+                )}
               </div>
             </div>
           )}
         </div>
+
+        {/* Batch actions footer */}
+        {pendingProposals.length > 0 && (
+          <div className="px-4 pb-3 pt-1 shrink-0 space-y-1.5" data-testid="batch-actions">
+            <button
+              onClick={onApplyAll}
+              className="w-full py-2.5 rounded-xl font-inter font-semibold text-sm text-white bg-[linear-gradient(135deg,var(--color-primary),#4F46E5)] hover:brightness-105 transition-all"
+              data-testid="apply-all-btn"
+            >
+              Apply All Remaining
+            </button>
+            <button
+              onClick={onDismissAll}
+              className="w-full py-2 rounded-xl font-inter font-semibold text-sm text-zinc-500 hover:text-zinc-700 hover:bg-zinc-100 transition-colors"
+              data-testid="dismiss-all-btn"
+            >
+              Dismiss All Remaining
+            </button>
+          </div>
+        )}
 
         {/* Footer: text input */}
         <div className="px-4 pb-4 pt-2 shrink-0">
@@ -147,12 +217,13 @@ export default function AtelierAssistantPanel({
               onChange={(e) => setInputValue(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder="What did you cover today?"
-              className="flex-1 bg-[#F4F2FD] border-0 focus-visible:ring-0 rounded-xl h-10 px-4 text-sm font-inter"
+              disabled={processing}
+              className="flex-1 bg-[#F4F2FD] border-0 focus-visible:ring-0 rounded-xl h-10 px-4 text-sm font-inter disabled:opacity-50"
               data-testid="assistant-input"
             />
             <button
               onClick={handleSubmit}
-              disabled={!inputValue.trim()}
+              disabled={!inputValue.trim() || processing}
               aria-label="Send message"
               className="h-10 w-10 flex items-center justify-center rounded-xl bg-[linear-gradient(135deg,var(--color-primary),#4F46E5)] text-white disabled:opacity-40 transition-opacity shrink-0"
               data-testid="assistant-send-btn"

--- a/frontend/src/components/assistant/ProposalCard.test.tsx
+++ b/frontend/src/components/assistant/ProposalCard.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi, describe, it, expect } from 'vitest'
+import ProposalCard from './ProposalCard'
+import type { ProposalWithStatus } from '@/hooks/useAtelierAssistant'
+
+function makeProposal(overrides: Partial<ProposalWithStatus> = {}): ProposalWithStatus {
+  return {
+    id: 'p1',
+    type: 'student',
+    field: 'cefrLevel',
+    label: 'CEFR Level',
+    oldValue: 'A2',
+    newValue: 'B1',
+    status: 'proposed',
+    undoVisible: false,
+    ...overrides,
+  }
+}
+
+function renderCard(proposal: ProposalWithStatus, handlers = {}) {
+  const props = {
+    onApply: vi.fn(),
+    onDismiss: vi.fn(),
+    onUndo: vi.fn(),
+    onRetry: vi.fn(),
+    ...handlers,
+  }
+  return { ...render(<ProposalCard proposal={proposal} {...props} />), props }
+}
+
+describe('ProposalCard', () => {
+  it('proposed: shows Apply and Dismiss buttons', () => {
+    renderCard(makeProposal({ status: 'proposed' }))
+    expect(screen.getByTestId('apply-btn-p1')).toBeInTheDocument()
+    expect(screen.getByTestId('dismiss-btn-p1')).toBeInTheDocument()
+  })
+
+  it('proposed: shows diff with old and new value', () => {
+    renderCard(makeProposal({ oldValue: 'A2', newValue: 'B1' }))
+    expect(screen.getByText('A2')).toBeInTheDocument()
+    expect(screen.getByText('B1')).toBeInTheDocument()
+    expect(screen.getByText('A2').className).toContain('line-through')
+  })
+
+  it('proposed: shows only new value when no old value', () => {
+    renderCard(makeProposal({ oldValue: null, newValue: 'Review passive voice' }))
+    expect(screen.getByText('Review passive voice')).toBeInTheDocument()
+    expect(screen.queryByText('→')).not.toBeInTheDocument()
+  })
+
+  it('proposed: calls onApply with id when Apply clicked', async () => {
+    const user = userEvent.setup()
+    const onApply = vi.fn()
+    renderCard(makeProposal(), { onApply })
+    await user.click(screen.getByTestId('apply-btn-p1'))
+    expect(onApply).toHaveBeenCalledWith('p1')
+  })
+
+  it('proposed: calls onDismiss with id when Dismiss clicked', async () => {
+    const user = userEvent.setup()
+    const onDismiss = vi.fn()
+    renderCard(makeProposal(), { onDismiss })
+    await user.click(screen.getByTestId('dismiss-btn-p1'))
+    expect(onDismiss).toHaveBeenCalledWith('p1')
+  })
+
+  it('applied: shows Applied pill, no action buttons', () => {
+    renderCard(makeProposal({ status: 'applied' }))
+    expect(screen.getByText(/applied/i)).toBeInTheDocument()
+    expect(screen.queryByTestId('apply-btn-p1')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('dismiss-btn-p1')).not.toBeInTheDocument()
+  })
+
+  it('dismissed: shows Dismissed pill and reduced opacity', () => {
+    renderCard(makeProposal({ status: 'dismissed', undoVisible: false }))
+    expect(screen.getByText(/dismissed/i)).toBeInTheDocument()
+    expect(screen.getByTestId('proposal-card-p1').className).toContain('opacity-40')
+  })
+
+  it('dismissed: shows Undo button when undoVisible is true', () => {
+    renderCard(makeProposal({ status: 'dismissed', undoVisible: true }))
+    expect(screen.getByTestId('undo-btn-p1')).toBeInTheDocument()
+  })
+
+  it('dismissed: hides Undo button when undoVisible is false', () => {
+    renderCard(makeProposal({ status: 'dismissed', undoVisible: false }))
+    expect(screen.queryByTestId('undo-btn-p1')).not.toBeInTheDocument()
+  })
+
+  it('dismissed: calls onUndo with id when Undo clicked', async () => {
+    const user = userEvent.setup()
+    const onUndo = vi.fn()
+    renderCard(makeProposal({ status: 'dismissed', undoVisible: true }), { onUndo })
+    await user.click(screen.getByTestId('undo-btn-p1'))
+    expect(onUndo).toHaveBeenCalledWith('p1')
+  })
+
+  it('error: shows Error pill, error message, Retry and Dismiss buttons', () => {
+    renderCard(makeProposal({ status: 'error', errorMessage: 'Network error' }))
+    expect(screen.getAllByText(/error/i).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('Network error')).toBeInTheDocument()
+    expect(screen.getByTestId('retry-btn-p1')).toBeInTheDocument()
+  })
+
+  it('error: calls onRetry with id when Retry clicked', async () => {
+    const user = userEvent.setup()
+    const onRetry = vi.fn()
+    renderCard(makeProposal({ status: 'error' }), { onRetry })
+    await user.click(screen.getByTestId('retry-btn-p1'))
+    expect(onRetry).toHaveBeenCalledWith('p1')
+  })
+
+  it('session type: uses Calendar icon config (violet accent)', () => {
+    const { container } = renderCard(makeProposal({ type: 'session' }))
+    expect(container.querySelector('.bg-violet-500')).toBeInTheDocument()
+  })
+
+  it('todo type: uses CheckSquare icon config (emerald accent)', () => {
+    const { container } = renderCard(makeProposal({ type: 'todo', oldValue: null, newValue: 'Review passive voice' }))
+    expect(container.querySelector('.bg-emerald-500')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/assistant/ProposalCard.tsx
+++ b/frontend/src/components/assistant/ProposalCard.tsx
@@ -1,0 +1,158 @@
+import { Calendar, CheckSquare, Loader2, User } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { ProposalWithStatus } from '@/hooks/useAtelierAssistant'
+
+interface Props {
+  proposal: ProposalWithStatus
+  onApply: (id: string) => void
+  onDismiss: (id: string) => void
+  onUndo: (id: string) => void
+  onRetry: (id: string) => void
+}
+
+const TYPE_CONFIG = {
+  student: {
+    Icon: User,
+    accent: 'bg-indigo-500',
+    iconBg: 'bg-indigo-100',
+    iconColor: 'text-indigo-600',
+  },
+  session: {
+    Icon: Calendar,
+    accent: 'bg-violet-500',
+    iconBg: 'bg-violet-100',
+    iconColor: 'text-violet-600',
+  },
+  todo: {
+    Icon: CheckSquare,
+    accent: 'bg-emerald-500',
+    iconBg: 'bg-emerald-100',
+    iconColor: 'text-emerald-600',
+  },
+} as const
+
+export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onRetry }: Props) {
+  const config = TYPE_CONFIG[proposal.type]
+  const { Icon } = config
+
+  const isDismissed = proposal.status === 'dismissed'
+  const isApplied = proposal.status === 'applied'
+  const isApplying = proposal.status === 'applying'
+  const isError = proposal.status === 'error'
+
+  return (
+    <div
+      data-testid={`proposal-card-${proposal.id}`}
+      className={cn(
+        'flex rounded-xl overflow-hidden transition-opacity duration-200',
+        'bg-white shadow-[0_1px_4px_0_rgb(0_0_0_/_0.06)]',
+        isDismissed && 'opacity-40',
+      )}
+    >
+      {/* Accent bar */}
+      <div className={cn('w-1 shrink-0', config.accent)} />
+
+      <div className="flex-1 px-3 py-3 min-w-0">
+        {/* Header row */}
+        <div className="flex items-center gap-2 mb-2">
+          <span className={cn('h-6 w-6 rounded-full flex items-center justify-center shrink-0', config.iconBg)}>
+            <Icon className={cn('h-3.5 w-3.5', config.iconColor)} aria-hidden="true" />
+          </span>
+          <span className="text-xs font-bold font-inter text-zinc-500 uppercase tracking-wide flex-1 truncate">
+            {proposal.label}
+          </span>
+          {/* Status pill */}
+          {isApplied && (
+            <span className="text-[0.625rem] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700 font-inter shrink-0">
+              Applied
+            </span>
+          )}
+          {isDismissed && (
+            <span className="text-[0.625rem] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full bg-zinc-100 text-zinc-400 font-inter shrink-0">
+              Dismissed
+            </span>
+          )}
+          {isError && (
+            <span className="text-[0.625rem] font-bold uppercase tracking-wide px-2 py-0.5 rounded-full bg-red-100 text-red-600 font-inter shrink-0">
+              Error
+            </span>
+          )}
+        </div>
+
+        {/* Diff */}
+        <div className="text-sm font-inter text-zinc-700 mb-2.5 leading-relaxed">
+          {proposal.oldValue ? (
+            <span>
+              <span className="line-through text-zinc-400">{proposal.oldValue}</span>
+              {' '}
+              <span className="text-zinc-400 mx-0.5">→</span>
+              {' '}
+              <span className="font-semibold text-zinc-800">{proposal.newValue}</span>
+            </span>
+          ) : (
+            <span className="font-semibold text-zinc-800">{proposal.newValue}</span>
+          )}
+        </div>
+
+        {/* Inline error */}
+        {isError && proposal.errorMessage && (
+          <p className="text-xs text-red-600 font-inter mb-2">{proposal.errorMessage}</p>
+        )}
+
+        {/* Actions */}
+        <div className="flex items-center gap-2">
+          {proposal.status === 'proposed' && (
+            <>
+              <button
+                onClick={() => onApply(proposal.id)}
+                data-testid={`apply-btn-${proposal.id}`}
+                className="text-xs font-semibold font-inter text-white bg-indigo-600 hover:bg-indigo-700 px-3 py-1 rounded-lg transition-colors"
+              >
+                Apply
+              </button>
+              <button
+                onClick={() => onDismiss(proposal.id)}
+                data-testid={`dismiss-btn-${proposal.id}`}
+                className="text-xs font-semibold font-inter text-zinc-500 hover:text-zinc-700 px-3 py-1 rounded-lg hover:bg-zinc-100 transition-colors"
+              >
+                Dismiss
+              </button>
+            </>
+          )}
+
+          {isApplying && (
+            <Loader2 className="h-4 w-4 animate-spin text-indigo-500" aria-label="Applying…" />
+          )}
+
+          {isDismissed && proposal.undoVisible && (
+            <button
+              onClick={() => onUndo(proposal.id)}
+              data-testid={`undo-btn-${proposal.id}`}
+              className="text-xs font-semibold font-inter text-indigo-600 hover:text-indigo-700 px-2 py-1 rounded-lg hover:bg-indigo-50 transition-colors"
+            >
+              Undo
+            </button>
+          )}
+
+          {isError && (
+            <>
+              <button
+                onClick={() => onRetry(proposal.id)}
+                data-testid={`retry-btn-${proposal.id}`}
+                className="text-xs font-semibold font-inter text-white bg-indigo-600 hover:bg-indigo-700 px-3 py-1 rounded-lg transition-colors"
+              >
+                Retry
+              </button>
+              <button
+                onClick={() => onDismiss(proposal.id)}
+                className="text-xs font-semibold font-inter text-zinc-500 hover:text-zinc-700 px-3 py-1 rounded-lg hover:bg-zinc-100 transition-colors"
+              >
+                Dismiss
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useAtelierAssistant.test.ts
+++ b/frontend/src/hooks/useAtelierAssistant.test.ts
@@ -1,0 +1,178 @@
+import { act, renderHook } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { useAtelierAssistant } from './useAtelierAssistant'
+
+vi.mock('../api/assistant', () => ({
+  proposeAssistant: vi.fn(),
+  applyStudentProposal: vi.fn(),
+  applySessionProposal: vi.fn(),
+  applyTodoProposal: vi.fn(),
+}))
+
+import * as assistantApi from '../api/assistant'
+
+const mockPropose = vi.mocked(assistantApi.proposeAssistant)
+const mockApplyStudent = vi.mocked(assistantApi.applyStudentProposal)
+const mockApplySession = vi.mocked(assistantApi.applySessionProposal)
+const mockApplyTodo = vi.mocked(assistantApi.applyTodoProposal)
+
+const sampleProposals = [
+  { id: 'p1', type: 'student' as const, field: 'cefrLevel', label: 'CEFR Level', oldValue: 'A2', newValue: 'B1' },
+  { id: 'p2', type: 'session' as const, field: 'title', label: 'Session Title', oldValue: null, newValue: 'Past Perfect' },
+  { id: 'p3', type: 'todo' as const, field: 'text', label: 'Teaching Todo', oldValue: null, newValue: 'Review passive voice' },
+]
+
+describe('useAtelierAssistant', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('initialises with null transcription, not processing, empty proposals', () => {
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'))
+    expect(result.current.transcription).toBeNull()
+    expect(result.current.processing).toBe(false)
+    expect(result.current.proposals).toHaveLength(0)
+  })
+
+  it('submit: sets transcription and processing immediately, then populates proposals', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: sampleProposals })
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'))
+
+    act(() => { result.current.submit('We covered past perfect.') })
+    expect(result.current.transcription).toBe('We covered past perfect.')
+    expect(result.current.processing).toBe(true)
+
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(result.current.processing).toBe(false)
+    expect(result.current.proposals).toHaveLength(3)
+    expect(result.current.proposals[0].status).toBe('proposed')
+  })
+
+  it('submit: calls proposeAssistant with studentId and sessionId', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: [] })
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'))
+    act(() => { result.current.submit('Some text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(mockPropose).toHaveBeenCalledWith('Some text', 'student-1', 'session-1')
+  })
+
+  it('apply: routes student proposal to applyStudentProposal', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[0]] })
+    mockApplyStudent.mockResolvedValueOnce(undefined)
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null))
+
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(result.current.proposals).toHaveLength(1)
+
+    await act(async () => { await result.current.apply('p1') })
+    expect(mockApplyStudent).toHaveBeenCalledWith('student-1', 'cefrLevel', 'B1')
+    expect(result.current.proposals[0].status).toBe('applied')
+  })
+
+  it('apply: routes session proposal to applySessionProposal', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[1]] })
+    mockApplySession.mockResolvedValueOnce(undefined)
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'))
+
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(result.current.proposals).toHaveLength(1)
+
+    await act(async () => { await result.current.apply('p2') })
+    expect(mockApplySession).toHaveBeenCalledWith('student-1', 'session-1', 'title', 'Past Perfect')
+    expect(result.current.proposals[0].status).toBe('applied')
+  })
+
+  it('apply: routes todo proposal to applyTodoProposal', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[2]] })
+    mockApplyTodo.mockResolvedValueOnce(undefined)
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null))
+
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(result.current.proposals).toHaveLength(1)
+
+    await act(async () => { await result.current.apply('p3') })
+    expect(mockApplyTodo).toHaveBeenCalledWith('student-1', 'Review passive voice')
+    expect(result.current.proposals[0].status).toBe('applied')
+  })
+
+  it('apply: sets error status on failure without affecting other cards', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: sampleProposals.slice(0, 2) })
+    mockApplyStudent.mockRejectedValueOnce(new Error('Network error'))
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'))
+
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(result.current.proposals).toHaveLength(2)
+
+    await act(async () => { await result.current.apply('p1') })
+    expect(result.current.proposals.find(p => p.id === 'p1')?.status).toBe('error')
+    expect(result.current.proposals.find(p => p.id === 'p2')?.status).toBe('proposed')
+  })
+
+  it('dismiss: sets status to dismissed and shows undo for 5s then hides', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[0]] })
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null))
+
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(result.current.proposals).toHaveLength(1)
+
+    act(() => { result.current.dismiss('p1') })
+    expect(result.current.proposals[0].status).toBe('dismissed')
+    expect(result.current.proposals[0].undoVisible).toBe(true)
+
+    act(() => { vi.advanceTimersByTime(5000) })
+    expect(result.current.proposals[0].undoVisible).toBe(false)
+  })
+
+  it('undoDismiss: cancels timer and reverts to proposed', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[0]] })
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null))
+
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    act(() => { result.current.dismiss('p1') })
+    act(() => { result.current.undoDismiss('p1') })
+    expect(result.current.proposals[0].status).toBe('proposed')
+    expect(result.current.proposals[0].undoVisible).toBe(false)
+
+    act(() => { vi.advanceTimersByTime(5000) })
+    expect(result.current.proposals[0].status).toBe('proposed')
+  })
+
+  it('applyAll: applies only proposed cards sequentially', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: sampleProposals.slice(0, 2) })
+    mockApplyStudent.mockResolvedValueOnce(undefined)
+    mockApplySession.mockResolvedValueOnce(undefined)
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'))
+
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(result.current.proposals).toHaveLength(2)
+
+    await act(async () => { await result.current.applyAll() })
+    expect(result.current.proposals.every(p => p.status === 'applied')).toBe(true)
+  })
+
+  it('reset: clears transcription, processing, and proposals', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[0]] })
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null))
+
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(result.current.proposals).toHaveLength(1)
+
+    act(() => { result.current.reset() })
+    expect(result.current.transcription).toBeNull()
+    expect(result.current.proposals).toHaveLength(0)
+  })
+})

--- a/frontend/src/hooks/useAtelierAssistant.test.ts
+++ b/frontend/src/hooks/useAtelierAssistant.test.ts
@@ -1,6 +1,14 @@
 import { act, renderHook } from '@testing-library/react'
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useAtelierAssistant } from './useAtelierAssistant'
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children)
+}
 
 vi.mock('../api/assistant', () => ({
   proposeAssistant: vi.fn(),
@@ -33,7 +41,7 @@ describe('useAtelierAssistant', () => {
   })
 
   it('initialises with null transcription, not processing, empty proposals', () => {
-    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'))
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'), { wrapper: makeWrapper() })
     expect(result.current.transcription).toBeNull()
     expect(result.current.processing).toBe(false)
     expect(result.current.proposals).toHaveLength(0)
@@ -41,7 +49,7 @@ describe('useAtelierAssistant', () => {
 
   it('submit: sets transcription and processing immediately, then populates proposals', async () => {
     mockPropose.mockResolvedValueOnce({ proposals: sampleProposals })
-    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'))
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'), { wrapper: makeWrapper() })
 
     act(() => { result.current.submit('We covered past perfect.') })
     expect(result.current.transcription).toBe('We covered past perfect.')
@@ -55,7 +63,7 @@ describe('useAtelierAssistant', () => {
 
   it('submit: calls proposeAssistant with studentId and sessionId', async () => {
     mockPropose.mockResolvedValueOnce({ proposals: [] })
-    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'))
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'), { wrapper: makeWrapper() })
     act(() => { result.current.submit('Some text') })
     await act(async () => { await vi.runAllTimersAsync() })
     expect(mockPropose).toHaveBeenCalledWith('Some text', 'student-1', 'session-1')
@@ -64,7 +72,7 @@ describe('useAtelierAssistant', () => {
   it('apply: routes student proposal to applyStudentProposal', async () => {
     mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[0]] })
     mockApplyStudent.mockResolvedValueOnce(undefined)
-    const { result } = renderHook(() => useAtelierAssistant('student-1', null))
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null), { wrapper: makeWrapper() })
 
     act(() => { result.current.submit('text') })
     await act(async () => { await vi.runAllTimersAsync() })
@@ -78,7 +86,7 @@ describe('useAtelierAssistant', () => {
   it('apply: routes session proposal to applySessionProposal', async () => {
     mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[1]] })
     mockApplySession.mockResolvedValueOnce(undefined)
-    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'))
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'), { wrapper: makeWrapper() })
 
     act(() => { result.current.submit('text') })
     await act(async () => { await vi.runAllTimersAsync() })
@@ -92,7 +100,7 @@ describe('useAtelierAssistant', () => {
   it('apply: routes todo proposal to applyTodoProposal', async () => {
     mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[2]] })
     mockApplyTodo.mockResolvedValueOnce(undefined)
-    const { result } = renderHook(() => useAtelierAssistant('student-1', null))
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null), { wrapper: makeWrapper() })
 
     act(() => { result.current.submit('text') })
     await act(async () => { await vi.runAllTimersAsync() })
@@ -106,7 +114,7 @@ describe('useAtelierAssistant', () => {
   it('apply: sets error status on failure without affecting other cards', async () => {
     mockPropose.mockResolvedValueOnce({ proposals: sampleProposals.slice(0, 2) })
     mockApplyStudent.mockRejectedValueOnce(new Error('Network error'))
-    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'))
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'), { wrapper: makeWrapper() })
 
     act(() => { result.current.submit('text') })
     await act(async () => { await vi.runAllTimersAsync() })
@@ -119,7 +127,7 @@ describe('useAtelierAssistant', () => {
 
   it('dismiss: sets status to dismissed and shows undo for 5s then hides', async () => {
     mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[0]] })
-    const { result } = renderHook(() => useAtelierAssistant('student-1', null))
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null), { wrapper: makeWrapper() })
 
     act(() => { result.current.submit('text') })
     await act(async () => { await vi.runAllTimersAsync() })
@@ -135,7 +143,7 @@ describe('useAtelierAssistant', () => {
 
   it('undoDismiss: cancels timer and reverts to proposed', async () => {
     mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[0]] })
-    const { result } = renderHook(() => useAtelierAssistant('student-1', null))
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null), { wrapper: makeWrapper() })
 
     act(() => { result.current.submit('text') })
     await act(async () => { await vi.runAllTimersAsync() })
@@ -153,7 +161,7 @@ describe('useAtelierAssistant', () => {
     mockPropose.mockResolvedValueOnce({ proposals: sampleProposals.slice(0, 2) })
     mockApplyStudent.mockResolvedValueOnce(undefined)
     mockApplySession.mockResolvedValueOnce(undefined)
-    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'))
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'), { wrapper: makeWrapper() })
 
     act(() => { result.current.submit('text') })
     await act(async () => { await vi.runAllTimersAsync() })
@@ -165,7 +173,7 @@ describe('useAtelierAssistant', () => {
 
   it('reset: clears transcription, processing, and proposals', async () => {
     mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[0]] })
-    const { result } = renderHook(() => useAtelierAssistant('student-1', null))
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null), { wrapper: makeWrapper() })
 
     act(() => { result.current.submit('text') })
     await act(async () => { await vi.runAllTimersAsync() })

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -1,0 +1,135 @@
+import { useCallback, useRef, useState } from 'react'
+import {
+  applySessionProposal,
+  applyStudentProposal,
+  applyTodoProposal,
+  type ProposalDto,
+  proposeAssistant,
+} from '../api/assistant'
+
+export type ProposalStatus = 'proposed' | 'applying' | 'applied' | 'dismissed' | 'error'
+
+export interface ProposalWithStatus extends ProposalDto {
+  status: ProposalStatus
+  errorMessage?: string
+  undoVisible: boolean
+}
+
+export interface AtelierAssistantState {
+  transcription: string | null
+  processing: boolean
+  proposals: ProposalWithStatus[]
+}
+
+export interface AtelierAssistantActions {
+  submit: (text: string) => void
+  apply: (id: string) => void
+  dismiss: (id: string) => void
+  undoDismiss: (id: string) => void
+  applyAll: () => void
+  dismissAll: () => void
+  reset: () => void
+}
+
+export function useAtelierAssistant(
+  studentId: string | null,
+  sessionId: string | null,
+): AtelierAssistantState & AtelierAssistantActions {
+  const [transcription, setTranscription] = useState<string | null>(null)
+  const [processing, setProcessing] = useState(false)
+  const [proposals, setProposals] = useState<ProposalWithStatus[]>([])
+  const undoTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
+  const updateProposal = useCallback((id: string, patch: Partial<ProposalWithStatus>) => {
+    setProposals(prev => prev.map(p => p.id === id ? { ...p, ...patch } : p))
+  }, [])
+
+  const submit = useCallback(async (text: string) => {
+    setTranscription(text)
+    setProcessing(true)
+    setProposals([])
+    try {
+      const { proposals: raw } = await proposeAssistant(
+        text,
+        studentId ?? undefined,
+        sessionId ?? undefined,
+      )
+      setProposals(raw.map(p => ({ ...p, status: 'proposed', undoVisible: false })))
+    } catch {
+      // Error state shown via empty proposals list; processing clears
+    } finally {
+      setProcessing(false)
+    }
+  }, [studentId, sessionId])
+
+  const apply = useCallback(async (id: string) => {
+    const proposal = proposals.find(p => p.id === id)
+    if (!proposal || proposal.status !== 'proposed') return
+
+    updateProposal(id, { status: 'applying', errorMessage: undefined })
+
+    try {
+      if (proposal.type === 'student' && studentId) {
+        await applyStudentProposal(studentId, proposal.field, proposal.newValue)
+      } else if (proposal.type === 'session' && studentId && sessionId) {
+        await applySessionProposal(studentId, sessionId, proposal.field, proposal.newValue)
+      } else if (proposal.type === 'todo' && studentId) {
+        await applyTodoProposal(studentId, proposal.newValue)
+      }
+      updateProposal(id, { status: 'applied' })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to apply change.'
+      updateProposal(id, { status: 'error', errorMessage: message })
+    }
+  }, [proposals, studentId, sessionId, updateProposal])
+
+  const dismiss = useCallback((id: string) => {
+    updateProposal(id, { status: 'dismissed', undoVisible: true })
+    const timer = setTimeout(() => {
+      updateProposal(id, { undoVisible: false })
+      undoTimers.current.delete(id)
+    }, 5000)
+    undoTimers.current.set(id, timer)
+  }, [updateProposal])
+
+  const undoDismiss = useCallback((id: string) => {
+    const timer = undoTimers.current.get(id)
+    if (timer) {
+      clearTimeout(timer)
+      undoTimers.current.delete(id)
+    }
+    updateProposal(id, { status: 'proposed', undoVisible: false })
+  }, [updateProposal])
+
+  const applyAll = useCallback(async () => {
+    const pending = proposals.filter(p => p.status === 'proposed')
+    for (const p of pending) {
+      await apply(p.id)
+    }
+  }, [proposals, apply])
+
+  const dismissAll = useCallback(() => {
+    proposals.filter(p => p.status === 'proposed').forEach(p => dismiss(p.id))
+  }, [proposals, dismiss])
+
+  const reset = useCallback(() => {
+    undoTimers.current.forEach(timer => clearTimeout(timer))
+    undoTimers.current.clear()
+    setTranscription(null)
+    setProcessing(false)
+    setProposals([])
+  }, [])
+
+  return {
+    transcription,
+    processing,
+    proposals,
+    submit,
+    apply,
+    dismiss,
+    undoDismiss,
+    applyAll,
+    dismissAll,
+    reset,
+  }
+}

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import {
   applySessionProposal,
@@ -41,6 +41,17 @@ export function useAtelierAssistant(
   const [processing, setProcessing] = useState(false)
   const [proposals, setProposals] = useState<ProposalWithStatus[]>([])
   const undoTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+  // Ref keeps apply/applyAll free of stale closure on proposals
+  const proposalsRef = useRef<ProposalWithStatus[]>([])
+  useEffect(() => { proposalsRef.current = proposals }, [proposals])
+
+  // Clear all undo timers on unmount to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      undoTimers.current.forEach(timer => clearTimeout(timer))
+      undoTimers.current.clear()
+    }
+  }, [])
 
   const updateProposal = useCallback((id: string, patch: Partial<ProposalWithStatus>) => {
     setProposals(prev => prev.map(p => p.id === id ? { ...p, ...patch } : p))
@@ -58,14 +69,14 @@ export function useAtelierAssistant(
       )
       setProposals(raw.map(p => ({ ...p, status: 'proposed', undoVisible: false })))
     } catch {
-      // Error state shown via empty proposals list; processing clears
+      // Error shown via empty proposals list; processing clears
     } finally {
       setProcessing(false)
     }
   }, [studentId, sessionId])
 
   const apply = useCallback(async (id: string) => {
-    const proposal = proposals.find(p => p.id === id)
+    const proposal = proposalsRef.current.find(p => p.id === id)
     if (!proposal || (proposal.status !== 'proposed' && proposal.status !== 'error')) return
 
     updateProposal(id, { status: 'applying', errorMessage: undefined })
@@ -90,7 +101,7 @@ export function useAtelierAssistant(
       const message = err instanceof Error ? err.message : 'Failed to apply change.'
       updateProposal(id, { status: 'error', errorMessage: message })
     }
-  }, [proposals, studentId, sessionId, updateProposal])
+  }, [studentId, sessionId, updateProposal, queryClient])
 
   const dismiss = useCallback((id: string) => {
     updateProposal(id, { status: 'dismissed', undoVisible: true })
@@ -111,15 +122,15 @@ export function useAtelierAssistant(
   }, [updateProposal])
 
   const applyAll = useCallback(async () => {
-    const pending = proposals.filter(p => p.status === 'proposed')
+    const pending = proposalsRef.current.filter(p => p.status === 'proposed')
     for (const p of pending) {
       await apply(p.id)
     }
-  }, [proposals, apply])
+  }, [apply])
 
   const dismissAll = useCallback(() => {
-    proposals.filter(p => p.status === 'proposed').forEach(p => dismiss(p.id))
-  }, [proposals, dismiss])
+    proposalsRef.current.filter(p => p.status === 'proposed').forEach(p => dismiss(p.id))
+  }, [dismiss])
 
   const reset = useCallback(() => {
     undoTimers.current.forEach(timer => clearTimeout(timer))

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import {
   applySessionProposal,
   applyStudentProposal,
@@ -35,6 +36,7 @@ export function useAtelierAssistant(
   studentId: string | null,
   sessionId: string | null,
 ): AtelierAssistantState & AtelierAssistantActions {
+  const queryClient = useQueryClient()
   const [transcription, setTranscription] = useState<string | null>(null)
   const [processing, setProcessing] = useState(false)
   const [proposals, setProposals] = useState<ProposalWithStatus[]>([])
@@ -64,7 +66,7 @@ export function useAtelierAssistant(
 
   const apply = useCallback(async (id: string) => {
     const proposal = proposals.find(p => p.id === id)
-    if (!proposal || proposal.status !== 'proposed') return
+    if (!proposal || (proposal.status !== 'proposed' && proposal.status !== 'error')) return
 
     updateProposal(id, { status: 'applying', errorMessage: undefined })
 
@@ -77,6 +79,13 @@ export function useAtelierAssistant(
         await applyTodoProposal(studentId, proposal.newValue)
       }
       updateProposal(id, { status: 'applied' })
+      // Invalidate relevant queries so the rest of the UI reflects the change
+      if (proposal.type === 'student' && studentId) {
+        await queryClient.invalidateQueries({ queryKey: ['student', studentId] })
+      } else if (proposal.type === 'session' && studentId && sessionId) {
+        await queryClient.invalidateQueries({ queryKey: ['session', studentId, sessionId] })
+        await queryClient.invalidateQueries({ queryKey: ['sessions', studentId] })
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to apply change.'
       updateProposal(id, { status: 'error', errorMessage: message })

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -10,4 +10,10 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 
 ## #1008 (2026-04-28)
 
-- **AppShell transcription state lift** (arch-reviewer): `transcription: string | null` for the Atelier Assistant lives in AppShell. This works for part 1 but deviates from the pattern of sub-panel state living local or in a dedicated context (compare `VoiceUpdateDrawer` state in `StudentDetail.tsx`). If parts 2/3 add more cross-cutting assistant state (proposals, selection, apply flow), refactor to a dedicated `AtelierAssistantContext` provider. Deferred — assess at #1009.
+- **AppShell transcription state lift** (arch-reviewer): `transcription: string | null` for the Atelier Assistant lives in AppShell. This works for part 1 but deviates from the pattern of sub-panel state living local or in a dedicated context (compare `VoiceUpdateDrawer` state in `StudentDetail.tsx`). If parts 2/3 add more cross-cutting assistant state (proposals, selection, apply flow), refactor to a dedicated `AtelierAssistantContext` provider. Resolved at #1009: all state now lives in `useAtelierAssistant` hook. Context provider can be considered for Part 3 (#1010) if cross-route state is needed.
+
+## #1009 (2026-04-28)
+
+- **Proposal field taxonomy hardcoded in C#** (Sophy): `AssistantController` emits `EmitProposal` calls for 7 hard-coded field/label pairs. `PatchStudentRequest`/`PatchSessionRequest` mirror this whitelist. Long-term: extract to `data/assistant/proposal-fields.json` consumed by both emission loop and patch dispatch. Assess at Part 3+ (#1010).
+- **CEFR regex duplicated** (Sophy): `PatchStudentRequest.CefrLevel` regex `^(A1|A2|B1|B2|C1|C2)$` duplicates `UpdateStudentRequest`. Both should read from `IPedagogyConfigService.AllowedCefrLevels`. Batch with #837-style deduplication in sprint close.
+- **`useAtelierAssistant` uses raw async/await instead of `useMutation`** (arch-reviewer): The multi-card orchestration pattern doesn't fit single-mutation well. Cache invalidation is handled via `invalidateQueries`. Reassess if retry/optimistic-update patterns become complex in Part 3.


### PR DESCRIPTION
Closes #1009

## Summary

- **`POST /api/assistant/propose`**: calls `StudentProfileExtractionService` + `ReflectionExtractionService` in parallel; returns typed `ProposalDto[]` (student/session/todo). Guards: no proposals for equal values, todos only when studentId provided.
- **`PATCH /api/students/{id}`** and **`PATCH /api/students/{id}/sessions/{sessionId}`**: typed partial-update endpoints (PatchStudentRequest / PatchSessionRequest) following existing typed-DTO convention.
- **`useAtelierAssistant` hook**: manages submit, per-card apply/dismiss/undo (5s undo timer), batch apply/dismiss, per-card error state, and React Query cache invalidation after apply.
- **`ProposalCard`**: entity icon + colored accent bar (indigo=student, violet=session, emerald=todo), diff display (~~old~~ → **new**), Apply/Dismiss/Undo/Retry actions, status pill.
- **`AtelierAssistantPanel`**: PROCESSING INSIGHT header state with animated dot, proposal cards list, Apply All / Dismiss All batch footer, input disabled during processing.
- **`AppShell`**: sessionId extraction from route regex, hook wiring replacing manual state.

## Test plan

- [ ] Open Log Session for Ana; open Atelier Assistant; type "We worked on past perfect, set writing level to B1, add a passive voice todo" — three typed cards appear
- [ ] Apply Student card only — Ana's profile updates (CEFR), other cards stay Proposed
- [ ] Dismiss Todo — Undo visible for 5s; click Undo — card reverts to Proposed
- [ ] Apply All Remaining — only remaining Proposed cards (Session) get applied
- [ ] Open panel on a non-student route — no student/todo cards, only session cards
- [ ] Backend tests: `dotnet test --filter AssistantController` (4 tests)
- [ ] Frontend tests: `npm test` (98 files, 1571 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI-powered assistant generates proposals for student profile updates (language proficiency level, profession, country of residence) and session details (title, notes, homework assignments).
  * Users can review proposals showing old and new values, then apply, dismiss, or undo changes individually.
  * Batch actions allow applying or dismissing all pending proposals at once.
  * Real-time processing indicator displays when the assistant is analyzing input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->