### PR TITLE
fix(#1121): streaming endpoints now silent-refresh on 401 (useGenerate + streamText)

### DIFF
--- a/frontend/src/components/lesson/FullLessonGenerateButton.test.tsx
+++ b/frontend/src/components/lesson/FullLessonGenerateButton.test.tsx
@@ -7,8 +7,12 @@ import type { LessonSection } from '../../api/lessons'
 import type { ContentBlockDto } from '../../api/generate'
 
 // Mock Auth0
+const mockLoginWithRedirect = vi.fn().mockResolvedValue(undefined)
 vi.mock('@auth0/auth0-react', () => ({
-  useAuth0: () => ({ getAccessTokenSilently: vi.fn().mockResolvedValue('fake-token') }),
+  useAuth0: () => ({
+    getAccessTokenSilently: vi.fn().mockResolvedValue('fake-token'),
+    loginWithRedirect: mockLoginWithRedirect,
+  }),
 }))
 
 // Mock streamText
@@ -20,6 +24,12 @@ vi.mock('../../lib/streamText', () => ({
       super(message)
       this.name = 'QuotaExceededError'
       this.resetsAt = resetsAt
+    }
+  },
+  AuthExpiredError: class AuthExpiredError extends Error {
+    constructor() {
+      super('Session expired. Please sign in again.')
+      this.name = 'AuthExpiredError'
     }
   },
 }))

--- a/frontend/src/components/lesson/FullLessonGenerateButton.tsx
+++ b/frontend/src/components/lesson/FullLessonGenerateButton.tsx
@@ -12,8 +12,9 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { streamText, QuotaExceededError, AuthExpiredError } from '../../lib/streamText'
-import type { GetAccessToken } from '../../lib/streamText'
+import { streamText, QuotaExceededError } from '../../lib/streamText'
+import { AuthExpiredError, makeRefreshOnce } from '../../lib/authHelpers'
+import type { GetAccessToken } from '../../lib/authHelpers'
 import { saveContentBlock, type ContentBlockDto } from '../../api/generate'
 import { useProfile } from '../../hooks/useProfile'
 import { useQueryClient } from '@tanstack/react-query'
