### PR TITLE
fix(#1065): todo intent leakage and due-date chip on proposal cards

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/StudentsControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/StudentsControllerTests.cs
@@ -417,7 +417,7 @@ public class StudentsControllerTests
 
         var appendResponse = await client.PostAsJsonAsync(
             $"/api/students/{student.Id}/teaching-todos",
-            new CreateTeachingTodoDto("Practicar subjuntivo", null));
+            new CreateTeachingTodoDto("Practicar subjuntivo", null, null));
         appendResponse.EnsureSuccessStatusCode();
         var withTodo = await appendResponse.Content.ReadFromJsonAsync<StudentDto>();
         var todoId = withTodo!.Profile.TeachingTodos[0].Id;
@@ -448,7 +448,7 @@ public class StudentsControllerTests
 
         var appendResponse = await client.PostAsJsonAsync(
             $"/api/students/{student.Id}/teaching-todos",
-            new CreateTeachingTodoDto("Practicar subjuntivo", null));
+            new CreateTeachingTodoDto("Practicar subjuntivo", null, null));
         appendResponse.EnsureSuccessStatusCode();
         var withTodo = await appendResponse.Content.ReadFromJsonAsync<StudentDto>();
         var todoId = withTodo!.Profile.TeachingTodos[0].Id;

--- a/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/ReflectionExtractionServiceTests.cs
@@ -462,7 +462,29 @@ public class ReflectionExtractionServiceTests
     }
 
     [Fact]
