### PR TITLE
fix(#1072): atelier extraction polish -- countryOfResidence gap, teacherText sanitization

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -3387,11 +3387,11 @@ public class PromptServiceTests
     }
 
     [Fact]
-    public void BuildReflectionExtractionPrompt_SanitizesTeacherText_StripsControlCharacters()
+    public void BuildReflectionExtractionPrompt_SanitizesTeacherText_StripsControlCharactersAndNormalizesNewlines()
     {
         var today = new DateOnly(2026, 4, 11);
-        const string dirtyText = "Hoy trabajamos el subjuntivo\x00 y también\x1F repasamos.";
-        const string expectedText = "Hoy trabajamos el subjuntivo y también repasamos.";
+        const string dirtyText = "Hoy trabajamos\nel subjuntivo\x00 y\r\ntambién\x1F repasamos.";
+        const string expectedText = "Hoy trabajamos el subjuntivo y  también repasamos.";
 
         var request = _sut.BuildReflectionExtractionPrompt(new ReflectionExtractionContext(today, dirtyText));
 

--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -3386,6 +3386,18 @@ public class PromptServiceTests
         request.SystemPrompt.Should().NotContain("no open session in scope");
     }
 
+    [Fact]
+    public void BuildReflectionExtractionPrompt_SanitizesTeacherText_StripsControlCharacters()
+    {
+        var today = new DateOnly(2026, 4, 11);
+        const string dirtyText = "Hoy trabajamos el subjuntivo\x00 y también\x1F repasamos.";
+        const string expectedText = "Hoy trabajamos el subjuntivo y también repasamos.";
+
+        var request = _sut.BuildReflectionExtractionPrompt(new ReflectionExtractionContext(today, dirtyText));
+
+        request.UserPrompt.Should().Be(expectedText);
+    }
+
     // --- BuildStudentProfileExtractionPrompt ---
 
     [Fact]

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1497,7 +1497,7 @@ public class PromptService : IPromptService
     public ClaudeRequest BuildReflectionExtractionPrompt(ReflectionExtractionContext ctx)
     {
         var today = ctx.Today;
-        var teacherText = InputSanitizer.Sanitize(ctx.TeacherText);
+        var teacherText = InputSanitizer.Sanitize(ctx.TeacherText?.Replace('\r', ' ').Replace('\n', ' '));
         var competencies = string.Join(", ", _pedagogy.GetValidDifficultyCompetencies().OrderBy(x => x));
         var severities = string.Join(" | ", _pedagogy.GetValidDifficultySeverities().OrderBy(x => x));
         const string weekdayBackwardRule =

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1497,7 +1497,7 @@ public class PromptService : IPromptService
     public ClaudeRequest BuildReflectionExtractionPrompt(ReflectionExtractionContext ctx)
     {
         var today = ctx.Today;
-        var teacherText = ctx.TeacherText;
+        var teacherText = InputSanitizer.Sanitize(ctx.TeacherText);
         var competencies = string.Join(", ", _pedagogy.GetValidDifficultyCompetencies().OrderBy(x => x));
         var severities = string.Join(" | ", _pedagogy.GetValidDifficultySeverities().OrderBy(x => x));
         const string weekdayBackwardRule =

--- a/backend/LangTeach.Api/Controllers/AssistantController.cs
+++ b/backend/LangTeach.Api/Controllers/AssistantController.cs
@@ -89,6 +89,7 @@ public class AssistantController : ControllerBase
                 birthYear = studentExtraction.BirthYear,
                 profession = studentExtraction.Profession,
                 cityOfResidence = studentExtraction.CityOfResidence,
+                countryOfResidence = studentExtraction.CountryOfResidence,
                 nativeLanguages = studentExtraction.NativeLanguages,
                 learningLanguage = studentExtraction.LearningLanguage,
                 cefrLevel = studentExtraction.CefrLevel,

--- a/frontend/src/api/assistant.ts
+++ b/frontend/src/api/assistant.ts
@@ -6,6 +6,7 @@ export interface NewStudentData {
   birthYear?: number | null
   profession?: string | null
   cityOfResidence?: string | null
+  countryOfResidence?: string | null
   nativeLanguages?: string[]
   learningLanguage?: string | null
   cefrLevel?: string | null

--- a/frontend/src/components/assistant/NewStudentFields.tsx
+++ b/frontend/src/components/assistant/NewStudentFields.tsx
@@ -45,6 +45,11 @@ export default function NewStudentFields({ payload, proposalId, onEditPayload }:
         onChange={v => update({ cityOfResidence: v || null })}
       />
       <FieldRow
+        label="Country"
+        value={payload.countryOfResidence ?? ''}
+        onChange={v => update({ countryOfResidence: v || null })}
+      />
+      <FieldRow
         label="Native Language(s)"
         value={payload.nativeLanguages?.join(', ') ?? ''}
         onChange={v => update({ nativeLanguages: v ? v.split(',').map(s => s.trim()).filter(Boolean) : [] })}

--- a/frontend/src/hooks/useAtelierAssistant.test.ts
+++ b/frontend/src/hooks/useAtelierAssistant.test.ts
@@ -226,6 +226,32 @@ describe('useAtelierAssistant', () => {
     expect(result.current.proposals[0].status).toBe('applied')
   })
 
+  it('apply: passes cityOfResidence and countryOfResidence to createStudent', async () => {
+    const studentPayload = { name: 'Sofía', learningLanguage: 'inglés', cefrLevel: 'B1', cityOfResidence: 'Madrid', countryOfResidence: 'Spain' }
+    const newStudentProposal = { id: 'p4b', type: 'newStudent' as const, field: 'profile', label: 'New Student', oldValue: null, newValue: 'Sofía', newStudentPayload: studentPayload }
+    mockPropose.mockResolvedValueOnce({ proposals: [newStudentProposal] })
+    mockCreateStudent.mockResolvedValueOnce({
+      id: 'new-student-id', name: 'Sofía', learningLanguage: 'English',
+      level: { cefrLevel: 'B1', officialCefrLevel: null, skillLevelOverrides: {} },
+      languages: { nativeLanguages: [], spokenLanguages: [] },
+      identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: 'Spain', cityOfResidence: 'Madrid' },
+      profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
+      commercial: { isActive: true, isCorporate: false, rate: null },
+      createdAt: '', updatedAt: '',
+    })
+
+    const { result } = renderHook(() => useAtelierAssistant(null, null), { wrapper: makeWrapper() })
+    act(() => { result.current.submit('Nueva alumna Sofía de Madrid, España') })
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    await act(async () => { await result.current.apply('p4b') })
+    expect(mockCreateStudent).toHaveBeenCalledWith(expect.objectContaining({
+      cityOfResidence: 'Madrid',
+      countryOfResidence: 'Spain',
+    }))
+    expect(result.current.proposals[0].status).toBe('applied')
+  })
+
   it('apply: normalizes Spanish language names to canonical English before creating student', async () => {
     const studentPayload = { name: 'María', learningLanguage: 'inglés', nativeLanguages: ['castellano'], cefrLevel: 'B1' }
     const newStudentProposal = { id: 'p5', type: 'newStudent' as const, field: 'profile', label: 'New Student', oldValue: null, newValue: 'María', newStudentPayload: studentPayload }

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -173,6 +173,7 @@ export function useAtelierAssistant(
           birthYear: data.birthYear ?? null,
           profession: data.profession ?? null,
           cityOfResidence: data.cityOfResidence ?? null,
+          countryOfResidence: data.countryOfResidence ?? null,
           nativeLanguages: normalizedNativeLanguages,
           reasonForStudying: data.reasonForStudying ?? null,
           interests: [],

--- a/plan/ui-review-skipped.md
+++ b/plan/ui-review-skipped.md
@@ -10,3 +10,4 @@ The sprint-close procedure (Stage 1) audits this log and clears it after each sp
 |-------|------|----|-------------------------------------------|
 | #1057 | 2026-05-03 | TBD | Zero frontend files changed; backend-only flag added to reflection extraction pipeline |
 | #1063 | 2026-05-03 | TBD | Pure deletion of dead Help NavLink from AppShell; <20 lines, no logic/state changes, no new elements |
+| #1072 | 2026-05-04 | TBD | Added one FieldRow for "Country" to NewStudentFields.tsx; 5 lines, single file, no new component logic or state |


### PR DESCRIPTION
## Summary

- **Item 1 (countryOfResidence gap):** `newStudentPayload` in `AssistantController` was missing `countryOfResidence`; the field was already extracted by the LLM and wired on the update-student path but never forwarded to the create-student path. Added to the controller payload, `NewStudentData` TS interface, `NewStudentFields` UI card (Country field row), and `useAtelierAssistant` createStudent call.
- **Item 2 (dangling preamble reference):** No change needed -- confirmed the phrase does not exist in the current codebase; prior fix already cleaned it up.
- **Item 3 (teacherText sanitization):** `BuildReflectionExtractionPrompt` now calls `InputSanitizer.Sanitize(ctx.TeacherText)`, consistent with `BuildStudentProfileExtractionPrompt` and all other prompt builders.

## Test plan

- [ ] `useAtelierAssistant.test.ts`: new test asserts `cityOfResidence` and `countryOfResidence` both flow through to `createStudent`
- [ ] `PromptServiceTests.cs`: new test asserts control characters in `teacherText` are stripped before reaching `UserPrompt`
- [ ] All existing tests pass (99 frontend, dotnet suite)
- [ ] Build verify: PASS

## Reviewer findings

| Reviewer | Finding | Action |
|----------|---------|--------|
| QA Verify | PASS WITH GAPS: no E2E for new-student country flow | Accepted -- no Atelier e2e harness exists |
| Architecture | PASS | No action |
| Sophy | APPROVE | No action |
| Prompt Health | CLEAN | No action |

Closes #1072

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added country of residence field to student profile creation.

* **Bug Fixes**
  * Fixed handling of control characters in teacher transcript data during processing.

* **Tests**
  * Added test coverage for text sanitization functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->