### PR TITLE
fix(#1063): remove Help sidebar link pointing to non-existent route

### DIFF
--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -102,18 +102,18 @@ describe('AppShell', () => {
     expect(allDashboardLinks.length).toBeGreaterThanOrEqual(2)
   })
 
-  it('renders nav items in correct order: Dashboard, Students, Sessions, Courses, Lessons, then Help and Settings separated at bottom', () => {
+  it('renders nav items in correct order: Dashboard, Students, Sessions, Courses, Lessons, then Settings separated at bottom', () => {
     renderShell()
     const links = document.querySelector('aside')?.querySelectorAll('a')
     const labels = Array.from(links ?? []).map(a => a.textContent?.trim())
-    expect(labels).toEqual(['Dashboard', 'Students', 'Sessions', 'Courses', 'Lessons', 'Help', 'Settings'])
+    expect(labels).toEqual(['Dashboard', 'Students', 'Sessions', 'Courses', 'Lessons', 'Settings'])
   })
 
-  it('Settings and Help links are outside the main nav element', () => {
+  it('Settings link is outside the main nav element', () => {
     renderShell()
     const nav = screen.getByRole('navigation')
     expect(within(nav).queryByRole('link', { name: /^settings$/i })).not.toBeInTheDocument()
-    expect(within(nav).queryByRole('link', { name: /^help$/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /^help$/i })).not.toBeInTheDocument()
     const settingsLinks = screen.getAllByRole('link', { name: /^settings$/i })
     expect(settingsLinks.length).toBeGreaterThanOrEqual(1)
   })
@@ -164,7 +164,7 @@ describe('AppShell', () => {
 
   it('sidebar renders the same nav items regardless of route', () => {
     const routes = ['/', '/sessions', '/settings']
-    const expectedLabels = ['Dashboard', 'Students', 'Sessions', 'Courses', 'Lessons', 'Help', 'Settings']
+    const expectedLabels = ['Dashboard', 'Students', 'Sessions', 'Courses', 'Lessons', 'Settings']
 
     for (const route of routes) {
       const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, type ElementType } from 'react'
 import { Link, Outlet, useLocation } from 'react-router-dom'
 import { useAuth0 } from '@auth0/auth0-react'
 import { useQuery } from '@tanstack/react-query'
-import { LayoutDashboard, Users, CalendarDays, BookOpen, GraduationCap, Settings, LogOut, Menu, Sparkles, HelpCircle, X } from 'lucide-react'
+import { LayoutDashboard, Users, CalendarDays, BookOpen, GraduationCap, Settings, LogOut, Menu, Sparkles, X } from 'lucide-react'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { cn } from '@/lib/utils'
 import LangTeachLogo from '@/components/LangTeachLogo'
@@ -80,10 +80,9 @@ function SidebarContent({ user, initials, logout, location }: {
         ))}
       </nav>
 
-      {/* Bottom: Help + Settings (visually separated) + teacher profile with tucked logout */}
+      {/* Bottom: Settings + teacher profile with tucked logout */}
       <div className="px-3 py-4 space-y-3 mt-auto">
         <div className="pt-2 space-y-0.5">
-          <NavLink to="/help" label="Help" icon={HelpCircle} location={location} />
           <NavLink to="/settings" label="Settings" icon={Settings} location={location} />
         </div>
         <div className="bg-white rounded-xl p-3 flex items-center gap-3" data-testid="teacher-profile-card">

--- a/plan/ui-review-skipped.md
+++ b/plan/ui-review-skipped.md
@@ -9,3 +9,4 @@ The sprint-close procedure (Stage 1) audits this log and clears it after each sp
 | Issue | Date | PR | What changed and why review-ui was skipped |
 |-------|------|----|-------------------------------------------|
 | #1057 | 2026-05-03 | TBD | Zero frontend files changed; backend-only flag added to reflection extraction pipeline |
+| #1063 | 2026-05-03 | TBD | Pure deletion of dead Help NavLink from AppShell; <20 lines, no logic/state changes, no new elements |


### PR DESCRIPTION
## Summary

- Removes the Help `NavLink` and `HelpCircle` import from `AppShell.tsx` (Path B from issue)
- Updates three test assertions in `AppShell.test.tsx` to reflect the new nav order

## Test plan

- [x] `AppShell.test.tsx` -- 47 tests all pass
- [x] Full build verify -- PASS (bicep, dotnet build, dotnet test, lint, npm build, npm test)
- [x] QA verify -- PASS
- [x] Code review -- PASS
- [x] Architecture review -- PASS
- [x] UI review -- skipped (trivial exemption: <20 lines, pure deletion, no logic/state changes)

Closes #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Help link from the sidebar navigation to streamline user access.
  * Updated sidebar layout to display Dashboard, Students, Sessions, Courses, Lessons, and Settings in optimized order.

* **Tests**
  * Updated component tests to verify the modified sidebar navigation structure and placement changes across routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->