@@ -135,6 +136,17 @@ export function FullLessonGenerateButton({
     const getToken: GetAccessToken = (opts) =>
       getAccessTokenSilently(opts?.forceRefresh ? { cacheMode: 'off' } : undefined)
 
+    // Shared across all parallel section streams: deduplicates concurrent forced-refresh
+    // calls (mirrors inflightRefresh in apiClient.ts). triggerReauth is guarded so
+    // loginWithRedirect fires at most once even when multiple sections get 401 together.
+    const refreshOnce = makeRefreshOnce(getToken)
+    let reauthTriggered = false
+    const triggerReauth = () => {
+      if (reauthTriggered) return
+      reauthTriggered = true
+      loginWithRedirect({ appState: { returnTo: window.location.pathname + window.location.search } }).catch(console.error)
+    }
+
     const errors: string[] = []
 
     const tName = lessonContext.templateName?.toLowerCase() ?? ''
@@ -160,7 +172,9 @@ export function FullLessonGenerateButton({
             sectionType,
           },
           getToken,
+          triggerReauth,
           controller.signal,
+          refreshOnce,
         )
         if (controller.signal.aborted) return
 
@@ -201,7 +215,6 @@ export function FullLessonGenerateButton({
 
     const authFailed = allResults.some(r => r.status === 'rejected' && r.reason instanceof AuthExpiredError)
     if (authFailed) {
-      loginWithRedirect({ appState: { returnTo: window.location.pathname + window.location.search } }).catch(console.error)
       setErrorMessage('Your session has expired. Redirecting to sign in...')
       setPhase('error')
       return

--- a/frontend/src/components/lesson/FullLessonGenerateButton.tsx
+++ b/frontend/src/components/lesson/FullLessonGenerateButton.tsx
@@ -12,7 +12,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { streamText, QuotaExceededError } from '../../lib/streamText'
+import { streamText, QuotaExceededError, AuthExpiredError } from '../../lib/streamText'
+import type { GetAccessToken } from '../../lib/streamText'
 import { saveContentBlock, type ContentBlockDto } from '../../api/generate'
 import { useProfile } from '../../hooks/useProfile'
 import { useQueryClient } from '@tanstack/react-query'
@@ -102,7 +103,7 @@ export function FullLessonGenerateButton({
   lessonContext,
   onBlockSaved,
 }: FullLessonGenerateButtonProps) {
-  const { getAccessTokenSilently } = useAuth0()
+  const { getAccessTokenSilently, loginWithRedirect } = useAuth0()
   const { data: profile } = useProfile()
   const queryClient = useQueryClient()
   const [phase, setPhase] = useState<Phase>('idle')
@@ -129,16 +130,10 @@ export function FullLessonGenerateButton({
     const controller = new AbortController()
     abortRef.current = controller
 
-    let token: string
-    try {
-      token = await getAccessTokenSilently()
-    } catch {
-      if (controller.signal.aborted) return
-      setErrorMessage('Failed to get auth token.')
-      setPhase('error')
-      return
-    }
     if (controller.signal.aborted) return
+
+    const getToken: GetAccessToken = (opts) =>
+      getAccessTokenSilently(opts?.forceRefresh ? { cacheMode: 'off' } : undefined)
 
     const errors: string[] = []
 
@@ -149,7 +144,7 @@ export function FullLessonGenerateButton({
     }
     const taskMap = resolvedMap ?? SECTION_TASK_MAP
 
-    await Promise.allSettled(activeSections.map(async (sectionType) => {
+    const allResults = await Promise.allSettled(activeSections.map(async (sectionType) => {
       const section = sections.find(s => s.sectionType === sectionType)!
       const taskType = taskMap[sectionType]
 
@@ -164,7 +159,7 @@ export function FullLessonGenerateButton({
             studentId: lessonContext.studentId,
             sectionType,
           },
-          token,
+          getToken,
           controller.signal,
         )
         if (controller.signal.aborted) return
@@ -188,6 +183,7 @@ export function FullLessonGenerateButton({
         setSectionStatus(prev => ({ ...prev, [sectionType]: 'done' }))
       } catch (err) {
         if (controller.signal.aborted || (err instanceof DOMException && err.name === 'AbortError')) return
+        if (err instanceof AuthExpiredError) throw err
         if (err instanceof QuotaExceededError) {
           controller.abort()
           setErrorMessage(err.message)
@@ -202,6 +198,14 @@ export function FullLessonGenerateButton({
     }))
 
     if (controller.signal.aborted) return
+
+    const authFailed = allResults.some(r => r.status === 'rejected' && r.reason instanceof AuthExpiredError)
+    if (authFailed) {
+      loginWithRedirect({ appState: { returnTo: window.location.pathname + window.location.search } }).catch(console.error)
+      setErrorMessage('Your session has expired. Redirecting to sign in...')
+      setPhase('error')
+      return
+    }
 
     queryClient.invalidateQueries({ queryKey: ['profile'] })
 

--- a/frontend/src/hooks/useGenerate.test.ts
+++ b/frontend/src/hooks/useGenerate.test.ts
@@ -4,9 +4,13 @@ import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
 import { useGenerate } from './useGenerate'
 
+const mockLoginWithRedirect = vi.fn().mockResolvedValue(undefined)
+const mockGetAccessTokenSilently = vi.fn().mockResolvedValue('test-token')
+
 vi.mock('@auth0/auth0-react', () => ({
   useAuth0: () => ({
-    getAccessTokenSilently: vi.fn().mockResolvedValue('test-token'),
+    getAccessTokenSilently: mockGetAccessTokenSilently,
+    loginWithRedirect: mockLoginWithRedirect,
   }),
 }))
 
@@ -15,7 +19,11 @@ const SSE_URL = 'http://localhost:5000/api/generate/vocabulary/stream'
 const server = setupServer()
 
 beforeAll(() => server.listen())
-afterEach(() => server.resetHandlers())
+afterEach(() => {
+  server.resetHandlers()
+  mockGetAccessTokenSilently.mockResolvedValue('test-token')
+  mockLoginWithRedirect.mockResolvedValue(undefined)
+})
 afterAll(() => server.close())
 
 function makeSseBody(...lines: string[]): ReadableStream<Uint8Array> {
@@ -157,6 +165,53 @@ describe('useGenerate', () => {
 
     expect(result.current.quotaExceeded).toBe(true)
     expect(result.current.error).toContain('Monthly generation limit reached.')
+  })
+
+  it('retries silently on 401 and completes the stream after token refresh', async () => {
+    let requestCount = 0
+    server.use(
+      http.post(SSE_URL, () => {
+        requestCount++
+        if (requestCount === 1) {
+          return new HttpResponse(null, { status: 401 })
+        }
+        const body = makeSseBody('data: "ok"\n\n', 'data: [DONE]\n\n')
+        return new HttpResponse(body, { headers: { 'Content-Type': 'text/event-stream' } })
+      }),
+    )
+    mockGetAccessTokenSilently
+      .mockResolvedValueOnce('expired-token')
+      .mockResolvedValueOnce('fresh-token')
+
+    const { result } = renderHook(() => useGenerate())
+
+    act(() => {
+      result.current.generate('vocabulary', validRequest)
+    })
+
+    await waitFor(() => expect(result.current.status).toBe('done'), { timeout: 3000 })
+
+    expect(result.current.output).toBe('ok')
+    expect(result.current.error).toBeNull()
+    expect(requestCount).toBe(2)
+  })
+
+  it('triggers loginWithRedirect and surfaces error when both 401 attempts fail', async () => {
+    server.use(
+      http.post(SSE_URL, () => new HttpResponse(null, { status: 401 })),
+    )
+    mockGetAccessTokenSilently.mockResolvedValue('always-expired')
+
+    const { result } = renderHook(() => useGenerate())
+
+    act(() => {
+      result.current.generate('vocabulary', validRequest)
+    })
+
+    await waitFor(() => expect(result.current.status).toBe('error'), { timeout: 3000 })
+
+    expect(mockLoginWithRedirect).toHaveBeenCalledTimes(1)
+    expect(result.current.error).toContain('session')
   })
 
   it('aborts the in-flight request when the hook unmounts during streaming', async () => {

--- a/frontend/src/hooks/useGenerate.ts
+++ b/frontend/src/hooks/useGenerate.ts
@@ -1,11 +1,13 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { useAuth0 } from '@auth0/auth0-react'
+import { fetchWithAuthRetry, AuthExpiredError } from '../lib/authHelpers'
+import type { GetAccessToken } from '../lib/authHelpers'
 import type { GenerateRequest, GenerateStatus } from '../api/generate'
 
 const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:5000'
 
 export function useGenerate() {
-  const { getAccessTokenSilently } = useAuth0()
+  const { getAccessTokenSilently, loginWithRedirect } = useAuth0()
   const [status, setStatus] = useState<GenerateStatus>('idle')
   const [output, setOutput] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -34,19 +36,19 @@ export function useGenerate() {
       setError(null)
       setQuotaExceeded(false)
 
+      const getToken: GetAccessToken = (opts) =>
+        getAccessTokenSilently(opts?.forceRefresh ? { cacheMode: 'off' } : undefined)
+
       try {
-        const token = await getAccessTokenSilently()
-        const response = await fetch(
+        const response = await fetchWithAuthRetry(
           `${BASE_URL}/api/generate/${taskType}/stream`,
           {
             method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${token}`,
-            },
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(request),
             signal: controller.signal,
           },
+          getToken,
         )
 
         if (response.status === 429) {
@@ -119,13 +121,17 @@ export function useGenerate() {
       } catch (err) {
         if (err instanceof DOMException && err.name === 'AbortError') {
           setStatus('idle')
+        } else if (err instanceof AuthExpiredError) {
+          loginWithRedirect({ appState: { returnTo: window.location.pathname + window.location.search } }).catch(console.error)
+          setError('Your session has expired. Redirecting to sign in...')
+          setStatus('error')
         } else {
           setError(err instanceof Error ? err.message : 'Unknown error')
           setStatus('error')
         }
       }
     },
-    [getAccessTokenSilently],
+    [getAccessTokenSilently, loginWithRedirect],
   )
 
   return { status, output, error, quotaExceeded, generate, abort }

--- a/frontend/src/hooks/useGenerate.ts
+++ b/frontend/src/hooks/useGenerate.ts
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { useAuth0 } from '@auth0/auth0-react'
-import { fetchWithAuthRetry, AuthExpiredError } from '../lib/authHelpers'
+import { fetchWithAuthRetry, makeRefreshOnce, AuthExpiredError } from '../lib/authHelpers'
 import type { GetAccessToken } from '../lib/authHelpers'
 import type { GenerateRequest, GenerateStatus } from '../api/generate'
 
@@ -39,6 +39,12 @@ export function useGenerate() {
       const getToken: GetAccessToken = (opts) =>
         getAccessTokenSilently(opts?.forceRefresh ? { cacheMode: 'off' } : undefined)
 
+      const triggerReauth = () => {
+        loginWithRedirect({ appState: { returnTo: window.location.pathname + window.location.search } }).catch(console.error)
+      }
+
+      const refreshOnce = makeRefreshOnce(getToken)
+
       try {
         const response = await fetchWithAuthRetry(
           `${BASE_URL}/api/generate/${taskType}/stream`,
@@ -49,6 +55,8 @@ export function useGenerate() {
             signal: controller.signal,
           },
           getToken,
+          triggerReauth,
+          refreshOnce,
         )
 
         if (response.status === 429) {
@@ -122,7 +130,6 @@ export function useGenerate() {
         if (err instanceof DOMException && err.name === 'AbortError') {
           setStatus('idle')
         } else if (err instanceof AuthExpiredError) {
-          loginWithRedirect({ appState: { returnTo: window.location.pathname + window.location.search } }).catch(console.error)
           setError('Your session has expired. Redirecting to sign in...')
           setStatus('error')
         } else {

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,15 +1,12 @@
 import axios, { AxiosError } from 'axios'
 import type { AxiosInstance, InternalAxiosRequestConfig } from 'axios'
+import type { GetAccessToken, GetAccessTokenOptions } from './authHelpers'
+
+export type { GetAccessToken, GetAccessTokenOptions }
 
 export const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:5000',
 })
-
-export interface GetAccessTokenOptions {
-  forceRefresh?: boolean
-}
-
-export type GetAccessToken = (opts?: GetAccessTokenOptions) => Promise<string>
 
 type RetriableConfig = InternalAxiosRequestConfig & { _retry?: boolean }
 

--- a/frontend/src/lib/authHelpers.test.ts
+++ b/frontend/src/lib/authHelpers.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fetchWithAuthRetry, makeRefreshOnce, AuthExpiredError } from './authHelpers'
+import type { GetAccessToken } from './authHelpers'
+
+function makeResponse(status: number, body: string | null = null): Response {
+  return new Response(body, { status })
+}
+
+describe('makeRefreshOnce', () => {
+  it('deduplicates concurrent forced-refresh calls into a single promise', async () => {
+    let callCount = 0
+    const getAccessToken: GetAccessToken = vi.fn().mockImplementation(async () => {
+      callCount++
+      return 'fresh-token'
+    })
+
+    const refreshOnce = makeRefreshOnce(getAccessToken)
+    const [r1, r2, r3] = await Promise.all([refreshOnce(), refreshOnce(), refreshOnce()])
+
+    expect(callCount).toBe(1)
+    expect(r1).toBe('fresh-token')
+    expect(r2).toBe('fresh-token')
+    expect(r3).toBe('fresh-token')
+  })
+
+  it('resets inflight after completion so a second call works', async () => {
+    let callCount = 0
+    const getAccessToken: GetAccessToken = vi.fn().mockImplementation(async () => {
+      callCount++
+      return `token-${callCount}`
+    })
+
+    const refreshOnce = makeRefreshOnce(getAccessToken)
+    await refreshOnce()
+    await refreshOnce()
+
+    expect(callCount).toBe(2)
+  })
+
+  it('returns null and resets when getAccessToken throws', async () => {
+    const getAccessToken: GetAccessToken = vi.fn().mockRejectedValue(new Error('network error'))
+    const refreshOnce = makeRefreshOnce(getAccessToken)
+
+    const result = await refreshOnce()
+    expect(result).toBeNull()
+    // Should allow a fresh attempt after failure
+    const result2 = await refreshOnce()
+    expect(result2).toBeNull()
+  })
+})
+
+describe('fetchWithAuthRetry', () => {
+  let getAccessToken: GetAccessToken
+  let triggerReauth: () => void
+  let refreshOnce: () => Promise<string | null>
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    getAccessToken = vi.fn().mockResolvedValue('initial-token')
+    triggerReauth = vi.fn()
+    refreshOnce = vi.fn().mockResolvedValue('refreshed-token')
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+
+  it('attaches bearer token and returns response on success', async () => {
+    fetchSpy.mockResolvedValue(makeResponse(200, 'ok'))
+
+    const response = await fetchWithAuthRetry('/api/test', { method: 'GET' }, getAccessToken, triggerReauth, refreshOnce)
+
+    expect(response.status).toBe(200)
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    const callArgs = fetchSpy.mock.calls[0][1]
+    expect(callArgs.headers.Authorization).toBe('Bearer initial-token')
+    expect(triggerReauth).not.toHaveBeenCalled()
+  })
+
+  it('retries with refreshed token after 401 and returns success', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(makeResponse(401))
+      .mockResolvedValueOnce(makeResponse(200, 'ok'))
+
+    const response = await fetchWithAuthRetry('/api/test', { method: 'GET' }, getAccessToken, triggerReauth, refreshOnce)
+
+    expect(response.status).toBe(200)
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    expect(refreshOnce).toHaveBeenCalledOnce()
+    const retryArgs = fetchSpy.mock.calls[1][1]
+    expect(retryArgs.headers.Authorization).toBe('Bearer refreshed-token')
+    expect(triggerReauth).not.toHaveBeenCalled()
+  })
+
+  it('calls triggerReauth and throws AuthExpiredError when refresh returns null', async () => {
+    fetchSpy.mockResolvedValue(makeResponse(401))
+    refreshOnce = vi.fn().mockResolvedValue(null)
+
+    await expect(
+      fetchWithAuthRetry('/api/test', { method: 'GET' }, getAccessToken, triggerReauth, refreshOnce),
+    ).rejects.toBeInstanceOf(AuthExpiredError)
+    expect(triggerReauth).toHaveBeenCalledOnce()
+  })
+
+  it('calls triggerReauth and throws AuthExpiredError when retry also returns 401', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(makeResponse(401))
+      .mockResolvedValueOnce(makeResponse(401))
+
+    await expect(
+      fetchWithAuthRetry('/api/test', { method: 'GET' }, getAccessToken, triggerReauth, refreshOnce),
+    ).rejects.toBeInstanceOf(AuthExpiredError)
+    expect(triggerReauth).toHaveBeenCalledOnce()
+  })
+
+  it('preserves init fields (signal, body) on the retry request', async () => {
+    const controller = new AbortController()
+    fetchSpy
+      .mockResolvedValueOnce(makeResponse(401))
+      .mockResolvedValueOnce(makeResponse(200))
+
+    await fetchWithAuthRetry(
+      '/api/test',
+      { method: 'POST', body: '{"x":1}', signal: controller.signal },
+      getAccessToken,
+      triggerReauth,
+      refreshOnce,
+    )
+
+    const retryArgs = fetchSpy.mock.calls[1][1]
+    expect(retryArgs.body).toBe('{"x":1}')
+    expect(retryArgs.signal).toBe(controller.signal)
+  })
+
+  it('does not retry non-401 errors', async () => {
+    fetchSpy.mockResolvedValue(makeResponse(503))
+
+    const response = await fetchWithAuthRetry('/api/test', { method: 'GET' }, getAccessToken, triggerReauth, refreshOnce)
+
+    expect(response.status).toBe(503)
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    expect(refreshOnce).not.toHaveBeenCalled()
+    expect(triggerReauth).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/authHelpers.ts
+++ b/frontend/src/lib/authHelpers.ts
@@ -11,10 +11,29 @@ export class AuthExpiredError extends Error {
   }
 }
 
+// Returns a refresh-once function that coalesces concurrent forced-refresh calls,
+// mirroring the inflightRefresh pattern in apiClient.ts's setupAuthInterceptor.
+export function makeRefreshOnce(getAccessToken: GetAccessToken): () => Promise<string | null> {
+  let inflight: Promise<string | null> | null = null
+  return () => {
+    if (inflight) return inflight
+    inflight = getAccessToken({ forceRefresh: true })
+      .catch(() => null)
+      .finally(() => { inflight = null })
+    return inflight
+  }
+}
+
+// Mirrors the triggerReauth callback pattern from setupAuthInterceptor in apiClient.ts.
+// Fetches with bearer token from getAccessToken, detects 401, silently refreshes via
+// refreshOnce and replays once. On second 401 or refresh failure: calls triggerReauth()
+// then throws AuthExpiredError.
 export async function fetchWithAuthRetry(
   input: RequestInfo | URL,
   init: RequestInit,
   getAccessToken: GetAccessToken,
+  triggerReauth: () => void,
+  refreshOnce: () => Promise<string | null>,
 ): Promise<Response> {
   const token = await getAccessToken()
   const response = await fetch(input, {
@@ -24,14 +43,20 @@ export async function fetchWithAuthRetry(
 
   if (response.status !== 401) return response
 
-  const newToken = await getAccessToken({ forceRefresh: true }).catch(() => null)
-  if (!newToken) throw new AuthExpiredError()
+  const newToken = await refreshOnce()
+  if (!newToken) {
+    triggerReauth()
+    throw new AuthExpiredError()
+  }
 
   const retryResponse = await fetch(input, {
     ...init,
     headers: { ...(init.headers as Record<string, string>), Authorization: `Bearer ${newToken}` },
   })
-  if (retryResponse.status === 401) throw new AuthExpiredError()
+  if (retryResponse.status === 401) {
+    triggerReauth()
+    throw new AuthExpiredError()
+  }
 
   return retryResponse
 }

--- a/frontend/src/lib/authHelpers.ts
+++ b/frontend/src/lib/authHelpers.ts
@@ -1,0 +1,37 @@
+export interface GetAccessTokenOptions {
+  forceRefresh?: boolean
+}
+
+export type GetAccessToken = (opts?: GetAccessTokenOptions) => Promise<string>
+
+export class AuthExpiredError extends Error {
+  constructor() {
+    super('Session expired. Please sign in again.')
+    this.name = 'AuthExpiredError'
+  }
+}
+
+export async function fetchWithAuthRetry(
+  input: RequestInfo | URL,
+  init: RequestInit,
+  getAccessToken: GetAccessToken,
+): Promise<Response> {
+  const token = await getAccessToken()
+  const response = await fetch(input, {
+    ...init,
+    headers: { ...(init.headers as Record<string, string>), Authorization: `Bearer ${token}` },
+  })
+
+  if (response.status !== 401) return response
+
+  const newToken = await getAccessToken({ forceRefresh: true }).catch(() => null)
+  if (!newToken) throw new AuthExpiredError()
+
+  const retryResponse = await fetch(input, {
+    ...init,
+    headers: { ...(init.headers as Record<string, string>), Authorization: `Bearer ${newToken}` },
+  })
+  if (retryResponse.status === 401) throw new AuthExpiredError()
+
+  return retryResponse
+}

--- a/frontend/src/lib/streamText.ts
+++ b/frontend/src/lib/streamText.ts
@@ -1,3 +1,9 @@
+import { fetchWithAuthRetry } from './authHelpers'
+import type { GetAccessToken } from './authHelpers'
+
+export type { GetAccessToken }
+export { AuthExpiredError } from './authHelpers'
+
 const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:5000'
 
 export class QuotaExceededError extends Error {
@@ -10,26 +16,22 @@ export class QuotaExceededError extends Error {
   }
 }
 
-/**
- * Streams an SSE generation endpoint and returns the full accumulated text.
- * Throws on non-2xx responses or stream errors.
- * Throws QuotaExceededError on 429 (quota exhausted).
- */
 export async function streamText(
   taskType: string,
   body: object,
-  token: string,
+  getAccessToken: GetAccessToken,
   signal?: AbortSignal,
 ): Promise<string> {
-  const response = await fetch(`${BASE_URL}/api/generate/${taskType}/stream`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
+  const response = await fetchWithAuthRetry(
+    `${BASE_URL}/api/generate/${taskType}/stream`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal,
     },
-    body: JSON.stringify(body),
-    signal,
-  })
+    getAccessToken,
+  )
 
   if (response.status === 429) {
     let resetsAt = ''

--- a/frontend/src/lib/streamText.ts
+++ b/frontend/src/lib/streamText.ts
@@ -1,8 +1,5 @@
-import { fetchWithAuthRetry } from './authHelpers'
+import { fetchWithAuthRetry, makeRefreshOnce } from './authHelpers'
 import type { GetAccessToken } from './authHelpers'
-
-export type { GetAccessToken }
-export { AuthExpiredError } from './authHelpers'
 
 const BASE_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:5000'
 
@@ -16,11 +13,15 @@ export class QuotaExceededError extends Error {
   }
 }
 
+// refreshOnce is optional: pass a shared instance when calling in parallel to
+// deduplicate concurrent forced-refresh calls across streams (mirrors apiClient.ts).
 export async function streamText(
   taskType: string,
   body: object,
   getAccessToken: GetAccessToken,
+  triggerReauth: () => void,
   signal?: AbortSignal,
+  refreshOnce?: () => Promise<string | null>,
 ): Promise<string> {
   const response = await fetchWithAuthRetry(
     `${BASE_URL}/api/generate/${taskType}/stream`,
@@ -31,6 +32,8 @@ export async function streamText(
       signal,
     },
     getAccessToken,
+    triggerReauth,
+    refreshOnce ?? makeRefreshOnce(getAccessToken),
   )
 
   if (response.status === 429) {


### PR DESCRIPTION
Fixes #1121.

## Summary

- Extracted `fetchWithAuthRetry` and `makeRefreshOnce` into `frontend/src/lib/authHelpers.ts`, mirroring the `refreshTokenOnce` + `triggerReauth` pattern already in `apiClient.ts`'s `setupAuthInterceptor`
- `useGenerate.ts`: replaced the raw `fetch` path with `fetchWithAuthRetry`; threads a `triggerReauth` callback that calls `loginWithRedirect`; silent refresh happens transparently on 401
- `streamText.ts`: replaced the raw `fetch` path with `fetchWithAuthRetry`; accepts `getAccessToken`, `triggerReauth`, and an optional shared `refreshOnce` instance
- `FullLessonGenerateButton.tsx`: creates a guarded `triggerReauth` (at most one `loginWithRedirect` across parallel section streams) and a single `makeRefreshOnce` instance shared across all sections in `Promise.allSettled`
- `apiClient.ts`: now imports and re-exports `GetAccessToken`/`GetAccessTokenOptions` from `authHelpers.ts` (no behavior change)

## Test plan

- [ ] `frontend/src/lib/authHelpers.test.ts` (new, 9 tests): covers `makeRefreshOnce` deduplication, `fetchWithAuthRetry` happy path, 401+refresh+replay, refresh-failure->triggerReauth, second-401->triggerReauth, signal/body preservation on retry
- [ ] `frontend/src/hooks/useGenerate.test.ts` (+2 tests): 401 silently retried with fresh token; double-401 calls `loginWithRedirect` and sets error state
- [ ] `frontend/src/components/lesson/FullLessonGenerateButton.test.tsx` (+AuthExpiredError in mock): existing 17 tests still pass
- [ ] Build verify: all 100 test files pass (1687 tests), lint clean, production build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented automatic token refresh during lesson generation to handle expired sessions
  * Added session expiration detection that redirects users to sign-in when needed
  * Improved error messages for authentication-related failures

* **Tests**
  * Added comprehensive test coverage for token refresh retry flows and session expiration scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->