### PR TITLE
fix(#1113): clean up header affordances on student detail + edit screens

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -108,8 +108,6 @@ All buttons: consistent height, no XL or oversized variants unless it's a full-w
 
 **Card micro-action exception:** inline action buttons inside transient AI cards (proposal cards, suggestion cards) may use raw `<button>` elements with hardcoded Tailwind classes instead of the DS Button component variants. These are micro-CTAs scoped to the card lifecycle, not page-level actions. They must still follow DS color tokens and sizing norms (see §11.10 for the canonical proposal card action row spec).
 
-**Known violation (filed for fix #1105):** The student detail header (`/students/:id`) places "Update via voice" and "Edit Student" as custom `bg-indigo-50 text-indigo-600` buttons next to the filled-primary "Log Session" button. These should be Secondary variant.
-
 ### FAB (Floating Action Button)
 
 A single app-level FAB triggers the Atelier Assistant. There is at most one FAB per screen.
@@ -278,8 +276,6 @@ Examples: `/students/:id/edit`, `/sessions/:id/edit`.
 **One Done per screen:** do not place a second Done in a sticky section nav if the page header already shows one. The sticky nav may repeat Done only if the page header Done has scrolled fully out of view (i.e., the sticky row is the only visible exit path). When both are simultaneously visible, remove the sticky one.
 
 **Competing top-right affordances:** do not place two distinct action buttons at the top-right of the same screen across adjacent rows. A "Create Course" shortcut in the page header row and a "Done" button in the sticky nav row one pixel below create two competing exit affordances. If a contextual shortcut (e.g. "Create Course") belongs on the edit screen, place it in the page body near the relevant section, not at top-right.
-
-**Known violation (filed for fix #1106):** `/students/:id/edit` (`StudentForm.tsx`) shows "Create Course" in the PageHeader actions at top-right and "Done" in the sticky section nav.
 
 ---
 

--- a/frontend/src/components/student/StudentDetailHeader.tsx
+++ b/frontend/src/components/student/StudentDetailHeader.tsx
@@ -4,7 +4,7 @@ import type { Student } from '@/api/students'
 import type { SessionLog } from '@/api/sessionLogs'
 import { formatDateShort } from '@/utils/formatDate'
 import { getInitials } from '@/utils/nameUtils'
-import { Button } from '@/components/ui/button'
+import { Button, buttonVariants } from '@/components/ui/button'
 import { CefrBadge } from '@/components/dashboard/CefrBadge'
 import { getObjectiveUrgency, getDaysRemaining, formatDaysRemaining } from '@/lib/objectiveUrgency'
 
@@ -185,21 +185,23 @@ export function StudentDetailHeader({ student, nextSession, sessionFrequency, on
         {/* Actions */}
         <div className="flex items-center gap-2 shrink-0 md:self-start">
           {onVoiceUpdateClick && (
-            <button
+            <Button
               onClick={onVoiceUpdateClick}
               disabled={voiceFlowActive}
               aria-label="Update via voice"
-              className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium bg-indigo-50 text-indigo-600 hover:bg-indigo-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              variant="secondary"
+              size="sm"
+              className="rounded-xl"
               data-testid="voice-update-button"
             >
               <Mic className="h-3.5 w-3.5" />
               <span className="md:hidden lg:inline">Update via voice</span>
-            </button>
+            </Button>
           )}
           <Link
             to={`/students/${student.id}/edit`}
             aria-label="Edit Student"
-            className="inline-flex items-center gap-1.5 rounded-xl px-3 py-2 text-sm font-medium bg-indigo-50 text-indigo-600 hover:bg-indigo-100 transition-colors"
+            className={buttonVariants({ variant: 'secondary', size: 'sm', className: 'rounded-xl' })}
             data-testid="edit-profile-link"
           >
             <Pencil className="h-3.5 w-3.5" />

--- a/frontend/src/components/student/StudentDetailHeader.tsx
+++ b/frontend/src/components/student/StudentDetailHeader.tsx
@@ -5,6 +5,7 @@ import type { SessionLog } from '@/api/sessionLogs'
 import { formatDateShort } from '@/utils/formatDate'
 import { getInitials } from '@/utils/nameUtils'
 import { Button, buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 import { CefrBadge } from '@/components/dashboard/CefrBadge'
 import { getObjectiveUrgency, getDaysRemaining, formatDaysRemaining } from '@/lib/objectiveUrgency'
 
@@ -201,7 +202,7 @@ export function StudentDetailHeader({ student, nextSession, sessionFrequency, on
           <Link
             to={`/students/${student.id}/edit`}
             aria-label="Edit Student"
-            className={buttonVariants({ variant: 'secondary', size: 'sm', className: 'rounded-xl' })}
+            className={cn(buttonVariants({ variant: 'secondary', size: 'sm' }), 'rounded-xl')}
             data-testid="edit-profile-link"
           >
             <Pencil className="h-3.5 w-3.5" />

--- a/frontend/src/pages/StudentForm.test.tsx
+++ b/frontend/src/pages/StudentForm.test.tsx
@@ -528,17 +528,6 @@ describe('StudentForm', () => {
     expect(descriptions[1]).toHaveValue('limited travel vocabulary')
   })
 
-  it('shows "Create Course" button and navigates correctly for a complete profile in edit mode', async () => {
-    const { default: userEvent } = await import('@testing-library/user-event')
-    const user = userEvent.setup()
-    renderEdit()
-    const btn = await screen.findByTestId('create-course-btn')
-    expect(btn).toBeInTheDocument()
-    expect(btn).not.toBeDisabled()
-    await user.click(btn)
-    expect(mockNavigate).toHaveBeenCalledWith('/courses/new?studentId=stu-1')
-  })
-
   it('loads all native languages in edit mode and displays them as chips', async () => {
     mockGetStudent.mockResolvedValue(makeMockStudent({ nativeLanguages: ['Portuguese', 'English', 'Catalan'] }))
 
@@ -551,13 +540,6 @@ describe('StudentForm', () => {
     expect(chips[0]).toHaveTextContent('Portuguese')
     expect(chips[1]).toHaveTextContent('English')
     expect(chips[2]).toHaveTextContent('Catalan')
-  })
-
-  it('"Create Course" button is disabled when student is missing CEFR level', async () => {
-    mockGetStudent.mockResolvedValue(makeMockStudent({ cefrLevel: '' }))
-    renderEdit()
-    const btn = await screen.findByTestId('create-course-btn')
-    expect(btn).toBeDisabled()
   })
 
   it('renders Personal Background section with all 6 identity fields', () => {

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -21,7 +21,6 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
-import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { MultiSelect } from '@/components/ui/multi-select'
 import { LearningGoalTreeEditor } from '@/components/student/LearningGoalTreeEditor'
 import { StudentCoursesCard } from '@/components/student/StudentCoursesCard'
@@ -620,25 +619,6 @@ export default function StudentForm() {
         subtitle={isEdit ? "Update this student's profile." : 'Create a new student profile.'}
         actions={
           <div className="flex items-center gap-3">
-            {isEdit && id && (() => {
-              const canCreateCourse = !!language && !!cefrLevel
-              return canCreateCourse ? (
-                <Button type="button" variant="outline" data-testid="create-course-btn" onClick={() => navigate(`/courses/new?studentId=${id}`)}>
-                  Create Course
-                </Button>
-              ) : (
-                <Tooltip>
-                  <TooltipTrigger render={<span tabIndex={0} className="inline-flex" />}>
-                    <Button type="button" variant="outline" disabled data-testid="create-course-btn">
-                      Create Course
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    Complete student profile (language and CEFR level required) to create a course.
-                  </TooltipContent>
-                </Tooltip>
-              )
-            })()}
             {!isEdit && (
               <Button type="submit" form="student-form" disabled={isPending} className="bg-indigo-600 hover:bg-indigo-700 text-white" data-testid="done-btn">
                 {isPending ? 'Saving...' : 'Done'}


### PR DESCRIPTION
## Summary

- **Student detail (`/students/:id`):** "Update via voice" and "Edit Student" converted from custom `bg-indigo-50 text-indigo-600` styling to DS Secondary variant (`Button variant="secondary"`). "Log Session" remains the only filled-primary CTA. Resolves DS §5 ghost-adjacent-to-filled violation.
- **Student edit (`/students/:id/edit`):** "Create Course" removed from PageHeader actions. "Done" in the sticky section nav is now the sole top-right affordance. Resolves DS §8.1 Pattern C competing-affordance violation.
- Removed two resolved known-violation entries from `docs/design-system.md` (§5 #1105 and §8.1 #1106).
- Deleted two unit tests that asserted the removed `create-course-btn` affordance (intentional removal per issue spec).
- Course creation remains accessible via `StudentCoursesCard` on the student detail page.

Supersedes #1105 and #1106.

## Test plan

- [x] TypeScript: clean
- [x] All 98 frontend tests pass (including `StudentDetailHeader.test.tsx` and remaining `StudentForm.test.tsx`)
- [x] Architecture review: PASS WITH NOTES (cn() wrapping fixed before merge)
- [ ] Sign in as E2E Teacher, open `/students/:id` (Ana Visual): Log Session is filled-primary, Update via voice + Edit Student are secondary (muted background, primary text, no border)
- [ ] Click Edit Student, confirm Done is the only top-right button -- no Create Course visible anywhere on the edit screen
- [ ] From the student detail page, confirm course creation is still accessible via the Courses card
- [ ] Check `md` and `lg` breakpoints for layout regressions on both screens

Note: review-ui agent finding ("Create Course still present") was a false positive -- Docker e2e stack builds from the main repo (`context: .`), not the worktree. The code change is verified by TypeScript, tests, and diff inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)