### PR TITLE
fix(#1000): update B-level CEFR badge text to indigo-700 (#4338CA)

### DIFF
--- a/frontend/src/components/dashboard/CefrBadge.test.tsx
+++ b/frontend/src/components/dashboard/CefrBadge.test.tsx
@@ -15,7 +15,7 @@ describe('CefrBadge', () => {
 
   it('applies B-level indigo styling', () => {
     const { container } = render(<CefrBadge level="B2" />)
-    expect(container.firstChild).toHaveClass('bg-[#ECEAFD]', 'text-[#3525CD]')
+    expect(container.firstChild).toHaveClass('bg-[#ECEAFD]', 'text-[#4338CA]')
   })
 
   it('applies C-level warm styling', () => {

--- a/frontend/src/lib/cefr-colors.ts
+++ b/frontend/src/lib/cefr-colors.ts
@@ -3,7 +3,7 @@ export const CEFR_LEVELS = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'] as const
 export function cefrColors(level: string): string {
   const prefix = level[0]?.toUpperCase()
   if (prefix === 'A') return 'bg-[#DDE8F5] text-[#1A4B7A]'
-  if (prefix === 'B') return 'bg-[#ECEAFD] text-[#3525CD]'
+  if (prefix === 'B') return 'bg-[#ECEAFD] text-[#4338CA]'
   if (prefix === 'C') return 'bg-[#F8E9D6] text-[#7E3000]'
   return 'bg-zinc-100 text-zinc-700'
 }


### PR DESCRIPTION
## Summary

- Corrects B1/B2 CEFR badge text color from `#3525CD` to `#4338CA` (`--lt-indigo-700`) per Atelier spec
- All other badge properties (shape `rounded-md`, A/C tier colors, typography) were already correct
- Updates the `CefrBadge.test.tsx` assertion to match the new color

## Test plan

- [x] Unit tests: `CefrBadge.test.tsx` and `cefr-colors.test.ts` pass with updated assertion
- [x] Build verify: all checks PASS (98 tests)
- [x] QA verify: all acceptance criteria confirmed
- [x] Architecture review: PASS WITH NOTES (note: `#3525CD` persists in brand accent/gradient contexts unrelated to CEFR badges -- intentional, out of scope)
- [x] UI review: PASS -- three color tiers visible in Dashboard roster and Student Overview; `rounded-md` shape confirmed, no `rounded-full` badges found

Closes #1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)