### PR TITLE
fix(#1135): exclude session-scoped content from student shortTermObjectives extraction

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -3459,6 +3459,22 @@ public class PromptServiceTests
         request.UserPrompt.Should().Contain("DELE");
     }
 
+    [Fact]
+    public void BuildStudentProfileExtractionPrompt_ShortTermObjectives_ExcludesSessionScopedPhrases()
+    {
+        var request = _sut.BuildStudentProfileExtractionPrompt("teacher notes");
+
+        // The prompt must explicitly exclude session-scoped planning asides from shortTermObjectives.
+        // These phrases route to nextLessonIdeas (session extractor), not to the student profile.
+        request.SystemPrompt.Should().Contain("para la próxima clase");
+        request.SystemPrompt.Should().Contain("para mañana");
+        request.SystemPrompt.Should().Contain("next class");
+        request.SystemPrompt.Should().Contain("next session");
+        request.SystemPrompt.Should().Contain("nextLessonIdeas");
+        // Must also confirm genuine long-term aims are still expected (the rule narrows, not disables).
+        request.SystemPrompt.Should().Contain("long-term student aims");
+    }
+
     // --- BuildReplanSuggestionPrompt ---
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -3464,15 +3464,14 @@ public class PromptServiceTests
     {
         var request = _sut.BuildStudentProfileExtractionPrompt("teacher notes");
 
-        // The prompt must explicitly exclude session-scoped planning asides from shortTermObjectives.
-        // These phrases route to nextLessonIdeas (session extractor), not to the student profile.
-        request.SystemPrompt.Should().Contain("para la próxima clase");
+        // The prompt must define shortTermObjectives as persistent cross-session aims only.
+        request.SystemPrompt.Should().Contain("six months from now");
+        // Must call out session-scoped tell-tale phrases so the model recognises them.
         request.SystemPrompt.Should().Contain("para mañana");
+        request.SystemPrompt.Should().Contain("para la próxima clase");
         request.SystemPrompt.Should().Contain("next class");
-        request.SystemPrompt.Should().Contain("next session");
-        request.SystemPrompt.Should().Contain("nextLessonIdeas");
-        // Must also confirm genuine long-term aims are still expected (the rule narrows, not disables).
-        request.SystemPrompt.Should().Contain("long-term student aims");
+        // Must confirm genuine long-term aims are in scope (the rule narrows, not disables).
+        request.SystemPrompt.Should().Contain("quiere preparar el DELE B2 para octubre");
     }
 
     // --- BuildReplanSuggestionPrompt ---

--- a/backend/LangTeach.Api.Tests/Controllers/AssistantControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/AssistantControllerTests.cs
@@ -327,6 +327,64 @@ public class AssistantControllerTests
     }
 
     [Fact]
