### PR TITLE
fix(#1058): normalize language names before newStudent API call

### DIFF
--- a/frontend/src/hooks/useAtelierAssistant.test.ts
+++ b/frontend/src/hooks/useAtelierAssistant.test.ts
@@ -222,8 +222,101 @@ describe('useAtelierAssistant', () => {
     expect(result.current.proposals).toHaveLength(1)
 
     await act(async () => { await result.current.apply('p4') })
-    expect(mockCreateStudent).toHaveBeenCalledWith(expect.objectContaining({ name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1' }))
+    expect(mockCreateStudent).toHaveBeenCalledWith(expect.objectContaining({ name: 'Sofía', learningLanguage: 'English', cefrLevel: 'B1' }))
     expect(result.current.proposals[0].status).toBe('applied')
+  })
+
+  it('apply: normalizes Spanish language names to canonical English before creating student', async () => {
+    const studentPayload = { name: 'María', learningLanguage: 'inglés', nativeLanguages: ['castellano'], cefrLevel: 'B1' }
+    const newStudentProposal = { id: 'p5', type: 'newStudent' as const, field: 'profile', label: 'New Student', oldValue: null, newValue: 'María', payload: studentPayload }
+    mockPropose.mockResolvedValueOnce({ proposals: [newStudentProposal] })
+    mockCreateStudent.mockResolvedValueOnce({
+      id: 'new-id', name: 'María', learningLanguage: 'English',
+      level: { cefrLevel: 'B1', officialCefrLevel: null, skillLevelOverrides: {} },
+      languages: { nativeLanguages: ['Spanish'], spokenLanguages: [] },
+      identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null },
+      profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
+      commercial: { isActive: true, isCorporate: false, rate: null },
+      createdAt: '', updatedAt: '',
+    })
+
+    const { result } = renderHook(() => useAtelierAssistant(null, null), { wrapper: makeWrapper() })
+    act(() => { result.current.submit('Nueva alumna María') })
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    await act(async () => { await result.current.apply('p5') })
+    expect(mockCreateStudent).toHaveBeenCalledWith(expect.objectContaining({
+      learningLanguage: 'English',
+      nativeLanguages: ['Spanish'],
+    }))
+    expect(result.current.proposals[0].status).toBe('applied')
+  })
+
+  it('apply: English-only input passes through without normalization regression', async () => {
+    const studentPayload = { name: 'John', learningLanguage: 'Spanish', nativeLanguages: ['English'], cefrLevel: 'A2' }
+    const newStudentProposal = { id: 'p6', type: 'newStudent' as const, field: 'profile', label: 'New Student', oldValue: null, newValue: 'John', payload: studentPayload }
+    mockPropose.mockResolvedValueOnce({ proposals: [newStudentProposal] })
+    mockCreateStudent.mockResolvedValueOnce({
+      id: 'new-id', name: 'John', learningLanguage: 'Spanish',
+      level: { cefrLevel: 'A2', officialCefrLevel: null, skillLevelOverrides: {} },
+      languages: { nativeLanguages: ['English'], spokenLanguages: [] },
+      identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null },
+      profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
+      commercial: { isActive: true, isCorporate: false, rate: null },
+      createdAt: '', updatedAt: '',
+    })
+
+    const { result } = renderHook(() => useAtelierAssistant(null, null), { wrapper: makeWrapper() })
+    act(() => { result.current.submit('New student John') })
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    await act(async () => { await result.current.apply('p6') })
+    expect(mockCreateStudent).toHaveBeenCalledWith(expect.objectContaining({
+      learningLanguage: 'Spanish',
+      nativeLanguages: ['English'],
+    }))
+    expect(result.current.proposals[0].status).toBe('applied')
+  })
+
+  it('apply: mixed Spanish aliases and canonical English in nativeLanguages both normalize correctly', async () => {
+    const studentPayload = { name: 'María', learningLanguage: 'Spanish', nativeLanguages: ['Portuguese', 'castellano'], cefrLevel: 'B2' }
+    const newStudentProposal = { id: 'p8', type: 'newStudent' as const, field: 'profile', label: 'New Student', oldValue: null, newValue: 'María', payload: studentPayload }
+    mockPropose.mockResolvedValueOnce({ proposals: [newStudentProposal] })
+    mockCreateStudent.mockResolvedValueOnce({
+      id: 'new-id', name: 'María', learningLanguage: 'Spanish',
+      level: { cefrLevel: 'B2', officialCefrLevel: null, skillLevelOverrides: {} },
+      languages: { nativeLanguages: ['Portuguese', 'Spanish'], spokenLanguages: [] },
+      identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null },
+      profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
+      commercial: { isActive: true, isCorporate: false, rate: null },
+      createdAt: '', updatedAt: '',
+    })
+
+    const { result } = renderHook(() => useAtelierAssistant(null, null), { wrapper: makeWrapper() })
+    act(() => { result.current.submit('Nueva alumna María') })
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    await act(async () => { await result.current.apply('p8') })
+    expect(mockCreateStudent).toHaveBeenCalledWith(expect.objectContaining({
+      learningLanguage: 'Spanish',
+      nativeLanguages: ['Portuguese', 'Spanish'],
+    }))
+    expect(result.current.proposals[0].status).toBe('applied')
+  })
+
+  it('apply: unrecognized language name sets proposal to error with offending value', async () => {
+    const studentPayload = { name: 'Test', learningLanguage: 'klingon', cefrLevel: 'B1' }
+    const newStudentProposal = { id: 'p7', type: 'newStudent' as const, field: 'profile', label: 'New Student', oldValue: null, newValue: 'Test', payload: studentPayload }
+    mockPropose.mockResolvedValueOnce({ proposals: [newStudentProposal] })
+
+    const { result } = renderHook(() => useAtelierAssistant(null, null), { wrapper: makeWrapper() })
+    act(() => { result.current.submit('Nueva alumna Test') })
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    await act(async () => { await result.current.apply('p7') })
+    expect(result.current.proposals[0].status).toBe('error')
+    expect(result.current.proposals[0].errorMessage).toContain('klingon')
+    expect(mockCreateStudent).not.toHaveBeenCalled()
   })
 
   it('onEditPayload: updates payload of proposal with matching id', async () => {

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -14,6 +14,7 @@ import {
 // Re-export so consumers don't need to import from api/assistant directly
 export type { NewSessionData, NewStudentData }
 import { createStudent } from '../api/students'
+import { normalizeLanguage, normalizeLanguages } from '../lib/extractionNormalizer'
 
 export type ProposalStatus = 'proposed' | 'applying' | 'applied' | 'dismissed' | 'error'
 
@@ -150,14 +151,24 @@ export function useAtelierAssistant(
           )
           if (exists) throw new Error(`A student named "${data.name}" already exists.`)
         }
+        const normalizedLearningLanguage = normalizeLanguage(data.learningLanguage)
+        if (!normalizedLearningLanguage) {
+          throw new Error(`Could not recognize learning language: "${data.learningLanguage}". Please edit it before applying.`)
+        }
+        const rawNativeLanguages = data.nativeLanguages ?? []
+        const badLang = rawNativeLanguages.find(lang => !normalizeLanguage(lang))
+        if (badLang) {
+          throw new Error(`Could not recognize language: "${badLang}". Please edit it before applying.`)
+        }
+        const normalizedNativeLanguages = normalizeLanguages(rawNativeLanguages)
         await createStudent({
           name: data.name,
-          learningLanguage: data.learningLanguage,
+          learningLanguage: normalizedLearningLanguage,
           cefrLevel: data.cefrLevel,
           birthYear: data.birthYear ?? null,
           profession: data.profession ?? null,
           cityOfResidence: data.cityOfResidence ?? null,
-          nativeLanguages: data.nativeLanguages ?? [],
+          nativeLanguages: normalizedNativeLanguages,
           reasonForStudying: data.reasonForStudying ?? null,
           interests: [],
           learningGoals: [],


### PR DESCRIPTION
Fixes #1058

## Summary

- In `useAtelierAssistant.ts` `newStudent` apply handler, call `normalizeLanguage` on `learningLanguage` and `normalizeLanguages` on `nativeLanguages` before `createStudent`, using the same normalizer already used by the voice-flow path (`voiceUpdateMerge.ts`).
- If `learningLanguage` or any entry in `nativeLanguages` cannot be resolved, throws an inline error displayed on the proposal card (not a silent fallback).
- No prompt changes, no backend changes, no new normalizer — reuses `extractionNormalizer.ts`.

## Test plan

- [x] `useAtelierAssistant.test.ts`: updated existing test (expected `learningLanguage: 'English'` after normalization from `'inglés'`) + 4 new tests: Spanish aliases, English passthrough, mixed aliases, unrecognized value error
- [x] Build verify PASS (28 tests passing, 0 failed)
- [x] UI review PASS (student list no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)