### PR TITLE
fix(#1134): surface mid-stream chunk rejections as [unintelligible] in transcript

### DIFF
--- a/backend/LangTeach.Api/Services/AzureSpeechTranscriptionService.cs
+++ b/backend/LangTeach.Api/Services/AzureSpeechTranscriptionService.cs
@@ -26,6 +26,10 @@ public class AzureSpeechTranscriptionService(
     private const int MaxChunkSeconds = 55;
     internal const int MaxChunkDataBytes = MaxChunkSeconds * BytesPerSecond; // 1 760 000
 
+    // Placed in the transcript where Azure Speech rejects a chunk (InitialSilenceTimeout / NoMatch).
+    // Downstream consumers that need to detect or filter this value should reference this constant.
+    internal const string UnintelligibleMarker = UnintelligibleMarker;
+
     // Safety cap: full WAV in memory must not exceed 300 MB (~156 minutes of recording).
     // The upstream VoiceNoteService already rejects uploads over 50 MB (compressed),
     // which decompresses to well under this limit.
@@ -71,7 +75,7 @@ public class AzureSpeechTranscriptionService(
         }
 
         var joined = string.Join(" ", results.Where(r => !string.IsNullOrWhiteSpace(r)));
-        var unintelligibleCount = results.Count(r => r == "[unintelligible]");
+        var unintelligibleCount = results.Count(r => r == UnintelligibleMarker);
         if (unintelligibleCount > 0)
             logger.LogWarning(
                 "Transcription complete with {Unintelligible} unintelligible chunk(s). Chunks={Chunks} TranscriptLength={Length}",
@@ -103,7 +107,7 @@ public class AzureSpeechTranscriptionService(
             logger.LogWarning(
                 "Azure Speech chunk rejected — audio will appear as [unintelligible] in transcript. Chunk={Chunk} StartSec={Start:F1} EndSec={End:F1} Status={Status}",
                 chunkIndex, startSec, endSec, status);
-            return "[unintelligible]";
+            return UnintelligibleMarker;
         }
 
         if (status != "Success")

--- a/backend/LangTeach.Api/Services/AzureSpeechTranscriptionService.cs
+++ b/backend/LangTeach.Api/Services/AzureSpeechTranscriptionService.cs
@@ -62,19 +62,26 @@ public class AzureSpeechTranscriptionService(
         {
             var chunkOffset = i * MaxChunkDataBytes;
             var chunkLength = Math.Min(MaxChunkDataBytes, dataLength - chunkOffset);
+            var chunkStartSec = (double)chunkOffset / BytesPerSecond;
+            var chunkEndSec = (double)(chunkOffset + chunkLength) / BytesPerSecond;
             var chunkStream = BuildWavChunk(wavBytes, dataOffset + chunkOffset, chunkLength);
 
-            var text = await TranscribeChunkAsync(client, url, chunkStream, ct);
-            if (!string.IsNullOrWhiteSpace(text))
-                results.Add(text);
+            var text = await TranscribeChunkAsync(client, url, chunkStream, i, chunkStartSec, chunkEndSec, ct);
+            results.Add(text);
         }
 
-        var joined = string.Join(" ", results);
-        logger.LogInformation("Transcription complete. Chunks={Chunks} TranscriptLength={Length}", totalChunks, joined.Length);
+        var joined = string.Join(" ", results.Where(r => !string.IsNullOrWhiteSpace(r)));
+        var unintelligibleCount = results.Count(r => r == "[unintelligible]");
+        if (unintelligibleCount > 0)
+            logger.LogWarning(
+                "Transcription complete with {Unintelligible} unintelligible chunk(s). Chunks={Chunks} TranscriptLength={Length}",
+                unintelligibleCount, totalChunks, joined.Length);
+        else
+            logger.LogInformation("Transcription complete. Chunks={Chunks} TranscriptLength={Length}", totalChunks, joined.Length);
         return joined;
     }
 
-    private async Task<string> TranscribeChunkAsync(HttpClient client, string url, MemoryStream chunkStream, CancellationToken ct)
+    private async Task<string> TranscribeChunkAsync(HttpClient client, string url, MemoryStream chunkStream, int chunkIndex, double startSec, double endSec, CancellationToken ct)
     {
         var content = new StreamContent(chunkStream);
         content.Headers.ContentType = new MediaTypeHeaderValue("audio/wav");
@@ -93,8 +100,10 @@ public class AzureSpeechTranscriptionService(
         var status = doc.RootElement.TryGetProperty("RecognitionStatus", out var s) ? s.GetString() : null;
         if (status == "InitialSilenceTimeout" || status == "NoMatch")
         {
-            logger.LogWarning("Azure Speech chunk returned silent/no-match status. Status={Status}", status);
-            return string.Empty;
+            logger.LogWarning(
+                "Azure Speech chunk rejected — audio will appear as [unintelligible] in transcript. Chunk={Chunk} StartSec={Start:F1} EndSec={End:F1} Status={Status}",
+                chunkIndex, startSec, endSec, status);
+            return "[unintelligible]";
         }
 
         if (status != "Success")

--- a/backend/LangTeach.Api/Services/AzureSpeechTranscriptionService.cs
+++ b/backend/LangTeach.Api/Services/AzureSpeechTranscriptionService.cs
@@ -28,7 +28,7 @@ public class AzureSpeechTranscriptionService(
 
     // Placed in the transcript where Azure Speech rejects a chunk (InitialSilenceTimeout / NoMatch).
     // Downstream consumers that need to detect or filter this value should reference this constant.
-    internal const string UnintelligibleMarker = UnintelligibleMarker;
+    internal const string UnintelligibleMarker = "[unintelligible]";
 
     // Safety cap: full WAV in memory must not exceed 300 MB (~156 minutes of recording).
     // The upstream VoiceNoteService already rejects uploads over 50 MB (compressed),

--- a/plan/sprints/unified-voice-chat-test-corpus.md
+++ b/plan/sprints/unified-voice-chat-test-corpus.md
@@ -482,7 +482,9 @@ These cases exercise the `newSession` proposal type. The teacher dictates a futu
 
 ### TC-35-jordi-gergana-descripciones — Real voice note (Jordi → Gergana, 2026-05-05) [#1110 ground truth]
 
-> "En la clase de hoy de las 10:00 H de la mañana. Hemos trabajado. Las descripciones de hemos seguido trabajando mi barrio, hemos trabajado mi barrio. Concretamente hemos hecho lo que está en la pizarra del 30 de abril. Que es relacionar los lugares. Relacionar los adjetivos. Vale y la página 104. Que es la de un barrio típico. Y relacionar los diferentes sitios que hay en el en el barrio y lo ha hecho muy bien para la clase de mañana día 6. Tenemos que. Continuar con la pizarra del día."
+> "En la clase de hoy de las 10:00 H de la mañana. Hemos trabajado. Las descripciones de hemos seguido trabajando mi barrio, hemos trabajado mi barrio. Concretamente hemos hecho lo que está en la pizarra del 30 de abril. Que es relacionar los lugares. Relacionar los adjetivos. Vale y la página 104. Que es la de un barrio típico. Y relacionar los diferentes sitios que hay en el en el barrio y lo ha hecho muy bien para la clase de mañana día 6. Tenemos que. Continuar con la pizarra del día. [unintelligible] atenta con el muy bastante algunos, etcétera"
+
+**Note (#1134):** The audio continues past "Continuar con la pizarra del día." with content that Azure Speech rejected (likely a pause at a 55-second chunk boundary causing InitialSilenceTimeout). Before #1134, the rejected chunk was silently dropped and "atenta" stitched directly after "del día", producing an apparent hallucination. After the #1134 fix, rejected chunks surface as `[unintelligible]` in the transcript. The above transcript reflects the expected post-fix output. Pending in-browser re-verification by Jordi (acceptance criterion 4 of #1134).
 
 **Context:** Panel open on Gergana's session log for today (2026-05-05, open session in scope). Original failure case for #1110.
 


### PR DESCRIPTION
## Summary

- When Azure Speech returns `InitialSilenceTimeout` or `NoMatch` for a 55-second chunk (e.g. the teacher paused just as a chunk boundary hit), the chunk was previously silently dropped and adjacent results joined without any gap marker. The output looked like hallucinated text -- words from before the dropped segment appeared directly next to words from after it.
- `TranscribeChunkAsync` now returns `UnintelligibleMarker` (`"[unintelligible]"`) for rejected chunks instead of `string.Empty`, making the gap visible in the transcript.
- A `LogWarning` with chunk index, start/end seconds, and Azure status is emitted for each rejection, enabling precise diagnosis from application logs.
- `UnintelligibleMarker` extracted as an `internal const` so downstream consumers can reference it by name rather than matching a magic string.
- TC-35 ground-truth transcript updated to reflect the expected post-fix shape (pending in-browser re-verification by Jordi per AC 4).

## Test plan

- [x] All 1274 unit tests pass (`AzureSpeechTranscriptionServiceTests` covers WAV parsing, chunk slicing, and round-trip fidelity)
- [x] Build verify: bicep, dotnet build, dotnet test, npm lint, npm build, npm test all PASS
- [x] Architecture review: PASS WITH NOTES (addressed -- constant extracted)
- [x] QA verify: PASS WITH GAPS (AC 4 is runtime-only -- Jordi must re-process the Gergana 2026-05-05 file in-browser and confirm the transcript is now complete or shows `[unintelligible]` where the gap was)
- [ ] In-browser verification pending (Jordi to re-process `voice_note_Gergana_20260505_0915.webm`)

Closes #1134

🤖 Generated with [Claude Code](https://claude.com/claude-code)