### PR TITLE
fix(tooling): review-ui-sprint stack health check + chrome verification gate (#1080)

### DIFF
--- a/.claude/agents/review-ui-sprint.md
+++ b/.claude/agents/review-ui-sprint.md
@@ -67,6 +67,43 @@ Wait for frontend:
 for i in $(seq 1 40); do curl -sf http://localhost:5174 > /dev/null 2>&1 && break; sleep 3; done
 ```
 
+**Stack health check (mandatory before taking screenshots):**
+
+Verify the API is reachable from the host AND that the frontend is calling the correct API port. A healthy frontend response to `/api/auth/me` confirms the API URL baked into the frontend build is reachable:
+```bash
+# 1. API directly reachable on the exposed port
+curl -sf http://localhost:5178/api/auth/me \
+  -H "Authorization: Bearer test-token" -H "Accept: application/json" \
+  -o /dev/null -w "%{http_code}" && echo " [API:5178 OK]" || echo " [API:5178 FAIL]"
+
+# 2. Frontend bundle is calling the right URL (check which API URL is baked in)
+curl -sf http://localhost:5174 | grep -o 'VITE_API_URL[^"]*\|localhost:[0-9]*' | head -5 || true
+
+# 3. A data endpoint returns real data (proves auth + API are wired up)
+curl -sf http://localhost:5178/api/students \
+  -H "Authorization: Bearer test-token" -H "Accept: application/json" | head -c 200
+```
+
+If the API health check returns a non-2xx response OR if step 3 returns an error/empty body, **STOP immediately** and report as BLOCKED:
+
+```
+BLOCKED: VISUAL STACK API NOT REACHABLE
+
+The frontend is running (http://localhost:5174 responds) but the API at
+http://localhost:5178 is not reachable or returning errors. Screenshots taken
+in this state would show the broken/empty app, not the real application.
+
+Root cause from sprint close 2026-05-03: VITE_API_URL was not set correctly
+at Docker build time, causing the frontend to call localhost:5000 (not exposed).
+The fix is in frontend/.env.e2e (tracked since #1059). Verify this file exists
+and contains VITE_API_URL=http://localhost:5178, then rebuild: docker compose
+-f docker-compose.e2e.yml -f docker-compose.visual.yml --env-file .env.e2e
+build api frontend
+
+Do NOT proceed to Playwright -- screenshots of a broken stack are worse than
+no screenshots.
+```
+
 **Teardown** (always, even on failure):
 ```bash
 docker compose -f docker-compose.e2e.yml --env-file .env.e2e down -v

--- a/.claude/procedures/sprint-lifecycle.md
+++ b/.claude/procedures/sprint-lifecycle.md
@@ -102,6 +102,25 @@ Each reviewer prompt must include:
 
 **Stage 2 (agent):** After user approves backlogs and branch review findings, run the `sprint-close` agent (`subagent_type: "sprint-close"`). It verifies board/issues, runs the comprehensive UI/UX sprint review (`review-ui-sprint`), Teacher QA, prompt health review, and pedagogy review. Returns READY / NOT READY.
 
+**Stage 2 UI finding verification (mandatory, runs in main conversation after sprint-close returns):**
+
+Background: during the Unified Voice & Chat sprint close (2026-05-03), `review-ui-sprint` produced findings about UI state that did not match the live app. Root cause: the visual stack was running with a broken API URL (VITE_API_URL not set at build time), so screenshots showed the app in a broken/empty state rather than the real working state. The underlying stack bug was fixed in #1059. Even so, vision-model misreading is a separate risk that cannot be eliminated by the stack fix alone.
+
+Every **Critical or Important** finding from `review-ui-sprint` must be chrome-verified before it affects the sprint gate verdict. Minor findings do not require verification and go directly to `plan/ui-review-backlog.md`.
+
+**Verification steps:**
+1. Collect all Critical and Important findings from the sprint-close report's UI/UX Review section.
+2. Group findings by route. For each route with findings, run one chrome session:
+   ```
+   claude --chrome
+   ```
+   Prompt the chrome agent: "Navigate to `<route>`. Verify each of the following claims one by one and report CONFIRMED, REFUTED, or PARTIAL with a one-line observation for each: [paste finding descriptions]."
+3. Triage results:
+   - **CONFIRMED**: keep the finding at its original severity.
+   - **REFUTED**: remove from the verdict. Log to `plan/observed-issues.md` as `| #review-ui-sprint-<sprint-slug> | <date> | minor | REFUTED: agent claimed <X> but chrome showed <Y> |`.
+   - **PARTIAL**: keep but downgrade severity by one level (Critical to Important, Important to Minor).
+4. Rebuild the finding list from surviving findings only. The READY / NOT READY verdict is based on this verified list, not the raw agent output.
+
 **Stage 2b (issue filing, mandatory):** After Stage 2 completes, review all findings from every reviewer (Stage 1b branch reviewers, Isaac pedagogy review, prompt health review, Teacher QA triage, UI/UX review). Every finding with severity >= minor that is not fixed in the current sprint **must** be filed as a GitHub issue (batch related findings into one issue) and assigned to the next sprint milestone. Findings without a GitHub issue are considered lost. The sprint cannot move to Stage 3 until all findings are filed.
 
 **Stage 3 (cleanup, after user triggers merge action):** Close the milestone, delete the sprint branch, update memory (task status, sprint overviews), clear remaining backlog entries.


### PR DESCRIPTION
## Summary

- Root cause for the Unified Voice & Chat sprint close false findings: the visual stack was running with `VITE_API_URL` unset at Docker build time (the bug fixed in #1059). Playwright took screenshots of an app where every API call failed silently. The vision model correctly described what it saw -- a broken/empty app -- but those descriptions were wrong relative to the real working application.
- Adds a mandatory API health check to `review-ui-sprint` that stops with BLOCKED before Playwright runs if the API is unreachable.
- Adds a mandatory chrome verification gate to `sprint-lifecycle.md` Stage 2 so Critical/Important findings are chrome-verified before driving the READY/NOT READY verdict.

## Changes

**`.claude/agents/review-ui-sprint.md`**
- After stack startup, before Playwright: curl the API health endpoint and a data endpoint (`/api/students`). If either fails, stop immediately with a BLOCKED report and instructions to check `frontend/.env.e2e` (the root cause of the 2026-05-03 incident).
- Prevents the "screenshots of a broken stack" scenario from silently producing a bad report.

**`.claude/procedures/sprint-lifecycle.md`**
- Stage 2 now has a mandatory "UI finding verification" section after `sprint-close` returns.
- Every Critical/Important finding is chrome-verified (one session per affected route).
- CONFIRMED: kept at original severity. REFUTED: removed from verdict, logged to `observed-issues.md`. PARTIAL: severity downgraded one level.
- Verdict is based on the verified list only.

## Test plan

- [ ] Verify that `.claude/agents/review-ui-sprint.md` now includes the API health check block between "Wait for frontend" and "Run ALL visual specs".
- [ ] Verify that `.claude/procedures/sprint-lifecycle.md` Stage 2 includes the new "Stage 2 UI finding verification" section with CONFIRMED/REFUTED/PARTIAL triage.
- [ ] Confirm the next sprint close uses this procedure: after `sprint-close` returns its report, run chrome verification for any Critical/Important UI findings before accepting the verdict.

Closes #1080

🤖 Generated with [Claude Code](https://claude.com/claude-code)