### PR TITLE
fix(tooling): resolve worktree path to absolute in task-build-verify.py

### DIFF
--- a/.claude/scripts/task-build-verify.py
+++ b/.claude/scripts/task-build-verify.py
@@ -56,7 +56,7 @@ def main() -> None:
         print("Usage: python3 task-build-verify.py <worktree-path>", file=sys.stderr)
         sys.exit(1)
 
-    worktree = Path(sys.argv[1])
+    worktree = Path(sys.argv[1]).resolve()
     if not worktree.exists():
         print(f"ERROR: path does not exist: {worktree}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Summary

- Fixes bicep build step failing with path-not-found inside worktrees when a relative path is passed to `task-build-verify.py`
- Single-line change: `Path(sys.argv[1]).resolve()` ensures all downstream paths (bicep_file, cwd) are absolute before `az bicep build` is invoked
- Closes #1084

## Test plan

- [x] `python3 .claude/scripts/task-build-verify.py <worktree-path>` runs cleanly (VERDICT: PASS, all 6 checks green)
- [x] Bicep build step passes without path-not-found error
- [x] qa-verify: PASS
- [x] architecture-reviewer: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build verification to normalize worktree paths to absolute format for improved consistency across different working directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->