### PR TITLE
fix(#1123): handle 0xFFFFFFFF pipe sentinel in ParseWavDataInfo

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/AzureSpeechTranscriptionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/AzureSpeechTranscriptionServiceTests.cs
@@ -6,14 +6,14 @@ namespace LangTeach.Api.Tests.Services;
 public class AzureSpeechTranscriptionServiceTests
 {
     // Builds a minimal PCM WAV byte array: 44-byte standard header + pcmLength bytes.
-    // When zeroChunkSize=true the RIFF and data chunk size fields are written as 0,
-    // mimicking ffmpeg output to a non-seekable pipe.
-    private static byte[] BuildTestWav(int pcmLength, bool zeroChunkSize = false)
+    // dataChunkSize overrides the value written into the data chunk size field;
+    // pass 0 or -1 (0xFFFFFFFF) to simulate ffmpeg pipe-mode sentinels.
+    private static byte[] BuildTestWav(int pcmLength, int? dataChunkSize = null)
     {
         var buf = new byte[44 + pcmLength];
         // RIFF
         "RIFF"u8.CopyTo(buf.AsSpan(0));
-        BitConverter.TryWriteBytes(buf.AsSpan(4), zeroChunkSize ? 0 : 36 + pcmLength);
+        BitConverter.TryWriteBytes(buf.AsSpan(4), 36 + pcmLength);
         "WAVE"u8.CopyTo(buf.AsSpan(8));
         // fmt
         "fmt "u8.CopyTo(buf.AsSpan(12));
@@ -26,7 +26,7 @@ public class AzureSpeechTranscriptionServiceTests
         BitConverter.TryWriteBytes(buf.AsSpan(34), (short)16);  // bits/sample
         // data
         "data"u8.CopyTo(buf.AsSpan(36));
-        BitConverter.TryWriteBytes(buf.AsSpan(40), zeroChunkSize ? 0 : pcmLength);
+        BitConverter.TryWriteBytes(buf.AsSpan(40), dataChunkSize ?? pcmLength);
         // PCM payload: sequential bytes so we can verify slicing
         for (var i = 0; i < pcmLength; i++)
             buf[44 + i] = (byte)(i % 251);
@@ -95,8 +95,22 @@ public class AzureSpeechTranscriptionServiceTests
     [Fact]
     public void ParseWavDataInfo_StreamingWavZeroChunkSize_FallsBackToRemainingBytes()
     {
+        // ffmpeg pipe sentinel: chunkSize written as 0
         const int pcmLength = 64_000; // 2 seconds
-        var wavBytes = BuildTestWav(pcmLength, zeroChunkSize: true);
+        var wavBytes = BuildTestWav(pcmLength, dataChunkSize: 0);
+
+        var (offset, length) = AzureSpeechTranscriptionService.ParseWavDataInfo(wavBytes);
+
+        offset.Should().Be(44);
+        length.Should().Be(pcmLength);
+    }
+
+    [Fact]
+    public void ParseWavDataInfo_StreamingWavNegativeOneChunkSize_FallsBackToRemainingBytes()
+    {
+        // ffmpeg pipe sentinel: chunkSize written as 0xFFFFFFFF (-1 as Int32)
+        const int pcmLength = 64_000; // 2 seconds
+        var wavBytes = BuildTestWav(pcmLength, dataChunkSize: -1);
 
         var (offset, length) = AzureSpeechTranscriptionService.ParseWavDataInfo(wavBytes);
 
@@ -108,7 +122,7 @@ public class AzureSpeechTranscriptionServiceTests
     public void ParseWavDataInfo_ZeroChunkSizeAndNoData_ReturnsZero()
     {
         // Genuinely empty: data header present but no PCM bytes follow.
-        var wavBytes = BuildTestWav(0, zeroChunkSize: true);
+        var wavBytes = BuildTestWav(0, dataChunkSize: 0);
 
         var (offset, length) = AzureSpeechTranscriptionService.ParseWavDataInfo(wavBytes);
 

--- a/backend/LangTeach.Api/Services/AzureSpeechTranscriptionService.cs
+++ b/backend/LangTeach.Api/Services/AzureSpeechTranscriptionService.cs
@@ -124,10 +124,12 @@ public class AzureSpeechTranscriptionService(
             var chunkSize = BitConverter.ToInt32(bytes, pos + 4);
             if (chunkId == "data")
             {
-                // ffmpeg writing to a non-seekable pipe leaves chunkSize=0 because it cannot
-                // seek back to fill in the size after writing PCM data. Fall back to the
-                // remaining bytes in the buffer, which is the actual PCM payload.
-                var actualLength = chunkSize == 0 ? bytes.Length - (pos + 8) : chunkSize;
+                // ffmpeg writing to a non-seekable pipe emits chunkSize=0 or 0xFFFFFFFF (-1 as
+                // Int32) because it cannot seek back to fill in the size. Fall back to the
+                // remaining bytes in the buffer (the actual PCM payload) in both cases, and
+                // also whenever the declared size exceeds what is actually in the buffer.
+                var remaining = bytes.Length - (pos + 8);
+                var actualLength = (chunkSize <= 0 || chunkSize > remaining) ? remaining : chunkSize;
                 return (pos + 8, actualLength);
             }
             pos += 8 + chunkSize;


### PR DESCRIPTION
Fixes #1123 (second attempt — first fix #1124 only handled chunkSize==0).

## Root cause

ffmpeg writing WAV to a non-seekable pipe emits **either** `chunkSize=0` (size unknown, zero-filled) **or** `chunkSize=0xFFFFFFFF` (`-1` as `Int32`, the RIFF sentinel for streaming). The first fix guarded only `== 0`; `-1` bypassed it, giving `dataLength = -1`, `totalChunks = 0`, and an empty transcript.

## Fix

`AzureSpeechTranscriptionService.cs:130` — broadened guard to `(chunkSize <= 0 || chunkSize > remaining)`:

```csharp
var remaining = bytes.Length - (pos + 8);
var actualLength = (chunkSize <= 0 || chunkSize > remaining) ? remaining : chunkSize;
```

This covers both pipe sentinels and any out-of-bounds declared size.

## Verification

**Unit tests** — 7 pass, including new regression test for `-1` sentinel:
- `ParseWavDataInfo_StreamingWavNegativeOneChunkSize_FallsBackToRemainingBytes` (new)
- `ParseWavDataInfo_StreamingWavZeroChunkSize_FallsBackToRemainingBytes` (existing)

**End-to-end API log** from uploading `voice_note_Gergana_20260505_0915.webm`:
```
Starting transcription. FileName=voice_note_Gergana_20260505_0915.webm Language=es-ES WavBytes=3569358 DurationSeconds=111.5 Chunks=3
Transcription complete. Chunks=3 TranscriptLength=799
```
`Chunks=3` and `TranscriptLength=799` — before this fix the same file produced `Chunks=0 TranscriptLength=0`.

Real transcript excerpt: *"En la clase de hoy de las 10:00 H de la mañana. Hemos trabajado. Las descripciones..."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio transcription reliability when using streaming sources like ffmpeg pipes by enhancing how audio data chunk sizes are parsed and processed. The system now properly handles edge cases and incomplete information by intelligently falling back to available remaining bytes, ensuring consistent and accurate transcription across all input sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->