### PR TITLE
fix(#1069): invalidate session-summary query after session proposal apply

### DIFF
--- a/frontend/src/hooks/useAtelierAssistant.test.ts
+++ b/frontend/src/hooks/useAtelierAssistant.test.ts
@@ -491,6 +491,20 @@ describe('useAtelierAssistant', () => {
     expect(result.current.proposals[0].status).toBe('error')
   })
 
+  it('apply: session proposal invalidates session-summary query', async () => {
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries')
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[1]] })
+    mockApplySession.mockResolvedValueOnce(undefined)
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'), { wrapper: makeWrapper() })
+
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    await act(async () => { await result.current.apply('p2') })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['session-summary', 'student-1'] })
+    invalidateSpy.mockRestore()
+  })
+
   it('apply: routes skillLevel.writing student proposal to applyStudentProposal with dotted field', async () => {
     const skillProposal = { id: 'psk1', type: 'student' as const, field: 'skillLevel.writing', label: 'Writing Level', oldValue: null, newValue: 'B1' }
     mockPropose.mockResolvedValueOnce({ proposals: [skillProposal] })

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -188,6 +188,7 @@ export function useAtelierAssistant(
       } else if (proposal.type === 'session' && studentId && sessionId) {
         await queryClient.invalidateQueries({ queryKey: ['session', studentId, sessionId] })
         await queryClient.invalidateQueries({ queryKey: ['sessions', studentId] })
+        await queryClient.invalidateQueries({ queryKey: ['session-summary', studentId] })
       } else if (proposal.type === 'newStudent') {
         await queryClient.invalidateQueries({ queryKey: ['students'] })
       } else if (proposal.type === 'newSession' && studentId) {


### PR DESCRIPTION
## Summary

- `useAtelierAssistant.ts` was missing `['session-summary', studentId]` invalidation in the `session` proposal apply branch, causing `SessionSummaryHeader` to show stale title/notes until navigation.
- Added the missing `queryClient.invalidateQueries({ queryKey: ['session-summary', studentId] })` call alongside the existing session and sessions invalidations.
- Added unit test asserting the invalidation fires on session proposal apply.

## Test plan

- [ ] All 29 `useAtelierAssistant` unit tests pass.
- [ ] New test `apply: session proposal invalidates session-summary query` verifies `['session-summary', studentId]` is invalidated.
- [ ] LogSession screen renders correctly (UI review passed, no regressions).
- [ ] In-browser: open LogSession, open assistant, apply a SESSION TITLE proposal, header updates immediately without navigation.

Closes #1069

🤖 Generated with [Claude Code](https://claude.com/claude-code)