### PR TITLE
fix(#1117): expired Auth0 token triggers re-auth instead of backend-error UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useAuth0 } from '@auth0/auth0-react'
-import { setupAuthInterceptor } from './lib/apiClient'
+import { apiClient, setupAuthInterceptor } from './lib/apiClient'
 import { ProtectedRoute } from './components/ProtectedRoute'
 import { OnboardingGuard } from './components/OnboardingGuard'
 import { TooltipProvider } from '@/components/ui/tooltip'
@@ -26,14 +26,22 @@ import Onboarding from './pages/Onboarding'
 const queryClient = new QueryClient()
 
 function AuthSetup({ children }: { children: React.ReactNode }) {
-  const { getAccessTokenSilently, logout } = useAuth0()
+  const { getAccessTokenSilently, loginWithRedirect } = useAuth0()
 
   useEffect(() => {
-    return setupAuthInterceptor(getAccessTokenSilently, () => {
-      localStorage.clear()
-      logout({ logoutParams: { returnTo: window.location.origin } })
-    })
-  }, [getAccessTokenSilently, logout])
+    return setupAuthInterceptor(
+      apiClient,
+      (opts) =>
+        getAccessTokenSilently(
+          opts?.forceRefresh ? { cacheMode: 'off' } : undefined,
+        ),
+      () => {
+        const returnTo =
+          window.location.pathname + window.location.search + window.location.hash
+        void loginWithRedirect({ appState: { returnTo } })
+      },
+    )
+  }, [getAccessTokenSilently, loginWithRedirect])
 
   return <>{children}</>
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,7 +38,13 @@ function AuthSetup({ children }: { children: React.ReactNode }) {
       () => {
         const returnTo =
           window.location.pathname + window.location.search + window.location.hash
-        void loginWithRedirect({ appState: { returnTo } })
+        loginWithRedirect({ appState: { returnTo } }).catch((err) => {
+          // Auth0 unreachable or redirect blocked. Log so it surfaces in
+          // devtools instead of becoming an unhandled rejection. No toast
+          // infra to surface this to the user yet (see #1117 QA gap on
+          // auth-down vs session-expired copy).
+          console.error('Re-authentication redirect failed', err)
+        })
       },
     )
   }, [getAccessTokenSilently, loginWithRedirect])

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useAuth0 } from '@auth0/auth0-react'
 import { apiClient, setupAuthInterceptor } from './lib/apiClient'
@@ -50,9 +50,8 @@ export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
-        <BrowserRouter>
-          <AuthSetup>
-            <Routes>
+        <AuthSetup>
+          <Routes>
               <Route path="/onboarding" element={<ProtectedRoute><Onboarding /></ProtectedRoute>} />
               <Route element={<ProtectedRoute><OnboardingGuard /></ProtectedRoute>}>
                 <Route element={<AppShell />}>
@@ -74,9 +73,8 @@ export default function App() {
                   <Route path="/courses/:id" element={<CourseDetail />} />
                 </Route>
               </Route>
-            </Routes>
-          </AuthSetup>
-        </BrowserRouter>
+          </Routes>
+        </AuthSetup>
       </TooltipProvider>
     </QueryClientProvider>
   )

--- a/frontend/src/Auth0ProviderWithNavigate.tsx
+++ b/frontend/src/Auth0ProviderWithNavigate.tsx
@@ -1,0 +1,27 @@
+import { Auth0Provider } from '@auth0/auth0-react'
+import type { AppState } from '@auth0/auth0-react'
+import { useNavigate } from 'react-router-dom'
+
+export function Auth0ProviderWithNavigate({ children }: { children: React.ReactNode }) {
+  const navigate = useNavigate()
+  return (
+    <Auth0Provider
+      domain={import.meta.env.VITE_AUTH0_DOMAIN}
+      clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
+      authorizationParams={{
+        redirect_uri: window.location.origin,
+        audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+      }}
+      cacheLocation="localstorage"
+      onRedirectCallback={(appState?: AppState) => {
+        const target =
+          appState && typeof appState.returnTo === 'string'
+            ? appState.returnTo
+            : window.location.pathname
+        navigate(target, { replace: true })
+      }}
+    >
+      {children}
+    </Auth0Provider>
+  )
+}

