### PR TITLE
feat(#1010): Atelier Assistant — modify-in-place and chat refinement

### DIFF
--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -273,6 +273,7 @@ export default function AppShell() {
         onDismiss={assistant.dismiss}
         onUndo={assistant.undoDismiss}
         onRetry={assistant.apply}
+        onModify={assistant.modifyProposal}
         onApplyAll={assistant.applyAll}
         onDismissAll={assistant.dismissAll}
       />

--- a/frontend/src/components/AtelierAssistantPanel.test.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.test.tsx
@@ -82,6 +82,7 @@ const defaultProps = {
   onDismiss: vi.fn(),
   onUndo: vi.fn(),
   onRetry: vi.fn(),
+  onModify: vi.fn(),
   onApplyAll: vi.fn(),
   onDismissAll: vi.fn(),
 }

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -77,6 +77,7 @@ export default function AtelierAssistantPanel({
 }: Props) {
   const [inputValue, setInputValue] = useState('')
   const [pendingClose, setPendingClose] = useState(false)
+  const chatInputRef = useRef<HTMLInputElement>(null)
 
   const [micState, setMicState] = useState<MicState>('idle')
   const [micError, setMicError] = useState<MicError>(null)
@@ -309,6 +310,11 @@ export default function AtelierAssistantPanel({
     }
   }
 
+  function handleRedirectToChat(prefill: string) {
+    setInputValue(prefill)
+    setTimeout(() => chatInputRef.current?.focus(), 0)
+  }
+
   const emptyPrompt = studentName
     ? `What did you cover with ${studentName} today?`
     : 'What would you like to cover today?'
@@ -437,6 +443,7 @@ export default function AtelierAssistantPanel({
                         onUndo={onUndo}
                         onRetry={onRetry}
                         onModify={onModify}
+                        onRedirectToChat={handleRedirectToChat}
                       />
                     ))}
                   </div>
@@ -526,6 +533,7 @@ export default function AtelierAssistantPanel({
                   <Mic className="h-4 w-4" />
                 </button>
                 <Input
+                  ref={chatInputRef}
                   value={inputValue}
                   onChange={(e) => setInputValue(e.target.value)}
                   onKeyDown={handleKeyDown}

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -53,6 +53,7 @@ interface Props {
   onDismiss: (id: string) => void
   onUndo: (id: string) => void
   onRetry: (id: string) => void
+  onModify: (id: string, newValue: string) => void
   onApplyAll: () => void
   onDismissAll: () => void
 }
@@ -70,6 +71,7 @@ export default function AtelierAssistantPanel({
   onDismiss,
   onUndo,
   onRetry,
+  onModify,
   onApplyAll,
   onDismissAll,
 }: Props) {
@@ -434,6 +436,7 @@ export default function AtelierAssistantPanel({
                         onDismiss={onDismiss}
                         onUndo={onUndo}
                         onRetry={onRetry}
+                        onModify={onModify}
                       />
                     ))}
                   </div>

--- a/frontend/src/components/assistant/ProposalCard.test.tsx
+++ b/frontend/src/components/assistant/ProposalCard.test.tsx
@@ -24,6 +24,7 @@ function renderCard(proposal: ProposalWithStatus, handlers = {}) {
     onDismiss: vi.fn(),
     onUndo: vi.fn(),
     onRetry: vi.fn(),
+    onModify: vi.fn(),
     ...handlers,
   }
   return { ...render(<ProposalCard proposal={proposal} {...props} />), props }
@@ -119,5 +120,86 @@ describe('ProposalCard', () => {
   it('todo type: uses CheckSquare icon config (emerald accent)', () => {
     const { container } = renderCard(makeProposal({ type: 'todo', oldValue: null, newValue: 'Review passive voice' }))
     expect(container.querySelector('.bg-emerald-500')).toBeInTheDocument()
+  })
+
+  it('proposed: shows Modify button', () => {
+    renderCard(makeProposal({ status: 'proposed' }))
+    expect(screen.getByTestId('modify-btn-p1')).toBeInTheDocument()
+  })
+
+  it('applied: does not show Modify button', () => {
+    renderCard(makeProposal({ status: 'applied' }))
+    expect(screen.queryByTestId('modify-btn-p1')).not.toBeInTheDocument()
+  })
+
+  it('dismissed: does not show Modify button', () => {
+    renderCard(makeProposal({ status: 'dismissed', undoVisible: false }))
+    expect(screen.queryByTestId('modify-btn-p1')).not.toBeInTheDocument()
+  })
+
+  it('clicking Modify shows inline input with current value', async () => {
+    const user = userEvent.setup()
+    renderCard(makeProposal({ status: 'proposed', newValue: 'B1' }))
+    await user.click(screen.getByTestId('modify-btn-p1'))
+    const input = screen.getByTestId('modify-input-p1') as HTMLInputElement
+    expect(input).toBeInTheDocument()
+    expect(input.value).toBe('B1')
+  })
+
+  it('Enter in inline input commits and calls onModify', async () => {
+    const user = userEvent.setup()
+    const onModify = vi.fn()
+    renderCard(makeProposal({ status: 'proposed', newValue: 'B1' }), { onModify })
+    await user.click(screen.getByTestId('modify-btn-p1'))
+    const input = screen.getByTestId('modify-input-p1')
+    await user.clear(input)
+    await user.type(input, 'B2')
+    await user.keyboard('{Enter}')
+    expect(onModify).toHaveBeenCalledWith('p1', 'B2')
+    expect(screen.queryByTestId('modify-input-p1')).not.toBeInTheDocument()
+  })
+
+  it('Escape in inline input cancels without calling onModify', async () => {
+    const user = userEvent.setup()
+    const onModify = vi.fn()
+    renderCard(makeProposal({ status: 'proposed', newValue: 'B1' }), { onModify })
+    await user.click(screen.getByTestId('modify-btn-p1'))
+    await user.type(screen.getByTestId('modify-input-p1'), 'B2')
+    await user.keyboard('{Escape}')
+    expect(onModify).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('modify-input-p1')).not.toBeInTheDocument()
+  })
+
+  it('Save button commits and calls onModify', async () => {
+    const user = userEvent.setup()
+    const onModify = vi.fn()
+    renderCard(makeProposal({ status: 'proposed', newValue: 'B1' }), { onModify })
+    await user.click(screen.getByTestId('modify-btn-p1'))
+    const input = screen.getByTestId('modify-input-p1')
+    await user.clear(input)
+    await user.type(input, 'B2')
+    await user.click(screen.getByTestId('modify-save-btn-p1'))
+    expect(onModify).toHaveBeenCalledWith('p1', 'B2')
+  })
+
+  it('Cancel button exits edit mode without calling onModify', async () => {
+    const user = userEvent.setup()
+    const onModify = vi.fn()
+    renderCard(makeProposal({ status: 'proposed', newValue: 'B1' }), { onModify })
+    await user.click(screen.getByTestId('modify-btn-p1'))
+    await user.click(screen.getByTestId('modify-cancel-btn-p1'))
+    expect(onModify).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('modify-input-p1')).not.toBeInTheDocument()
+  })
+
+  it('empty value on Enter does not call onModify', async () => {
+    const user = userEvent.setup()
+    const onModify = vi.fn()
+    renderCard(makeProposal({ status: 'proposed', newValue: 'B1' }), { onModify })
+    await user.click(screen.getByTestId('modify-btn-p1'))
+    const input = screen.getByTestId('modify-input-p1')
+    await user.clear(input)
+    await user.keyboard('{Enter}')
+    expect(onModify).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/assistant/ProposalCard.test.tsx
+++ b/frontend/src/components/assistant/ProposalCard.test.tsx
@@ -25,6 +25,7 @@ function renderCard(proposal: ProposalWithStatus, handlers = {}) {
     onUndo: vi.fn(),
     onRetry: vi.fn(),
     onModify: vi.fn(),
+    onRedirectToChat: vi.fn(),
     ...handlers,
   }
   return { ...render(<ProposalCard proposal={proposal} {...props} />), props }
@@ -189,6 +190,16 @@ describe('ProposalCard', () => {
     await user.click(screen.getByTestId('modify-btn-p1'))
     await user.click(screen.getByTestId('modify-cancel-btn-p1'))
     expect(onModify).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('modify-input-p1')).not.toBeInTheDocument()
+  })
+
+  it('Wrong entity button calls onRedirectToChat with prefill and exits edit mode', async () => {
+    const user = userEvent.setup()
+    const onRedirectToChat = vi.fn()
+    renderCard(makeProposal({ status: 'proposed', type: 'session', field: 'title' }), { onRedirectToChat })
+    await user.click(screen.getByTestId('modify-btn-p1'))
+    await user.click(screen.getByTestId('redirect-to-chat-btn-p1'))
+    expect(onRedirectToChat).toHaveBeenCalledWith(expect.stringContaining('student profile'))
     expect(screen.queryByTestId('modify-input-p1')).not.toBeInTheDocument()
   })
 

--- a/frontend/src/components/assistant/ProposalCard.tsx
+++ b/frontend/src/components/assistant/ProposalCard.tsx
@@ -1,3 +1,4 @@
+import { useState, useRef, useEffect } from 'react'
 import { Calendar, CheckSquare, Loader2, User } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { ProposalWithStatus } from '@/hooks/useAtelierAssistant'
@@ -8,7 +9,10 @@ interface Props {
   onDismiss: (id: string) => void
   onUndo: (id: string) => void
   onRetry: (id: string) => void
+  onModify: (id: string, newValue: string) => void
 }
+
+const MULTILINE_FIELDS = new Set(['actualContent', 'generalNotes', 'homeworkAssigned'])
 
 const TYPE_CONFIG = {
   student: {
@@ -31,7 +35,7 @@ const TYPE_CONFIG = {
   },
 } as const
 
-export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onRetry }: Props) {
+export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onRetry, onModify }: Props) {
   const config = TYPE_CONFIG[proposal.type]
   const { Icon } = config
 
@@ -39,6 +43,58 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
   const isApplied = proposal.status === 'applied'
   const isApplying = proposal.status === 'applying'
   const isError = proposal.status === 'error'
+
+  const [editing, setEditing] = useState(false)
+  const [editValue, setEditValue] = useState('')
+  const editingRef = useRef(false)
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null)
+
+  useEffect(() => {
+    editingRef.current = editing
+  }, [editing])
+
+  function startEdit() {
+    setEditValue(proposal.newValue)
+    setEditing(true)
+  }
+
+  function commitEdit() {
+    const trimmed = editValue.trim()
+    setEditing(false)
+    if (trimmed && trimmed !== proposal.newValue) {
+      onModify(proposal.id, trimmed)
+    }
+  }
+
+  function cancelEdit() {
+    setEditing(false)
+  }
+
+  function handleEditKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      commitEdit()
+    } else if (e.key === 'Escape') {
+      cancelEdit()
+    }
+  }
+
+  function handleEditBlur() {
+    if (!editingRef.current) return
+    const trimmed = editValue.trim()
+    setEditing(false)
+    if (trimmed && trimmed !== proposal.newValue) {
+      onModify(proposal.id, trimmed)
+    }
+  }
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus()
+    }
+  }, [editing])
+
+  const isMultiline = MULTILINE_FIELDS.has(proposal.field)
 
   return (
     <div
@@ -79,9 +135,33 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
           )}
         </div>
 
