### PR TITLE
fix(#1091): align keyvault softDeleteRetentionInDays to live value (7d)

### DIFF
--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -24,7 +24,7 @@ resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
     tenantId: subscription().tenantId
     enableRbacAuthorization: true
     enableSoftDelete: true
-    softDeleteRetentionInDays: 90  // extended to 90d; purge protection makes this the minimum recovery window
+    softDeleteRetentionInDays: 7  // matches the live vault; immutable once set, so this must equal the provisioned value (7 is the Azure minimum)
     enablePurgeProtection: true    // irreversible once set — vault cannot be purged within retention window
   }
 }


### PR DESCRIPTION
## Summary
- The live KV `kv-lt-dev-5ba22u` was provisioned with `softDeleteRetentionInDays: 7`, but `infra/modules/keyvault.bicep` declared `90`. The property is immutable in Azure, so any redeploy of `rg-langteach-dev` was failing with `BadRequest: The property "softDeleteRetentionInDays" has been set already and it can't be modified`.
- This PR aligns bicep to the live (immutable) value so future infra deploys go through cleanly. No live resource changes; bicep just stops disagreeing with what Azure already has.

## Test plan
- [x] `bicep build` clean
- [x] `dotnet build` / `dotnet test` clean
- [x] frontend lint / build / test clean (100 files / 1696 tests)
- [ ] Post-merge: next `merge-sprint-to-main` deploy succeeds (was previously failing on this property)
- [ ] Verify in Azure portal that `kv-lt-dev-5ba22u` retention is still `7` (no recreate)

Closes #1091

🤖 Generated with [Claude Code](https://claude.com/claude-code)