### PR TITLE
fix(#1050): remove "Wrong entity?" affordance from proposal cards

### DIFF
--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -81,7 +81,6 @@ export default function AtelierAssistantPanel({
 }: Props) {
   const [inputValue, setInputValue] = useState('')
   const [pendingClose, setPendingClose] = useState(false)
-  const chatInputRef = useRef<HTMLInputElement>(null)
 
   const [micState, setMicState] = useState<MicState>('idle')
   const [micError, setMicError] = useState<MicError>(null)
@@ -332,11 +331,6 @@ export default function AtelierAssistantPanel({
     }
   }
 
-  function handleRedirectToChat(prefill: string) {
-    setInputValue(prefill)
-    setTimeout(() => chatInputRef.current?.focus(), 0)
-  }
-
   const emptyPrompt = studentName
     ? `What did you cover with ${studentName} today?`
     : 'What would you like to cover today?'
@@ -466,7 +460,6 @@ export default function AtelierAssistantPanel({
                         onUndo={onUndo}
                         onRetry={onRetry}
                         onModify={onModify}
-                        onRedirectToChat={handleRedirectToChat}
                         onEditPayload={onEditPayload}
                         studentId={studentId}
                       />

--- a/frontend/src/components/assistant/ProposalCard.test.tsx
+++ b/frontend/src/components/assistant/ProposalCard.test.tsx
@@ -25,7 +25,6 @@ function renderCard(proposal: ProposalWithStatus, handlers = {}) {
     onUndo: vi.fn(),
     onRetry: vi.fn(),
     onModify: vi.fn(),
-    onRedirectToChat: vi.fn(),
     onEditPayload: vi.fn(),
     ...handlers,
   }
@@ -191,16 +190,6 @@ describe('ProposalCard', () => {
     await user.click(screen.getByTestId('modify-btn-p1'))
     await user.click(screen.getByTestId('modify-cancel-btn-p1'))
     expect(onModify).not.toHaveBeenCalled()
-    expect(screen.queryByTestId('modify-input-p1')).not.toBeInTheDocument()
-  })
-
-  it('Wrong entity button calls onRedirectToChat with prefill and exits edit mode', async () => {
-    const user = userEvent.setup()
-    const onRedirectToChat = vi.fn()
-    renderCard(makeProposal({ status: 'proposed', type: 'session', field: 'title' }), { onRedirectToChat })
-    await user.click(screen.getByTestId('modify-btn-p1'))
-    await user.click(screen.getByTestId('redirect-to-chat-btn-p1'))
-    expect(onRedirectToChat).toHaveBeenCalledWith(expect.stringContaining('student profile'))
     expect(screen.queryByTestId('modify-input-p1')).not.toBeInTheDocument()
   })
 

--- a/frontend/src/components/assistant/ProposalCard.tsx
+++ b/frontend/src/components/assistant/ProposalCard.tsx
@@ -13,18 +13,11 @@ interface Props {
   onUndo: (id: string) => void
   onRetry: (id: string) => void
   onModify: (id: string, newValue: string) => void
-  onRedirectToChat: (prefill: string) => void
   onEditPayload?: (id: string, payload: NewStudentData | NewSessionData) => void
   studentId?: string | null
 }
 
 const MULTILINE_FIELDS = new Set(['actualContent', 'generalNotes', 'homeworkAssigned'])
-
-function getRedirectPrefill(type: string): string {
-  if (type === 'session') return 'Actually for the student profile not the session — '
-  if (type === 'student') return 'Actually for the session not the student — '
-  return 'Actually — '
-}
 
 const TYPE_CONFIG = {
   student: {
@@ -59,7 +52,7 @@ const TYPE_CONFIG = {
   },
 } as const
 
-export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onRetry, onModify, onRedirectToChat, onEditPayload, studentId }: Props) {
+export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onRetry, onModify, onEditPayload, studentId }: Props) {
   const config = TYPE_CONFIG[proposal.type]
   const { Icon } = config
 
@@ -287,14 +280,6 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
                 className="text-xs font-semibold font-inter text-zinc-500 hover:text-zinc-700 px-3 py-1 rounded-lg hover:bg-zinc-100 transition-colors"
               >
                 Cancel
-              </button>
-              <button
-                onMouseDown={e => { e.preventDefault(); cancelEdit(); onRedirectToChat(getRedirectPrefill(proposal.type)) }}
-                data-testid={`redirect-to-chat-btn-${proposal.id}`}
-                className="text-xs font-inter text-zinc-400 hover:text-indigo-600 px-2 py-1 rounded-lg hover:bg-indigo-50 transition-colors ml-auto"
-                title="Wrong entity or scope? Redirect to chat"
-              >
-                Wrong entity?
               </button>
             </>
           )}


### PR DESCRIPTION
## Summary

- Removes the "Wrong entity?" button from ProposalCard edit state (the button, its `onRedirectToChat` prop, the `getRedirectPrefill` helper, the `handleRedirectToChat` handler, and the now-unused `chatInputRef`)
- Dismiss + re-prompt is the documented flow for mis-routed proposals; the affordance was adding friction with three failure points for a rare edge case
- One test case removed; all remaining 1628 tests pass

## Test plan

- [x] `npm test` passes (1628 tests, 98 files)
- [x] `npm build` passes
- [x] `dotnet test` passes
- [x] Architecture review: PASS (zero remaining references to removed symbols)
- [x] UI review: PASS (no "Wrong entity?" link visible; Apply / Dismiss / Modify still render correctly)

Closes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)