### PR TITLE
fix(#997): student detail header buttons icon-only at md-lg breakpoints

### DIFF
--- a/frontend/src/components/student/StudentDetailHeader.tsx
+++ b/frontend/src/components/student/StudentDetailHeader.tsx
@@ -188,29 +188,32 @@ export function StudentDetailHeader({ student, nextSession, sessionFrequency, on
             <button
               onClick={onVoiceUpdateClick}
               disabled={voiceFlowActive}
-              className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium bg-indigo-50 text-indigo-600 hover:bg-indigo-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+              aria-label="Update via voice"
+              className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium bg-indigo-50 text-indigo-600 hover:bg-indigo-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               data-testid="voice-update-button"
             >
               <Mic className="h-3.5 w-3.5" />
-              Update via voice
+              <span className="md:hidden lg:inline">Update via voice</span>
             </button>
           )}
           <Link
             to={`/students/${student.id}/edit`}
+            aria-label="Edit Student"
             className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium bg-indigo-50 text-indigo-600 hover:bg-indigo-100 transition-colors"
             data-testid="edit-profile-link"
           >
             <Pencil className="h-3.5 w-3.5" />
-            Edit Student
+            <span className="md:hidden lg:inline">Edit Student</span>
           </Link>
           <Button
             onClick={() => navigate(`/students/${student.id}/log-session`)}
+            aria-label="Log Session"
             className="rounded-xl text-sm font-medium"
             size="sm"
             data-testid="log-session-button"
           >
-            <NotebookPen className="h-4 w-4 mr-1.5" />
-            Log Session
+            <NotebookPen className="h-4 w-4 lg:mr-1.5" />
+            <span className="md:hidden lg:inline">Log Session</span>
           </Button>
         </div>
       </div>

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -8,6 +8,10 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 
 *Cleared 2026-04-27 during Student Profile Voice Input sprint close. Actionable entries batched into #989 (DS component polish), #990 (code hardening), #992 (navigation UX). Dismissed and cosmetic entries deleted (#927 dismissed, #947 rename too cosmetic).*
 
+## #997 (2026-04-29)
+
+- `StudentDetailHeader.tsx` uses `md:hidden lg:inline` for responsive button labels. Other components (`LessonEditor`, `CourseDetail`, `StudentRoster`) use `hidden sm:inline`. The wider breakpoint in the header is intentional: 3 buttons share a row with avatar/name/badges/objectives making it denser than typical toolbars. Low priority; worth aligning if a global responsive-label convention is ever formalised.
+
 ## #1008 (2026-04-28)
 
 - **AppShell transcription state lift** (arch-reviewer): `transcription: string | null` for the Atelier Assistant lives in AppShell. This works for part 1 but deviates from the pattern of sub-panel state living local or in a dedicated context (compare `VoiceUpdateDrawer` state in `StudentDetail.tsx`). If parts 2/3 add more cross-cutting assistant state (proposals, selection, apply flow), refactor to a dedicated `AtelierAssistantContext` provider. Resolved at #1009: all state now lives in `useAtelierAssistant` hook. Context provider can be considered for Part 3 (#1010) if cross-route state is needed.

--- a/plan/ui-review-backlog.md
+++ b/plan/ui-review-backlog.md
@@ -8,6 +8,10 @@ Non-blocking findings from review-ui runs. Periodically review this file and bat
 
 *Cleared 2026-04-27 during Student Profile Voice Input sprint close. DS/component findings batched into #989 (DS component polish batch). Seeder coverage gap (#904) batched into #991 (e2e test fixes). Environment-only entry (#906) deleted. Navigation findings batched into #992.*
 
+## #997 (2026-04-29) — Student detail header icon-only buttons
+
+- [1] `md:hidden lg:inline` responsive label pattern (icon-only at 768-1024px) has no visual spec coverage at the 768px breakpoint. Consider adding a `@visual header stable - sessions tab 768px` test to `student-detail.visual.spec.ts`. Pattern also not described in design-system.md — needs Vera discussion before it propagates to other screens.
+
 ## #1008 (2026-04-28) — Atelier Assistant panel (new patterns, not violations)
 
 - [1] Inline discard confirm (amber-50 bg, "Close and discard?" + Discard/Keep editing): new pattern for inline confirmation inside a Sheet panel — not covered in design-system.md. Works visually, needs Vera review before it becomes a repeated pattern.


### PR DESCRIPTION
Fixes #997

## Summary
- Wrapped action button text labels in `<span className="md:hidden lg:inline">` so the three header buttons (Update via voice, Edit Student, Log Session) collapse to icon-only between 768px and 1024px, where they share horizontal space with the student info column
- Added `aria-label` to each button for accessibility when text is hidden
- Changed `mr-1.5` to `lg:mr-1.5` on the Log Session icon to avoid dangling margin when icon-only
- Removed `whitespace-nowrap` from voice button (no longer needed with responsive text)
- No change to `SessionHistoryTab.tsx` — the "Open full session" link already renders unconditionally on all expanded rows (verified against issue #928 AC)

## Test plan
- [ ] Wide desktop (1280px+): all three buttons show full text + icons
- [ ] 768px: buttons show icon-only, no overflow or crowding
- [ ] Mobile (375px): column layout, buttons below student info with full text
- [ ] Expand SCHEDULED session row: "Open full session" link visible
- [ ] Expand COMPLETED session row: "Open full session" link visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)