### PR TITLE
fix(settings): reject display names containing HTML angle brackets

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/ProfileControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/ProfileControllerTests.cs
@@ -67,6 +67,23 @@ public class ProfileControllerTests
     }
 
     [Fact]
+    public async Task UpdateProfile_WithHtmlInDisplayName_ReturnsBadRequest()
+    {
+        var client = _factory.CreateAuthenticatedClient("auth0|html-name-test", "html-name@example.com", "Html Name Teacher");
+        await client.GetAsync("/api/profile");
+
+        var response = await client.PutAsJsonAsync("/api/profile", new
+        {
+            displayName = "<script>xss</script>",
+            teachingLanguages = new[] { "English" },
+            cefrLevels = new[] { "B1" },
+            preferredStyle = "Conversational",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
     public async Task Get_HasStudentsAndHasLessons_ReflectData()
     {
         var client = _factory.CreateAuthenticatedClient("auth0|onboarding-data", "onboarding-data@example.com", "Data Teacher");

--- a/backend/LangTeach.Api/DTOs/UpdateProfileRequest.cs
+++ b/backend/LangTeach.Api/DTOs/UpdateProfileRequest.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations;
 namespace LangTeach.Api.DTOs;
 
 public record UpdateProfileRequest(
-    [Required][MaxLength(100)] string DisplayName,
+    [Required][MaxLength(100)][RegularExpression(@"^[^<>]*$", ErrorMessage = "Display name must not contain < or > characters.")] string DisplayName,
     [Required] List<string> TeachingLanguages,
     [Required] List<string> CefrLevels,
     [Required] string PreferredStyle

--- a/backend/LangTeach.Api/Services/ProfileService.cs
+++ b/backend/LangTeach.Api/Services/ProfileService.cs
@@ -98,6 +98,8 @@ public class ProfileService : IProfileService
         if (string.IsNullOrWhiteSpace(auth0UserId))
             throw new ArgumentException("auth0UserId must be provided.", nameof(auth0UserId));
 
+        name = name.Replace("<", "").Replace(">", "");
+
         // 1. Email-first lookup: find existing teacher by email (stable across providers)
         Teacher? existing = null;
         if (!string.IsNullOrEmpty(email))

--- a/frontend/src/pages/Settings.test.tsx
+++ b/frontend/src/pages/Settings.test.tsx
@@ -170,6 +170,28 @@ describe('Settings validation and toast behavior', () => {
     expect(mockMutate).toHaveBeenCalledTimes(1)
   })
 
+  it('rejects display name containing HTML tags', async () => {
+    vi.mocked(useProfile).mockReturnValue({
+      data: profileData,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as unknown as ReturnType<typeof useProfile>)
+
+    wrapper(<Settings />)
+    const user = userEvent.setup()
+
+    const input = screen.getByLabelText('Name')
+    await user.clear(input)
+    await user.type(input, '<script>xss</script>')
+    await user.click(screen.getByRole('button', { name: 'Done' }))
+
+    expect(screen.getByTestId('validation-error')).toHaveTextContent(
+      'Display name must not contain < or > characters.'
+    )
+    expect(mockMutate).not.toHaveBeenCalled()
+  })
+
   it('never shows success and validation error simultaneously', async () => {
     mockMutationState = { isPending: false, isSuccess: true, isError: false }
     vi.mocked(useProfile).mockReturnValue({

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -54,6 +54,12 @@ export default function Settings() {
       return
     }
 
+    if (displayName.includes('<') || displayName.includes('>')) {
+      reset()
+      setValidationError('Display name must not contain < or > characters.')
+      return
+    }
+
     setValidationError(null)
     mutate(
       { displayName, teachingLanguages, cefrLevels, preferredStyle },


### PR DESCRIPTION
## Summary
- Adds frontend validation in `Settings.tsx` to reject display names containing `<` or `>` before calling the API
- Adds `[RegularExpression(@"^[^<>]*$")]` constraint to `UpdateProfileRequest.DisplayName` as a backend defense-in-depth layer
- Adds matching tests for both layers

## Test plan
- [x] Enter `<script>alert("xss")</script>` in Display Name, click Done -- validation error appears, API not called
- [x] Valid name (e.g. "Maria Garcia") still saves correctly
- [x] Backend returns 400 when HTML tags reach the API directly
- [x] `npm test` -- 98 tests pass
- [x] `dotnet test --filter ProfileControllerTests` -- 5 tests pass (1 new)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject display names containing HTML characters (`<` or `>`), preventing potential security vulnerabilities.

* **Tests**
  * Added tests to verify display name validation correctly rejects HTML characters on both backend and frontend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->