### PR TITLE
fix(#1007): DS per-screen UX polish -- chips, ghost button, chevron hover, input, hover color

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -254,6 +254,8 @@ Sessions are edited inline in their expanded row. No modal, no separate edit pag
 - No animation is better than gratuitous animation.
 - Avoid transitions longer than 300ms for any interactive element.
 
+**Interactive vs. ambient animations.** The 300ms cap applies to **interaction-response animations** (hover states, expand/collapse, click feedback). **Ambient state animations** (processing pulses, loading indicators, streaming cursors) are exempt from the cap -- they communicate ongoing background state, not user-action feedback. Ambient animations must still have purpose and should loop smoothly with `ease-in-out`. Example: `extraction-pulse` at 2.8s total is acceptable because it signals a background extraction process, not a user-triggered state change.
+
 ---
 
 ## 11. Cross-Screen Control Specifications
@@ -337,3 +339,42 @@ LogSession stages new todos and followups locally before committing on Done. Thi
 - New items (not yet committed) are displayed as plain text with an X remove button. They do not have status toggles because they are always pending by definition.
 - Existing items (from the left panel) use the full lifecycle controls from 11.4.
 - The colored container backgrounds (`#F0EFFF` for todos, `#FFFBEB` for followups) are permitted in LogSession to visually separate the "new items" area from the form fields.
+
+### 11.7 Toggle Pill Chips (Settings Language / CEFR)
+
+Used for toggle selections on the Settings page (interface language, CEFR level). Not to be confused with enter-to-add Interests chips.
+
+- **Shape:** `rounded-full px-3 py-1 text-sm font-medium`
+- **Selected:** `bg-indigo-100 text-indigo-800 ring-1 ring-indigo-300`
+- **Unselected:** `bg-zinc-100 text-zinc-600 hover:bg-zinc-200`
+- No border on unselected state (DS no-line rule). Ring on selected communicates active state without a decorative line.
+- CEFR chips: single-select (only one active at a time). Language chips: follow the field's cardinality.
+
+### 11.8 Compact Row Clickability Signal (Chevron)
+
+For any list row that navigates or expands on click, a trailing chevron is required as a passive affordance signal. Hover state alone is insufficient -- it is invisible to new users and absent on mobile.
+
+Use the parent `group` class and `group-hover:text-zinc-600 transition-colors` on the chevron icon.
+
+**Navigation rows** (click takes the user to a new page or detail view):
+- **Icon:** `<ChevronRight />` from `lucide-react`, `w-4 h-4`, `ml-auto`
+- Static -- does not change on expand/collapse.
+
+**Expand/collapse rows** (click reveals inline detail below the row):
+- **Icons:** `<ChevronDown />` when collapsed, `<ChevronUp />` when expanded, `w-4 h-4`
+- The icon change itself communicates expanded state; no separate affordance needed.
+- Example: session history compact rows.
+
+Both patterns:
+- **Color:** `text-zinc-400` at rest, `text-zinc-600` on row hover (`group-hover:text-zinc-600 transition-colors`)
+- **Transition:** `transition-colors` (150ms, matches DS default)
+
+### 11.9 Drawer Footer Button Pairing
+
+All drawer footers (side drawers overlaying the screen) use this exact button pairing in the footer action row:
+
+- **Cancel:** `<Button variant="ghost" size="sm">Cancel</Button>` -- ghost style, dismisses without saving
+- **Primary action:** `<Button size="sm">` (default variant, filled primary) -- confirms/saves the operation
+- **Layout:** `flex items-center justify-end gap-3` row, Cancel left of primary action
+- **Disabled state:** Primary action disabled while saving; Cancel also disabled while saving to prevent double-dismiss
+- The primary action label describes the operation (e.g. "Save 3 changes", "Create student"), not a generic "Save"

--- a/frontend/src/components/SelectionChip.tsx
+++ b/frontend/src/components/SelectionChip.tsx
@@ -15,8 +15,8 @@ export function SelectionChip({ label, selected, onToggle }: SelectionChipProps)
       className={cn(
         'rounded-full text-sm px-3 select-none transition-colors min-h-[36px] border-0 outline-none',
         selected
-          ? 'bg-primary text-white'
-          : 'bg-[#F4F2FD] text-zinc-600 hover:bg-[#E8E7F1]'
+          ? 'bg-indigo-100 text-indigo-800 ring-1 ring-indigo-300'
+          : 'bg-zinc-100 text-zinc-600 hover:bg-zinc-200'
       )}
     >
       {label}

--- a/frontend/src/components/session/SessionHistoryTab.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.tsx
@@ -163,7 +163,7 @@ function SessionEntry({
         {/* Header row: expand button only (no kebab) */}
         <button
           onClick={handleToggle}
-          className="w-full text-left p-4 hover:bg-[#F4F2FD]/40 transition-colors"
+          className="group w-full text-left p-4 hover:bg-[#F4F2FD]/40 transition-colors"
           aria-expanded={expanded}
           data-testid="session-entry-toggle"
         >
@@ -293,9 +293,9 @@ function SessionEntry({
                 </span>
               )}
               {expanded ? (
-                <ChevronUp className="h-4 w-4 text-zinc-400" />
+                <ChevronUp className="h-4 w-4 text-zinc-400 group-hover:text-zinc-600 transition-colors" />
               ) : (
-                <ChevronDown className="h-4 w-4 text-zinc-400" />
+                <ChevronDown className="h-4 w-4 text-zinc-400 group-hover:text-zinc-600 transition-colors" />
               )}
             </div>
           </div>

--- a/frontend/src/components/student/LastSessionCard.tsx
+++ b/frontend/src/components/student/LastSessionCard.tsx
@@ -43,7 +43,7 @@ export function LastSessionCard({ session, studentId }: Props) {
         </p>
         <Link
           to={`/students/${studentId}/log-session`}
-          className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-800"
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-700"
           data-testid="last-session-log-link"
         >
           <NotebookPen className="h-3.5 w-3.5" />
@@ -132,7 +132,7 @@ export function LastSessionCard({ session, studentId }: Props) {
           <div className="mt-4">
             <Link
               to={`/students/${studentId}/sessions/${session.id}/edit`}
-              className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-800"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-700"
               data-testid="last-session-view-link"
             >
               <ExternalLink className="h-3.5 w-3.5" />

--- a/frontend/src/components/student/LessonHistoryCard.tsx
+++ b/frontend/src/components/student/LessonHistoryCard.tsx
@@ -57,7 +57,7 @@ export function LessonHistoryCard({ studentId }: LessonHistoryCardProps) {
                 <div className="flex items-center gap-2 flex-wrap">
                   <Link
                     to={`/lessons/${entry.lessonId}`}
-                    className="text-sm font-medium text-indigo-600 hover:text-indigo-800 hover:underline"
+                    className="text-sm font-medium text-indigo-600 hover:text-indigo-700 hover:underline"
                     data-testid="lesson-history-title"
                   >
                     {entry.title}

--- a/frontend/src/components/student/TeachingTodosCard.tsx
+++ b/frontend/src/components/student/TeachingTodosCard.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react'
 import { useMutation } from '@tanstack/react-query'
 import { Plus, Trash2, Check } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import type { TeachingTodo } from '@/api/students'
 import { appendTeachingTodo, updateTeachingTodo, deleteTeachingTodo } from '@/api/students'
 import { relativeTime } from '@/utils/formatDate'
@@ -252,14 +253,16 @@ export function TeachingTodosCard({ todos, studentId, onStudentChange, allowEdit
           )}
 
           {completedCount > 0 && (
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="sm"
               onClick={() => setShowCompleted(v => !v)}
               data-testid="todo-show-completed-toggle"
-              className="mb-3 text-xs text-zinc-400 hover:text-zinc-600 transition-colors"
+              className="mb-3 h-auto px-2 py-1 text-xs text-zinc-400 hover:text-zinc-600"
             >
               {showCompleted ? `Hide completed (${completedCount})` : `Show ${completedCount} completed`}
-            </button>
+            </Button>
           )}
         </>
       )}

--- a/frontend/src/components/student/VoiceUpdateDrawer.tsx
+++ b/frontend/src/components/student/VoiceUpdateDrawer.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Pencil, X, ChevronRight, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import type { Student } from '@/api/students'
 import type { ExtractedStudentProfile } from '@/api/studentExtraction'
 import { buildDrawerRows, buildCreateDrawerRows, mergeExtractedIntoStudent } from '@/lib/voiceUpdateMerge'
@@ -157,9 +158,9 @@ export function VoiceUpdateDrawer(props: VoiceUpdateDrawerProps) {
                     </div>
                   )}
                   {editingId === row.id ? (
-                    <input
+                    <Input
                       autoFocus
-                      className="w-full text-sm text-indigo-700 font-medium bg-indigo-50 rounded-lg px-2 py-1 outline-none"
+                      className="h-auto w-full text-sm text-indigo-700 font-medium bg-indigo-50 border-0 ring-1 ring-indigo-200 focus-visible:ring-indigo-400 rounded-lg px-2 py-1"
                       value={editValue}
                       onChange={(e) => setEditValue(e.target.value)}
                       onBlur={() => commitEdit(row.id)}

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -3,6 +3,7 @@
 Out-of-scope observations logged by agents during implementation. Each row is something an agent noticed but did not fix because it was outside the current task's scope. These get batched into future GitHub issues by the PM.
 
 | Source issue | Date | Severity | Observation |
+| #1007 | 2026-04-29 | P3:nice | `hover:text-indigo-800` vs `hover:text-indigo-700` split across codebase -- lesson renderers, StudentRoster, PendingFollowups, CourseDetail still use -800; student cards now use -700. Needs a sweep to standardize. |
 | #1002 | 2026-04-28 | low | Keyboard shortcut hint (⌘K label-sm text below sidebar CTA) is an undocumented pattern in the design system. Needs Vera sign-off before it becomes a reusable convention. |
 | #1002 | 2026-04-28 | medium | AppShell sidebar links to `/help` (added by #1002) but no route exists in App.tsx. Clicking Help navigates to an unmatched screen. Needs a Help page or the link removed. |
 | #1004 | 2026-04-28 | low | `TeachingTodosCard.test.tsx` line 141 flakes in full suite runs (passes in isolation) due to date-relative text matching combined with test ordering. Pre-existing; not introduced by this task. |


### PR DESCRIPTION
Closes #1007

## Summary

- **Design system:** Added §10 interactive/ambient animation distinction (extraction-pulse 2.8s exempt from 300ms cap), §11.7 toggle pill chip spec, §11.8 compact row chevron spec (navigation vs expand/collapse), §11.9 drawer footer button pairing spec.
- **SelectionChip:** Selected state changed to tonal indigo pill (`bg-indigo-100 text-indigo-800 ring-1 ring-indigo-300`); unselected to `bg-zinc-100 text-zinc-600`. Applied to Settings and Onboarding.
- **VoiceUpdateDrawer:** Raw `<input>` in inline edit field replaced with shadcn `<Input>` per DS §11.1.
- **TeachingTodosCard:** "Show N completed" toggle upgraded from plain `<button>` to `<Button variant="ghost" size="sm">` for visible shape affordance.
- **SessionHistoryTab:** `group` class added to session entry toggle button; ChevronDown/Up get `group-hover:text-zinc-600 transition-colors` per DS §11.8.
- **LastSessionCard + LessonHistoryCard:** All indigo link hover colors standardized to `hover:text-indigo-700`.

## Vera decisions (pre-approved before implementation)

- Trailing chevron on compact session rows: **YES** (DS §11.8, expand/collapse rows use ChevronDown/Up)
- extraction-pulse animation exemption from DS §10 cap: **YES** (ambient state animation, documented in DS §10)
- Language/CEFR toggle pill chip spec: **APPROVED** (DS §11.7)

## Test plan

- [ ] Settings page: Language, CEFR, and Content Style chips render with rounded-full pill shape; selected chip shows light indigo fill + ring, unselected shows zinc muted background
- [ ] Onboarding Step 1: chip selection works, selected state shows tonal indigo (confirmed in UI review via Onboarding screenshot)
- [ ] Student profile with completed todos: "Show N completed" renders as a ghost button with visible hover shape
- [ ] Session history: hovering a row causes the chevron to darken from zinc-400 to zinc-600
- [ ] VoiceUpdateDrawer: clicking edit on an extracted row shows a styled Input (not a plain browser input)
- [ ] LastSessionCard and LessonHistoryCard: hovering title links shows indigo-700 (not indigo-800)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated color palette across components from purple to indigo/zinc theme
  * Enhanced hover state styling for improved visual feedback on links and interactive elements

* **Refactor**
  * Standardized button controls using shared UI component library
  * Standardized input fields using shared UI component with ring-based border styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->