-    public void ParseResponse_ExtractsTeachingTodos()
+    public void ParseResponse_ExtractsTeachingTodos_ObjectFormat()
+    {
+        var sut = CreateSut("{}");
+        var json = """
+            {
+              "suggestedDifficulties": [],
+              "teachingTodos": [
+                {"text": "Trabajar conectores adversativos", "dueDate": null},
+                {"text": "Practicar el subjuntivo en concesivas", "dueDate": "2026-05-12"}
+              ]
+            }
+            """;
+
+        var result = sut.ParseResponse(json);
+
+        result.TeachingTodos.Select(t => t.Text).Should()
+            .BeEquivalentTo(["Trabajar conectores adversativos", "Practicar el subjuntivo en concesivas"]);
+        result.TeachingTodos[0].DueDate.Should().BeNull();
+        result.TeachingTodos[1].DueDate.Should().Be("2026-05-12");
+    }
+
+    [Fact]
+    public void ParseResponse_ExtractsTeachingTodos_LegacyStringFormat()
     {
         var sut = CreateSut("{}");
         var json = """
@@ -474,7 +496,9 @@ public class ReflectionExtractionServiceTests
 
         var result = sut.ParseResponse(json);
 
-        result.TeachingTodos.Should().BeEquivalentTo(["Trabajar conectores adversativos", "Practicar el subjuntivo en concesivas"]);
+        result.TeachingTodos.Select(t => t.Text).Should()
+            .BeEquivalentTo(["Trabajar conectores adversativos", "Practicar el subjuntivo en concesivas"]);
+        result.TeachingTodos.Should().AllSatisfy(t => t.DueDate.Should().BeNull());
     }
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/StudentServiceTests.cs
@@ -312,7 +312,7 @@ public class StudentServiceTests : IDisposable
     public async Task TeachingTodos_StatusTransition_Covered_Succeeds()
     {
         var created = await _sut.CreateAsync(_teacherId, BaseRequest());
-        var appended = await _sut.AppendTeachingTodoAsync(_teacherId, created.Id, new CreateTeachingTodoDto("Work on ser/estar", null));
+        var appended = await _sut.AppendTeachingTodoAsync(_teacherId, created.Id, new CreateTeachingTodoDto("Work on ser/estar", null, null));
         var todoId = appended!.Profile.TeachingTodos.Single().Id;
 
         var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, todoId, new UpdateTeachingTodoDto("Covered", null, null));
@@ -324,7 +324,7 @@ public class StudentServiceTests : IDisposable
     public async Task TeachingTodos_StatusTransition_Dismissed_Succeeds()
     {
         var created = await _sut.CreateAsync(_teacherId, BaseRequest());
-        var appended = await _sut.AppendTeachingTodoAsync(_teacherId, created.Id, new CreateTeachingTodoDto("Work on ser/estar", null));
+        var appended = await _sut.AppendTeachingTodoAsync(_teacherId, created.Id, new CreateTeachingTodoDto("Work on ser/estar", null, null));
         var todoId = appended!.Profile.TeachingTodos.Single().Id;
 
         var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, todoId, new UpdateTeachingTodoDto("Dismissed", null, null));
@@ -348,7 +348,7 @@ public class StudentServiceTests : IDisposable
         var otherTeacherId = Guid.NewGuid();
         var created = await _sut.CreateAsync(_teacherId, BaseRequest());
 
-        var result = await _sut.AppendTeachingTodoAsync(otherTeacherId, created.Id, new CreateTeachingTodoDto("Some text", null));
+        var result = await _sut.AppendTeachingTodoAsync(otherTeacherId, created.Id, new CreateTeachingTodoDto("Some text", null, null));
 
         result.Should().BeNull();
     }
@@ -358,7 +358,7 @@ public class StudentServiceTests : IDisposable
     {
         var created = await _sut.CreateAsync(_teacherId, BaseRequest());
 
-        var result = await _sut.AppendTeachingTodoAsync(_teacherId, created.Id, new CreateTeachingTodoDto("Trabajar ser/estar", null));
+        var result = await _sut.AppendTeachingTodoAsync(_teacherId, created.Id, new CreateTeachingTodoDto("Trabajar ser/estar", null, null));
 
         result!.Profile.TeachingTodos.Should().HaveCount(1);
         result.Profile.TeachingTodos[0].Text.Should().Be("Trabajar ser/estar");
@@ -372,8 +372,8 @@ public class StudentServiceTests : IDisposable
     public async Task DeleteTeachingTodoAsync_RemovesTodo_ReturnsUpdatedStudent()
     {
         var created = await _sut.CreateAsync(_teacherId, BaseRequest());
-        var after1 = await _sut.AppendTeachingTodoAsync(_teacherId, created.Id, new CreateTeachingTodoDto("Todo one", null));
-        var after2 = await _sut.AppendTeachingTodoAsync(_teacherId, created.Id, new CreateTeachingTodoDto("Todo two", null));
+        var after1 = await _sut.AppendTeachingTodoAsync(_teacherId, created.Id, new CreateTeachingTodoDto("Todo one", null, null));
+        var after2 = await _sut.AppendTeachingTodoAsync(_teacherId, created.Id, new CreateTeachingTodoDto("Todo two", null, null));
         var firstId = after1!.Profile.TeachingTodos[0].Id;
         var secondId = after2!.Profile.TeachingTodos[1].Id;
 
@@ -410,7 +410,7 @@ public class StudentServiceTests : IDisposable
     public async Task UpdateTeachingTodoAsync_WithText_UpdatesText()
     {
         var created = await _sut.CreateAsync(_teacherId, BaseRequest());
-        var appended = await _sut.AppendTeachingTodoAsync(_teacherId, created.Id, new CreateTeachingTodoDto("Original text", null));
+        var appended = await _sut.AppendTeachingTodoAsync(_teacherId, created.Id, new CreateTeachingTodoDto("Original text", null, null));
         var todoId = appended!.Profile.TeachingTodos.Single().Id;
 
         var result = await _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, todoId,
@@ -423,7 +423,7 @@ public class StudentServiceTests : IDisposable
     public async Task UpdateTeachingTodoAsync_TextTooLong_ThrowsValidation()
     {
         var created = await _sut.CreateAsync(_teacherId, BaseRequest());
-        var appended = await _sut.AppendTeachingTodoAsync(_teacherId, created.Id, new CreateTeachingTodoDto("Some text", null));
+        var appended = await _sut.AppendTeachingTodoAsync(_teacherId, created.Id, new CreateTeachingTodoDto("Some text", null, null));
         var todoId = appended!.Profile.TeachingTodos.Single().Id;
 
         var act = () => _sut.UpdateTeachingTodoAsync(_teacherId, created.Id, todoId,

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1524,7 +1524,11 @@ public class PromptService : IPromptService
         var weekdayFactsSection = weekdayFacts != null ? $"\n            {weekdayFacts}" : string.Empty;
 
         var sessionContextHint = ctx.HasOpenSession
-            ? string.Empty
+            ? """
+
+
+            IMPORTANT CONTEXT: There IS an open session in scope. Future-tense planning asides ("la semana que viene quiero hacer el subjuntivo", "quiero trabajar X la próxima vez") are teaching ideas — capture them in teachingTodos or nextLessonIdeas, not as new session records.
+            """
             : """
 
 
@@ -1567,13 +1571,18 @@ public class PromptService : IPromptService
             - suggestedDifficulties: array of objects (can be empty []) — structured breakdown of the same difficulties mentioned in areasToImprove
             - topicTags: array of objects with "tag" (string) and "category" (string or null) — topics, grammar structures, vocabulary areas covered. Each tag as a concise noun phrase. Empty array if none mentioned.
             - previousHomeworkStatus: "done" | "partial" | "notDone" | null — whether the student completed homework from the previous session. Null if not mentioned.
-            - teachingTodos: array of strings — pedagogical ideas for future sessions (grammar points to revisit, vocabulary to practise, skills to develop; e.g. "hay que practicar el subjuntivo"). Also triggered by imperative phrases like "apunta como teaching todo [X]", "añade como idea [X]". Empty array if none.
+            - teachingTodos: array of objects — pedagogical ideas for future sessions. Each object has:
+                - "text": string — the pedagogical idea (grammar points to revisit, vocabulary, skills to develop)
+                - "dueDate": string or null — ISO 8601 date (YYYY-MM-DD) if a specific target date is mentioned for this todo; resolve forward from today using the same rules as newSessionDate. Null if no date is mentioned.
+                Triggered by imperative phrases like "apunta como teaching todo [X]", "añade como idea [X]", "añade un teaching todo para [X]". Empty array if none.
+                Example: input "Añade un teaching todo para repasar la voz pasiva el martes que viene" produces one todo object with text "Repasar la voz pasiva" and dueDate set to the next Tuesday from today.
             - teacherFollowups: array of strings — operational actions owed by the teacher (send materials, book a test, contact a school; e.g. "le tengo que mandar ejercicios", "tengo que preparar ejercicios"). Also triggered by imperative phrases like "añade follow up [X]", "apunta follow up [X]", "añade como follow up [X]" — extract the action after the trigger phrase. Empty array if none.
             - levelReassessment: CEFR level string (e.g. "B1", "B2") or null — if the teacher mentions reassessing or updating the student's level. Null if not mentioned. If the teacher explicitly states they are NOT changing the level (e.g. "no toco el nivel", "no quiero cambiar el nivel", "todavía no", "solo tomar nota"), set to null even when CEFR strings appear elsewhere in the utterance. Examples: "ha mejorado mucho, creo que ya está en B2, súbele el nivel" → "B2" (positive: level change stated); "habla a nivel B2 pero el nivel global no lo toco" → null (negative: level mentioned but suppressed).
             - durationMinutes: integer or null — session duration in minutes. Null if not mentioned.
             - isCancelled: true | false | null — true only if the session was cancelled or the student did not show up. Null if not mentioned.
             - difficultiesWorkedOn: array of strings — copy verbatim from the student's known difficulties list any difficulty that was explicitly worked on in this session. Empty array if none or if no known difficulties were provided.
             - newSessionTitle: string or null — concise title (under 60 chars) for a NEW session record the teacher is creating, either scheduled for the future or retroactively registered for a past date. Set for explicit scheduling statements ("next Monday I want to do a session on the subjunctive", "la semana que viene hagamos una sesión sobre el subjuntivo") and for retrospective registration when the teacher explicitly says they forgot to register a past session ("que se me olvidó registrarla", "apunta una sesión del lunes pasado sobre X"). Distinct from nextLessonIdeas (planning ideas without a scheduled appointment). Both newSessionTitle and nextLessonIdeas may be set simultaneously if the teacher is scheduling AND has broader ideas.
+                When the teacher uses a todo-creation trigger phrase ("añade un teaching todo", "apunta como teaching todo", "ponme un todo para", "añade como idea"), produce a todo object with dueDate and leave newSessionTitle null — the date belongs to the todo, not a new session.
             - newSessionDate: string or null — ISO 8601 date (YYYY-MM-DD) for the proposed new session. For future dates: resolve forward from today — "el lunes" or "next Monday" = the next Monday strictly after today (count forward to the first occurrence of that weekday; if today is Saturday, the next Monday is exactly 2 days away, NOT 3). "la semana que viene" = same day next week. For retrospective sessions with explicit past markers ("pasado", "de la semana pasada", "que se me olvidó registrar"): resolve backward — {weekdayBackwardRule} Null only when no specific day or date can be inferred (e.g. "next class", "soon") — do NOT default to today when no date cue is present. Null if newSessionTitle is null. If a date is mentioned without a topic, set both fields to null.
 
             For suggestedDifficulties, each object must have:

--- a/backend/LangTeach.Api/Controllers/AssistantController.cs
+++ b/backend/LangTeach.Api/Controllers/AssistantController.cs
@@ -127,8 +127,11 @@ public class AssistantController : ControllerBase
 
             foreach (var todo in reflectionExtraction.TeachingTodos)
             {
-                if (!string.IsNullOrWhiteSpace(todo))
-                    proposals.Add(new ProposalDto(Guid.NewGuid().ToString(), "todo", "text", "Teaching Todo", null, todo));
+                if (!string.IsNullOrWhiteSpace(todo.Text))
+                {
+                    var todoPayload = JsonSerializer.SerializeToElement(new { dueDate = todo.DueDate }, camelCaseOpts);
+                    proposals.Add(new ProposalDto(Guid.NewGuid().ToString(), "todo", "text", "Teaching Todo", null, todo.Text, Payload: todoPayload));
+                }
             }
 
             if (studentExtraction.Interests.Count > 0)

--- a/backend/LangTeach.Api/DTOs/ReflectionExtractionDtos.cs
+++ b/backend/LangTeach.Api/DTOs/ReflectionExtractionDtos.cs
@@ -38,6 +38,8 @@ public record TopicTagDto(string Tag, string? Category);
 
 public record ProposedNewSession(string Title, string? Date);
 
+public record ExtractedTeachingTodoDto(string Text, string? DueDate);
+
 public record ExtractedReflectionDto(
     ExtractedTextFieldDto? WhatWasCovered,
     ExtractedTextFieldDto? AreasToImprove,
@@ -50,7 +52,7 @@ public record ExtractedReflectionDto(
     string? SessionTitle,
     List<TopicTagDto> TopicTags,
     ExtractedHomeworkStatus? PreviousHomeworkStatus,
-    List<string> TeachingTodos,
+    List<ExtractedTeachingTodoDto> TeachingTodos,
     List<string> TeacherFollowups,
     string? LevelReassessment,
     int? DurationMinutes,

--- a/backend/LangTeach.Api/DTOs/TeachingTodoDto.cs
+++ b/backend/LangTeach.Api/DTOs/TeachingTodoDto.cs
@@ -8,11 +8,13 @@ public record TeachingTodoDto(
     DateTime CreatedAt,
     string? SourceSessionLogId,
     string Status,
-    string? CoveredInSessionLogId);
+    string? CoveredInSessionLogId,
+    DateOnly? DueDate);
 
 public record CreateTeachingTodoDto(
     [MaxLength(500)] string Text,
-    string? SourceSessionLogId);
+    string? SourceSessionLogId,
+    string? DueDate);
 
 public record UpdateTeachingTodoDto(
     [Required]

--- a/backend/LangTeach.Api/DTOs/TeachingTodoDtoProjection.cs
+++ b/backend/LangTeach.Api/DTOs/TeachingTodoDtoProjection.cs
@@ -12,7 +12,8 @@ public static class TeachingTodoDtoProjection
             f.CreatedAt,
             f.SourceSessionLogId != null ? f.SourceSessionLogId.ToString() : null,
             f.Status,
-            f.CoveredInSessionLogId != null ? f.CoveredInSessionLogId.ToString() : null);
+            f.CoveredInSessionLogId != null ? f.CoveredInSessionLogId.ToString() : null,
+            f.DueDate);
 
     public static readonly Func<TeacherFollowup, TeachingTodoDto> Compiled = Projection.Compile();
 }

