### PR TITLE
fix(infra): grant Key Vault Secrets User to backup service principal (#1048)

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -32,6 +32,9 @@ param auth0Domain string
 @description('Auth0 API audience (e.g. https://api.langteach.io)')
 param auth0Audience string
 
+@description('Object ID of the GitHub Actions service principal used by the BACPAC backup workflow. Grants Key Vault Secrets User so it can read the SQL connection string. Leave empty to skip the role assignment.')
+param backupServicePrincipalId string = ''
+
 // ── Derived names ─────────────────────────────────────────────────────────────
 
 var sqlServerName = 'langteach-sql-${env}'
@@ -86,6 +89,7 @@ module kv 'modules/keyvault.bicep' = {
     location: location
     sqlConnectionString: 'Server=tcp:${sqlServerName}${environment().suffixes.sqlServerHostname},1433;Initial Catalog=${sqlDbName};User ID=${sqlAdminUser};Password=${sqlAdminPassword};Encrypt=True;Connection Timeout=30;'
     appPrincipalId: containerApp.outputs.principalId
+    backupServicePrincipalId: backupServicePrincipalId
     storageConnectionString: storage.outputs.connectionString
     auth0Domain: auth0Domain
     auth0Audience: auth0Audience

--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -3,6 +3,8 @@ param location string
 @secure()
 param sqlConnectionString string
 param appPrincipalId string
+@description('Object ID of the GitHub Actions service principal that runs the BACPAC backup workflow. When non-empty, grants Key Vault Secrets User so the workflow can read the SQL connection string.')
+param backupServicePrincipalId string = ''
 @secure()
 param storageConnectionString string
 param auth0Domain string
@@ -27,13 +29,25 @@ resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
   }
 }
 
-// Grant App Service managed identity read access to secrets
+// Grant Container App managed identity read access to secrets
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(kv.id, appPrincipalId, kvSecretsUserRoleId)
   scope: kv
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', kvSecretsUserRoleId)
     principalId: appPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Grant GitHub Actions OIDC service principal read access so the backup workflow
+// can fetch the SQL connection string to run the BACPAC export.
+resource backupRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(backupServicePrincipalId)) {
+  name: guid(kv.id, backupServicePrincipalId, kvSecretsUserRoleId)
+  scope: kv
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', kvSecretsUserRoleId)
+    principalId: backupServicePrincipalId
     principalType: 'ServicePrincipal'
   }
 }

--- a/infra/parameters/dev.bicepparam
+++ b/infra/parameters/dev.bicepparam
@@ -12,3 +12,5 @@ param alertEmail        = 'robert.freire@gmail.com'
 param allowedOriginSwa  = 'https://white-cliff-02f270f03.4.azurestaticapps.net'
 param auth0Domain       = 'langteach-dev.eu.auth0.com'
 param auth0Audience     = 'https://api.langteach.io'
+// Object ID of the GitHub Actions OIDC service principal (az ad sp show --id $AZURE_CLIENT_ID --query id -o tsv)
+param backupServicePrincipalId = '1ab59fda-472d-438e-9ee3-c939debd746e'

--- a/infra/parameters/prod.bicepparam
+++ b/infra/parameters/prod.bicepparam
@@ -12,9 +12,9 @@ param sqlAdminPassword  = readEnvironmentVariable('LANGTEACH_SQL_PASSWORD')
 //   $env:LANGTEACH_AUTH0_DOMAIN    = "<from Bitwarden: LangTeach Auth0 Prod Domain>"
 //   $env:LANGTEACH_AUTH0_AUDIENCE  = "https://api.langteach.io"
 //   $env:LANGTEACH_SWA_URL_PROD    = "<prod SWA URL from Azure portal>"
+//   $env:AZURE_BACKUP_SP_OID       = "<az ad sp show --id $AZURE_CLIENT_ID --query id -o tsv>"
 param alertEmail        = 'robert.freire@gmail.com'
 param auth0Domain       = readEnvironmentVariable('LANGTEACH_AUTH0_DOMAIN')
 param auth0Audience     = readEnvironmentVariable('LANGTEACH_AUTH0_AUDIENCE')
 param allowedOriginSwa  = readEnvironmentVariable('LANGTEACH_SWA_URL_PROD')
-// Object ID of the GitHub Actions OIDC service principal (az ad sp show --id $AZURE_CLIENT_ID --query id -o tsv)
-param backupServicePrincipalId = '1ab59fda-472d-438e-9ee3-c939debd746e'
+param backupServicePrincipalId = readEnvironmentVariable('AZURE_BACKUP_SP_OID')

--- a/infra/parameters/prod.bicepparam
+++ b/infra/parameters/prod.bicepparam
@@ -16,3 +16,5 @@ param alertEmail        = 'robert.freire@gmail.com'
 param auth0Domain       = readEnvironmentVariable('LANGTEACH_AUTH0_DOMAIN')
 param auth0Audience     = readEnvironmentVariable('LANGTEACH_AUTH0_AUDIENCE')
 param allowedOriginSwa  = readEnvironmentVariable('LANGTEACH_SWA_URL_PROD')
+// Object ID of the GitHub Actions OIDC service principal (az ad sp show --id $AZURE_CLIENT_ID --query id -o tsv)
+param backupServicePrincipalId = '1ab59fda-472d-438e-9ee3-c939debd746e'


### PR DESCRIPTION
## Summary

- **Root cause**: The weekly BACPAC export workflow failed with `ForbiddenByRbac` because the GitHub Actions OIDC service principal had no role assignment on Key Vault `kv-lt-dev-5ba22u`. `keyvault.bicep` only granted `Key Vault Secrets User` to the Container App's managed identity.
- **Fix**: Added optional `backupServicePrincipalId` param to `keyvault.bicep` with a conditional role assignment. Wired through `main.bicep` and both parameter files.
- The role assignment is guarded with `if (!empty(backupServicePrincipalId))`, so deployments that omit the param are unaffected.

## Files changed

| File | Change |
|------|--------|
| `infra/modules/keyvault.bicep` | New optional param + conditional `Key Vault Secrets User` role assignment |
| `infra/main.bicep` | New optional `backupServicePrincipalId` param, passed to keyvault module |
| `infra/parameters/dev.bicepparam` | SP object ID hardcoded (stable identifier, not a secret) |
| `infra/parameters/prod.bicepparam` | `readEnvironmentVariable('AZURE_BACKUP_SP_OID')` consistent with prod pattern |

## Test plan

- [x] `bicep build` passes
- [x] `dotnet build` / `dotnet test` / `npm lint` / `npm build` / `npm test` all pass
- [ ] Re-deploy infra with the new param to apply the role assignment:
  ```sh
  export LANGTEACH_SQL_PASSWORD="..."
  # dev:
  az deployment group create --resource-group rg-langteach-dev \
    --template-file infra/main.bicep \
    --parameters infra/parameters/dev.bicepparam
  # Then trigger manually:
  gh workflow run db-backup.yml
  ```
- [ ] Confirm workflow run completes without `ForbiddenByRbac`

Closes #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)