### PR TITLE
fix(e2e): align E2E test email across db-helper, auth handler, and mock provider

### DIFF
--- a/backend/LangTeach.Api/Auth/E2ETestAuthHandler.cs
+++ b/backend/LangTeach.Api/Auth/E2ETestAuthHandler.cs
@@ -10,7 +10,7 @@ public class E2ETestAuthHandler : AuthenticationHandler<AuthenticationSchemeOpti
 {
     public const string SchemeName = "Test";
     public const string Auth0Id = "auth0|e2e-test-teacher";
-    public const string Email = "e2e-test@langteach.io";
+    public static readonly string Email = Environment.GetEnvironmentVariable("E2E_TEST_EMAIL") ?? "e2e-test@langteach.dev";
     public const string Name = "E2E Teacher";
 
     public E2ETestAuthHandler(

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -66,6 +66,7 @@ services:
       Claude__ApiKey: "${CLAUDE_API_KEY}"
       AllowedOrigins__E2e: "http://frontend:5174"
       AzureBlobStorage__ConnectionString: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
+      E2E_TEST_EMAIL: "${E2E_TEST_EMAIL}"
     healthcheck:
       test: curl -sf http://localhost:5000/health || exit 1
       interval: 10s
@@ -90,6 +91,7 @@ services:
       VITE_AUTH0_DOMAIN: "${AUTH0_DOMAIN}"
       VITE_AUTH0_CLIENT_ID: "${VITE_AUTH0_CLIENT_ID}"
       VITE_AUTH0_AUDIENCE: "${AUTH0_AUDIENCE}"
+      VITE_E2E_TEST_EMAIL: "${E2E_TEST_EMAIL}"
     ports:
       - "5174:5174"
     healthcheck:

--- a/e2e/helpers/db-helper.ts
+++ b/e2e/helpers/db-helper.ts
@@ -59,7 +59,7 @@ export async function updateTeacherAuth0Id(email: string, newAuth0UserId: string
   }
 }
 
-export const E2E_TEST_EMAIL = 'e2e-test@langteach.io'
+export const E2E_TEST_EMAIL = process.env.E2E_TEST_EMAIL ?? 'e2e-test@langteach.dev'
 
 export async function resetE2ETestTeacher(): Promise<void> {
   const pool = await new sql.ConnectionPool(config).connect()

--- a/frontend/src/test-utils/MockAuth0Provider.tsx
+++ b/frontend/src/test-utils/MockAuth0Provider.tsx
@@ -3,7 +3,7 @@ import { Auth0Context, type Auth0ContextInterface, type User } from '@auth0/auth
 
 const mockUser: User = {
   sub: 'auth0|e2e-test-teacher',
-  email: 'e2e-test@langteach.io',
+  email: import.meta.env.VITE_E2E_TEST_EMAIL ?? 'e2e-test@langteach.dev',
   name: 'E2E Teacher',
 }
 


### PR DESCRIPTION
## Summary

- `e2e/helpers/db-helper.ts` hardcoded `e2e-test@langteach.io` while env files provision `E2E_TEST_EMAIL=e2e-test@langteach.dev`, causing every Atelier visual spec to fail at the seed step (db-helper could not find the teacher because the email in DB matched the backend auth handler, not the hardcode)
- Aligns all three test identity components to read from `E2E_TEST_EMAIL` env var with a consistent `e2e-test@langteach.dev` fallback
- Passes `E2E_TEST_EMAIL` and `VITE_E2E_TEST_EMAIL` to API and frontend containers in `docker-compose.e2e.yml` so the runtime value flows through the whole stack

## Files changed

| File | Change |
|------|--------|
| `e2e/helpers/db-helper.ts` | Read from `process.env.E2E_TEST_EMAIL ?? 'e2e-test@langteach.dev'` |
| `backend/LangTeach.Api/Auth/E2ETestAuthHandler.cs` | `static readonly` reading `Environment.GetEnvironmentVariable("E2E_TEST_EMAIL") ?? "e2e-test@langteach.dev"` |
| `frontend/src/test-utils/MockAuth0Provider.tsx` | Read from `import.meta.env.VITE_E2E_TEST_EMAIL ?? 'e2e-test@langteach.dev'` |
| `docker-compose.e2e.yml` | Pass `E2E_TEST_EMAIL` to API service; `VITE_E2E_TEST_EMAIL` to frontend service |

## Test plan

- [ ] `grep -rn 'e2e-test@langteach.io' . --include='*.ts' --include='*.tsx' --include='*.cs'` returns no results
- [ ] Build passes: `dotnet build`, `npm run build`, `npm run lint`
- [ ] Visual spec suite (`npm run test:visual` inside the e2e docker stack) reaches assertion phase instead of failing at seed

Closes #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)