### PR TITLE
fix(e2e-stack): correct VITE_API_URL variable name to stop port-5000 fallback in visual stack

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -40,21 +40,10 @@ Read `plan/sprints/<slug>.md`. You need the full content: teacher narrative, app
 docker ps --filter "name=langteachsaas-e2e" --format "{{.Names}}\t{{.Status}}"
 ```
 
-If api + frontend are not healthy, start the stack:
+If api + frontend are not healthy, start the stack using the script (handles build, health checks, mock teacher registration, and visual seed):
 
 ```bash
-docker compose -f docker-compose.e2e.yml -f docker-compose.visual.yml --env-file .env.e2e up -d api sqlserver frontend 2>&1
-```
-
-Poll until healthy (max 90s):
-
-```bash
-for i in $(seq 1 18); do
-  HEALTHY=$(docker ps --filter "name=langteachsaas-e2e" --format "{{.Status}}" | grep -c "healthy" || true)
-  echo "[$i/18] healthy containers: $HEALTHY"
-  [ "$HEALTHY" -ge 3 ] && break
-  sleep 5
-done
+bash e2e/scripts/start-visual-stack.sh
 ```
 
 Note whether you started the stack or it was already running (affects teardown at the end).

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Thumbs.db
 .env.*.local
 .env.e2e
 .env.qa
+!frontend/.env.e2e
 
 # Claude Code local session cache
 .claude/settings.local.json

--- a/frontend/.env.e2e
+++ b/frontend/.env.e2e
@@ -1,0 +1,5 @@
+VITE_E2E_TEST_MODE=true
+VITE_AUTH0_DOMAIN=langteach-dev.eu.auth0.com
+VITE_AUTH0_CLIENT_ID=zyrXAmvWU8ppE5dxo4VmMUzvWMWAf9dT
+VITE_AUTH0_AUDIENCE=https://api.langteach.io
+VITE_API_URL=http://localhost:5000

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,5 +1,5 @@
 VITE_AUTH0_DOMAIN=your-tenant.auth0.com
 VITE_AUTH0_CLIENT_ID=your-spa-client-id
 VITE_AUTH0_AUDIENCE=https://api.langteach.io
-VITE_API_BASE_URL=http://localhost:5000
+VITE_API_URL=http://localhost:5000
 VITE_TELEGRAM_BOT_HANDLE=@langteach13_bot

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,7 +11,6 @@ node_modules
 dist
 dist-ssr
 *.local
-.env.e2e
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Summary

- **Root cause**: `frontend/.env.e2e` set `VITE_API_BASE_URL=http://localhost:5000` but all frontend browser code (`apiClient.ts`, `useGenerate.ts`, `streamText.ts`) reads `VITE_API_URL`. When the Vite dev server started in mode `e2e`, `VITE_API_URL` was undefined unless Docker explicitly set it. If the visual stack was started without the overlay, or if there was any env propagation gap, the browser fell back to `http://localhost:5000` (not exposed in visual mode).
- **Fix**: Rename to `VITE_API_URL` in `frontend/.env.e2e` and `.env.local.example`. Track `frontend/.env.e2e` in git (file only contains non-secret public values). Update smoke-test skill Step 3 to use `e2e/scripts/start-visual-stack.sh` (builds images first + proper health waiting + seed).
- **Note on `VITE_API_URL` vs `VITE_API_BASE_URL`**: these are intentionally different variables. `VITE_API_URL` is for the Vite browser bundle; `VITE_API_BASE_URL` is for Playwright Node.js test runner. The script's hint line and visual specs all correctly use `VITE_API_BASE_URL` for Playwright.

## Verification done

- Visual stack started via `e2e/scripts/start-visual-stack.sh` - all containers healthy
- `curl http://localhost:5178/health` returns `{"status":"healthy"}`
- `curl --connect-timeout 3 http://localhost:5000/health` times out (NOT exposed)
- `docker inspect langteachsaas-e2e-frontend-1` shows `VITE_API_URL=http://localhost:5178` (visual overlay overrides .env.e2e)
- All 1655 frontend unit tests pass

## Test plan

- [ ] Merge PR
- [ ] Run `/smoke-test` skill - it should call `start-visual-stack.sh`, start the visual stack cleanly
- [ ] Run `claude --chrome "$(cat /tmp/smoke-test-hardening.txt)"` and verify the browser reaches a student-detail page and opens the Atelier Assistant without port-5000 errors (AC3 from issue #1059)

Closes #1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)