--- a/backend/LangTeach.Api/Services/DashboardService.cs
+++ b/backend/LangTeach.Api/Services/DashboardService.cs
@@ -226,7 +226,8 @@ public class DashboardService : IDashboardService
                         f.Id.ToString(), f.Text, f.CreatedAt,
                         f.SourceSessionLogId != null ? f.SourceSessionLogId.ToString() : null,
                         f.Status,
-                        f.CoveredInSessionLogId != null ? f.CoveredInSessionLogId.ToString() : null))
+                        f.CoveredInSessionLogId != null ? f.CoveredInSessionLogId.ToString() : null,
+                        f.DueDate))
                     .ToList(),
                 LastSessionDate = s.SessionLogs
                     .Where(sl => !sl.IsDeleted && sl.SessionDate.HasValue && sl.SessionDate.Value < now)

--- a/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
@@ -147,7 +147,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
                 SessionTitle: GetStringOrNull(root, "sessionTitle"),
                 TopicTags: ParseTopicTags(root),
                 PreviousHomeworkStatus: ParseHomeworkStatus(root),
-                TeachingTodos: ParseStringArray(root, "teachingTodos"),
+                TeachingTodos: ParseTeachingTodos(root),
                 TeacherFollowups: ParseStringArray(root, "teacherFollowups"),
                 LevelReassessment: ParseCefrLevel(root, "levelReassessment"),
                 DurationMinutes: GetIntOrNull(root, "durationMinutes"),
