### PR TITLE
fix(#611): deduplicate weakness blocks in lesson plan prompt

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -1390,7 +1390,7 @@ public class PromptServiceTests
 
         var req = _sut.BuildLessonPlanPrompt(ctx);
 
-        req.UserPrompt.Should().Contain("Design at least one Practice exercise",
+        req.UserPrompt.Should().Contain("at most 1-2 weakness-targeting exercises",
             because: "lessonWeaknessProfileGuidance from config must appear in the error profile block");
         req.UserPrompt.Should().Contain("subjunctive",
             because: "weakness text must be listed in the error profile block");

--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -1371,7 +1371,7 @@ public class PromptServiceTests
 
         var req = _sut.BuildLessonPlanPrompt(ctx);
 
-        req.UserPrompt.Should().Contain("DECLARED WEAKNESSES");
+        req.UserPrompt.Should().Contain("STUDENT ERROR PROFILE");
         req.UserPrompt.Should().Contain("articles");
     }
 
@@ -1380,23 +1380,24 @@ public class PromptServiceTests
     {
         var req = _sut.BuildLessonPlanPrompt(BaseCtx());
 
-        req.UserPrompt.Should().NotContain("DECLARED WEAKNESSES");
+        req.UserPrompt.Should().NotContain("STUDENT ERROR PROFILE");
     }
 
     [Fact]
-    public void LessonPlanPrompt_WeaknessBlock_ContainsSectionSpecificGuidanceFromConfig()
+    public void LessonPlanPrompt_WeaknessBlock_IncludesProfileGuidanceAndOmitsSectionLabels()
     {
         var ctx = BaseCtx() with { StudentWeaknesses = [new StudentWeakness("subjunctive")] };
 
         var req = _sut.BuildLessonPlanPrompt(ctx);
 
-        // Verify section-specific labels and guidance are assembled from config
-        req.UserPrompt.Should().Contain("Practice (grammatical):", because: "practice has weaknessTargetingGuidance in config");
-        req.UserPrompt.Should().Contain("Production (grammatical):", because: "production has weaknessTargetingGuidance in config");
-        req.UserPrompt.Should().Contain("WrapUp (grammatical):", because: "wrapup has weaknessTargetingGuidance in config");
-        req.UserPrompt.Should().NotContain("WarmUp:", because: "warmup does not participate in weakness targeting");
-        req.UserPrompt.Should().NotContain("Presentation:", because: "presentation does not participate in weakness targeting");
-        req.UserPrompt.Should().Contain("subjunctive", because: "weakness text must be interpolated into the practice guidance");
+        req.UserPrompt.Should().Contain("Design at least one Practice exercise",
+            because: "lessonWeaknessProfileGuidance from config must appear in the error profile block");
+        req.UserPrompt.Should().Contain("subjunctive",
+            because: "weakness text must be listed in the error profile block");
+        req.UserPrompt.Should().NotContain("Practice (grammatical):",
+            because: "per-section DECLARED WEAKNESSES labels are removed from lesson plan prompt (#611)");
+        req.UserPrompt.Should().NotContain("Production (grammatical):",
+            because: "per-section DECLARED WEAKNESSES labels are removed from lesson plan prompt (#611)");
     }
 
     [Fact]

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1217,22 +1217,6 @@ public class PromptService : IPromptService
             }
             profileSb.Append(_pedagogy.GetLessonWeaknessProfileGuidance());
             baseInstruction += profileSb.ToString();
-
-            var sb = new StringBuilder("\n\nDECLARED WEAKNESSES (max 1-2 targeted exercises per lesson):\n");
-            foreach (var section in SectionOrder)
-            {
-                var label = char.ToUpper(section[0]) + section[1..];
-                foreach (var group in weaknesses.GroupBy(w => w.WeaknessType))
-                {
-                    var guidance = _pedagogy.GetWeaknessTargetingGuidance(section, group.Key);
-                    if (!string.IsNullOrEmpty(guidance))
-                    {
-                        var typeText = string.Join("; ", group.Select(w => w.Description));
-                        sb.AppendLine($"{label} ({group.Key}): {guidance.Replace("{weaknesses}", typeText, StringComparison.Ordinal)}");
-                    }
-                }
-            }
-            baseInstruction += sb.ToString().TrimEnd();
         }
 
         // Section coherence rules from config

--- a/data/pedagogy/course-rules.json
+++ b/data/pedagogy/course-rules.json
@@ -1,5 +1,5 @@
 {
-  "lessonWeaknessProfileGuidance": "Design at least one Practice exercise and one Production task that directly address these patterns.",
+  "lessonWeaknessProfileGuidance": "Ensure practice and production sections target these patterns. Include at most 1-2 weakness-targeting exercises across the whole lesson; do not repeat weakness remediation in every section.",
   "sectionCoherenceRules": [
     "The THEME of Warm Up must relate to the THEME of Presentation (same field, not identical).",
     "Practice MUST use EXCLUSIVELY content from Presentation. No new grammar or vocabulary.",


### PR DESCRIPTION
## Summary
- Removes the `DECLARED WEAKNESSES` block from `BuildLessonPlanUserPrompt` in `PromptService.cs`. The `STUDENT ERROR PROFILE` block is retained as the single weakness block.
- Updates `lessonWeaknessProfileGuidance` in `course-rules.json` to use lesson-planning language and restore the "at most 1-2 exercises" cap that was implicit in the removed block's header.
- Updates 3 tests in `PromptServiceTests.cs` to reflect the removal; adjusts guidance text assertion to match the updated config.

Both blocks presented the same weakness data with different framing, which could confuse the model. The per-section targeting via `BuildWeaknessTargetingForSection` (exercises, conversation, guided-writing, error-correction) is separate and unchanged.

Closes #611

## Test plan
- [ ] `dotnet test` passes (418 tests, 0 failures)
- [ ] `LessonPlanPrompt_InjectsDifficultyTargeting_WhenWeaknessesPresent` asserts STUDENT ERROR PROFILE present
- [ ] `LessonPlanPrompt_NoDifficultyBlock_WhenWeaknessesNull` asserts STUDENT ERROR PROFILE absent
- [ ] `LessonPlanPrompt_WeaknessBlock_IncludesProfileGuidanceAndOmitsSectionLabels` asserts cap guidance present and per-section labels absent
- [ ] Lesson generated for a student with declared weaknesses still targets weakness in practice/production sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)