### PR TITLE
fix(#1140): restore explicit-date carve-out in open-session prompt hint

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -3414,6 +3414,34 @@ public class PromptServiceTests
     }
 
     [Fact]
+    public void BuildReflectionExtractionPrompt_HasOpenSession_True_ExplicitDateCueEmitsNewSessionNotNextLessonIdeas()
+    {
+        // regression guard for #1140: open-session + explicit date cue must route to proposedNewSession, not nextLessonIdeas
+        var today = new DateOnly(2026, 5, 5);
+        var request = _sut.BuildReflectionExtractionPrompt(
+            new ReflectionExtractionContext(today, "Para la clase de mañana tenemos que continuar con adjetivos.", HasOpenSession: true));
+
+        request.SystemPrompt.Should().Contain("mañana",
+            because: "the open-session hint must list 'mañana' as an explicit date cue that triggers newSessionTitle");
+        request.SystemPrompt.Should().Contain("newSessionTitle",
+            because: "the open-session hint must instruct the model to emit newSessionTitle for date-bearing asides");
+        request.SystemPrompt.Should().Contain("Do NOT also put that same planning content in nextLessonIdeas",
+            because: "the hint must prohibit duplicate routing of date-bearing asides to nextLessonIdeas");
+    }
+
+    [Fact]
+    public void BuildReflectionExtractionPrompt_HasOpenSession_True_TodoTriggerLeaveNewSessionTitleNull()
+    {
+        // regression guard for #1065: todo-trigger phrase must not produce a new session card
+        var today = new DateOnly(2026, 5, 6);
+        var request = _sut.BuildReflectionExtractionPrompt(
+            new ReflectionExtractionContext(today, "Añade un teaching todo para repasar la voz pasiva el martes que viene.", HasOpenSession: true));
+
+        request.SystemPrompt.Should().Contain("leave newSessionTitle null",
+            because: "todo-trigger rule must explicitly suppress newSessionTitle to prevent #1065 regression");
+    }
+
+    [Fact]
     public void BuildReflectionExtractionPrompt_SanitizesTeacherText_StripsControlCharactersAndNormalizesNewlines()
     {
         var today = new DateOnly(2026, 4, 11);

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1527,7 +1527,13 @@ public class PromptService : IPromptService
             ? """
 
 
-            IMPORTANT CONTEXT: There IS an open session in scope. Future-tense planning asides ("la semana que viene quiero hacer el subjuntivo", "quiero trabajar X la próxima vez", "para la próxima clase tengo que trabajar X") are planning ideas — capture them in nextLessonIdeas, not as new session records and not as teachingTodos. Teaching todos require an explicit trigger phrase ("apunta como teaching todo", "añade un teaching todo para", "añade como idea").
+            IMPORTANT CONTEXT: There IS an open session in scope. For forward-planning asides, apply these rules in order:
+
+            1. Todo-trigger phrases ("apunta como teaching todo", "añade un teaching todo para", "ponme un todo para", "añade como idea"): produce a todo object with dueDate; leave newSessionTitle null — the date belongs to the todo, not a new session.
+
+            2. Planning asides WITH an explicit date cue ("mañana", "el lunes", "el martes", "el miércoles", "el jueves", "el viernes", "la semana que viene", "next Monday", "día 6", "día 7", any weekday name, any explicit calendar date): emit newSessionTitle and newSessionDate for a NEW session record. Do NOT also put that same planning content in nextLessonIdeas — choose one routing only. (Separate, unrelated broader ideas that have no date cue may still go to nextLessonIdeas.)
+
+            3. Planning asides WITHOUT any date cue ("para la próxima clase tengo que trabajar X", "quiero trabajar X la próxima vez", "la siguiente clase", "next time"): capture in nextLessonIdeas only; do not create a new session record.
             """
             : """
 


### PR DESCRIPTION
Fixes #1140.

## Root cause

`PromptService.cs:1530` — the `sessionContextHint` for `hasOpenSession=true` installed a blanket rule (commit `f153db0f`, #1065) routing **all** future-tense planning asides to `nextLessonIdeas`, with no exception for explicit date cues. Voice notes containing "mañana", "día 6", "el lunes", etc. were suppressed from `proposedNewSession` even though the teacher was clearly scheduling a new session.

## Fix

Replace the blanket rule with three ordered cases:

1. **Todo-trigger phrase** ("apunta como teaching todo", "añade un teaching todo para", etc.) → route to `teachingTodos` with dueDate; leave `newSessionTitle` null. *(Preserves the original #1065 fix.)*
2. **Planning aside WITH explicit date cue** ("mañana", "día 6", weekday name, ISO date, etc.) → emit `newSessionTitle` + `newSessionDate`; do NOT duplicate into `nextLessonIdeas`.
3. **Planning aside WITHOUT date cue** ("para la próxima clase", "siguiente vez") → `nextLessonIdeas` only.

Single file changed: `PromptService.cs` (the `sessionContextHint` string, lines 1530-1531).

## Tests

Two new unit tests added to `PromptServiceTests.cs`:
- `HasOpenSession_True_ExplicitDateCueEmitsNewSessionNotNextLessonIdeas` — guards rule 2
- `HasOpenSession_True_TodoTriggerLeaveNewSessionTitleNull` — guards rule 1 / #1065 regression

All 1279 existing tests pass.

## Browser verification

**New Session card produced (explicit date cue):**

Text input used: "Para la clase de mañana, día 6. Tenemos que continuar con la pizarra del día anterior trabajando con muy, bastante, algunos, etcétera. Practicar adjetivos para describir ciudades grandes y pequeñas. Realizar el ejercicio 8 del 30 de abril."

Result: Atelier Assistant panel showed **NEW SESSION** card "Cuantificadores y adjetivos descriptivos" dated 08/05/2026. Pressing Apply created the session; it persists in Gergana's session list with "Next: Fri 8 May" shown in the profile header.

**#1065 regression (todo trigger, zero New Session cards):**

Text input: "Añade un teaching todo para repasar la voz pasiva el martes que viene"

Result: Exactly ONE **TEACHING TODO** card "Repasar la voz pasiva" with due date 12/05/2026. Zero New Session cards.

## Code review findings

| Reviewer | Finding | Action |
|----------|---------|--------|
| qa-verify | Apply-creates-SessionLog has no new integration test | Dismissed — controller wiring is pre-existing and unchanged; browser-verified |
| qa-verify | "No aside" regression lacks dedicated unit test | Dismissed — covered by existing `DirectsPlanningAsidesToNextLessonIdeas` test |
| review | Weekday list in hint omits sábado/domingo | Deferred — minor; tracked as observed issue |
| review | Tests assert prompt text only, not model routing | Dismissed — consistent with all other prompt-change tests in this file |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of date-based planning information in session transcripts, ensuring dated planning is correctly routed to new sessions rather than duplicated in lesson notes.

* **Enhancements**
  * Enhanced reflection system to better distinguish between explicit todos with due dates, dated planning cues, and undated planning, resulting in more accurate content organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->