-        {/* Diff */}
+        {/* Diff / inline edit */}
         <div className="text-sm font-inter text-zinc-700 mb-2.5 leading-relaxed">
-          {proposal.oldValue ? (
+          {editing ? (
+            isMultiline ? (
+              <textarea
+                ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+                value={editValue}
+                onChange={e => setEditValue(e.target.value)}
+                onKeyDown={handleEditKeyDown}
+                onBlur={handleEditBlur}
+                rows={3}
+                data-testid={`modify-input-${proposal.id}`}
+                className="w-full border border-indigo-300 rounded-lg px-2 py-1.5 text-sm font-inter text-zinc-800 focus:outline-none focus:ring-2 focus:ring-indigo-400 resize-none"
+              />
+            ) : (
+              <input
+                ref={inputRef as React.RefObject<HTMLInputElement>}
+                type="text"
+                value={editValue}
+                onChange={e => setEditValue(e.target.value)}
+                onKeyDown={handleEditKeyDown}
+                onBlur={handleEditBlur}
+                data-testid={`modify-input-${proposal.id}`}
+                className="w-full border border-indigo-300 rounded-lg px-2 py-1.5 text-sm font-inter text-zinc-800 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+              />
+            )
+          ) : proposal.oldValue ? (
             <span>
               <span className="line-through text-zinc-400">{proposal.oldValue}</span>
               {' '}
@@ -101,7 +181,7 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
 
         {/* Actions */}
         <div className="flex items-center gap-2">
-          {proposal.status === 'proposed' && (
+          {proposal.status === 'proposed' && !editing && (
             <>
               <button
                 onClick={() => onApply(proposal.id)}
@@ -116,6 +196,32 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
                 className="text-xs font-semibold font-inter text-zinc-500 hover:text-zinc-700 px-3 py-1 rounded-lg hover:bg-zinc-100 transition-colors"
               >
                 Dismiss
+              </button>
+              <button
+                onClick={startEdit}
+                data-testid={`modify-btn-${proposal.id}`}
+                className="text-xs font-semibold font-inter text-indigo-600 hover:text-indigo-700 px-3 py-1 rounded-lg hover:bg-indigo-50 transition-colors"
+              >
+                Modify
+              </button>
+            </>
+          )}
+
+          {proposal.status === 'proposed' && editing && (
+            <>
+              <button
+                onMouseDown={e => { e.preventDefault(); commitEdit() }}
+                data-testid={`modify-save-btn-${proposal.id}`}
+                className="text-xs font-semibold font-inter text-white bg-indigo-600 hover:bg-indigo-700 px-3 py-1 rounded-lg transition-colors"
+              >
+                Save
+              </button>
+              <button
+                onMouseDown={e => { e.preventDefault(); cancelEdit() }}
+                data-testid={`modify-cancel-btn-${proposal.id}`}
+                className="text-xs font-semibold font-inter text-zinc-500 hover:text-zinc-700 px-3 py-1 rounded-lg hover:bg-zinc-100 transition-colors"
+              >
+                Cancel
               </button>
             </>
           )}

--- a/frontend/src/components/assistant/ProposalCard.tsx
+++ b/frontend/src/components/assistant/ProposalCard.tsx
@@ -1,6 +1,8 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState } from 'react'
 import { Calendar, CheckSquare, Loader2, User } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import type { ProposalWithStatus } from '@/hooks/useAtelierAssistant'
 
 interface Props {
@@ -53,12 +55,6 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
 
   const [editing, setEditing] = useState(false)
   const [editValue, setEditValue] = useState('')
-  const editingRef = useRef(false)
-  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null)
-
-  useEffect(() => {
-    editingRef.current = editing
-  }, [editing])
 
   function startEdit() {
     setEditValue(proposal.newValue)
@@ -87,19 +83,12 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
   }
 
   function handleEditBlur() {
-    if (!editingRef.current) return
     const trimmed = editValue.trim()
     setEditing(false)
     if (trimmed && trimmed !== proposal.newValue) {
       onModify(proposal.id, trimmed)
     }
   }
-
-  useEffect(() => {
-    if (editing && inputRef.current) {
-      inputRef.current.focus()
-    }
-  }, [editing])
 
   const isMultiline = MULTILINE_FIELDS.has(proposal.field)
 
@@ -146,26 +135,26 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
         <div className="text-sm font-inter text-zinc-700 mb-2.5 leading-relaxed">
           {editing ? (
             isMultiline ? (
-              <textarea
-                ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+              <Textarea
                 value={editValue}
                 onChange={e => setEditValue(e.target.value)}
                 onKeyDown={handleEditKeyDown}
                 onBlur={handleEditBlur}
                 rows={3}
+                autoFocus
                 data-testid={`modify-input-${proposal.id}`}
-                className="w-full border border-indigo-300 rounded-lg px-2 py-1.5 text-sm font-inter text-zinc-800 focus:outline-none focus:ring-2 focus:ring-indigo-400 resize-none"
+                className="text-sm font-inter resize-none"
               />
             ) : (
-              <input
-                ref={inputRef as React.RefObject<HTMLInputElement>}
+              <Input
                 type="text"
                 value={editValue}
                 onChange={e => setEditValue(e.target.value)}
                 onKeyDown={handleEditKeyDown}
                 onBlur={handleEditBlur}
+                autoFocus
                 data-testid={`modify-input-${proposal.id}`}
-                className="w-full border border-indigo-300 rounded-lg px-2 py-1.5 text-sm font-inter text-zinc-800 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                className="text-sm font-inter"
               />
             )
           ) : proposal.oldValue ? (

--- a/frontend/src/components/assistant/ProposalCard.tsx
+++ b/frontend/src/components/assistant/ProposalCard.tsx
@@ -10,9 +10,16 @@ interface Props {
   onUndo: (id: string) => void
   onRetry: (id: string) => void
   onModify: (id: string, newValue: string) => void
+  onRedirectToChat: (prefill: string) => void
 }
 
 const MULTILINE_FIELDS = new Set(['actualContent', 'generalNotes', 'homeworkAssigned'])
+
+function getRedirectPrefill(type: string): string {
+  if (type === 'session') return 'Actually for the student profile not the session — '
+  if (type === 'student') return 'Actually for the session not the student — '
+  return 'Actually — '
+}
 
 const TYPE_CONFIG = {
   student: {
@@ -35,7 +42,7 @@ const TYPE_CONFIG = {
   },
 } as const
 
-export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onRetry, onModify }: Props) {
+export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onRetry, onModify, onRedirectToChat }: Props) {
   const config = TYPE_CONFIG[proposal.type]
   const { Icon } = config
 
@@ -222,6 +229,14 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
                 className="text-xs font-semibold font-inter text-zinc-500 hover:text-zinc-700 px-3 py-1 rounded-lg hover:bg-zinc-100 transition-colors"
               >
                 Cancel
+              </button>
+              <button
+                onMouseDown={e => { e.preventDefault(); cancelEdit(); onRedirectToChat(getRedirectPrefill(proposal.type)) }}
+                data-testid={`redirect-to-chat-btn-${proposal.id}`}
+                className="text-xs font-inter text-zinc-400 hover:text-indigo-600 px-2 py-1 rounded-lg hover:bg-indigo-50 transition-colors ml-auto"
+                title="Wrong entity or scope? Redirect to chat"
+              >
+                Wrong entity?
               </button>
             </>
           )}

--- a/frontend/src/hooks/useAtelierAssistant.test.ts
+++ b/frontend/src/hooks/useAtelierAssistant.test.ts
@@ -183,4 +183,99 @@ describe('useAtelierAssistant', () => {
     expect(result.current.transcription).toBeNull()
     expect(result.current.proposals).toHaveLength(0)
   })
+
+  it('modifyProposal: updates newValue on a proposed card', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[0]] })
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null), { wrapper: makeWrapper() })
+
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(result.current.proposals[0].newValue).toBe('B1')
+
+    act(() => { result.current.modifyProposal('p1', 'B2') })
+    expect(result.current.proposals[0].newValue).toBe('B2')
+    expect(result.current.proposals[0].status).toBe('proposed')
+  })
+
+  it('modifyProposal: no-op on dismissed card', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[0]] })
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null), { wrapper: makeWrapper() })
+
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    act(() => { result.current.dismiss('p1') })
+    act(() => { result.current.modifyProposal('p1', 'B2') })
+
+    expect(result.current.proposals[0].newValue).toBe('B1')
+    expect(result.current.proposals[0].status).toBe('dismissed')
+  })
+
+  it('modifyProposal: no-op when newValue is empty', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[0]] })
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null), { wrapper: makeWrapper() })
+
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    act(() => { result.current.modifyProposal('p1', '  ') })
+
+    expect(result.current.proposals[0].newValue).toBe('B1')
+  })
+
+  it('submit follow-up: merges proposed card in place (updates newValue, keeps id)', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[0]] })
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'), { wrapper: makeWrapper() })
+
+    act(() => { result.current.submit('first message') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(result.current.proposals).toHaveLength(1)
+    expect(result.current.proposals[0].id).toBe('p1')
+    expect(result.current.proposals[0].newValue).toBe('B1')
+
+    const followUp = [{ id: 'px', type: 'student' as const, field: 'cefrLevel', label: 'CEFR Level', oldValue: 'A2', newValue: 'B2' }]
+    mockPropose.mockResolvedValueOnce({ proposals: followUp })
+    act(() => { result.current.submit('actually B2') })
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    expect(result.current.proposals).toHaveLength(1)
+    expect(result.current.proposals[0].id).toBe('p1')
+    expect(result.current.proposals[0].newValue).toBe('B2')
+  })
+
+  it('submit follow-up: appends new proposal not matched by type+field', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[0]] })
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'), { wrapper: makeWrapper() })
+
+    act(() => { result.current.submit('first') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(result.current.proposals).toHaveLength(1)
+
+    const followUp = [{ id: 'px', type: 'session' as const, field: 'title', label: 'Session Title', oldValue: null, newValue: 'New Title' }]
+    mockPropose.mockResolvedValueOnce({ proposals: followUp })
+    act(() => { result.current.submit('also set title') })
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    expect(result.current.proposals).toHaveLength(2)
+    expect(result.current.proposals[1].field).toBe('title')
+    expect(result.current.proposals[1].status).toBe('proposed')
+  })
+
+  it('submit follow-up: does not re-propose applied card', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: sampleProposals.slice(0, 2) })
+    mockApplyStudent.mockResolvedValueOnce(undefined)
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'), { wrapper: makeWrapper() })
+
+    act(() => { result.current.submit('first') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    await act(async () => { await result.current.apply('p1') })
+    expect(result.current.proposals[0].status).toBe('applied')
+
+    const followUp = [{ id: 'px', type: 'student' as const, field: 'cefrLevel', label: 'CEFR Level', oldValue: 'A2', newValue: 'C1' }]
+    mockPropose.mockResolvedValueOnce({ proposals: followUp })
+    act(() => { result.current.submit('actually C1') })
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    const cefrCard = result.current.proposals.find(p => p.type === 'student' && p.field === 'cefrLevel')
+    expect(cefrCard?.status).toBe('applied')
+    expect(cefrCard?.newValue).toBe('B1')
+  })
 })

