### PR TITLE
feat(#1005): create new student from Atelier Assistant

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/AssistantControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/AssistantControllerTests.cs
@@ -95,14 +95,16 @@ public class AssistantControllerTests
     }
 
     [Fact]
-    public async Task Propose_WithoutStudentId_ReturnsOnlySessionProposals()
+    public async Task Propose_WithoutStudentId_ReturnsSessionAndNewStudentProposals()
     {
+        // StubStudentProfileExtractionService returns Name="[Extracted] María García".
+        // With no student context, this triggers new student intent.
         var (client, _) = await SeedTeacherWithStudent(
             "auth0|assistant-propose-nosid", "assistant-propose-nosid@example.com");
 
         var request = new AssistantProposeRequest
         {
-            Text = "We covered grammar topics today.",
+            Text = "Nueva alumna: María García, ingeniera, aprende inglés.",
             StudentId = null,
             SessionId = null,
         };
@@ -112,12 +114,91 @@ public class AssistantControllerTests
         var body = await response.Content.ReadFromJsonAsync<AssistantProposeResponse>();
         body.Should().NotBeNull();
 
-        // No student or todo proposals when studentId is absent
+        // No per-field student or todo proposals when studentId is absent
         body!.Proposals.Should().NotContain(p => p.Type == "student");
         body.Proposals.Should().NotContain(p => p.Type == "todo");
 
+        // New student proposal should be present
+        body.Proposals.Should().Contain(p => p.Type == "newStudent" && p.Field == "profile");
+
         // Session proposals should still be present
         body.Proposals.Should().Contain(p => p.Type == "session");
+    }
+
+    [Fact]
+    public async Task Propose_WithStudentIdMatchingExtractedName_DoesNotEmitNewStudentProposal()
+    {
+        // Seed a student whose name exactly matches what the stub extracts.
+        // The stub always returns Name="[Extracted] María García".
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var teacher = new Teacher
+        {
+            Id = Guid.NewGuid(),
+            Auth0UserId = "auth0|assistant-same-name",
+            Email = "assistant-same-name@example.com",
+            DisplayName = "Same Name Teacher",
+            IsApproved = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        db.Teachers.Add(teacher);
+        var student = new Student
+        {
+            Id = Guid.NewGuid(),
+            TeacherId = teacher.Id,
+            Name = "[Extracted] María García",
+            LearningLanguage = "English",
+            CefrLevel = "A2",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        db.Students.Add(student);
+        await db.SaveChangesAsync();
+
+        var client = _factory.CreateAuthenticatedClient("auth0|assistant-same-name", "assistant-same-name@example.com");
+        var request = new AssistantProposeRequest
+        {
+            Text = "Working on María García's pronunciation.",
+            StudentId = student.Id,
+        };
+        var response = await client.PostAsJsonAsync("/api/assistant/propose", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<AssistantProposeResponse>();
+        body.Should().NotBeNull();
+
+        // No newStudent proposal when extracted name matches current student
+        body!.Proposals.Should().NotContain(p => p.Type == "newStudent");
+
+        // Regular student update proposals should still be present
+        body.Proposals.Should().Contain(p => p.Type == "student");
+    }
+
+    [Fact]
+    public async Task Propose_WithStudentIdButDifferentExtractedName_EmitsNewStudentProposal()
+    {
+        // Student "Ana" is context; stub extracts "[Extracted] María García" (different name).
+        // Should emit newStudent proposal alongside Ana's update proposals.
+        var (client, studentId) = await SeedTeacherWithStudent(
+            "auth0|assistant-diff-name", "assistant-diff-name@example.com", cefrLevel: "A1");
+
+        var request = new AssistantProposeRequest
+        {
+            Text = "Also I have a new student: María García, engineer, learning English at B2.",
+            StudentId = studentId,
+        };
+        var response = await client.PostAsJsonAsync("/api/assistant/propose", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<AssistantProposeResponse>();
+        body.Should().NotBeNull();
+
+        // newStudent proposal for the new person
+        body!.Proposals.Should().Contain(p => p.Type == "newStudent" && p.Field == "profile");
+
+        // Regular student update proposals for Ana still present
+        body.Proposals.Should().Contain(p => p.Type == "student");
     }
 
     [Fact]

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1654,7 +1654,7 @@ public class PromptService : IPromptService
             - cityOfResidence: string or null — city where the student currently lives. Null if not mentioned.
             - reasonForStudying: string or null — why the student is learning the language. Null if not mentioned.
             - nativeLanguages: array of strings — student's native or mother tongue(s). Empty array [] if not mentioned.
-            - spokenLanguages: array of strings — other languages the student speaks (not the target language being taught, not the native language). Empty array [] if not mentioned.
+            - spokenLanguages: array of strings — other languages the student speaks (not the target language, not the native language). Empty array [] if not mentioned.
             - learningLanguage: string or null — the language the student is learning or being taught (e.g. "English", "French", "inglés"). Null if not mentioned.
             - cefrLevel: string or null — teacher's own CEFR assessment of the student (e.g. "B1", "B2+"). Null if not mentioned.
             - officialCefrLevel: string or null — official/exam-certified CEFR level (e.g. from a DELE, DELF certificate). Null if not mentioned.

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1655,6 +1655,7 @@ public class PromptService : IPromptService
             - reasonForStudying: string or null — why the student is learning the language. Null if not mentioned.
             - nativeLanguages: array of strings — student's native or mother tongue(s). Empty array [] if not mentioned.
             - spokenLanguages: array of strings — other languages the student speaks (not the target language being taught, not the native language). Empty array [] if not mentioned.
+            - learningLanguage: string or null — the language the student is learning or being taught (e.g. "English", "French", "inglés"). Null if not mentioned.
             - cefrLevel: string or null — teacher's own CEFR assessment of the student (e.g. "B1", "B2+"). Null if not mentioned.
             - officialCefrLevel: string or null — official/exam-certified CEFR level (e.g. from a DELE, DELF certificate). Null if not mentioned.
             - shortTermObjectives: array of objects — near-term learning goals mentioned by the teacher. Each object has:

--- a/backend/LangTeach.Api/Controllers/AssistantController.cs
+++ b/backend/LangTeach.Api/Controllers/AssistantController.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using System.Text.Json;
 using LangTeach.Api.DTOs;
 using LangTeach.Api.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -68,6 +69,29 @@ public class AssistantController : ControllerBase
             session = await _sessionLogService.GetByIdAsync(teacherId, student.Id, request.SessionId.Value, ct);
 
         var proposals = new List<ProposalDto>();
+
+        // Detect new student intent: extracted name is present and differs from current student context
+        var extractedName = studentExtraction.Name?.Trim();
+        bool isNewStudentIntent = !string.IsNullOrWhiteSpace(extractedName)
+            && (student == null
+                || !string.Equals(student.Name.Trim(), extractedName, StringComparison.OrdinalIgnoreCase));
+
+        if (isNewStudentIntent)
+        {
+            var newStudentPayload = new
+            {
+                name = extractedName,
+                birthYear = studentExtraction.BirthYear,
+                profession = studentExtraction.Profession,
+                cityOfResidence = studentExtraction.CityOfResidence,
+                nativeLanguages = studentExtraction.NativeLanguages,
+                learningLanguage = studentExtraction.LearningLanguage,
+                cefrLevel = studentExtraction.CefrLevel,
+                reasonForStudying = studentExtraction.ReasonForStudying,
+            };
+            var json = JsonSerializer.Serialize(newStudentPayload, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+            proposals.Add(new ProposalDto(Guid.NewGuid().ToString(), "newStudent", "profile", "New Student", null, json));
+        }
 
         if (student != null)
         {

--- a/backend/LangTeach.Api/Controllers/AssistantController.cs
+++ b/backend/LangTeach.Api/Controllers/AssistantController.cs
@@ -89,8 +89,9 @@ public class AssistantController : ControllerBase
                 cefrLevel = studentExtraction.CefrLevel,
                 reasonForStudying = studentExtraction.ReasonForStudying,
             };
-            var json = JsonSerializer.Serialize(newStudentPayload, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
-            proposals.Add(new ProposalDto(Guid.NewGuid().ToString(), "newStudent", "profile", "New Student", null, json));
+            var opts = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            var payloadElement = JsonSerializer.SerializeToElement(newStudentPayload, opts);
+            proposals.Add(new ProposalDto(Guid.NewGuid().ToString(), "newStudent", "profile", "New Student", null, extractedName!, payloadElement));
         }
 
         if (student != null)

--- a/backend/LangTeach.Api/DTOs/AssistantDtos.cs
+++ b/backend/LangTeach.Api/DTOs/AssistantDtos.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 
 namespace LangTeach.Api.DTOs;
 
@@ -11,13 +12,16 @@ public class AssistantProposeRequest
     public Guid? SessionId { get; set; }
 }
 
+// Payload carries structured data for compound proposal types (e.g. newStudent).
+// Scalar proposal types (student, session, todo) leave Payload null.
 public record ProposalDto(
     string Id,
     string Type,
     string Field,
     string Label,
     string? OldValue,
-    string NewValue
+    string NewValue,
+    JsonElement? Payload = null
 );
 
 public record AssistantProposeResponse(List<ProposalDto> Proposals);

--- a/backend/LangTeach.Api/DTOs/StudentProfileExtractionDtos.cs
+++ b/backend/LangTeach.Api/DTOs/StudentProfileExtractionDtos.cs
@@ -18,6 +18,7 @@ public record ExtractedStudentProfileDto(
     string? ReasonForStudying,
     List<string> NativeLanguages,
     List<string> SpokenLanguages,
+    string? LearningLanguage,
     string? CefrLevel,
     string? OfficialCefrLevel,
     List<ExtractedObjectiveDto> ShortTermObjectives,

--- a/backend/LangTeach.Api/Services/StubStudentProfileExtractionService.cs
+++ b/backend/LangTeach.Api/Services/StubStudentProfileExtractionService.cs
@@ -23,6 +23,7 @@ public class StubStudentProfileExtractionService : IStudentProfileExtractionServ
             ReasonForStudying: "[Extracted] Work promotion",
             NativeLanguages: ["Spanish"],
             SpokenLanguages: ["English"],
+            LearningLanguage: "[Extracted] English",
             CefrLevel: "B2",
             OfficialCefrLevel: null,
             ShortTermObjectives: [new ExtractedObjectiveDto("[Extracted] Pass B2 exam", "2026-06-30")],

--- a/backend/LangTeach.Api/Services/StudentProfileExtractionService.cs
+++ b/backend/LangTeach.Api/Services/StudentProfileExtractionService.cs
@@ -61,6 +61,7 @@ public class StudentProfileExtractionService : IStudentProfileExtractionService
                 ReasonForStudying: GetStringOrNull(root, "reasonForStudying"),
                 NativeLanguages: ParseStringArray(root, "nativeLanguages"),
                 SpokenLanguages: ParseStringArray(root, "spokenLanguages"),
+                LearningLanguage: GetStringOrNull(root, "learningLanguage"),
                 CefrLevel: ParseCefrLevel(root, "cefrLevel"),
                 OfficialCefrLevel: ParseCefrLevel(root, "officialCefrLevel"),
                 ShortTermObjectives: ParseObjectives(root),
@@ -78,7 +79,7 @@ public class StudentProfileExtractionService : IStudentProfileExtractionService
     }
 
     private static ExtractedStudentProfileDto Empty() =>
-        new(null, null, null, null, null, null, [], [], null, null, [], [], [], []);
+        new(null, null, null, null, null, null, [], [], null, null, null, [], [], [], []);
 
     private static string? GetStringOrNull(JsonElement root, string key)
     {

--- a/frontend/src/api/assistant.ts
+++ b/frontend/src/api/assistant.ts
@@ -1,14 +1,5 @@
 import { apiClient } from '../lib/apiClient'
 
-export interface ProposalDto {
-  id: string
-  type: 'student' | 'session' | 'todo' | 'newStudent'
-  field: string
-  label: string
-  oldValue: string | null
-  newValue: string
-}
-
 export interface NewStudentData {
   name: string
   birthYear?: number | null
@@ -18,6 +9,16 @@ export interface NewStudentData {
   learningLanguage?: string | null
   cefrLevel?: string | null
   reasonForStudying?: string | null
+}
+
+export interface ProposalDto {
+  id: string
+  type: 'student' | 'session' | 'todo' | 'newStudent'
+  field: string
+  label: string
+  oldValue: string | null
+  newValue: string
+  payload?: NewStudentData | null
 }
 
 export interface ProposeResponse {

--- a/frontend/src/api/assistant.ts
+++ b/frontend/src/api/assistant.ts
@@ -62,8 +62,3 @@ export async function applyTodoProposal(
 ): Promise<void> {
   await apiClient.post(`/api/students/${studentId}/teaching-todos`, { text })
 }
-
-export async function createStudentFromAssistant(data: NewStudentData): Promise<{ id: string }> {
-  const res = await apiClient.post<{ id: string }>('/api/students', data)
-  return res.data
-}

--- a/frontend/src/api/assistant.ts
+++ b/frontend/src/api/assistant.ts
@@ -2,11 +2,22 @@ import { apiClient } from '../lib/apiClient'
 
 export interface ProposalDto {
   id: string
-  type: 'student' | 'session' | 'todo'
+  type: 'student' | 'session' | 'todo' | 'newStudent'
   field: string
   label: string
   oldValue: string | null
   newValue: string
+}
+
+export interface NewStudentData {
+  name: string
+  birthYear?: number | null
+  profession?: string | null
+  cityOfResidence?: string | null
+  nativeLanguages?: string[]
+  learningLanguage?: string | null
+  cefrLevel?: string | null
+  reasonForStudying?: string | null
 }
 
 export interface ProposeResponse {
@@ -50,4 +61,9 @@ export async function applyTodoProposal(
   text: string,
 ): Promise<void> {
   await apiClient.post(`/api/students/${studentId}/teaching-todos`, { text })
+}
+
+export async function createStudentFromAssistant(data: NewStudentData): Promise<{ id: string }> {
+  const res = await apiClient.post<{ id: string }>('/api/students', data)
+  return res.data
 }

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -273,6 +273,7 @@ export default function AppShell() {
         onDismiss={assistant.dismiss}
         onUndo={assistant.undoDismiss}
         onRetry={assistant.apply}
+        onModify={assistant.modifyProposal}
         onApplyAll={assistant.applyAll}
         onDismissAll={assistant.dismissAll}
         onEditPayload={assistant.onEditPayload}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -275,7 +275,7 @@ export default function AppShell() {
         onRetry={assistant.apply}
         onApplyAll={assistant.applyAll}
         onDismissAll={assistant.dismissAll}
-        onEdit={assistant.onEdit}
+        onEditPayload={assistant.onEditPayload}
       />
     </div>
   )

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -275,6 +275,7 @@ export default function AppShell() {
         onRetry={assistant.apply}
         onApplyAll={assistant.applyAll}
         onDismissAll={assistant.dismissAll}
+        onEdit={assistant.onEdit}
       />
     </div>
   )

--- a/frontend/src/components/AtelierAssistantPanel.test.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.test.tsx
@@ -84,6 +84,7 @@ const defaultProps = {
   onRetry: vi.fn(),
   onApplyAll: vi.fn(),
   onDismissAll: vi.fn(),
+  onEdit: vi.fn(),
 }
 
 function renderPanel(overrides: Partial<typeof defaultProps> = {}) {

--- a/frontend/src/components/AtelierAssistantPanel.test.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.test.tsx
@@ -84,7 +84,7 @@ const defaultProps = {
   onRetry: vi.fn(),
   onApplyAll: vi.fn(),
   onDismissAll: vi.fn(),
-  onEdit: vi.fn(),
+  onEditPayload: vi.fn(),
 }
 
 function renderPanel(overrides: Partial<typeof defaultProps> = {}) {

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -79,6 +79,7 @@ export default function AtelierAssistantPanel({
 }: Props) {
   const [inputValue, setInputValue] = useState('')
   const [pendingClose, setPendingClose] = useState(false)
+  const chatInputRef = useRef<HTMLInputElement>(null)
 
   const [micState, setMicState] = useState<MicState>('idle')
   const [micError, setMicError] = useState<MicError>(null)

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -55,6 +55,7 @@ interface Props {
   onRetry: (id: string) => void
   onApplyAll: () => void
   onDismissAll: () => void
+  onEdit?: (id: string, newValue: string) => void
 }
 
 export default function AtelierAssistantPanel({
@@ -72,6 +73,7 @@ export default function AtelierAssistantPanel({
   onRetry,
   onApplyAll,
   onDismissAll,
+  onEdit,
 }: Props) {
   const [inputValue, setInputValue] = useState('')
   const [pendingClose, setPendingClose] = useState(false)
@@ -434,6 +436,7 @@ export default function AtelierAssistantPanel({
                         onDismiss={onDismiss}
                         onUndo={onUndo}
                         onRetry={onRetry}
+                        onEdit={onEdit}
                       />
                     ))}
                   </div>

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -55,7 +55,7 @@ interface Props {
   onRetry: (id: string) => void
   onApplyAll: () => void
   onDismissAll: () => void
-  onEdit?: (id: string, newValue: string) => void
+  onEditPayload?: (id: string, payload: import('@/api/assistant').NewStudentData) => void
 }
 
 export default function AtelierAssistantPanel({
@@ -73,7 +73,7 @@ export default function AtelierAssistantPanel({
   onRetry,
   onApplyAll,
   onDismissAll,
-  onEdit,
+  onEditPayload,
 }: Props) {
   const [inputValue, setInputValue] = useState('')
   const [pendingClose, setPendingClose] = useState(false)
@@ -436,7 +436,7 @@ export default function AtelierAssistantPanel({
                         onDismiss={onDismiss}
                         onUndo={onUndo}
                         onRetry={onRetry}
-                        onEdit={onEdit}
+                        onEditPayload={onEditPayload}
                       />
                     ))}
                   </div>

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -53,6 +53,7 @@ interface Props {
   onDismiss: (id: string) => void
   onUndo: (id: string) => void
   onRetry: (id: string) => void
+  onModify: (id: string, newValue: string) => void
   onApplyAll: () => void
   onDismissAll: () => void
   onEditPayload?: (id: string, payload: import('@/api/assistant').NewStudentData) => void
@@ -71,6 +72,7 @@ export default function AtelierAssistantPanel({
   onDismiss,
   onUndo,
   onRetry,
+  onModify,
   onApplyAll,
   onDismissAll,
   onEditPayload,
@@ -309,6 +311,11 @@ export default function AtelierAssistantPanel({
     }
   }
 
+  function handleRedirectToChat(prefill: string) {
+    setInputValue(prefill)
+    setTimeout(() => chatInputRef.current?.focus(), 0)
+  }
+
   const emptyPrompt = studentName
     ? `What did you cover with ${studentName} today?`
     : 'What would you like to cover today?'
@@ -436,6 +443,8 @@ export default function AtelierAssistantPanel({
                         onDismiss={onDismiss}
                         onUndo={onUndo}
                         onRetry={onRetry}
+                        onModify={onModify}
+                        onRedirectToChat={handleRedirectToChat}
                         onEditPayload={onEditPayload}
                       />
                     ))}

--- a/frontend/src/components/assistant/NewStudentFields.tsx
+++ b/frontend/src/components/assistant/NewStudentFields.tsx
@@ -1,22 +1,16 @@
-import { useMemo } from 'react'
 import type { NewStudentData } from '@/api/assistant'
 
 const CEFR_LEVELS = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2']
 
 interface Props {
-  value: string
+  payload: NewStudentData
   proposalId: string
-  onEdit: (id: string, newValue: string) => void
+  onEditPayload: (id: string, payload: NewStudentData) => void
 }
 
-export default function NewStudentFields({ value, proposalId, onEdit }: Props) {
-  const fields = useMemo<NewStudentData>(() => {
-    try { return JSON.parse(value) as NewStudentData }
-    catch { return { name: '' } }
-  }, [value])
-
+export default function NewStudentFields({ payload, proposalId, onEditPayload }: Props) {
   const update = (patch: Partial<NewStudentData>) => {
-    onEdit(proposalId, JSON.stringify({ ...fields, ...patch }))
+    onEditPayload(proposalId, { ...payload, ...patch })
   }
 
   return (
@@ -24,41 +18,41 @@ export default function NewStudentFields({ value, proposalId, onEdit }: Props) {
       <FieldRow
         label="Name"
         required
-        value={fields.name}
+        value={payload.name}
         onChange={v => update({ name: v })}
       />
       <FieldRow
         label="Learning Language"
         required
-        value={fields.learningLanguage ?? ''}
+        value={payload.learningLanguage ?? ''}
         onChange={v => update({ learningLanguage: v || null })}
       />
       <SelectRow
         label="CEFR Level"
         required
-        value={fields.cefrLevel ?? ''}
+        value={payload.cefrLevel ?? ''}
         options={CEFR_LEVELS}
         onChange={v => update({ cefrLevel: v || null })}
       />
       <FieldRow
         label="Profession"
-        value={fields.profession ?? ''}
+        value={payload.profession ?? ''}
         onChange={v => update({ profession: v || null })}
       />
       <FieldRow
         label="City"
-        value={fields.cityOfResidence ?? ''}
+        value={payload.cityOfResidence ?? ''}
         onChange={v => update({ cityOfResidence: v || null })}
       />
       <FieldRow
         label="Native Language(s)"
-        value={fields.nativeLanguages?.join(', ') ?? ''}
+        value={payload.nativeLanguages?.join(', ') ?? ''}
         onChange={v => update({ nativeLanguages: v ? v.split(',').map(s => s.trim()).filter(Boolean) : [] })}
         placeholder="e.g. Spanish, Catalan"
       />
       <FieldRow
         label="Reason for Studying"
-        value={fields.reasonForStudying ?? ''}
+        value={payload.reasonForStudying ?? ''}
         onChange={v => update({ reasonForStudying: v || null })}
       />
     </div>

--- a/frontend/src/components/assistant/NewStudentFields.tsx
+++ b/frontend/src/components/assistant/NewStudentFields.tsx
@@ -1,4 +1,5 @@
 import type { NewStudentData } from '@/api/assistant'
+import { Input } from '@/components/ui/input'
 
 const CEFR_LEVELS = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2']
 
@@ -14,7 +15,7 @@ export default function NewStudentFields({ payload, proposalId, onEditPayload }:
   }
 
   return (
-    <div className="space-y-2 text-sm font-inter">
+    <div className="space-y-2.5">
       <FieldRow
         label="Name"
         required
@@ -69,16 +70,16 @@ interface FieldRowProps {
 
 function FieldRow({ label, value, onChange, required, placeholder }: FieldRowProps) {
   return (
-    <div className="flex items-center gap-2">
-      <span className="w-32 shrink-0 text-xs text-zinc-500 font-inter">
+    <div className="space-y-0.5">
+      <label className="text-xs font-medium text-zinc-500 font-inter">
         {label}{required && <span className="text-red-500 ml-0.5">*</span>}
-      </span>
-      <input
+      </label>
+      <Input
         type="text"
         value={value}
         onChange={e => onChange(e.target.value)}
         placeholder={placeholder}
-        className="flex-1 text-xs text-zinc-800 border border-zinc-200 rounded-md px-2 py-1 focus:outline-none focus:ring-1 focus:ring-indigo-400 bg-white min-w-0"
+        className="h-7 text-xs"
       />
     </div>
   )
@@ -94,14 +95,14 @@ interface SelectRowProps {
 
 function SelectRow({ label, value, options, onChange, required }: SelectRowProps) {
   return (
-    <div className="flex items-center gap-2">
-      <span className="w-32 shrink-0 text-xs text-zinc-500 font-inter">
+    <div className="space-y-0.5">
+      <label className="text-xs font-medium text-zinc-500 font-inter">
         {label}{required && <span className="text-red-500 ml-0.5">*</span>}
-      </span>
+      </label>
       <select
         value={value}
         onChange={e => onChange(e.target.value)}
-        className="flex-1 text-xs text-zinc-800 border border-zinc-200 rounded-md px-2 py-1 focus:outline-none focus:ring-1 focus:ring-indigo-400 bg-white min-w-0"
+        className="h-7 w-full text-xs text-zinc-800 rounded-lg border border-input bg-transparent px-2.5 py-1 outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 transition-colors"
       >
         <option value="">-- select --</option>
         {options.map(o => (

--- a/frontend/src/components/assistant/NewStudentFields.tsx
+++ b/frontend/src/components/assistant/NewStudentFields.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useMemo } from 'react'
 import type { NewStudentData } from '@/api/assistant'
 
 const CEFR_LEVELS = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2']
@@ -10,21 +10,13 @@ interface Props {
 }
 
 export default function NewStudentFields({ value, proposalId, onEdit }: Props) {
-  const [fields, setFields] = useState<NewStudentData>({ name: '' })
-
-  useEffect(() => {
-    try {
-      const parsed = JSON.parse(value) as NewStudentData
-      setFields(parsed)
-    } catch {
-      // keep previous state
-    }
+  const fields = useMemo<NewStudentData>(() => {
+    try { return JSON.parse(value) as NewStudentData }
+    catch { return { name: '' } }
   }, [value])
 
   const update = (patch: Partial<NewStudentData>) => {
-    const updated = { ...fields, ...patch }
-    setFields(updated)
-    onEdit(proposalId, JSON.stringify(updated))
+    onEdit(proposalId, JSON.stringify({ ...fields, ...patch }))
   }
 
   return (

--- a/frontend/src/components/assistant/NewStudentFields.tsx
+++ b/frontend/src/components/assistant/NewStudentFields.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react'
+import type { NewStudentData } from '@/api/assistant'
+
+const CEFR_LEVELS = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2']
+
+interface Props {
+  value: string
+  proposalId: string
+  onEdit: (id: string, newValue: string) => void
+}
+
+export default function NewStudentFields({ value, proposalId, onEdit }: Props) {
+  const [fields, setFields] = useState<NewStudentData>({ name: '' })
+
+  useEffect(() => {
+    try {
+      const parsed = JSON.parse(value) as NewStudentData
+      setFields(parsed)
+    } catch {
+      // keep previous state
+    }
+  }, [value])
+
+  const update = (patch: Partial<NewStudentData>) => {
+    const updated = { ...fields, ...patch }
+    setFields(updated)
+    onEdit(proposalId, JSON.stringify(updated))
+  }
+
+  return (
+    <div className="space-y-2 text-sm font-inter">
+      <FieldRow
+        label="Name"
+        required
+        value={fields.name}
+        onChange={v => update({ name: v })}
+      />
+      <FieldRow
+        label="Learning Language"
+        required
+        value={fields.learningLanguage ?? ''}
+        onChange={v => update({ learningLanguage: v || null })}
+      />
+      <SelectRow
+        label="CEFR Level"
+        required
+        value={fields.cefrLevel ?? ''}
+        options={CEFR_LEVELS}
+        onChange={v => update({ cefrLevel: v || null })}
+      />
+      <FieldRow
+        label="Profession"
+        value={fields.profession ?? ''}
+        onChange={v => update({ profession: v || null })}
+      />
+      <FieldRow
+        label="City"
+        value={fields.cityOfResidence ?? ''}
+        onChange={v => update({ cityOfResidence: v || null })}
+      />
+      <FieldRow
+        label="Native Language(s)"
+        value={fields.nativeLanguages?.join(', ') ?? ''}
+        onChange={v => update({ nativeLanguages: v ? v.split(',').map(s => s.trim()).filter(Boolean) : [] })}
+        placeholder="e.g. Spanish, Catalan"
+      />
+      <FieldRow
+        label="Reason for Studying"
+        value={fields.reasonForStudying ?? ''}
+        onChange={v => update({ reasonForStudying: v || null })}
+      />
+    </div>
+  )
+}
+
+interface FieldRowProps {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  required?: boolean
+  placeholder?: string
+}
+
+function FieldRow({ label, value, onChange, required, placeholder }: FieldRowProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-32 shrink-0 text-xs text-zinc-500 font-inter">
+        {label}{required && <span className="text-red-500 ml-0.5">*</span>}
+      </span>
+      <input
+        type="text"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="flex-1 text-xs text-zinc-800 border border-zinc-200 rounded-md px-2 py-1 focus:outline-none focus:ring-1 focus:ring-indigo-400 bg-white min-w-0"
+      />
+    </div>
+  )
+}
+
+interface SelectRowProps {
+  label: string
+  value: string
+  options: string[]
+  onChange: (v: string) => void
+  required?: boolean
+}
+
+function SelectRow({ label, value, options, onChange, required }: SelectRowProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-32 shrink-0 text-xs text-zinc-500 font-inter">
+        {label}{required && <span className="text-red-500 ml-0.5">*</span>}
+      </span>
+      <select
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        className="flex-1 text-xs text-zinc-800 border border-zinc-200 rounded-md px-2 py-1 focus:outline-none focus:ring-1 focus:ring-indigo-400 bg-white min-w-0"
+      >
+        <option value="">-- select --</option>
+        {options.map(o => (
+          <option key={o} value={o}>{o}</option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/frontend/src/components/assistant/ProposalCard.test.tsx
+++ b/frontend/src/components/assistant/ProposalCard.test.tsx
@@ -142,12 +142,13 @@ describe('ProposalCard', () => {
       makeProposal({ type: 'newStudent', field: 'profile', label: 'New Student', oldValue: null, newValue: newStudentPayload }),
       { onEdit },
     )
+    // Component is fully controlled: typing appends to the current prop value
     const nameInput = screen.getByDisplayValue('Sofía')
-    await user.clear(nameInput)
-    await user.type(nameInput, 'Lucía')
+    await user.type(nameInput, 'X')
     expect(onEdit).toHaveBeenCalled()
     const lastCall = onEdit.mock.calls[onEdit.mock.calls.length - 1]
     expect(lastCall[0]).toBe('p1')
-    expect(JSON.parse(lastCall[1]).name).toBe('Lucía')
+    // The name field has the original value plus the typed character
+    expect(JSON.parse(lastCall[1]).name).toBe('SofíaX')
   })
 })

--- a/frontend/src/components/assistant/ProposalCard.test.tsx
+++ b/frontend/src/components/assistant/ProposalCard.test.tsx
@@ -24,6 +24,8 @@ function renderCard(proposal: ProposalWithStatus, handlers = {}) {
     onDismiss: vi.fn(),
     onUndo: vi.fn(),
     onRetry: vi.fn(),
+    onModify: vi.fn(),
+    onRedirectToChat: vi.fn(),
     onEditPayload: vi.fn(),
     ...handlers,
   }
@@ -122,6 +124,97 @@ describe('ProposalCard', () => {
     expect(container.querySelector('.bg-emerald-500')).toBeInTheDocument()
   })
 
+  it('proposed: shows Modify button', () => {
+    renderCard(makeProposal({ status: 'proposed' }))
+    expect(screen.getByTestId('modify-btn-p1')).toBeInTheDocument()
+  })
+
+  it('applied: does not show Modify button', () => {
+    renderCard(makeProposal({ status: 'applied' }))
+    expect(screen.queryByTestId('modify-btn-p1')).not.toBeInTheDocument()
+  })
+
+  it('dismissed: does not show Modify button', () => {
+    renderCard(makeProposal({ status: 'dismissed', undoVisible: false }))
+    expect(screen.queryByTestId('modify-btn-p1')).not.toBeInTheDocument()
+  })
+
+  it('clicking Modify shows inline input with current value', async () => {
+    const user = userEvent.setup()
+    renderCard(makeProposal({ status: 'proposed', newValue: 'B1' }))
+    await user.click(screen.getByTestId('modify-btn-p1'))
+    const input = screen.getByTestId('modify-input-p1') as HTMLInputElement
+    expect(input).toBeInTheDocument()
+    expect(input.value).toBe('B1')
+  })
+
+  it('Enter in inline input commits and calls onModify', async () => {
+    const user = userEvent.setup()
+    const onModify = vi.fn()
+    renderCard(makeProposal({ status: 'proposed', newValue: 'B1' }), { onModify })
+    await user.click(screen.getByTestId('modify-btn-p1'))
+    const input = screen.getByTestId('modify-input-p1')
+    await user.clear(input)
+    await user.type(input, 'B2')
+    await user.keyboard('{Enter}')
+    expect(onModify).toHaveBeenCalledWith('p1', 'B2')
+    expect(screen.queryByTestId('modify-input-p1')).not.toBeInTheDocument()
+  })
+
+  it('Escape in inline input cancels without calling onModify', async () => {
+    const user = userEvent.setup()
+    const onModify = vi.fn()
+    renderCard(makeProposal({ status: 'proposed', newValue: 'B1' }), { onModify })
+    await user.click(screen.getByTestId('modify-btn-p1'))
+    await user.type(screen.getByTestId('modify-input-p1'), 'B2')
+    await user.keyboard('{Escape}')
+    expect(onModify).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('modify-input-p1')).not.toBeInTheDocument()
+  })
+
+  it('Save button commits and calls onModify', async () => {
+    const user = userEvent.setup()
+    const onModify = vi.fn()
+    renderCard(makeProposal({ status: 'proposed', newValue: 'B1' }), { onModify })
+    await user.click(screen.getByTestId('modify-btn-p1'))
+    const input = screen.getByTestId('modify-input-p1')
+    await user.clear(input)
+    await user.type(input, 'B2')
+    await user.click(screen.getByTestId('modify-save-btn-p1'))
+    expect(onModify).toHaveBeenCalledWith('p1', 'B2')
+  })
+
+  it('Cancel button exits edit mode without calling onModify', async () => {
+    const user = userEvent.setup()
+    const onModify = vi.fn()
+    renderCard(makeProposal({ status: 'proposed', newValue: 'B1' }), { onModify })
+    await user.click(screen.getByTestId('modify-btn-p1'))
+    await user.click(screen.getByTestId('modify-cancel-btn-p1'))
+    expect(onModify).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('modify-input-p1')).not.toBeInTheDocument()
+  })
+
+  it('Wrong entity button calls onRedirectToChat with prefill and exits edit mode', async () => {
+    const user = userEvent.setup()
+    const onRedirectToChat = vi.fn()
+    renderCard(makeProposal({ status: 'proposed', type: 'session', field: 'title' }), { onRedirectToChat })
+    await user.click(screen.getByTestId('modify-btn-p1'))
+    await user.click(screen.getByTestId('redirect-to-chat-btn-p1'))
+    expect(onRedirectToChat).toHaveBeenCalledWith(expect.stringContaining('student profile'))
+    expect(screen.queryByTestId('modify-input-p1')).not.toBeInTheDocument()
+  })
+
+  it('empty value on Enter does not call onModify', async () => {
+    const user = userEvent.setup()
+    const onModify = vi.fn()
+    renderCard(makeProposal({ status: 'proposed', newValue: 'B1' }), { onModify })
+    await user.click(screen.getByTestId('modify-btn-p1'))
+    const input = screen.getByTestId('modify-input-p1')
+    await user.clear(input)
+    await user.keyboard('{Enter}')
+    expect(onModify).not.toHaveBeenCalled()
+  })
+
   it('newStudent type: uses teal accent', () => {
     const { container } = renderCard(makeProposal({
       type: 'newStudent', field: 'profile', label: 'New Student', oldValue: null, newValue: 'Sofía',
@@ -137,6 +230,14 @@ describe('ProposalCard', () => {
     }))
     expect(screen.getByDisplayValue('Sofía')).toBeInTheDocument()
     expect(screen.getByDisplayValue('inglés')).toBeInTheDocument()
+  })
+
+  it('newStudent type: does not show Modify button', () => {
+    renderCard(makeProposal({
+      type: 'newStudent', field: 'profile', label: 'New Student', oldValue: null, newValue: 'Sofía',
+      payload: { name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' },
+    }))
+    expect(screen.queryByTestId('modify-btn-p1')).not.toBeInTheDocument()
   })
 
   it('newStudent type: calls onEditPayload when a field is changed', async () => {

--- a/frontend/src/components/assistant/ProposalCard.test.tsx
+++ b/frontend/src/components/assistant/ProposalCard.test.tsx
@@ -120,4 +120,34 @@ describe('ProposalCard', () => {
     const { container } = renderCard(makeProposal({ type: 'todo', oldValue: null, newValue: 'Review passive voice' }))
     expect(container.querySelector('.bg-emerald-500')).toBeInTheDocument()
   })
+
+  it('newStudent type: uses teal accent', () => {
+    const newStudentPayload = JSON.stringify({ name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' })
+    const { container } = renderCard(makeProposal({ type: 'newStudent', field: 'profile', label: 'New Student', oldValue: null, newValue: newStudentPayload }))
+    expect(container.querySelector('.bg-teal-500')).toBeInTheDocument()
+  })
+
+  it('newStudent type: renders inline field inputs instead of diff', () => {
+    const newStudentPayload = JSON.stringify({ name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' })
+    renderCard(makeProposal({ type: 'newStudent', field: 'profile', label: 'New Student', oldValue: null, newValue: newStudentPayload }))
+    expect(screen.getByDisplayValue('Sofía')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('inglés')).toBeInTheDocument()
+  })
+
+  it('newStudent type: calls onEdit when a field is changed', async () => {
+    const user = userEvent.setup()
+    const onEdit = vi.fn()
+    const newStudentPayload = JSON.stringify({ name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' })
+    renderCard(
+      makeProposal({ type: 'newStudent', field: 'profile', label: 'New Student', oldValue: null, newValue: newStudentPayload }),
+      { onEdit },
+    )
+    const nameInput = screen.getByDisplayValue('Sofía')
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Lucía')
+    expect(onEdit).toHaveBeenCalled()
+    const lastCall = onEdit.mock.calls[onEdit.mock.calls.length - 1]
+    expect(lastCall[0]).toBe('p1')
+    expect(JSON.parse(lastCall[1]).name).toBe('Lucía')
+  })
 })

--- a/frontend/src/components/assistant/ProposalCard.test.tsx
+++ b/frontend/src/components/assistant/ProposalCard.test.tsx
@@ -24,6 +24,7 @@ function renderCard(proposal: ProposalWithStatus, handlers = {}) {
     onDismiss: vi.fn(),
     onUndo: vi.fn(),
     onRetry: vi.fn(),
+    onEditPayload: vi.fn(),
     ...handlers,
   }
   return { ...render(<ProposalCard proposal={proposal} {...props} />), props }
@@ -122,33 +123,37 @@ describe('ProposalCard', () => {
   })
 
   it('newStudent type: uses teal accent', () => {
-    const newStudentPayload = JSON.stringify({ name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' })
-    const { container } = renderCard(makeProposal({ type: 'newStudent', field: 'profile', label: 'New Student', oldValue: null, newValue: newStudentPayload }))
+    const { container } = renderCard(makeProposal({
+      type: 'newStudent', field: 'profile', label: 'New Student', oldValue: null, newValue: 'Sofía',
+      payload: { name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' },
+    }))
     expect(container.querySelector('.bg-teal-500')).toBeInTheDocument()
   })
 
   it('newStudent type: renders inline field inputs instead of diff', () => {
-    const newStudentPayload = JSON.stringify({ name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' })
-    renderCard(makeProposal({ type: 'newStudent', field: 'profile', label: 'New Student', oldValue: null, newValue: newStudentPayload }))
+    renderCard(makeProposal({
+      type: 'newStudent', field: 'profile', label: 'New Student', oldValue: null, newValue: 'Sofía',
+      payload: { name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' },
+    }))
     expect(screen.getByDisplayValue('Sofía')).toBeInTheDocument()
     expect(screen.getByDisplayValue('inglés')).toBeInTheDocument()
   })
 
-  it('newStudent type: calls onEdit when a field is changed', async () => {
+  it('newStudent type: calls onEditPayload when a field is changed', async () => {
     const user = userEvent.setup()
-    const onEdit = vi.fn()
-    const newStudentPayload = JSON.stringify({ name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' })
+    const onEditPayload = vi.fn()
     renderCard(
-      makeProposal({ type: 'newStudent', field: 'profile', label: 'New Student', oldValue: null, newValue: newStudentPayload }),
-      { onEdit },
+      makeProposal({
+        type: 'newStudent', field: 'profile', label: 'New Student', oldValue: null, newValue: 'Sofía',
+        payload: { name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' },
+      }),
+      { onEditPayload },
     )
-    // Component is fully controlled: typing appends to the current prop value
     const nameInput = screen.getByDisplayValue('Sofía')
     await user.type(nameInput, 'X')
-    expect(onEdit).toHaveBeenCalled()
-    const lastCall = onEdit.mock.calls[onEdit.mock.calls.length - 1]
+    expect(onEditPayload).toHaveBeenCalled()
+    const lastCall = onEditPayload.mock.calls[onEditPayload.mock.calls.length - 1]
     expect(lastCall[0]).toBe('p1')
-    // The name field has the original value plus the typed character
-    expect(JSON.parse(lastCall[1]).name).toBe('SofíaX')
+    expect(lastCall[1].name).toBe('SofíaX')
   })
 })

--- a/frontend/src/components/assistant/ProposalCard.tsx
+++ b/frontend/src/components/assistant/ProposalCard.tsx
@@ -1,6 +1,6 @@
 import { Calendar, CheckSquare, Loader2, User, UserPlus } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import type { ProposalWithStatus } from '@/hooks/useAtelierAssistant'
+import type { NewStudentData, ProposalWithStatus } from '@/hooks/useAtelierAssistant'
 import NewStudentFields from './NewStudentFields'
 
 interface Props {
@@ -9,7 +9,7 @@ interface Props {
   onDismiss: (id: string) => void
   onUndo: (id: string) => void
   onRetry: (id: string) => void
-  onEdit?: (id: string, newValue: string) => void
+  onEditPayload?: (id: string, payload: NewStudentData) => void
 }
 
 const TYPE_CONFIG = {
@@ -39,7 +39,7 @@ const TYPE_CONFIG = {
   },
 } as const
 
-export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onRetry, onEdit }: Props) {
+export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onRetry, onEditPayload }: Props) {
   const config = TYPE_CONFIG[proposal.type]
   const { Icon } = config
 
@@ -91,9 +91,9 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
         <div className="mb-2.5">
           {proposal.type === 'newStudent' ? (
             <NewStudentFields
-              value={proposal.newValue}
+              payload={proposal.payload as NewStudentData ?? { name: proposal.newValue }}
               proposalId={proposal.id}
-              onEdit={onEdit ?? (() => {})}
+              onEditPayload={onEditPayload ?? (() => {})}
             />
           ) : (
             <div className="text-sm font-inter text-zinc-700 leading-relaxed">

--- a/frontend/src/components/assistant/ProposalCard.tsx
+++ b/frontend/src/components/assistant/ProposalCard.tsx
@@ -1,5 +1,8 @@
+import { useState } from 'react'
 import { Calendar, CheckSquare, Loader2, User, UserPlus } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import type { NewStudentData, ProposalWithStatus } from '@/hooks/useAtelierAssistant'
 import NewStudentFields from './NewStudentFields'
 
@@ -9,7 +12,17 @@ interface Props {
   onDismiss: (id: string) => void
   onUndo: (id: string) => void
   onRetry: (id: string) => void
+  onModify: (id: string, newValue: string) => void
+  onRedirectToChat: (prefill: string) => void
   onEditPayload?: (id: string, payload: NewStudentData) => void
+}
+
+const MULTILINE_FIELDS = new Set(['actualContent', 'generalNotes', 'homeworkAssigned'])
+
+function getRedirectPrefill(type: string): string {
+  if (type === 'session') return 'Actually for the student profile not the session — '
+  if (type === 'student') return 'Actually for the session not the student — '
+  return 'Actually — '
 }
 
 const TYPE_CONFIG = {
@@ -39,7 +52,7 @@ const TYPE_CONFIG = {
   },
 } as const
 
-export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onRetry, onEditPayload }: Props) {
+export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onRetry, onModify, onRedirectToChat, onEditPayload }: Props) {
   const config = TYPE_CONFIG[proposal.type]
   const { Icon } = config
 
@@ -47,6 +60,46 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
   const isApplied = proposal.status === 'applied'
   const isApplying = proposal.status === 'applying'
   const isError = proposal.status === 'error'
+
+  const [editing, setEditing] = useState(false)
+  const [editValue, setEditValue] = useState('')
+
+  function startEdit() {
+    setEditValue(proposal.newValue)
+    setEditing(true)
+  }
+
+  function commitEdit() {
+    const trimmed = editValue.trim()
+    setEditing(false)
+    if (trimmed && trimmed !== proposal.newValue) {
+      onModify(proposal.id, trimmed)
+    }
+  }
+
+  function cancelEdit() {
+    setEditing(false)
+  }
+
+  function handleEditKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      commitEdit()
+    } else if (e.key === 'Escape') {
+      cancelEdit()
+    }
+  }
+
+  function handleEditBlur() {
+    const trimmed = editValue.trim()
+    setEditing(false)
+    if (trimmed && trimmed !== proposal.newValue) {
+      onModify(proposal.id, trimmed)
+    }
+  }
+
+  const isMultiline = MULTILINE_FIELDS.has(proposal.field)
+  const isNewStudent = proposal.type === 'newStudent'
 
   return (
     <div
@@ -89,12 +142,38 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
 
         {/* Content */}
         <div className="mb-2.5">
-          {proposal.type === 'newStudent' ? (
+          {isNewStudent ? (
             <NewStudentFields
               payload={proposal.payload as NewStudentData ?? { name: proposal.newValue }}
               proposalId={proposal.id}
               onEditPayload={onEditPayload ?? (() => {})}
             />
+          ) : editing ? (
+            <div className="text-sm font-inter text-zinc-700 leading-relaxed">
+              {isMultiline ? (
+                <Textarea
+                  value={editValue}
+                  onChange={e => setEditValue(e.target.value)}
+                  onKeyDown={handleEditKeyDown}
+                  onBlur={handleEditBlur}
+                  rows={3}
+                  autoFocus
+                  data-testid={`modify-input-${proposal.id}`}
+                  className="text-sm font-inter resize-none"
+                />
+              ) : (
+                <Input
+                  type="text"
+                  value={editValue}
+                  onChange={e => setEditValue(e.target.value)}
+                  onKeyDown={handleEditKeyDown}
+                  onBlur={handleEditBlur}
+                  autoFocus
+                  data-testid={`modify-input-${proposal.id}`}
+                  className="text-sm font-inter"
+                />
+              )}
+            </div>
           ) : (
             <div className="text-sm font-inter text-zinc-700 leading-relaxed">
               {proposal.oldValue ? (
@@ -119,7 +198,7 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
 
         {/* Actions */}
         <div className="flex items-center gap-2">
-          {proposal.status === 'proposed' && (
+          {proposal.status === 'proposed' && !editing && (
             <>
               <button
                 onClick={() => onApply(proposal.id)}
@@ -134,6 +213,42 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
                 className="text-xs font-semibold font-inter text-zinc-500 hover:text-zinc-700 px-3 py-1 rounded-lg hover:bg-zinc-100 transition-colors"
               >
                 Dismiss
+              </button>
+              {!isNewStudent && (
+                <button
+                  onClick={startEdit}
+                  data-testid={`modify-btn-${proposal.id}`}
+                  className="text-xs font-semibold font-inter text-indigo-600 hover:text-indigo-700 px-3 py-1 rounded-lg hover:bg-indigo-50 transition-colors"
+                >
+                  Modify
+                </button>
+              )}
+            </>
+          )}
+
+          {proposal.status === 'proposed' && editing && (
+            <>
+              <button
+                onMouseDown={e => { e.preventDefault(); commitEdit() }}
+                data-testid={`modify-save-btn-${proposal.id}`}
+                className="text-xs font-semibold font-inter text-white bg-indigo-600 hover:bg-indigo-700 px-3 py-1 rounded-lg transition-colors"
+              >
+                Save
+              </button>
+              <button
+                onMouseDown={e => { e.preventDefault(); cancelEdit() }}
+                data-testid={`modify-cancel-btn-${proposal.id}`}
+                className="text-xs font-semibold font-inter text-zinc-500 hover:text-zinc-700 px-3 py-1 rounded-lg hover:bg-zinc-100 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onMouseDown={e => { e.preventDefault(); cancelEdit(); onRedirectToChat(getRedirectPrefill(proposal.type)) }}
+                data-testid={`redirect-to-chat-btn-${proposal.id}`}
+                className="text-xs font-inter text-zinc-400 hover:text-indigo-600 px-2 py-1 rounded-lg hover:bg-indigo-50 transition-colors ml-auto"
+                title="Wrong entity or scope? Redirect to chat"
+              >
+                Wrong entity?
               </button>
             </>
           )}

--- a/frontend/src/components/assistant/ProposalCard.tsx
+++ b/frontend/src/components/assistant/ProposalCard.tsx
@@ -1,6 +1,7 @@
-import { Calendar, CheckSquare, Loader2, User } from 'lucide-react'
+import { Calendar, CheckSquare, Loader2, User, UserPlus } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { ProposalWithStatus } from '@/hooks/useAtelierAssistant'
+import NewStudentFields from './NewStudentFields'
 
 interface Props {
   proposal: ProposalWithStatus
@@ -8,6 +9,7 @@ interface Props {
   onDismiss: (id: string) => void
   onUndo: (id: string) => void
   onRetry: (id: string) => void
+  onEdit?: (id: string, newValue: string) => void
 }
 
 const TYPE_CONFIG = {
@@ -29,9 +31,15 @@ const TYPE_CONFIG = {
     iconBg: 'bg-emerald-100',
     iconColor: 'text-emerald-600',
   },
+  newStudent: {
+    Icon: UserPlus,
+    accent: 'bg-teal-500',
+    iconBg: 'bg-teal-100',
+    iconColor: 'text-teal-600',
+  },
 } as const
 
-export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onRetry }: Props) {
+export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onRetry, onEdit }: Props) {
   const config = TYPE_CONFIG[proposal.type]
   const { Icon } = config
 
@@ -79,18 +87,28 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
           )}
         </div>
 
-        {/* Diff */}
-        <div className="text-sm font-inter text-zinc-700 mb-2.5 leading-relaxed">
-          {proposal.oldValue ? (
-            <span>
-              <span className="line-through text-zinc-400">{proposal.oldValue}</span>
-              {' '}
-              <span className="text-zinc-400 mx-0.5">→</span>
-              {' '}
-              <span className="font-semibold text-zinc-800">{proposal.newValue}</span>
-            </span>
+        {/* Content */}
+        <div className="mb-2.5">
+          {proposal.type === 'newStudent' ? (
+            <NewStudentFields
+              value={proposal.newValue}
+              proposalId={proposal.id}
+              onEdit={onEdit ?? (() => {})}
+            />
           ) : (
-            <span className="font-semibold text-zinc-800">{proposal.newValue}</span>
+            <div className="text-sm font-inter text-zinc-700 leading-relaxed">
+              {proposal.oldValue ? (
+                <span>
+                  <span className="line-through text-zinc-400">{proposal.oldValue}</span>
+                  {' '}
+                  <span className="text-zinc-400 mx-0.5">→</span>
+                  {' '}
+                  <span className="font-semibold text-zinc-800">{proposal.newValue}</span>
+                </span>
+              ) : (
+                <span className="font-semibold text-zinc-800">{proposal.newValue}</span>
+              )}
+            </div>
           )}
         </div>
 

--- a/frontend/src/hooks/useAtelierAssistant.test.ts
+++ b/frontend/src/hooks/useAtelierAssistant.test.ts
@@ -15,16 +15,20 @@ vi.mock('../api/assistant', () => ({
   applyStudentProposal: vi.fn(),
   applySessionProposal: vi.fn(),
   applyTodoProposal: vi.fn(),
-  createStudentFromAssistant: vi.fn(),
+}))
+
+vi.mock('../api/students', () => ({
+  createStudent: vi.fn(),
 }))
 
 import * as assistantApi from '../api/assistant'
+import * as studentsApi from '../api/students'
 
 const mockPropose = vi.mocked(assistantApi.proposeAssistant)
 const mockApplyStudent = vi.mocked(assistantApi.applyStudentProposal)
 const mockApplySession = vi.mocked(assistantApi.applySessionProposal)
 const mockApplyTodo = vi.mocked(assistantApi.applyTodoProposal)
-const mockCreateStudent = vi.mocked(assistantApi.createStudentFromAssistant)
+const mockCreateStudent = vi.mocked(studentsApi.createStudent)
 
 const sampleProposals = [
   { id: 'p1', type: 'student' as const, field: 'cefrLevel', label: 'CEFR Level', oldValue: 'A2', newValue: 'B1' },
@@ -173,11 +177,19 @@ describe('useAtelierAssistant', () => {
     expect(result.current.proposals.every(p => p.status === 'applied')).toBe(true)
   })
 
-  it('apply: routes newStudent proposal to createStudentFromAssistant and invalidates students query', async () => {
+  it('apply: routes newStudent proposal to createStudent and invalidates students query', async () => {
     const payload = JSON.stringify({ name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' })
     const newStudentProposal = { id: 'p4', type: 'newStudent' as const, field: 'profile', label: 'New Student', oldValue: null, newValue: payload }
     mockPropose.mockResolvedValueOnce({ proposals: [newStudentProposal] })
-    mockCreateStudent.mockResolvedValueOnce({ id: 'new-student-id' })
+    mockCreateStudent.mockResolvedValueOnce({
+      id: 'new-student-id', name: 'Sofía', learningLanguage: 'inglés',
+      level: { cefrLevel: 'B1', officialCefrLevel: null, skillLevelOverrides: {} },
+      languages: { nativeLanguages: [], spokenLanguages: [] },
+      identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null },
+      profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
+      commercial: { isActive: true, isCorporate: false, rate: null },
+      createdAt: '', updatedAt: '',
+    })
 
     const { result } = renderHook(() => useAtelierAssistant(null, null), { wrapper: makeWrapper() })
     act(() => { result.current.submit('Nueva alumna Sofía') })
@@ -185,7 +197,7 @@ describe('useAtelierAssistant', () => {
     expect(result.current.proposals).toHaveLength(1)
 
     await act(async () => { await result.current.apply('p4') })
-    expect(mockCreateStudent).toHaveBeenCalledWith({ name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' })
+    expect(mockCreateStudent).toHaveBeenCalledWith(expect.objectContaining({ name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' }))
     expect(result.current.proposals[0].status).toBe('applied')
   })
 

--- a/frontend/src/hooks/useAtelierAssistant.test.ts
+++ b/frontend/src/hooks/useAtelierAssistant.test.ts
@@ -15,6 +15,7 @@ vi.mock('../api/assistant', () => ({
   applyStudentProposal: vi.fn(),
   applySessionProposal: vi.fn(),
   applyTodoProposal: vi.fn(),
+  createStudentFromAssistant: vi.fn(),
 }))
 
 import * as assistantApi from '../api/assistant'
@@ -23,6 +24,7 @@ const mockPropose = vi.mocked(assistantApi.proposeAssistant)
 const mockApplyStudent = vi.mocked(assistantApi.applyStudentProposal)
 const mockApplySession = vi.mocked(assistantApi.applySessionProposal)
 const mockApplyTodo = vi.mocked(assistantApi.applyTodoProposal)
+const mockCreateStudent = vi.mocked(assistantApi.createStudentFromAssistant)
 
 const sampleProposals = [
   { id: 'p1', type: 'student' as const, field: 'cefrLevel', label: 'CEFR Level', oldValue: 'A2', newValue: 'B1' },
@@ -169,6 +171,36 @@ describe('useAtelierAssistant', () => {
 
     await act(async () => { await result.current.applyAll() })
     expect(result.current.proposals.every(p => p.status === 'applied')).toBe(true)
+  })
+
+  it('apply: routes newStudent proposal to createStudentFromAssistant and invalidates students query', async () => {
+    const payload = JSON.stringify({ name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' })
+    const newStudentProposal = { id: 'p4', type: 'newStudent' as const, field: 'profile', label: 'New Student', oldValue: null, newValue: payload }
+    mockPropose.mockResolvedValueOnce({ proposals: [newStudentProposal] })
+    mockCreateStudent.mockResolvedValueOnce({ id: 'new-student-id' })
+
+    const { result } = renderHook(() => useAtelierAssistant(null, null), { wrapper: makeWrapper() })
+    act(() => { result.current.submit('Nueva alumna Sofía') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(result.current.proposals).toHaveLength(1)
+
+    await act(async () => { await result.current.apply('p4') })
+    expect(mockCreateStudent).toHaveBeenCalledWith({ name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' })
+    expect(result.current.proposals[0].status).toBe('applied')
+  })
+
+  it('onEdit: updates newValue of proposal with matching id', async () => {
+    const payload = JSON.stringify({ name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' })
+    const newStudentProposal = { id: 'p4', type: 'newStudent' as const, field: 'profile', label: 'New Student', oldValue: null, newValue: payload }
+    mockPropose.mockResolvedValueOnce({ proposals: [newStudentProposal] })
+
+    const { result } = renderHook(() => useAtelierAssistant(null, null), { wrapper: makeWrapper() })
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    const updatedPayload = JSON.stringify({ name: 'Lucía', learningLanguage: 'inglés', cefrLevel: 'B1' })
+    act(() => { result.current.onEdit('p4', updatedPayload) })
+    expect(result.current.proposals[0].newValue).toBe(updatedPayload)
   })
 
   it('reset: clears transcription, processing, and proposals', async () => {

--- a/frontend/src/hooks/useAtelierAssistant.test.ts
+++ b/frontend/src/hooks/useAtelierAssistant.test.ts
@@ -178,8 +178,8 @@ describe('useAtelierAssistant', () => {
   })
 
   it('apply: routes newStudent proposal to createStudent and invalidates students query', async () => {
-    const payload = JSON.stringify({ name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' })
-    const newStudentProposal = { id: 'p4', type: 'newStudent' as const, field: 'profile', label: 'New Student', oldValue: null, newValue: payload }
+    const studentPayload = { name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' }
+    const newStudentProposal = { id: 'p4', type: 'newStudent' as const, field: 'profile', label: 'New Student', oldValue: null, newValue: 'Sofía', payload: studentPayload }
     mockPropose.mockResolvedValueOnce({ proposals: [newStudentProposal] })
     mockCreateStudent.mockResolvedValueOnce({
       id: 'new-student-id', name: 'Sofía', learningLanguage: 'inglés',
@@ -201,18 +201,18 @@ describe('useAtelierAssistant', () => {
     expect(result.current.proposals[0].status).toBe('applied')
   })
 
-  it('onEdit: updates newValue of proposal with matching id', async () => {
-    const payload = JSON.stringify({ name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' })
-    const newStudentProposal = { id: 'p4', type: 'newStudent' as const, field: 'profile', label: 'New Student', oldValue: null, newValue: payload }
+  it('onEditPayload: updates payload of proposal with matching id', async () => {
+    const studentPayload = { name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' }
+    const newStudentProposal = { id: 'p4', type: 'newStudent' as const, field: 'profile', label: 'New Student', oldValue: null, newValue: 'Sofía', payload: studentPayload }
     mockPropose.mockResolvedValueOnce({ proposals: [newStudentProposal] })
 
     const { result } = renderHook(() => useAtelierAssistant(null, null), { wrapper: makeWrapper() })
     act(() => { result.current.submit('text') })
     await act(async () => { await vi.runAllTimersAsync() })
 
-    const updatedPayload = JSON.stringify({ name: 'Lucía', learningLanguage: 'inglés', cefrLevel: 'B1' })
-    act(() => { result.current.onEdit('p4', updatedPayload) })
-    expect(result.current.proposals[0].newValue).toBe(updatedPayload)
+    const updatedPayload = { name: 'Lucía', learningLanguage: 'inglés', cefrLevel: 'B1' }
+    act(() => { result.current.onEditPayload('p4', updatedPayload) })
+    expect(result.current.proposals[0].payload).toEqual(updatedPayload)
   })
 
   it('reset: clears transcription, processing, and proposals', async () => {

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -4,11 +4,11 @@ import {
   applySessionProposal,
   applyStudentProposal,
   applyTodoProposal,
-  createStudentFromAssistant,
   type NewStudentData,
   type ProposalDto,
   proposeAssistant,
 } from '../api/assistant'
+import { createStudent } from '../api/students'
 
 export type ProposalStatus = 'proposed' | 'applying' | 'applied' | 'dismissed' | 'error'
 
@@ -93,6 +93,9 @@ export function useAtelierAssistant(
         await applyTodoProposal(studentId, proposal.newValue)
       } else if (proposal.type === 'newStudent') {
         const data = JSON.parse(proposal.newValue) as NewStudentData
+        if (!data.name?.trim()) throw new Error('Name is required.')
+        if (!data.learningLanguage?.trim()) throw new Error('Learning Language is required.')
+        if (!data.cefrLevel?.trim()) throw new Error('CEFR Level is required.')
         // Guard against creating a duplicate if the students list is cached
         const cached = queryClient.getQueryData<{ items: Array<{ name: string }> }>(['students'])
         if (cached && data.name) {
@@ -101,7 +104,20 @@ export function useAtelierAssistant(
           )
           if (exists) throw new Error(`A student named "${data.name}" already exists.`)
         }
-        await createStudentFromAssistant(data)
+        await createStudent({
+          name: data.name,
+          learningLanguage: data.learningLanguage,
+          cefrLevel: data.cefrLevel,
+          birthYear: data.birthYear ?? null,
+          profession: data.profession ?? null,
+          cityOfResidence: data.cityOfResidence ?? null,
+          nativeLanguages: data.nativeLanguages ?? [],
+          reasonForStudying: data.reasonForStudying ?? null,
+          interests: [],
+          learningGoals: [],
+          weaknesses: [],
+          difficulties: [],
+        })
       }
       updateProposal(id, { status: 'applied' })
       // Invalidate relevant queries so the rest of the UI reflects the change

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -8,6 +8,8 @@ import {
   type ProposalDto,
   proposeAssistant,
 } from '../api/assistant'
+// Re-export NewStudentData so consumers don't need to import from api/assistant directly
+export type { NewStudentData }
 import { createStudent } from '../api/students'
 
 export type ProposalStatus = 'proposed' | 'applying' | 'applied' | 'dismissed' | 'error'
@@ -32,7 +34,7 @@ export interface AtelierAssistantActions {
   applyAll: () => void
   dismissAll: () => void
   reset: () => void
-  onEdit: (id: string, newValue: string) => void
+  onEditPayload: (id: string, payload: NewStudentData) => void
 }
 
 export function useAtelierAssistant(
@@ -92,7 +94,8 @@ export function useAtelierAssistant(
       } else if (proposal.type === 'todo' && studentId) {
         await applyTodoProposal(studentId, proposal.newValue)
       } else if (proposal.type === 'newStudent') {
-        const data = JSON.parse(proposal.newValue) as NewStudentData
+        const data = proposal.payload as NewStudentData | null | undefined
+        if (!data) throw new Error('Student data is missing.')
         if (!data.name?.trim()) throw new Error('Name is required.')
         if (!data.learningLanguage?.trim()) throw new Error('Learning Language is required.')
         if (!data.cefrLevel?.trim()) throw new Error('CEFR Level is required.')
@@ -100,7 +103,7 @@ export function useAtelierAssistant(
         const cached = queryClient.getQueryData<{ items: Array<{ name: string }> }>(['students'])
         if (cached && data.name) {
           const exists = cached.items.some(
-            s => s.name.trim().toLowerCase() === data.name.trim().toLowerCase()
+            s => s.name.trim().toLowerCase() === data.name!.trim().toLowerCase()
           )
           if (exists) throw new Error(`A student named "${data.name}" already exists.`)
         }
@@ -164,8 +167,8 @@ export function useAtelierAssistant(
     proposalsRef.current.filter(p => p.status === 'proposed').forEach(p => dismiss(p.id))
   }, [dismiss])
 
-  const onEdit = useCallback((id: string, newValue: string) => {
-    setProposals(prev => prev.map(p => p.id === id ? { ...p, newValue } : p))
+  const onEditPayload = useCallback((id: string, payload: NewStudentData) => {
+    setProposals(prev => prev.map(p => p.id === id ? { ...p, payload } : p))
   }, [])
 
   const reset = useCallback(() => {
@@ -187,6 +190,6 @@ export function useAtelierAssistant(
     applyAll,
     dismissAll,
     reset,
-    onEdit,
+    onEditPayload,
   }
 }

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -93,6 +93,14 @@ export function useAtelierAssistant(
         await applyTodoProposal(studentId, proposal.newValue)
       } else if (proposal.type === 'newStudent') {
         const data = JSON.parse(proposal.newValue) as NewStudentData
+        // Guard against creating a duplicate if the students list is cached
+        const cached = queryClient.getQueryData<{ items: Array<{ name: string }> }>(['students'])
+        if (cached && data.name) {
+          const exists = cached.items.some(
+            s => s.name.trim().toLowerCase() === data.name.trim().toLowerCase()
+          )
+          if (exists) throw new Error(`A student named "${data.name}" already exists.`)
+        }
         await createStudentFromAssistant(data)
       }
       updateProposal(id, { status: 'applied' })

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -4,6 +4,8 @@ import {
   applySessionProposal,
   applyStudentProposal,
   applyTodoProposal,
+  createStudentFromAssistant,
+  type NewStudentData,
   type ProposalDto,
   proposeAssistant,
 } from '../api/assistant'
@@ -30,6 +32,7 @@ export interface AtelierAssistantActions {
   applyAll: () => void
   dismissAll: () => void
   reset: () => void
+  onEdit: (id: string, newValue: string) => void
 }
 
 export function useAtelierAssistant(
@@ -88,6 +91,9 @@ export function useAtelierAssistant(
         await applySessionProposal(studentId, sessionId, proposal.field, proposal.newValue)
       } else if (proposal.type === 'todo' && studentId) {
         await applyTodoProposal(studentId, proposal.newValue)
+      } else if (proposal.type === 'newStudent') {
+        const data = JSON.parse(proposal.newValue) as NewStudentData
+        await createStudentFromAssistant(data)
       }
       updateProposal(id, { status: 'applied' })
       // Invalidate relevant queries so the rest of the UI reflects the change
@@ -96,6 +102,8 @@ export function useAtelierAssistant(
       } else if (proposal.type === 'session' && studentId && sessionId) {
         await queryClient.invalidateQueries({ queryKey: ['session', studentId, sessionId] })
         await queryClient.invalidateQueries({ queryKey: ['sessions', studentId] })
+      } else if (proposal.type === 'newStudent') {
+        await queryClient.invalidateQueries({ queryKey: ['students'] })
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to apply change.'
@@ -132,6 +140,10 @@ export function useAtelierAssistant(
     proposalsRef.current.filter(p => p.status === 'proposed').forEach(p => dismiss(p.id))
   }, [dismiss])
 
+  const onEdit = useCallback((id: string, newValue: string) => {
+    setProposals(prev => prev.map(p => p.id === id ? { ...p, newValue } : p))
+  }, [])
+
   const reset = useCallback(() => {
     undoTimers.current.forEach(timer => clearTimeout(timer))
     undoTimers.current.clear()
@@ -151,5 +163,6 @@ export function useAtelierAssistant(
     applyAll,
     dismissAll,
     reset,
+    onEdit,
   }
 }

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -31,6 +31,7 @@ export interface AtelierAssistantActions {
   apply: (id: string) => void
   dismiss: (id: string) => void
   undoDismiss: (id: string) => void
+  modifyProposal: (id: string, newValue: string) => void
   applyAll: () => void
   dismissAll: () => void
   reset: () => void
@@ -46,6 +47,7 @@ export function useAtelierAssistant(
   const [processing, setProcessing] = useState(false)
   const [proposals, setProposals] = useState<ProposalWithStatus[]>([])
   const undoTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+  const applyingIdsRef = useRef<Set<string>>(new Set())
   // Ref keeps apply/applyAll free of stale closure on proposals
   const proposalsRef = useRef<ProposalWithStatus[]>([])
   useEffect(() => { proposalsRef.current = proposals }, [proposals])
@@ -81,9 +83,11 @@ export function useAtelierAssistant(
   }, [studentId, sessionId])
 
   const apply = useCallback(async (id: string) => {
+    if (applyingIdsRef.current.has(id)) return
     const proposal = proposalsRef.current.find(p => p.id === id)
     if (!proposal || (proposal.status !== 'proposed' && proposal.status !== 'error')) return
 
+    applyingIdsRef.current.add(id)
     updateProposal(id, { status: 'applying', errorMessage: undefined })
 
     try {
@@ -135,6 +139,8 @@ export function useAtelierAssistant(
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to apply change.'
       updateProposal(id, { status: 'error', errorMessage: message })
+    } finally {
+      applyingIdsRef.current.delete(id)
     }
   }, [studentId, sessionId, updateProposal, queryClient])
 
@@ -167,11 +173,19 @@ export function useAtelierAssistant(
     proposalsRef.current.filter(p => p.status === 'proposed').forEach(p => dismiss(p.id))
   }, [dismiss])
 
+  const modifyProposal = useCallback((id: string, newValue: string) => {
+    if (!newValue.trim()) return
+    setProposals(prev => prev.map(p =>
+      p.id === id && p.status === 'proposed' ? { ...p, newValue } : p
+    ))
+  }, [])
+
   const onEditPayload = useCallback((id: string, payload: NewStudentData) => {
     setProposals(prev => prev.map(p => p.id === id ? { ...p, payload } : p))
   }, [])
 
   const reset = useCallback(() => {
+    applyingIdsRef.current.clear()
     undoTimers.current.forEach(timer => clearTimeout(timer))
     undoTimers.current.clear()
     setTranscription(null)
@@ -187,6 +201,7 @@ export function useAtelierAssistant(
     apply,
     dismiss,
     undoDismiss,
+    modifyProposal,
     applyAll,
     dismissAll,
     reset,

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -12,6 +12,10 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 
 - **AppShell transcription state lift** (arch-reviewer): `transcription: string | null` for the Atelier Assistant lives in AppShell. This works for part 1 but deviates from the pattern of sub-panel state living local or in a dedicated context (compare `VoiceUpdateDrawer` state in `StudentDetail.tsx`). If parts 2/3 add more cross-cutting assistant state (proposals, selection, apply flow), refactor to a dedicated `AtelierAssistantContext` provider. Resolved at #1009: all state now lives in `useAtelierAssistant` hook. Context provider can be considered for Part 3 (#1010) if cross-route state is needed.
 
+## #1005 (2026-04-28)
+
+- **JSON-blob in ProposalDto.newValue for newStudent type** (arch-reviewer): All other proposal types store a plain human-readable string in `newValue`. The `newStudent` type encodes a JSON object. This diverges from the existing pattern and will complicate generic proposal handling if/when needed. Consider a proper discriminated union for proposals or a dedicated `newStudentPayload` field in the response DTO if compound proposals are added for other types in Part 3.
+
 ## #1009 (2026-04-28)
 
 - **Proposal field taxonomy hardcoded in C#** (Sophy): `AssistantController` emits `EmitProposal` calls for 7 hard-coded field/label pairs. `PatchStudentRequest`/`PatchSessionRequest` mirror this whitelist. Long-term: extract to `data/assistant/proposal-fields.json` consumed by both emission loop and patch dispatch. Assess at Part 3+ (#1010).

--- a/plan/ui-review-backlog.md
+++ b/plan/ui-review-backlog.md
@@ -15,6 +15,10 @@ Non-blocking findings from review-ui runs. Periodically review this file and bat
 - [3] "READY" status indicator (green dot + all-caps Label-SM in panel header): new pattern for live panel status — not covered in design-system.md.
 - [4] "PROPOSED UPDATES / (coming soon)" placeholder section: new pattern for pending-feature sections — acceptable for part 1 stub, will be replaced in #1009.
 
+## #1005 (2026-04-28) — New Student proposal card (novel pattern)
+
+- [1] Inline mini-form inside a proposal card (NewStudentFields): label-above + Input component + select inside a proposal card body. Design system covers autosave-on-blur for detail screens (Pattern A) but does not address editable fields embedded in action/proposal cards in the assistant panel. This pattern should be reviewed by Vera before it becomes a template for other compound proposals.
+
 ## #1004 (2026-04-28) — Atelier Assistant voice input (new patterns)
 
 - [1] Ghost mic button paired with filled-primary send button in the same input row. design-system.md §5 forbids ghost + filled primary in the same row, but the mic is a mode-toggle affordance and the send is a submit CTA — semantically different roles. Compound input bar pattern not covered by design-system.md. Needs Vera discussion before it becomes a reusable pattern.


### PR DESCRIPTION
## Summary

- Detects "new student" intent from voice/text in the Atelier Assistant: if the extracted name is absent from the current student context, a `newStudent` proposal card is emitted; if it differs from the current student's name, both a `newStudent` card and update proposals for the current student are emitted side-by-side (handling the "también tengo un nuevo alumno" scenario).
- New `NewStudentFields` component renders an inline-editable mini-form (label-above, `<Input>` component, design system tokens) inside the proposal card for name, learning language, CEFR level, profession, city, native languages, and reason for studying.
- On Apply: required-field validation runs client-side, then calls `createStudent` from `students.ts` (no duplicate API function), and invalidates the `['students']` query so the roster refreshes immediately. A cache-based duplicate guard prevents creating a student whose name already exists in the loaded list.
- `ProposalDto` gains an optional `JsonElement? Payload` field for compound proposal types; `newValue` remains the student name (human-readable scalar) so the existing proposal rendering contract is preserved.
- `learningLanguage` added to `ExtractedStudentProfileDto` and the extraction prompt so the target language can be captured from voice notes.

## Test plan

- [ ] Open student list, open Assistant, submit "Nueva alumna: Sofía García, 28 años, ingeniera. Aprende inglés, nivel B1, quiere mejorar para entrevistas." -- New Student card appears with teal accent and all fields populated; Apply creates student in list.
- [ ] Open Assistant from Ana's detail page, submit "También tengo un nuevo alumno, Pedro, aprende francés nivel A2." -- New Student card for Pedro appears alongside any Ana update proposals; applying the newStudent card creates Pedro.
- [ ] Submit the same new student text twice; after applying the first card, applying the second shows "A student named X already exists" error on the card.
- [ ] Clear the Name field in the new student card and click Apply -- shows "Name is required." error.
- [ ] Backend unit tests: 6 AssistantController tests (including 3 new intent-detection tests). Frontend unit tests: 1588 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new student creation workflow directly through the assistant interface, allowing users to propose and create new student profiles with comprehensive details.
  * Enhanced student profile extraction to capture the language being learned in addition to existing language data.
  * Added interactive form editor for composing new student proposals with profile fields including name, learning language, CEFR level, profession, city, and study reason.

* **Tests**
  * Added comprehensive test coverage for new student creation logic and payload editing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->