@@ -281,6 +281,29 @@ public class ReflectionExtractionService : IReflectionExtractionService
         return TimeOnly.TryParseExact(raw, "HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out _)
             ? raw
             : null;
+    }
+
+    private static List<ExtractedTeachingTodoDto> ParseTeachingTodos(JsonElement root)
+    {
+        var result = new List<ExtractedTeachingTodoDto>();
+        if (!root.TryGetProperty("teachingTodos", out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return result;
+        foreach (var item in arr.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String)
+            {
+                var s = item.GetString();
+                if (!string.IsNullOrWhiteSpace(s)) result.Add(new ExtractedTeachingTodoDto(s, null));
+            }
+            else if (item.ValueKind == JsonValueKind.Object)
+            {
+                var text = GetStringOrNull(item, "text");
+                if (string.IsNullOrWhiteSpace(text)) continue;
+                var dueDate = GetIsoDateOrNull(item, "dueDate");
+                result.Add(new ExtractedTeachingTodoDto(text, dueDate));
+            }
+        }
+        return result;
     }
 
     private static List<string> ParseStringArray(JsonElement root, string key)

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -403,6 +403,7 @@ public class StudentService : IStudentService
             Kind = TeacherFollowupKinds.Pedagogical,
             CreatedAt = DateTime.UtcNow,
             SourceSessionLogId = sourceSessionLogId,
+            DueDate = ParseDueDate(request.DueDate),
         };
         _db.TeacherFollowups.Add(followup);
         await _db.SaveChangesAsync(cancellationToken);