--- a/frontend/src/hooks/useAtelierAssistant.test.ts
+++ b/frontend/src/hooks/useAtelierAssistant.test.ts
@@ -259,6 +259,26 @@ describe('useAtelierAssistant', () => {
     expect(result.current.proposals[1].status).toBe('proposed')
   })
 
+  it('submit follow-up: always appends todo cards (type+field not unique)', async () => {
+    const firstTodo = { id: 'pt1', type: 'todo' as const, field: 'text', label: 'Teaching Todo', oldValue: null, newValue: 'Review passive voice' }
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[0], firstTodo] })
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'), { wrapper: makeWrapper() })
+
+    act(() => { result.current.submit('first') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(result.current.proposals).toHaveLength(2)
+
+    const secondTodo = { id: 'pt2', type: 'todo' as const, field: 'text', label: 'Teaching Todo', oldValue: null, newValue: 'Practice subjunctive' }
+    mockPropose.mockResolvedValueOnce({ proposals: [secondTodo] })
+    act(() => { result.current.submit('also add another todo') })
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    const todos = result.current.proposals.filter(p => p.type === 'todo')
+    expect(todos).toHaveLength(2)
+    expect(todos.find(p => p.newValue === 'Review passive voice')).toBeDefined()
+    expect(todos.find(p => p.newValue === 'Practice subjunctive')).toBeDefined()
+  })
+
   it('submit follow-up: does not re-propose applied card', async () => {
     mockPropose.mockResolvedValueOnce({ proposals: sampleProposals.slice(0, 2) })
     mockApplyStudent.mockResolvedValueOnce(undefined)

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -75,6 +75,12 @@ export function useAtelierAssistant(
         setProposals(prev => {
           const updated = [...prev]
           for (const incoming of raw) {
+            // todos share type+field ('todo'+'text') so type+field is not a unique key;
+            // always append them rather than risk overwriting the wrong card
+            if (incoming.type === 'todo') {
+              updated.push({ ...incoming, status: 'proposed', undoVisible: false })
+              continue
+            }
             const idx = updated.findIndex(
               e => e.type === incoming.type && e.field === incoming.field
             )

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -27,6 +27,7 @@ export interface AtelierAssistantActions {
   apply: (id: string) => void
   dismiss: (id: string) => void
   undoDismiss: (id: string) => void
+  modifyProposal: (id: string, newValue: string) => void
   applyAll: () => void
   dismissAll: () => void
   reset: () => void
@@ -60,14 +61,35 @@ export function useAtelierAssistant(
   const submit = useCallback(async (text: string) => {
     setTranscription(text)
     setProcessing(true)
-    setProposals([])
+    const hasPending = proposalsRef.current.some(p => p.status === 'proposed')
+    if (!hasPending) setProposals([])
     try {
       const { proposals: raw } = await proposeAssistant(
         text,
         studentId ?? undefined,
         sessionId ?? undefined,
       )
-      setProposals(raw.map(p => ({ ...p, status: 'proposed', undoVisible: false })))
+      if (!hasPending) {
+        setProposals(raw.map(p => ({ ...p, status: 'proposed', undoVisible: false })))
+      } else {
+        setProposals(prev => {
+          const updated = [...prev]
+          for (const incoming of raw) {
+            const idx = updated.findIndex(
+              e => e.type === incoming.type && e.field === incoming.field
+            )
+            if (idx !== -1) {
+              if (updated[idx].status === 'proposed') {
+                updated[idx] = { ...updated[idx], newValue: incoming.newValue, oldValue: incoming.oldValue }
+              }
+              // applied/dismissed — leave untouched
+            } else {
+              updated.push({ ...incoming, status: 'proposed', undoVisible: false })
+            }
+          }
+          return updated
+        })
+      }
     } catch {
       // Error shown via empty proposals list; processing clears
     } finally {
@@ -112,6 +134,13 @@ export function useAtelierAssistant(
     undoTimers.current.set(id, timer)
   }, [updateProposal])
 
+  const modifyProposal = useCallback((id: string, newValue: string) => {
+    if (!newValue.trim()) return
+    setProposals(prev => prev.map(p =>
+      p.id === id && p.status === 'proposed' ? { ...p, newValue } : p
+    ))
+  }, [])
+
   const undoDismiss = useCallback((id: string) => {
     const timer = undoTimers.current.get(id)
     if (timer) {
@@ -148,6 +177,7 @@ export function useAtelierAssistant(
     apply,
     dismiss,
     undoDismiss,
+    modifyProposal,
     applyAll,
     dismissAll,
     reset,

--- a/plan/ui-review-backlog.md
+++ b/plan/ui-review-backlog.md
@@ -18,3 +18,5 @@ Non-blocking findings from review-ui runs. Periodically review this file and bat
 ## #1004 (2026-04-28) — Atelier Assistant voice input (new patterns)
 
 - [1] Ghost mic button paired with filled-primary send button in the same input row. design-system.md §5 forbids ghost + filled primary in the same row, but the mic is a mode-toggle affordance and the send is a submit CTA — semantically different roles. Compound input bar pattern not covered by design-system.md. Needs Vera discussion before it becomes a reusable pattern.
+
+| #1010 | 2026-04-28 | ProposalCard: three-button action row (Apply/Dismiss/Modify) is a new pattern in AI-generated cards with no DS spec. Document via Vera discussion before reusing. |


### PR DESCRIPTION
Closes #1010

## Summary

- **Inline Modify on ProposalCard**: proposed cards now have a Modify button alongside Apply and Dismiss. Clicking it puts the value field into inline edit mode using the shadcn `Input` (single-line) or `Textarea` (multi-line fields). Enter/Save commits, Escape/Cancel discards, blur auto-commits. The `autoFocus` attribute is used per the existing codebase convention.
- **Wrong entity redirect**: while in edit mode a "Wrong entity?" button prefills the chat input with a correction prompt ("Actually for the student profile not the session — " etc.) and exits edit mode, so the teacher can redirect and resubmit without starting over.
- **Chat refinement (merge on follow-up)**: when the teacher submits a follow-up message while proposed cards are still visible, `useAtelierAssistant.submit` now merges the new proposals into the existing list by `type+field` key instead of replacing everything. Applied/dismissed cards are left untouched. Fresh submits (no pending proposals) keep the existing replace-all behaviour.
- **modifyProposal action**: new hook action that patches a proposed card's `newValue` in place. No-op on applied/dismissed/error cards or empty values.

## Test plan

- [ ] Open the Atelier Assistant panel, submit "set Ana's CEFR level to B1". Verify the student card shows Apply, Dismiss, and Modify buttons.
- [ ] Click Modify on the student card. Verify the value becomes an inline input pre-filled with "B1".
- [ ] Type "B2", press Enter. Verify the card shows "B2" and is back in proposed state.
- [ ] Click Modify again, click "Wrong entity?". Verify the chat input at the bottom is pre-filled with "Actually for the session not the student — " and is focused.
- [ ] Submit "actually B1.2" as a follow-up chat message. Verify the card updates to B1.2 without a duplicate card appearing.
- [ ] Apply the card, then verify Modify button is absent on the applied card.
- [ ] 98 test files, 1599 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now modify proposals inline before applying them
  * Edit mode supports keyboard shortcuts (Enter to save, Escape to cancel) and action buttons
  * Quick redirect to chat option when editing the wrong entity
  * Improved proposal handling that preserves your existing changes when resubmitting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->