--- a/frontend/src/lib/apiClient.test.ts
+++ b/frontend/src/lib/apiClient.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import axios from 'axios'
+import type { AxiosAdapter, AxiosResponse, AxiosError } from 'axios'
+import { setupAuthInterceptor } from './apiClient'
+import type { GetAccessToken } from './apiClient'
+
+interface AdapterCall {
+  url?: string
+  authorization?: unknown
+  retryFlag?: boolean
+}
+
+function makeStubAdapter(plan: Array<AxiosResponse | AxiosError>): {
+  adapter: AxiosAdapter
+  calls: AdapterCall[]
+} {
+  const calls: AdapterCall[] = []
+  let i = 0
+  const adapter: AxiosAdapter = async (config) => {
+    calls.push({
+      url: config.url,
+      authorization: config.headers?.Authorization,
+      retryFlag: (config as { _retry?: boolean })._retry,
+    })
+    const next = plan[i++]
+    if (!next) throw new Error(`stub adapter exhausted at call ${i}`)
+    if (next instanceof Error) {
+      ;(next as AxiosError).config = config
+      throw next
+    }
+    return { ...next, config }
+  }
+  return { adapter, calls }
+}
+
+function makeAxiosError(status: number): AxiosError {
+  const err = new Error(`status ${status}`) as AxiosError
+  err.isAxiosError = true
+  err.name = 'AxiosError'
+  err.response = {
+    status,
+    data: {},
+    statusText: '',
+    headers: {},
+    config: {} as never,
+  }
+  err.config = {} as never
+  err.toJSON = () => ({})
+  return err
+}
+
+function okResponse(body: unknown = {}): AxiosResponse {
+  return {
+    data: body,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {} as never,
+  }
+}
+
+function makeClient(plan: Array<AxiosResponse | AxiosError>) {
+  const { adapter, calls } = makeStubAdapter(plan)
+  const client = axios.create({ adapter })
+  return { client, calls }
+}
+
+describe('setupAuthInterceptor', () => {
+  let getToken: ReturnType<typeof vi.fn<GetAccessToken>>
+  let triggerReauth: ReturnType<typeof vi.fn<() => void>>
+
+  beforeEach(() => {
+    triggerReauth = vi.fn<() => void>()
+  })
+
+  it('attaches bearer token on every request', async () => {
+    getToken = vi.fn<GetAccessToken>().mockResolvedValue('token-1')
+    const { client, calls } = makeClient([okResponse()])
+    setupAuthInterceptor(client, getToken, triggerReauth)
+
+    await client.get('/api/x')
+
+    expect(calls[0]?.authorization).toBe('Bearer token-1')
+    expect(triggerReauth).not.toHaveBeenCalled()
+  })
+
+  it('on 401: refreshes token and replays the original request', async () => {
+    let current = 'stale'
+    getToken = vi
+      .fn<GetAccessToken>()
+      .mockImplementation(async (opts) => {
+        if (opts?.forceRefresh) current = 'fresh'
+        return current
+      })
+    const { client, calls } = makeClient([makeAxiosError(401), okResponse({ ok: true })])
+    setupAuthInterceptor(client, getToken, triggerReauth)
+
+    const res = await client.get('/api/x')
+
+    expect(res.data).toEqual({ ok: true })
+    expect(calls).toHaveLength(2)
+    expect(calls[0]?.authorization).toBe('Bearer stale')
+    expect(calls[1]?.authorization).toBe('Bearer fresh')
+    expect(calls[1]?.retryFlag).toBe(true)
+    expect(triggerReauth).not.toHaveBeenCalled()
+  })
+
+  it('on 401: triggers re-auth when refresh fails', async () => {
+    getToken = vi.fn<GetAccessToken>()
+    getToken.mockResolvedValueOnce('stale')
+    getToken.mockRejectedValueOnce(new Error('login_required'))
+    const { client } = makeClient([makeAxiosError(401)])
+    setupAuthInterceptor(client, getToken, triggerReauth)
+
+    await expect(client.get('/api/x')).rejects.toBeDefined()
+    expect(triggerReauth).toHaveBeenCalledTimes(1)
+  })
+
+  it('dedupes concurrent 401s into a single refresh call', async () => {
+    let current = 'stale'
+    getToken = vi
+      .fn<GetAccessToken>()
+      .mockImplementation(async (opts) => {
+        if (opts?.forceRefresh) current = 'fresh'
+        return current
+      })
+    const { client } = makeClient([
+      makeAxiosError(401),
+      makeAxiosError(401),
+      okResponse({ a: 1 }),
+      okResponse({ b: 2 }),
+    ])
+    setupAuthInterceptor(client, getToken, triggerReauth)
+
+    const [r1, r2] = await Promise.all([client.get('/api/a'), client.get('/api/b')])
+
+    expect([r1.data, r2.data]).toEqual(expect.arrayContaining([{ a: 1 }, { b: 2 }]))
+    const refreshCalls = getToken.mock.calls.filter((c) => c[0]?.forceRefresh).length
+    expect(refreshCalls).toBe(1)
+    expect(triggerReauth).not.toHaveBeenCalled()
+  })
+
+  it('does not loop when the replayed request also returns 401', async () => {
+    getToken = vi.fn<GetAccessToken>().mockResolvedValue('any')
+    const { client, calls } = makeClient([makeAxiosError(401), makeAxiosError(401)])
+    setupAuthInterceptor(client, getToken, triggerReauth)
+
+    await expect(client.get('/api/x')).rejects.toBeDefined()
+    expect(calls).toHaveLength(2)
+    expect(triggerReauth).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes through non-401 errors untouched', async () => {
+    getToken = vi.fn<GetAccessToken>().mockResolvedValue('token-1')
+    const { client } = makeClient([makeAxiosError(500)])
+    setupAuthInterceptor(client, getToken, triggerReauth)
+
+    await expect(client.get('/api/x')).rejects.toMatchObject({
+      response: { status: 500 },
+    })
+    expect(triggerReauth).not.toHaveBeenCalled()
+  })
+
+  it('triggers re-auth if the request-time getAccessToken throws', async () => {
+    getToken = vi.fn<GetAccessToken>().mockRejectedValue(new Error('login_required'))
+    const { client, calls } = makeClient([okResponse()])
+    setupAuthInterceptor(client, getToken, triggerReauth)
+
+    await expect(client.get('/api/x')).rejects.toBeDefined()
+    expect(calls).toHaveLength(0)
+    expect(triggerReauth).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,36 +1,79 @@
-import axios from 'axios'
+import axios, { AxiosError } from 'axios'
+import type { AxiosInstance, InternalAxiosRequestConfig } from 'axios'
 
 export const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:5000',
 })
 
-export function setupAuthInterceptor(
-  getAccessToken: () => Promise<string>,
-  onUnauthorized?: () => void,
-) {
-  const requestId = apiClient.interceptors.request.use(async (config) => {
-    const token = await getAccessToken()
-    config.headers.Authorization = `Bearer ${token}`
-    return config
-  })
+export interface GetAccessTokenOptions {
+  forceRefresh?: boolean
+}
 
-  let responseId: number | undefined
-  if (onUnauthorized) {
-    responseId = apiClient.interceptors.response.use(
-      (response) => response,
-      (error) => {
-        if (axios.isAxiosError(error) && error.response?.status === 401) {
-          onUnauthorized()
-        }
-        return Promise.reject(error)
-      },
-    )
+export type GetAccessToken = (opts?: GetAccessTokenOptions) => Promise<string>
+
+type RetriableConfig = InternalAxiosRequestConfig & { _retry?: boolean }
+
+export function setupAuthInterceptor(
+  client: AxiosInstance,
+  getAccessToken: GetAccessToken,
+  triggerReauth: () => void,
+) {
+  let inflightRefresh: Promise<string | null> | null = null
+  let reauthTriggered = false
+
+  const refreshTokenOnce = (): Promise<string | null> => {
+    if (inflightRefresh) return inflightRefresh
+    inflightRefresh = getAccessToken({ forceRefresh: true })
+      .catch(() => null)
+      .finally(() => {
+        inflightRefresh = null
+      })
+    return inflightRefresh
   }
 
-  return () => {
-    apiClient.interceptors.request.eject(requestId)
-    if (responseId !== undefined) {
-      apiClient.interceptors.response.eject(responseId)
+  const fireReauth = () => {
+    if (reauthTriggered) return
+    reauthTriggered = true
+    triggerReauth()
+  }
+
+  const requestId = client.interceptors.request.use(async (config) => {
+    try {
+      const token = await getAccessToken()
+      config.headers.Authorization = `Bearer ${token}`
+      return config
+    } catch {
+      fireReauth()
+      throw new axios.Cancel('auth-session-expired')
     }
+  })
+
+  const responseId = client.interceptors.response.use(
+    (response) => response,
+    async (error: AxiosError) => {
+      if (!axios.isAxiosError(error) || error.response?.status !== 401) {
+        return Promise.reject(error)
+      }
+      const original = error.config as RetriableConfig | undefined
+      if (!original || original._retry) {
+        fireReauth()
+        return Promise.reject(error)
+      }
+      original._retry = true
+      const newToken = await refreshTokenOnce()
+      if (!newToken) {
+        fireReauth()
+        return Promise.reject(error)
+      }
+      // The request interceptor will re-fetch the (now cached) fresh token
+      // and attach it on replay. Auth0 SDK guarantees subsequent
+      // getAccessTokenSilently calls return the refreshed token from cache.
+      return client(original)
+    },
+  )
+
+  return () => {
+    client.interceptors.request.eject(requestId)
+    client.interceptors.response.eject(responseId)
   }
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,37 +1,12 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { Auth0Provider } from '@auth0/auth0-react'
-import type { AppState } from '@auth0/auth0-react'
-import { BrowserRouter, useNavigate } from 'react-router-dom'
+import { BrowserRouter } from 'react-router-dom'
+import { Auth0ProviderWithNavigate } from './Auth0ProviderWithNavigate'
 import { MockAuth0Provider } from './test-utils/MockAuth0Provider'
 import './index.css'
 import App from './App'
 
 const isE2ETestMode = import.meta.env.DEV && import.meta.env.VITE_E2E_TEST_MODE === 'true'
-
-function Auth0ProviderWithNavigate({ children }: { children: React.ReactNode }) {
-  const navigate = useNavigate()
-  return (
-    <Auth0Provider
-      domain={import.meta.env.VITE_AUTH0_DOMAIN}
-      clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
-      authorizationParams={{
-        redirect_uri: window.location.origin,
-        audience: import.meta.env.VITE_AUTH0_AUDIENCE,
-      }}
-      cacheLocation="localstorage"
-      onRedirectCallback={(appState?: AppState) => {
-        const target =
-          appState && typeof appState.returnTo === 'string'
-            ? appState.returnTo
-            : window.location.pathname
-        navigate(target, { replace: true })
-      }}
-    >
-      {children}
-    </Auth0Provider>
-  )
-}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -22,6 +22,13 @@ createRoot(document.getElementById('root')!).render(
           audience: import.meta.env.VITE_AUTH0_AUDIENCE,
         }}
         cacheLocation="localstorage"
+        onRedirectCallback={(appState) => {
+          const target =
+            appState && typeof appState.returnTo === 'string'
+              ? appState.returnTo
+              : window.location.pathname
+          window.history.replaceState({}, document.title, target)
+        }}
       >
         <App />
       </Auth0Provider>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,37 +1,52 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { Auth0Provider } from '@auth0/auth0-react'
+import type { AppState } from '@auth0/auth0-react'
+import { BrowserRouter, useNavigate } from 'react-router-dom'
 import { MockAuth0Provider } from './test-utils/MockAuth0Provider'
 import './index.css'
 import App from './App'
 
 const isE2ETestMode = import.meta.env.DEV && import.meta.env.VITE_E2E_TEST_MODE === 'true'
 
+function Auth0ProviderWithNavigate({ children }: { children: React.ReactNode }) {
+  const navigate = useNavigate()
+  return (
+    <Auth0Provider
+      domain={import.meta.env.VITE_AUTH0_DOMAIN}
+      clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
+      authorizationParams={{
+        redirect_uri: window.location.origin,
+        audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+      }}
+      cacheLocation="localstorage"
+      onRedirectCallback={(appState?: AppState) => {
+        const target =
+          appState && typeof appState.returnTo === 'string'
+            ? appState.returnTo
+            : window.location.pathname
+        navigate(target, { replace: true })
+      }}
+    >
+      {children}
+    </Auth0Provider>
+  )
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     {isE2ETestMode ? (
-      <MockAuth0Provider>
-        <App />
-      </MockAuth0Provider>
+      <BrowserRouter>
+        <MockAuth0Provider>
+          <App />
+        </MockAuth0Provider>
+      </BrowserRouter>
     ) : (
-      <Auth0Provider
-        domain={import.meta.env.VITE_AUTH0_DOMAIN}
-        clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
-        authorizationParams={{
-          redirect_uri: window.location.origin,
-          audience: import.meta.env.VITE_AUTH0_AUDIENCE,
-        }}
-        cacheLocation="localstorage"
-        onRedirectCallback={(appState) => {
-          const target =
-            appState && typeof appState.returnTo === 'string'
-              ? appState.returnTo
-              : window.location.pathname
-          window.history.replaceState({}, document.title, target)
-        }}
-      >
-        <App />
-      </Auth0Provider>
+      <BrowserRouter>
+        <Auth0ProviderWithNavigate>
+          <App />
+        </Auth0ProviderWithNavigate>
+      </BrowserRouter>
     )}
   </StrictMode>,
 )


### PR DESCRIPTION
Closes #1117.

## Summary

- `setupAuthInterceptor` in `frontend/src/lib/apiClient.ts` now forces a silent token refresh (`cacheMode: 'off'`) on a 401 and replays the original request once. Concurrent 401s share a single in-flight refresh promise. If the refresh fails (or `getAccessTokenSilently` throws at request time), `triggerReauth` runs `loginWithRedirect` with `appState.returnTo` so the teacher lands back on the same screen.
- `BrowserRouter` is hoisted from `App.tsx` to `main.tsx`, above a new `Auth0ProviderWithNavigate` wrapper. `onRedirectCallback` calls `useNavigate()` (the canonical Auth0 React SDK pattern), which actually advances React Router's history. The previous design used `window.history.replaceState`, which would have changed the URL without notifying the router.
- New `frontend/src/lib/apiClient.test.ts`: 7 unit tests covering happy path, refresh + replay, refresh failure -> reauth, concurrent-401 dedup, retry-loop guard, non-401 passthrough, and request-time token failure.
- Streaming endpoints (`useGenerate.ts`, `streamText.ts`) bypass `apiClient` and are explicitly out of scope; follow-up tracked in #1121.

## Test plan

- [x] Unit: `npx vitest run src/lib/apiClient.test.ts` -- 7/7 pass.
- [x] Full frontend test suite: 1685/1685 pass.
- [x] Type-check + lint clean.
- [x] `task-build-verify.py`: PASS (bicep, dotnet build, dotnet test, npm lint, npm build, npm test all green).
- [x] `qa-verify`: PASS WITH GAPS (only gap is criterion 7 -- distinguishing Auth0-down from session-expired UI copy; issue specifies no required wording, app has no toast infra).
- [x] `architecture-reviewer`: PASS (after restructuring `onRedirectCallback` to use `useNavigate`).
- [x] `review-ui`: PASS (Dashboard, Students, Lessons render normally; no routing regressions from the BrowserRouter hoist).
- [ ] Manual real-browser walkthrough of the four scenarios in #1117 (token expired, refresh-token also dead, backend down, two-tab race) -- requires interactive Auth0 session manipulation; not covered by automated tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic token refresh mechanism for seamless authentication continuity
  * Improved authentication provider with enhanced navigation handling post-login

* **Bug Fixes**
  * Enhanced 401 error recovery with token refresh and automatic request retry
  * Concurrent authentication request deduplication to prevent redundant operations

* **Tests**
  * Added comprehensive test suite for authentication interceptor behavior, including token refresh, error handling, and re-authentication flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->