+    public async Task Propose_WithLongTermAimAndNextLessonIdeas_EmitsBothProposalsSeparately()
+    {
+        // AC2 (#1135): a transcript containing BOTH a long-term student aim AND a next-class
+        // planning aside must produce exactly two separate proposal cards with no overlap.
+        // Stub: [has-learning-goals] returns ShortTermObjectives = "Presentaciones en español"
+        //       reflection stub always returns NextLessonIdeas = "[Extracted] Next lesson ideas"
+        var (client, studentId) = await SeedTeacherWithStudent(
+            "auth0|assistant-dual-content", "assistant-dual-content@example.com");
+
+        var request = new AssistantProposeRequest
+        {
+            Text = "Gergana quiere preparar el DELE B2 para octubre. Para mañana continuar con la pizarra. [has-learning-goals]",
+            StudentId = studentId,
+        };
+        var response = await client.PostAsJsonAsync("/api/assistant/propose", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<AssistantProposeResponse>();
+        body.Should().NotBeNull();
+
+        var goalsProp = body!.Proposals.FirstOrDefault(p => p.Type == "student" && p.Field == "learningGoals");
+        goalsProp.Should().NotBeNull("a long-term aim must produce a Learning Goals proposal");
+        goalsProp!.NewValue.Should().Contain("Presentaciones");
+
+        var nextSessionProp = body.Proposals.FirstOrDefault(p => p.Type == "session" && p.Field == "nextSessionTopics");
+        nextSessionProp.Should().NotBeNull("a next-class aside must produce a Next Session Topics proposal");
+        nextSessionProp!.NewValue.Should().Contain("Next lesson ideas");
+
+        goalsProp.NewValue.Should().NotBe(nextSessionProp.NewValue, "the two proposals must not contain identical content");
+    }
+
+    [Fact]
+    public async Task Propose_WithSessionScopedContentOnly_NoLearningGoalsProposal()
+    {
+        // AC1 (#1135): when the student extractor correctly filters out session-scoped content,
+        // no Learning Goals proposal must be emitted, but Next Session Topics still appears.
+        var (client, studentId) = await SeedTeacherWithStudent(
+            "auth0|assistant-no-goals", "assistant-no-goals@example.com");
+
+        var request = new AssistantProposeRequest
+        {
+            Text = "Para mañana continuar con la pizarra del día. [no-learning-goals]",
+            StudentId = studentId,
+        };
+        var response = await client.PostAsJsonAsync("/api/assistant/propose", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<AssistantProposeResponse>();
+        body.Should().NotBeNull();
+
+        body!.Proposals.Should().NotContain(p => p.Type == "student" && p.Field == "learningGoals",
+            "session-scoped content must not leak into a Learning Goals proposal");
+
+        var nextSessionProp = body.Proposals.FirstOrDefault(p => p.Type == "session" && p.Field == "nextSessionTopics");
+        nextSessionProp.Should().NotBeNull("Next Session Topics proposal must still appear independently");
+    }
+
+    [Fact]
     public async Task Propose_EmptyText_Returns400()
     {
         var (client, _) = await SeedTeacherWithStudent(

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1672,11 +1672,11 @@ public class PromptService : IPromptService
             - learningLanguage: string or null — the language the student is learning or being taught (e.g. "English", "French", "inglés"). Null if not mentioned.
             - cefrLevel: string or null — teacher's own CEFR assessment of the student (e.g. "B1", "C1"). Null if not mentioned.
             - officialCefrLevel: string or null — official/exam-certified CEFR level (e.g. from a DELE, DELF certificate). Null if not mentioned.
-            - shortTermObjectives: array of objects — near-term learning goals mentioned by the teacher about the STUDENT (e.g. "quiere preparar el DELE B2 para octubre", "her goal is to work at a Spanish company", "wants to reach B1 by June"). Each object has:
+            - shortTermObjectives: array of objects — aims that belong to the student's overall learning journey across many sessions (e.g. "quiere preparar el DELE B2 para octubre", "her goal is to work at a Spanish company", "wants to reach B1 by June"). Each object has:
                 - text: string — description of the objective
                 - targetDate: string or null — ISO 8601 date (YYYY-MM-DD) if a date is mentioned, otherwise null
               Empty array [] if no objectives mentioned.
-              IMPORTANT: Do NOT include session-scoped planning asides here. Phrases like "para la próxima clase / sesión", "para mañana", "para la siguiente clase", "next class", "next session", "tenemos que trabajar X la próxima vez", or any forward-looking aside about what to cover in the next class belong in nextLessonIdeas (handled by the session extractor), NOT here. If the same content would appear in nextLessonIdeas, it must NOT appear in shortTermObjectives. Only extract genuine long-term student aims that persist across many sessions.
+              IMPORTANT: Only extract aims that would still be meaningful six months from now. Session-level planning content must not appear here — a tell-tale sign is language like "para mañana", "para la próxima clase / sesión", "next class", or "next time I want to cover X". Those describe what happens in the next class, not what the student is trying to achieve overall.
             - difficulties: array of objects — student weaknesses or trouble areas explicitly mentioned. Each object has:
                 - description: string — full description of the difficulty
                 - competency: string — must be one of: {competencies}

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1672,10 +1672,11 @@ public class PromptService : IPromptService
             - learningLanguage: string or null — the language the student is learning or being taught (e.g. "English", "French", "inglés"). Null if not mentioned.
             - cefrLevel: string or null — teacher's own CEFR assessment of the student (e.g. "B1", "C1"). Null if not mentioned.
             - officialCefrLevel: string or null — official/exam-certified CEFR level (e.g. from a DELE, DELF certificate). Null if not mentioned.
-            - shortTermObjectives: array of objects — near-term learning goals mentioned by the teacher. Each object has:
+            - shortTermObjectives: array of objects — near-term learning goals mentioned by the teacher about the STUDENT (e.g. "quiere preparar el DELE B2 para octubre", "her goal is to work at a Spanish company", "wants to reach B1 by June"). Each object has:
                 - text: string — description of the objective
                 - targetDate: string or null — ISO 8601 date (YYYY-MM-DD) if a date is mentioned, otherwise null
               Empty array [] if no objectives mentioned.
+              IMPORTANT: Do NOT include session-scoped planning asides here. Phrases like "para la próxima clase / sesión", "para mañana", "para la siguiente clase", "next class", "next session", "tenemos que trabajar X la próxima vez", or any forward-looking aside about what to cover in the next class belong in nextLessonIdeas (handled by the session extractor), NOT here. If the same content would appear in nextLessonIdeas, it must NOT appear in shortTermObjectives. Only extract genuine long-term student aims that persist across many sessions.
             - difficulties: array of objects — student weaknesses or trouble areas explicitly mentioned. Each object has:
                 - description: string — full description of the difficulty
                 - competency: string — must be one of: {competencies}

--- a/backend/LangTeach.Api/Services/StubStudentProfileExtractionService.cs
+++ b/backend/LangTeach.Api/Services/StubStudentProfileExtractionService.cs
@@ -19,6 +19,7 @@ public class StubStudentProfileExtractionService : IStudentProfileExtractionServ
         var hasInterests = text.Contains("[has-interests]");
         var hasDifficulties = text.Contains("[has-difficulties]");
         var hasLearningGoals = text.Contains("[has-learning-goals]");
+        var noLearningGoals = text.Contains("[no-learning-goals]");
         var hasTeachingNotes = text.Contains("[has-teaching-notes]");
 
         return Task.FromResult(new ExtractedStudentProfileDto(
@@ -33,9 +34,11 @@ public class StubStudentProfileExtractionService : IStudentProfileExtractionServ
             LearningLanguage: "[Extracted] English",
             CefrLevel: "B2",
             OfficialCefrLevel: null,
-            ShortTermObjectives: hasLearningGoals
-                ? [new ExtractedObjectiveDto("[Extracted] Presentaciones en español", null)]
-                : [new ExtractedObjectiveDto("[Extracted] Pass B2 exam", "2026-06-30")],
+            ShortTermObjectives: noLearningGoals
+                ? []
+                : hasLearningGoals
+                    ? [new ExtractedObjectiveDto("[Extracted] Presentaciones en español", null)]
+                    : [new ExtractedObjectiveDto("[Extracted] Pass B2 exam", "2026-06-30")],
             Difficulties: hasDifficulties
                 ? [new ExtractedDifficultyDto("[Extracted] Indefinido vs perfecto", "Grammar", "past tense")]
                 : [new ExtractedDifficultyDto("[Extracted] Subjunctive usage", "Grammar", "subjunctive")],

--- a/plan/sprints/unified-voice-chat-test-corpus.md
+++ b/plan/sprints/unified-voice-chat-test-corpus.md
@@ -508,6 +508,7 @@ Both were wrong. The fix anchors `sessionDate` to the opening clause ("en la cla
 - The 30 April session must NOT receive an update.
 - A separate `newSession` proposal must NOT be produced.
 - The transcript must NOT be silently truncated (post-#1127 the chunked WAV path covers full audio).
+- A Learning Goals proposal card MUST NOT surface with the forward-planning content ("continuar con la pizarra del día"). That content belongs exclusively in Next Session Topics. `shortTermObjectives` expected = empty [] for this transcript (#1135).
 
 **Forward-looking phrase routing:** "para la clase de mañana día 6, tenemos que continuar con la pizarra del día" → `nextLessonIdeas` (regression check for #1126). It is NOT a teachingTodo (no trigger phrase) and NOT a newSession (a planning aside, not an explicit "schedule a session for…").
 


### PR DESCRIPTION
## Summary

- Narrows the `shortTermObjectives` field definition in `BuildStudentProfileExtractionPrompt` (PromptService.cs) to exclude session-scoped planning asides. The key rule: only extract aims meaningful six months from now. Tell-tale session phrases ("para mañana", "para la próxima clase / sesión", "next class") are called out as examples of what must not be extracted.
- Adds `[no-learning-goals]` trigger to `StubStudentProfileExtractionService` (returns empty ShortTermObjectives) and two AssistantController integration tests: dual-content scenario (long-term aim + next-class aside produces both learningGoals and nextSessionTopics proposals) and no-leakage scenario (session-scoped only produces no learningGoals proposal).
- Adds PromptServiceTests assertion verifying the exclusion rule is present in the system prompt.
- Updates TC-35 corpus entry to document `shortTermObjectives` expected = empty.

Closes #1135. Companion to #1132.

## Test plan

- [ ] `dotnet test` passes (all 3 new tests green).
- [ ] Drop `voice_note_Gergana_20260505_0915.webm` into Atelier Assistant. Confirm Next Session Topics card appears with planning content. Confirm NO Learning Goals card with the same content.
- [ ] Drop a contrived voice note with both a long-term aim ("Gergana quiere preparar el DELE B2 para octubre") and a next-class aside ("para mañana continuar con la pizarra"). Confirm exactly two cards, one per kind, no overlap.
- [ ] Screenshots of both scenarios attached to PR.

## Reviewer findings

| Reviewer | Finding | Action |
|----------|---------|--------|
| qa-verify | AC2 (dual-content) not covered | Fixed: added two controller tests |
| code-review | Phrase assertions in PromptServiceTests brittle to wording | Accepted: tests now anchor on semantic markers |
| architecture-review | [no-learning-goals] is first negative-override stub trigger | Accepted: pattern is clear, comment explains intent |
| prompt-health | Negative phrase enumeration, cross-extractor reference, redundant sentence | Fixed: rewritten with positive framing, removed cross-extractor ref and redundant sentence |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for distinguishing long-term learning goals from session-specific planning topics.

* **Bug Fixes**
  * Refined AI prompt handling to properly separate long-term learning objectives from next-session topics.
  * Fixed extraction logic to respect "no learning goals" markers when present in input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->