### PR TITLE
fix(#1123): fix AzureSpeech empty transcript for streaming WAV from pipe

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/AzureSpeechTranscriptionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/AzureSpeechTranscriptionServiceTests.cs
@@ -5,13 +5,15 @@ namespace LangTeach.Api.Tests.Services;
 
 public class AzureSpeechTranscriptionServiceTests
 {
-    // Builds a minimal PCM WAV byte array: 44-byte standard header + pcmLength bytes of zeros.
-    private static byte[] BuildTestWav(int pcmLength)
+    // Builds a minimal PCM WAV byte array: 44-byte standard header + pcmLength bytes.
+    // When zeroChunkSize=true the RIFF and data chunk size fields are written as 0,
+    // mimicking ffmpeg output to a non-seekable pipe.
+    private static byte[] BuildTestWav(int pcmLength, bool zeroChunkSize = false)
     {
         var buf = new byte[44 + pcmLength];
         // RIFF
         "RIFF"u8.CopyTo(buf.AsSpan(0));
-        BitConverter.TryWriteBytes(buf.AsSpan(4), 36 + pcmLength);
+        BitConverter.TryWriteBytes(buf.AsSpan(4), zeroChunkSize ? 0 : 36 + pcmLength);
         "WAVE"u8.CopyTo(buf.AsSpan(8));
         // fmt
         "fmt "u8.CopyTo(buf.AsSpan(12));
@@ -24,7 +26,7 @@ public class AzureSpeechTranscriptionServiceTests
         BitConverter.TryWriteBytes(buf.AsSpan(34), (short)16);  // bits/sample
         // data
         "data"u8.CopyTo(buf.AsSpan(36));
-        BitConverter.TryWriteBytes(buf.AsSpan(40), pcmLength);
+        BitConverter.TryWriteBytes(buf.AsSpan(40), zeroChunkSize ? 0 : pcmLength);
         // PCM payload: sequential bytes so we can verify slicing
         for (var i = 0; i < pcmLength; i++)
             buf[44 + i] = (byte)(i % 251);
@@ -88,6 +90,30 @@ public class AzureSpeechTranscriptionServiceTests
         // PCM content from chunks reconstructs original PCM
         var reconstructed = c1[44..].Concat(c2[44..]).ToArray();
         reconstructed.Should().Equal(sourceBytes[44..]);
+    }
+
+    [Fact]
+    public void ParseWavDataInfo_StreamingWavZeroChunkSize_FallsBackToRemainingBytes()
+    {
+        const int pcmLength = 64_000; // 2 seconds
+        var wavBytes = BuildTestWav(pcmLength, zeroChunkSize: true);
+
+        var (offset, length) = AzureSpeechTranscriptionService.ParseWavDataInfo(wavBytes);
+
+        offset.Should().Be(44);
+        length.Should().Be(pcmLength);
+    }
+
+    [Fact]
+    public void ParseWavDataInfo_ZeroChunkSizeAndNoData_ReturnsZero()
+    {
+        // Genuinely empty: data header present but no PCM bytes follow.
+        var wavBytes = BuildTestWav(0, zeroChunkSize: true);
+
+        var (offset, length) = AzureSpeechTranscriptionService.ParseWavDataInfo(wavBytes);
+
+        offset.Should().Be(44);
+        length.Should().Be(0);
     }
 
     [Fact]

--- a/backend/LangTeach.Api/Services/AzureSpeechTranscriptionService.cs
+++ b/backend/LangTeach.Api/Services/AzureSpeechTranscriptionService.cs
@@ -45,6 +45,11 @@ public class AzureSpeechTranscriptionService(
         var wavBytes = wavStream.ToArray();
         var (dataOffset, dataLength) = ParseWavDataInfo(wavBytes);
 
+        if (dataLength == 0)
+            logger.LogWarning(
+                "WAV data chunk has zero length after parsing — transcription will be empty. FileName={FileName}",
+                fileName);
+
         var totalChunks = (int)Math.Ceiling((double)dataLength / MaxChunkDataBytes);
         logger.LogInformation(
             "Starting transcription. FileName={FileName} Language={Language} WavBytes={Bytes} DurationSeconds={Duration:F1} Chunks={Chunks}",
@@ -118,7 +123,13 @@ public class AzureSpeechTranscriptionService(
             var chunkId = System.Text.Encoding.ASCII.GetString(bytes, pos, 4);
             var chunkSize = BitConverter.ToInt32(bytes, pos + 4);
             if (chunkId == "data")
-                return (pos + 8, chunkSize);
+            {
+                // ffmpeg writing to a non-seekable pipe leaves chunkSize=0 because it cannot
+                // seek back to fill in the size after writing PCM data. Fall back to the
+                // remaining bytes in the buffer, which is the actual PCM payload.
+                var actualLength = chunkSize == 0 ? bytes.Length - (pos + 8) : chunkSize;
+                return (pos + 8, actualLength);
+            }
             pos += 8 + chunkSize;
             if (chunkSize % 2 != 0) pos++; // WAV padding byte
         }


### PR DESCRIPTION
## Summary

- `ParseWavDataInfo` returned `dataLength=0` for any recording because ffmpeg writing to a non-seekable pipe (`pipe:1`) leaves the WAV `data` chunk size field as 0, even though all PCM bytes are present after the header.
- `totalChunks = ceil(0 / MaxChunkDataBytes) = 0`, so the Azure Speech loop never ran and the service silently returned `""`.
- Fix: when `chunkSize == 0` for the `data` chunk, fall back to `bytes.Length - (pos + 8)` (remaining bytes after the header). Normal WAV files with `chunkSize > 0` are unaffected.
- Added a WARN log when `dataLength == 0` after parsing so this failure class can never silently look like a successful empty transcription.
- Added two regression tests: streaming WAV (zero chunk size, real PCM present) and genuinely empty WAV (zero chunk size, no PCM).

Closes #1123. Downstream fix for #1119 (thumbs missing) -- that symptom disappears once the backend returns a non-empty transcript.

## Test plan

- [x] `dotnet test --filter AzureSpeechTranscriptionServiceTests` -- 6 tests pass (4 existing + 2 new)
- [x] Full build verify: bicep, dotnet build, dotnet test (99 tests), npm lint, npm build, npm test -- all green
- [ ] Integration: upload `voice_note_Gergana_20260505_0915.webm` via Atelier Assistant -- API logs show `Chunks >= 1` and `TranscriptLength > 0`, voice flow produces a real transcript, thumbs render next to PROPOSED UPDATES

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of streaming audio input to prevent errors in certain edge cases.
  * Improved robustness when processing audio from non-seekable sources such as pipes and streams.

* **Tests**
  * Expanded test coverage for streaming audio scenarios and edge conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->