@@ -513,4 +514,15 @@ public class StudentService : IStudentService
 
     private static string Serialize<T>(List<T> list) =>
         JsonStorageHelper.Serialize(list);
+
+    private DateOnly? ParseDueDate(string? raw)
+    {
+        if (raw is null) return null;
+        if (DateOnly.TryParseExact(raw, "yyyy-MM-dd",
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.None, out var parsed))
+            return parsed;
+        _logger.LogWarning("Teaching todo DueDate '{DueDate}' could not be parsed as yyyy-MM-dd; storing null", raw);
+        return null;
+    }
 }

--- a/frontend/src/api/assistant.ts
+++ b/frontend/src/api/assistant.ts
@@ -80,8 +80,9 @@ export async function applySessionProposal(
 export async function applyTodoProposal(
   studentId: string,
   text: string,
+  dueDate?: string | null,
 ): Promise<void> {
-  await apiClient.post(`/api/students/${studentId}/teaching-todos`, { text })
+  await apiClient.post(`/api/students/${studentId}/teaching-todos`, { text, dueDate: dueDate ?? null })
 }
 
 export async function applyNewSessionProposal(

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -49,7 +49,7 @@ interface Props {
   onModify: (id: string, newValue: string) => void
   onApplyAll: () => void
   onDismissAll: () => void
-  onEditPayload?: (id: string, payload: import('@/api/assistant').NewStudentData | import('@/api/assistant').NewSessionData) => void
+  onEditPayload?: (id: string, payload: import('@/api/assistant').NewStudentData | import('@/api/assistant').NewSessionData | Record<string, unknown>) => void
   studentId?: string | null
 }
 

--- a/frontend/src/components/assistant/ProposalCard.test.tsx
+++ b/frontend/src/components/assistant/ProposalCard.test.tsx
@@ -123,6 +123,31 @@ describe('ProposalCard', () => {
     expect(container.querySelector('.bg-emerald-500')).toBeInTheDocument()
   })
 
+  it('todo type: shows editable date chip when payload has dueDate', async () => {
+    const onEditPayload = vi.fn()
+    renderCard(
+      makeProposal({ type: 'todo', oldValue: null, newValue: 'Repasar la voz pasiva', payload: { dueDate: '2026-05-12' } }),
+      { onEditPayload }
+    )
+    const dateInput = screen.getByTestId('todo-date-input-p1') as HTMLInputElement
+    expect(dateInput).toBeInTheDocument()
+    expect(dateInput.value).toBe('2026-05-12')
+    fireEvent.change(dateInput, { target: { value: '2026-05-19' } })
+    expect(onEditPayload).toHaveBeenCalledWith('p1', { dueDate: '2026-05-19' })
+  })
+
+  it('todo type: shows empty date chip when payload has no dueDate', () => {
+    renderCard(makeProposal({ type: 'todo', oldValue: null, newValue: 'Repasar la voz pasiva', payload: { dueDate: null } }))
+    const dateInput = screen.getByTestId('todo-date-input-p1') as HTMLInputElement
+    expect(dateInput.value).toBe('')
+  })
+
+  it('todo type: date chip is disabled when card is applied', () => {
+    renderCard(makeProposal({ type: 'todo', oldValue: null, newValue: 'Repasar la voz pasiva', status: 'applied', payload: { dueDate: '2026-05-12' } }))
+    const dateInput = screen.getByTestId('todo-date-input-p1') as HTMLInputElement
+    expect(dateInput).toBeDisabled()
+  })
+
   it('proposed: shows Modify button', () => {
     renderCard(makeProposal({ status: 'proposed' }))
     expect(screen.getByTestId('modify-btn-p1')).toBeInTheDocument()

--- a/frontend/src/components/assistant/ProposalCard.tsx
+++ b/frontend/src/components/assistant/ProposalCard.tsx
@@ -14,7 +14,7 @@ interface Props {
   onUndo: (id: string) => void
   onRetry: (id: string) => void
   onModify: (id: string, newValue: string) => void
-  onEditPayload?: (id: string, payload: NewStudentData | NewSessionData) => void
+  onEditPayload?: (id: string, payload: NewStudentData | NewSessionData | Record<string, unknown>) => void
   studentId?: string | null
 }
 
@@ -104,9 +104,12 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
   const isMultiline = MULTILINE_FIELDS.has(proposal.field)
   const isNewStudent = proposal.type === 'newStudent'
   const isNewSession = proposal.type === 'newSession'
+  const isTodo = proposal.type === 'todo'
   const newSessionPayload = isNewSession ? (proposal.payload as NewSessionData | null | undefined) : null
   const newSessionApplyDisabled = isNewSession && !studentId
   const newSessionDateEditable = isNewSession && (proposal.status === 'proposed' || proposal.status === 'error')
+  const todoPayload = isTodo ? (proposal.payload as { dueDate?: string | null } | null | undefined) : null
+  const todoDateEditable = isTodo && (proposal.status === 'proposed' || proposal.status === 'error')
 
   return (
     <div
@@ -222,6 +225,27 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
                 </span>
               ) : (
                 <span className="font-semibold text-zinc-800">{proposal.newValue}</span>
+              )}
+              {isTodo && (
+                <div className="flex items-center gap-2 mt-1.5">
+                  <span className="text-xs font-inter text-zinc-500">Due:</span>
+                  <input
+                    type="date"
+                    value={todoPayload?.dueDate ?? ''}
+                    disabled={!todoDateEditable}
+                    onChange={e => {
+                      const date = e.target.value || null
+                      if (onEditPayload && todoDateEditable) {
+                        onEditPayload(proposal.id, { dueDate: date })
+                      }
+                    }}
+                    data-testid={`todo-date-input-${proposal.id}`}
+                    className={cn(
+                      'text-sm font-inter border border-zinc-200 rounded-md px-2 py-0.5 text-zinc-700 focus:outline-none focus:ring-2 focus:ring-indigo-300',
+                      !todoDateEditable && 'cursor-not-allowed opacity-60'
+                    )}
+                  />
+                </div>
               )}
             </div>
           )}

--- a/frontend/src/hooks/useAtelierAssistant.test.ts
+++ b/frontend/src/hooks/useAtelierAssistant.test.ts
@@ -138,8 +138,21 @@ describe('useAtelierAssistant', () => {
     expect(result.current.proposals).toHaveLength(1)
 
     await act(async () => { await result.current.apply('p3') })
-    expect(mockApplyTodo).toHaveBeenCalledWith('student-1', 'Review passive voice')
+    expect(mockApplyTodo).toHaveBeenCalledWith('student-1', 'Review passive voice', null)
     expect(result.current.proposals[0].status).toBe('applied')
+  })
+
+  it('apply: passes dueDate from todo payload to applyTodoProposal', async () => {
+    const todoWithDate = { id: 'pt-date', type: 'todo' as const, field: 'text', label: 'Teaching Todo', oldValue: null, newValue: 'Repasar la voz pasiva', payload: { dueDate: '2026-05-12' } }
+    mockPropose.mockResolvedValueOnce({ proposals: [todoWithDate] })
+    mockApplyTodo.mockResolvedValueOnce(undefined)
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null), { wrapper: makeWrapper() })
+
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    await act(async () => { await result.current.apply('pt-date') })
+    expect(mockApplyTodo).toHaveBeenCalledWith('student-1', 'Repasar la voz pasiva', '2026-05-12')
   })
 
   it('apply: sets error status on failure without affecting other cards', async () => {

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -39,7 +39,7 @@ export interface AtelierAssistantActions {
   applyAll: () => void
   dismissAll: () => void
   reset: () => void
-  onEditPayload: (id: string, payload: NewStudentData | NewSessionData) => void
+  onEditPayload: (id: string, payload: NewStudentData | NewSessionData | Record<string, unknown>) => void
 }
 
 export function useAtelierAssistant(
@@ -141,7 +141,8 @@ export function useAtelierAssistant(
       } else if (proposal.type === 'session' && studentId && sessionId) {
         await applySessionProposal(studentId, sessionId, proposal.field, proposal.newValue)
       } else if (proposal.type === 'todo' && studentId) {
-        await applyTodoProposal(studentId, proposal.newValue)
+        const dueDate = (proposal.payload as { dueDate?: string | null } | null | undefined)?.dueDate ?? null
+        await applyTodoProposal(studentId, proposal.newValue, dueDate)
       } else if (proposal.type === 'newStudent') {
         const data = proposal.newStudentPayload as NewStudentData | null | undefined
         if (!data) throw new Error('Student data is missing.')
@@ -245,10 +246,11 @@ export function useAtelierAssistant(
     proposalsRef.current.filter(p => p.status === 'proposed').forEach(p => dismiss(p.id))
   }, [dismiss])
 
-  const onEditPayload = useCallback((id: string, payload: NewStudentData | NewSessionData) => {
+  const onEditPayload = useCallback((id: string, payload: NewStudentData | NewSessionData | Record<string, unknown>) => {
     setProposals(prev => prev.map(p => {
       if (p.id !== id) return p
       if (p.type === 'newStudent') return { ...p, newStudentPayload: payload as NewStudentData }
+      if (p.type === 'todo') return { ...p, payload: payload as Record<string, unknown> }
       return { ...p, payload: payload as NewSessionData }
     }))
   }, [])

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -200,6 +200,9 @@ export function useAtelierAssistant(
         await queryClient.invalidateQueries({ queryKey: ['students'] })
       } else if (proposal.type === 'newSession' && studentId) {
         await queryClient.invalidateQueries({ queryKey: ['sessions', studentId] })
+      } else if (proposal.type === 'todo' && studentId) {
+        await queryClient.invalidateQueries({ queryKey: ['student', studentId] })
+        await queryClient.invalidateQueries({ queryKey: ['dashboard'] })
       }
     } catch (err) {
       if (generationRef.current !== gen) return

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -4,6 +4,9 @@ Out-of-scope observations logged by agents during implementation. Each row is so
 
 | Source issue | Date | Severity | Observation |
 | #smoke-hardening | 2026-05-04 | medium | `/dashboard` route renders blank white page; correct route is `/` - sidebar link uses `/` but direct navigation to `/dashboard` silently fails |
+| #1065 | 2026-05-04 | low | CreateTeachingTodoDto.DueDate lacks [RegularExpression] format attribute; invalid dates accepted at model-binding boundary and silently become null (Sophy) |
+| #1065 | 2026-05-04 | low | Todo trigger phrases ("añade un teaching todo", etc.) duplicated in two PromptService.cs blocks; should be extracted to data/atelier/intent-triggers.json in a future cleanup (Sophy) |
+| #1065 | 2026-05-04 | low | CreateTeachingTodoDto.DueDate is string? while sibling CreateTeacherFollowupRequest.DueDate is DateOnly?; inconsistent binding strategy for same entity field (arch review) |
 | #smoke-hardening | 2026-05-04 | low | "Apply" button in Atelier Assistant proposal flow not smoke-testable without real audio; #1065 fix end-to-end unconfirmed |
 
 *Cleared 2026-04-22 during UI Redesign & Student Profile Polish sprint close. Actionable entries batched into: #833 (bug batch), #834 (seeder gaps), #835 (e2e session-log rewrite), #836 (ScenarioSeeder Hans B1), #837 (deduplication), #838 (session title from web UI), #839 (debug log privacy), #840 (Edit Student UX), #841 (stale closure + LogSession pre-populate). Already-tracked entries removed (referenced #737/#707/#644/#714/#715/#716/#683/#741/#742/#756/#809/#657). Dismissed entries removed (defensive-only, intentional, or resolved).*


### PR DESCRIPTION
## Summary

- Fixes intent leakage where teaching-todo inputs ("Añade un teaching todo para repasar la voz pasiva el martes que viene") incorrectly produced both a TEACHING TODO card and a NEW SESSION card
- Adds an inline-editable due-date chip to todo proposal cards, matching the existing newSession date chip pattern
- Fixes open-session path where future-tense planning asides ("La semana que viene quiero hacer el subjuntivo") spawned unwanted newSession cards

## What changed

**Backend:**
- `PromptService.cs`: `teachingTodos` field changed from array of strings to array of objects `{text, dueDate}`; `newSessionTitle` gets an explicit positive-framed exclusion for todo-trigger phrases; HasOpenSession=true path gets a planning-aside routing hint
- `ExtractedReflectionDto.TeachingTodos`: `List<string>` -> `List<ExtractedTeachingTodoDto>` (new record with Text + DueDate)
- `ReflectionExtractionService`: new `ParseTeachingTodos` method handles object format and legacy plain-string fallback
- `CreateTeachingTodoDto` / `TeachingTodoDto`: `DateOnly? DueDate` added (matching the `TeacherFollowup` entity which already had the field)
- `TeachingTodoDtoProjection` + `DashboardService`: updated to include DueDate
- `AssistantController`: todo proposals now carry `{dueDate}` in payload
- `StudentService.AppendTeachingTodoAsync`: saves DueDate; logs a warning if date string is malformed

**Frontend:**
- `ProposalCard.tsx`: todo cards render an inline-editable date chip (same styling as newSession chip); `onEditPayload` prop type widened to support todo payloads
- `useAtelierAssistant.ts`: `apply` extracts dueDate from todo payload; `onEditPayload` handles todo type; type signature widened
- `AtelierAssistantPanel.tsx`: `onEditPayload` type signature widened to match

## Test plan

- [ ] "Añade un teaching todo para repasar la voz pasiva el martes que viene" produces ONE TEACHING TODO card with a date chip showing next Tuesday, no NEW SESSION card
- [ ] "Le di clase ayer, trabajamos el subjuntivo" still produces a NEW SESSION card (regression check)
- [ ] Todo proposal card date chip is editable (click date, change it, Apply sends updated date)
- [ ] Existing newSession date chip still works
- [ ] Backend unit tests: 1273 passed / 0 failed
- [ ] Frontend unit tests: 1677 passed / 0 failed

## Reviewer findings

| Reviewer | Finding | Action |
|---|---|---|
| qa-verify | No unit test for "Le di clase ayer" regression (model behavior can't be unit tested without real API) | Accepted - covered by prompt not removing session detection logic |
| architecture-reviewer | `CreateTeachingTodoDto.DueDate` is `string?` vs sibling `CreateTeacherFollowupRequest.DueDate` as `DateOnly?` | Deferred -- logged to observed-issues.md |
| Sophy | Trigger phrases duplicated in two prompt blocks | Logged to observed-issues.md (future data-config extraction) |
| Sophy | Silent DueDate parse failure | Fixed -- added log warning in `ParseDueDate` method |
| Sophy | `CreateTeachingTodoDto.DueDate` lacks format validation attribute | Logged to observed-issues.md |
| prompt-health | Open-session hint overlapped with field-level routing rules | Fixed -- tightened hint to just the unique signal |
| prompt-health | Duplicated example in `newSessionTitle` block | Fixed -- removed redundant example from `newSessionTitle` |
| prompt-health | Negative-first framing on `newSessionTitle` exclusion | Fixed -- reordered to positive-first |
| review-ui | PASS -- todo date chip consistent with newSession chip styling; no regressions observed | Accepted |

Closes #1065

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Teaching todos now support optional due dates that can be set and edited
  * AI assistant now extracts and suggests due dates from lesson reflections when proposing teaching todos

* **Tests**
  * Added test coverage for due date handling and parsing in teaching todos

<!-- end of auto-generated comment: release notes by coderabbit.ai -->