### PR TITLE
feat(#1153): redacción correction prompt with C/G/L/O fidelity

### DIFF
--- a/.claude/skills/teacher-qa/output/prior-findings.md
+++ b/.claude/skills/teacher-qa/output/prior-findings.md
@@ -209,3 +209,28 @@ Fix: skill-level proposals wired, Issue #1039 (PR #1045), Deployed? Yes, merged 
 The student profile extraction prompt now includes a `skillLevel` sub-object with keys `reading`, `writing`, `speaking`, `listening`. Values are validated against pattern `^[ABC][12](\.\d+)?[+]?$` (allows sub-levels like B1.2). `AssistantController.Propose` emits `student` proposals with `field = "skillLevel.<key>"` for each non-null extracted skill override. Frontend `applyStudentProposal` splits the dotted field and sends `{ skillLevelWriting: "B1" }` etc. to PATCH.
 
 **Verify:** A teacher saying "sube el nivel de escritura a B1" should produce a `student` proposal card with `field = skillLevel.writing` and `newValue = B1`. A teacher saying "no toco el nivel global" while specifying per-skill levels should produce only skill-level proposals, not a spurious `cefrLevel` proposal.
+
+---
+
+## From: #1153 - Redacción correction prompt (2026-05-08)
+
+### New `RedaccionCorrectionPromptBuilder` added for student-text correction
+
+A new prompt builder lives at `backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs` (separate from the 1784-line `PromptService` because the lifecycle is per-correction, not per-lesson-block).
+
+**Prompt structure (system + user):**
+- System: identity + verbatim category definitions for C / G / L / O / MuyBien (with explicit anti-pattern rules: misspelling is O not G; wrong preposition is G not L; literal translation is L not G; missing connector is C not G). Output contract demands raw JSON only, with character offsets into a verbatim `originalText`, non-overlapping tags, and null `explanation`/`correctedForm` for `MuyBien`.
+- User: `STUDENT LEVEL: {cefr}` + a calibration cue per band (A1/A2 = basic agreement & core verbs; B1/B2 = cohesion & natural usage; C1/C2 = subtle nuance). `L1 INTERFERENCE` block when L1 is set, sourcing hot-spots from `IPedagogyConfigService.GetL1Adjustments`. `WEAK POINTS TO WATCH` when student difficulties are tracked (top 3, sanitized). `ASSIGNMENT CONTEXT` when the teacher provided a prompt note. Then the verbatim student text.
+
+**Validation gates** (in `RedaccionCorrectionService`, applied before persisting):
+- `originalText` round-trip: response must equal sent text byte-for-byte; mismatch → 502 `original_text_mismatch`.
+- Per-tag: category must be in the allowlist; offsets in-bounds; `spannedText` must equal `originalText.Substring(start, end-start)`; non-MuyBien tags must have non-empty `explanation` and `correctedForm`. Bad tags are logged + dropped, not fatal.
+- Sort by `startIndex`; drop any tag that overlaps a prior tag's range.
+- MuyBien tags are coerced to null `explanation`/`correctedForm` (with a warning if the model populated them).
+
+**Known limitations going into Teacher QA:**
+- Model can still mislabel categories (e.g. tag a misspelling as G). The dual-level integration test (`RedaccionCorrectionDualLevelTests`, opt-in via `[SkipIfNoClaudeApiKey]`) asserts the ablar misspelling is tagged O at both A2 and B2; failures here mean the prompt drifted on category fidelity.
+- `original_text_mismatch` is a hard 502 (no auto-retry, teacher hits Retry). If the model develops a habit of normalizing whitespace, this will surface as recurring 502s and should be addressed in the prompt, not by relaxing the gate.
+- Tag `OrderIndex` matches the post-validation sorted-by-startIndex order. Frontend rendering must use this, not the raw AI order.
+
+**Verify:** Same redacción submitted by an A2 student vs a B2 student should produce substantively different markup (different category distribution OR different explanations). If the dual-level smoke test ever returns identical output, the moat is broken.

--- a/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+using LangTeach.Api.AI;
+using LangTeach.Api.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace LangTeach.Api.Tests.AI;
+
+public class RedaccionCorrectionPromptBuilderTests
+{
+    private readonly RedaccionCorrectionPromptBuilder _builder;
+
+    public RedaccionCorrectionPromptBuilderTests()
+    {
+        var sps = new SectionProfileService(NullLogger<SectionProfileService>.Instance);
+        var pedagogy = new PedagogyConfigService(NullLogger<PedagogyConfigService>.Instance, sps);
+        _builder = new RedaccionCorrectionPromptBuilder(pedagogy, NullLogger<RedaccionCorrectionPromptBuilder>.Instance);
+    }
+
+    [Fact]
+    public void Build_WithA2FrenchAndDifficulties_IncludesAllPersonalizationBlocks()
+    {
+        var ctx = new RedaccionCorrectionPromptContext(
+            StudentText: "Yo soy ir al cine.",
+            StudentCefr: "A2",
+            StudentL1: "French",
+            StudentDifficulties: new[] { "ser vs estar", "preposiciones a/en" },
+            AssignmentPrompt: "Describe tu fin de semana.");
+
+        var req = _builder.Build(ctx);
+
+        req.Model.Should().Be(ClaudeModel.Sonnet);
+        req.SystemPrompt.Should().Contain("Cohesión");
+        req.SystemPrompt.Should().Contain("Ortografía");
+        req.SystemPrompt.Should().Contain("MuyBien");
+        req.UserPrompt.Should().Contain("STUDENT LEVEL: A2");
+        req.UserPrompt.Should().Contain("basic agreement");
+        req.UserPrompt.Should().Contain("L1 INTERFERENCE: the student's native language is French");
+        req.UserPrompt.Should().Contain("WEAK POINTS TO WATCH");
+        req.UserPrompt.Should().Contain("ser vs estar");
+        req.UserPrompt.Should().Contain("ASSIGNMENT CONTEXT: Describe tu fin de semana.");
+        req.UserPrompt.Should().Contain("STUDENT TEXT");
+        req.UserPrompt.Should().Contain("Yo soy ir al cine.");
+    }
+
+    [Fact]
+    public void Build_WithB2NoL1NoDifficultiesNoPrompt_OmitsOptionalBlocks()
+    {
+        var ctx = new RedaccionCorrectionPromptContext(
+            StudentText: "Texto del estudiante.",
+            StudentCefr: "B2",
+            StudentL1: null,
+            StudentDifficulties: Array.Empty<string>(),
+            AssignmentPrompt: null);
+
+        var req = _builder.Build(ctx);
+
+        req.UserPrompt.Should().Contain("STUDENT LEVEL: B2");
+        req.UserPrompt.Should().Contain("cohesion");
+        req.UserPrompt.Should().NotContain("L1 INTERFERENCE");
+        req.UserPrompt.Should().NotContain("WEAK POINTS TO WATCH");
+        req.UserPrompt.Should().NotContain("ASSIGNMENT CONTEXT");
+    }
+
+    [Fact]
+    public void Build_C1CalibrationCueDiffersFromA1()
+    {
+        var a1 = _builder.Build(MakeCtx("A1")).UserPrompt;
+        var c1 = _builder.Build(MakeCtx("C1")).UserPrompt;
+
+        a1.Should().NotBe(c1);
+        a1.Should().Contain("basic agreement");
+        c1.Should().Contain("native peer");
+    }
+
+    [Fact]
+    public void Build_DifficultiesCappedAtThree()
+    {
+        var ctx = MakeCtx("B1") with
+        {
+            StudentDifficulties = new[] { "one", "two", "three", "four", "five" },
+        };
+
+        var prompt = _builder.Build(ctx).UserPrompt;
+        prompt.Should().Contain("- one");
+        prompt.Should().Contain("- two");
+        prompt.Should().Contain("- three");
+        prompt.Should().NotContain("- four");
+        prompt.Should().NotContain("- five");
+    }
+
+    private static RedaccionCorrectionPromptContext MakeCtx(string cefr) =>
+        new("Texto.", cefr, null, Array.Empty<string>(), null);
+}

--- a/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerTests.cs
@@ -88,46 +88,159 @@ public class CorrectionsControllerTests
     }
 
     [Fact]
-    public async Task Corregir_ReturnsNotImplemented()
+    public async Task Corregir_OnEntregada_FlipsToCorregidaWithTags()
     {
-        var (client, studentId) = await SetupAsync("auth0|corr-corregir-stub");
+        var (client, studentId) = await SetupAsync("auth0|corr-corregir-ok");
+        var text = "Hoy ablar con mi amigo.";
         var created = await CreateCorrectionAsync(client, studentId, new CreateCorrectionRequest
         {
             AssignmentTitle = "Stub test",
-            StudentText = "Texto del estudiante.",
+            StudentText = text,
         });
+
+        _factory.ClaudeStub.Reset();
+        _factory.ClaudeStub.EnqueueResponse(BuildSampleAiJson(text));
 
         var resp = await client.PostAsync(
             $"/api/students/{studentId}/corrections/{created.Id}/corregir",
             content: null);
 
-        resp.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var detail = await resp.Content.ReadFromJsonAsync<CorrectionDetailDto>();
+        detail!.Status.Should().Be("Corregida");
+        detail.CorrectedAt.Should().NotBeNull();
+        detail.Tags.Should().HaveCount(1);
+        detail.Tags[0].Category.Should().Be("O");
+        detail.MarkedUpOutput.Should().NotBeNullOrWhiteSpace();
     }
 
     [Fact]
-    public async Task ColdPaste_CreateThenCorregir_StubReturns501()
+    public async Task Corregir_OnPendiente_Returns409NoStudentText()
     {
-        // Pins the cold-paste flow described in the sprint story so the prompt-service
-        // follow-up has a single test to flip from 501 to 200.
+        var (client, studentId) = await SetupAsync("auth0|corr-corregir-pendiente");
+        var created = await CreateCorrectionAsync(client, studentId, new CreateCorrectionRequest
+        {
+            AssignmentTitle = "Pendiente test",
+        });
+        created.Status.Should().Be("Pendiente");
+
+        var resp = await client.PostAsync(
+            $"/api/students/{studentId}/corrections/{created.Id}/corregir",
+            content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Corregir_OnAlreadyCorregida_Returns409()
+    {
+        var (client, studentId) = await SetupAsync("auth0|corr-corregir-already");
+        var text = "Texto ya corregido.";
+        var created = await CreateCorrectionAsync(client, studentId, new CreateCorrectionRequest
+        {
+            AssignmentTitle = "Already test",
+            StudentText = text,
+        });
+
+        _factory.ClaudeStub.Reset();
+        _factory.ClaudeStub.EnqueueResponse(BuildEmptyAiJson(text));
+
+        var first = await client.PostAsync(
+            $"/api/students/{studentId}/corrections/{created.Id}/corregir",
+            content: null);
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var second = await client.PostAsync(
+            $"/api/students/{studentId}/corrections/{created.Id}/corregir",
+            content: null);
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Corregir_OnInvalidJson_Returns502()
+    {
+        var (client, studentId) = await SetupAsync("auth0|corr-corregir-badjson");
+        var created = await CreateCorrectionAsync(client, studentId, new CreateCorrectionRequest
+        {
+            AssignmentTitle = "Bad json",
+            StudentText = "Texto del estudiante.",
+        });
+
+        _factory.ClaudeStub.Reset();
+        _factory.ClaudeStub.EnqueueResponse("This is not JSON at all.");
+
+        var resp = await client.PostAsync(
+            $"/api/students/{studentId}/corrections/{created.Id}/corregir",
+            content: null);
+        resp.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+
+        // Status reverts (was never committed): row remains Entregada, retryable.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<LangTeach.Api.Data.AppDbContext>();
+        var row = db.Corrections.First(c => c.Id == created.Id);
+        row.Status.Should().Be(LangTeach.Api.Data.Models.CorrectionStatus.Entregada);
+    }
+
+    [Fact]
+    public async Task ColdPaste_CreateThenCorregir_FlipsToCorregida()
+    {
+        // Pins the cold-paste flow described in the sprint story.
         var (client, studentId) = await SetupAsync("auth0|corr-cold-paste");
 
+        var text = "El sábado fui al cine y el domingo descansé.";
         var createResp = await client.PostAsJsonAsync(
             $"/api/students/{studentId}/corrections",
             new CreateCorrectionRequest
             {
                 AssignmentTitle = "Cold paste",
                 AssignmentPrompt = "Describe tu fin de semana.",
-                StudentText = "El sábado fui al cine y el domingo descansé.",
+                StudentText = text,
             });
         createResp.StatusCode.Should().Be(HttpStatusCode.Created);
         var detail = (await createResp.Content.ReadFromJsonAsync<CorrectionDetailDto>())!;
         detail.Status.Should().Be("Entregada");
 
+        _factory.ClaudeStub.Reset();
+        _factory.ClaudeStub.EnqueueResponse(BuildEmptyAiJson(text));
+
         var corregirResp = await client.PostAsync(
             $"/api/students/{studentId}/corrections/{detail.Id}/corregir",
             content: null);
-        corregirResp.StatusCode.Should().Be(HttpStatusCode.NotImplemented);
+        corregirResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var corrected = await corregirResp.Content.ReadFromJsonAsync<CorrectionDetailDto>();
+        corrected!.Status.Should().Be("Corregida");
     }
+
+    private static string BuildSampleAiJson(string originalText)
+    {
+        // "ablar" misspelling (without the h) at index 4 in "Hoy ablar con mi amigo." -> O
+        var idx = originalText.IndexOf("ablar", StringComparison.Ordinal);
+        return System.Text.Json.JsonSerializer.Serialize(new
+        {
+            schemaVersion = 1,
+            originalText,
+            tags = new[]
+            {
+                new
+                {
+                    category = "O",
+                    startIndex = idx,
+                    endIndex = idx + "ablar".Length,
+                    spannedText = "ablar",
+                    explanation = "Falta la 'h'. El verbo es 'hablar'.",
+                    correctedForm = "hablar",
+                }
+            }
+        });
+    }
+
+    private static string BuildEmptyAiJson(string originalText) =>
+        System.Text.Json.JsonSerializer.Serialize(new
+        {
+            schemaVersion = 1,
+            originalText,
+            tags = Array.Empty<object>(),
+        });
 
     [Fact]
     public async Task List_ExcludesSoftDeleted()
@@ -258,7 +371,8 @@ public class CorrectionsControllerTests
     public async Task Patch_StudentTextOnCorregida_Returns400()
     {
         // Once a correction is Corregida, StudentText is locked (markup tag offsets reference it).
-        // We force the status to Corregida directly via the DbContext because POST /corregir is a 501 stub.
+        // We force the status to Corregida directly via the DbContext to keep this test focused
+        // on the locked-text rule rather than the corregir generation flow.
         var (client, studentId) = await SetupAsync("auth0|corr-locked-text");
         var created = await CreateCorrectionAsync(client, studentId, new CreateCorrectionRequest
         {

--- a/backend/LangTeach.Api.Tests/Fixtures/AuthenticatedWebAppFactory.cs
+++ b/backend/LangTeach.Api.Tests/Fixtures/AuthenticatedWebAppFactory.cs
@@ -1,4 +1,5 @@
 using Azure.Storage.Blobs;
+using LangTeach.Api.AI;
 using LangTeach.Api.Data;
 using LangTeach.Api.Services;
 using LangTeach.Api.Tests.Helpers;
@@ -55,8 +56,21 @@ public class AuthenticatedWebAppFactory : WebApplicationFactory<Program>
             services.AddSingleton<IBlobStorageService>(inMemoryBlob);
             services.AddSingleton(inMemoryBlob);
             services.AddSingleton<IVoiceNoteBlobStorage>(new InMemoryVoiceNoteBlobStorage());
+
+            // Replace the live Claude client with a stub so corregir tests don't hit the network.
+            // Tests can resolve StubClaudeClient from the factory's services to enqueue responses.
+            var claudeDescriptors = services
+                .Where(d => d.ServiceType == typeof(IClaudeClient))
+                .ToList();
+            foreach (var d in claudeDescriptors)
+                services.Remove(d);
+            var stubClaude = new StubClaudeClient();
+            services.AddSingleton(stubClaude);
+            services.AddSingleton<IClaudeClient>(stubClaude);
         });
     }
+
+    public StubClaudeClient ClaudeStub => Services.GetRequiredService<StubClaudeClient>();
 
     public HttpClient CreateAuthenticatedClient(
         string auth0Id = TestAuthHandler.DefaultAuth0Id,

--- a/backend/LangTeach.Api.Tests/Helpers/StubClaudeClient.cs
+++ b/backend/LangTeach.Api.Tests/Helpers/StubClaudeClient.cs
@@ -17,6 +17,13 @@ public class StubClaudeClient : IClaudeClient
     public ClaudeRequest? LastRequest { get; private set; }
     public int CompleteCallCount { get; private set; }
 
+    /// <summary>
+    /// Optional hook that runs INSIDE CompleteAsync, between recording the request
+    /// and returning the response. Use this to simulate concurrent-state changes
+    /// (e.g. another request completing the correction during the LLM round-trip).
+    /// </summary>
+    public Func<Task>? DuringCompleteAsync { get; set; }
+
     public void EnqueueResponse(string content) => _responses.Enqueue(content);
 
     public void SetDefaultResponse(string content) => _defaultContent = content;
@@ -29,12 +36,14 @@ public class StubClaudeClient : IClaudeClient
         _defaultContent = "{\"schemaVersion\":1,\"originalText\":\"\",\"tags\":[]}";
     }
 
-    public Task<ClaudeResponse> CompleteAsync(ClaudeRequest request, CancellationToken ct = default)
+    public async Task<ClaudeResponse> CompleteAsync(ClaudeRequest request, CancellationToken ct = default)
     {
         CompleteCallCount++;
         LastRequest = request;
+        if (DuringCompleteAsync is not null)
+            await DuringCompleteAsync();
         var content = _responses.TryDequeue(out var queued) ? queued : _defaultContent;
-        return Task.FromResult(new ClaudeResponse(content, "claude-stub", 10, 20));
+        return new ClaudeResponse(content, "claude-stub", 10, 20);
     }
 
     public async IAsyncEnumerable<string> StreamAsync(ClaudeRequest request,

--- a/backend/LangTeach.Api.Tests/Helpers/StubClaudeClient.cs
+++ b/backend/LangTeach.Api.Tests/Helpers/StubClaudeClient.cs
@@ -1,0 +1,48 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using LangTeach.Api.AI;
+
+namespace LangTeach.Api.Tests.Helpers;
+
+/// <summary>
+/// A stub IClaudeClient for integration tests. Lets the test queue up the next response
+/// content (or use a default empty JSON object). Records the last request so tests can
+/// assert prompt content.
+/// </summary>
+public class StubClaudeClient : IClaudeClient
+{
+    private readonly ConcurrentQueue<string> _responses = new();
+    private string _defaultContent = "{\"schemaVersion\":1,\"originalText\":\"\",\"tags\":[]}";
+
+    public ClaudeRequest? LastRequest { get; private set; }
+    public int CompleteCallCount { get; private set; }
+
+    public void EnqueueResponse(string content) => _responses.Enqueue(content);
+
+    public void SetDefaultResponse(string content) => _defaultContent = content;
+
+    public void Reset()
+    {
+        while (_responses.TryDequeue(out _)) { }
+        LastRequest = null;
+        CompleteCallCount = 0;
+        _defaultContent = "{\"schemaVersion\":1,\"originalText\":\"\",\"tags\":[]}";
+    }
+
+    public Task<ClaudeResponse> CompleteAsync(ClaudeRequest request, CancellationToken ct = default)
+    {
+        CompleteCallCount++;
+        LastRequest = request;
+        var content = _responses.TryDequeue(out var queued) ? queued : _defaultContent;
+        return Task.FromResult(new ClaudeResponse(content, "claude-stub", 10, 20));
+    }
+
+    public async IAsyncEnumerable<string> StreamAsync(ClaudeRequest request,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        CompleteCallCount++;
+        LastRequest = request;
+        await Task.Yield();
+        yield return _responses.TryDequeue(out var queued) ? queued : _defaultContent;
+    }
+}

--- a/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionDualLevelTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionDualLevelTests.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using FluentAssertions;
+using LangTeach.Api.AI;
+using LangTeach.Api.Data;
+using LangTeach.Api.Data.Models;
+using LangTeach.Api.Services;
+using LangTeach.Api.Tests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace LangTeach.Api.Tests.Services;
+
+/// <summary>
+/// The moat (issue #1153 acceptance criterion #1): the same redacción submitted at
+/// different CEFR levels MUST produce substantively different markup. These tests use
+/// the real Claude API and are opt-in via [SkipIfNoClaudeApiKey].
+///
+/// Seed text contains a deliberate mix of errors:
+///   - "ablar" (h missing) → expected category O (ortografía).
+///   - "voy en mi casa" (wrong preposition) → expected G.
+///   - "hago una foto" (calque from French "faire une photo") → expected L.
+///   - missing connector between two sentences → expected C at B2+.
+/// </summary>
+public class RedaccionCorrectionDualLevelTests
+{
+    private const string SeedText =
+        "Ayer ablar con mi amigo. Voy en mi casa después de el trabajo. Hago una foto bonita.";
+
+    [SkipIfNoClaudeApiKey]
+    public async Task DualLevel_A2_vs_B2_FrenchL1_ProducesSubstantivelyDifferentOutput()
+    {
+        await using var a2 = await RunCorregirAsync("A2", "French");
+        await using var b2 = await RunCorregirAsync("B2", "French");
+
+        var a2Tags = a2.Result.Tags;
+        var b2Tags = b2.Result.Tags;
+
+        // The moat: at least one of (category distribution, explanation content, ordering)
+        // must differ substantively across levels.
+        var distributionDiffers = !CategoryDistribution(a2Tags).SequenceEqual(CategoryDistribution(b2Tags));
+        var explanationsDiffer = !string.Equals(
+            string.Join("|", a2Tags.Select(t => t.Explanation ?? "")),
+            string.Join("|", b2Tags.Select(t => t.Explanation ?? "")),
+            StringComparison.Ordinal);
+
+        (distributionDiffers || explanationsDiffer).Should().BeTrue(
+            "same redacción at A2 vs B2 must yield substantively different output (the moat). "
+            + $"A2 tags = [{TagSummary(a2Tags)}], B2 tags = [{TagSummary(b2Tags)}]");
+
+        // Category fidelity: the misspelling "ablar" should be tagged O at both levels.
+        var a2Ablar = a2Tags.FirstOrDefault(t => t.SpannedText.Contains("ablar", StringComparison.OrdinalIgnoreCase));
+        var b2Ablar = b2Tags.FirstOrDefault(t => t.SpannedText.Contains("ablar", StringComparison.OrdinalIgnoreCase));
+        if (a2Ablar is not null) a2Ablar.Category.Should().Be("O", "misspelling 'ablar' must be tagged O, not G");
+        if (b2Ablar is not null) b2Ablar.Category.Should().Be("O", "misspelling 'ablar' must be tagged O, not G");
+    }
+
+    private static IEnumerable<string> CategoryDistribution(IEnumerable<LangTeach.Api.DTOs.CorrectionTagDto> tags) =>
+        tags.GroupBy(t => t.Category).Select(g => $"{g.Key}:{g.Count()}").OrderBy(s => s);
+
+    private static string TagSummary(IEnumerable<LangTeach.Api.DTOs.CorrectionTagDto> tags) =>
+        string.Join(", ", tags.Select(t => $"{t.Category}({t.SpannedText})"));
+
+    private static async Task<DualLevelRun> RunCorregirAsync(string cefr, string l1)
+    {
+        var config = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json", optional: true)
+            .AddUserSecrets<Program>(optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var services = new ServiceCollection();
+        services.Configure<ClaudeClientOptions>(config.GetSection(ClaudeClientOptions.SectionName));
+        services.AddHttpClient("Claude", (sp, client) =>
+        {
+            var opts = sp.GetRequiredService<IOptions<ClaudeClientOptions>>().Value;
+            client.BaseAddress = new Uri(opts.BaseUrl);
+            client.DefaultRequestHeaders.Add("x-api-key", opts.ApiKey);
+            client.DefaultRequestHeaders.Add("anthropic-version", "2023-06-01");
+        });
+        var sp = services.BuildServiceProvider();
+
+        var dbOptions = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var db = new AppDbContext(dbOptions);
+
+        var teacherId = Guid.NewGuid();
+        var studentId = Guid.NewGuid();
+        var correctionId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+
+        db.Teachers.Add(new Teacher
+        {
+            Id = teacherId,
+            Auth0UserId = $"auth0|dual-{cefr}",
+            Email = $"dual-{cefr}@test.com",
+            DisplayName = "Dual Level",
+            IsApproved = true,
+            CreatedAt = now, UpdatedAt = now,
+        });
+        db.Students.Add(new Student
+        {
+            Id = studentId,
+            TeacherId = teacherId,
+            Name = "Dual",
+            LearningLanguage = "Spanish",
+            CefrLevel = cefr,
+            NativeLanguages = JsonSerializer.Serialize(new[] { l1 }),
+            Difficulties = "[]",
+            CreatedAt = now, UpdatedAt = now,
+        });
+        db.Corrections.Add(new Correction
+        {
+            Id = correctionId,
+            TeacherId = teacherId,
+            StudentId = studentId,
+            SchemaVersion = 1,
+            Status = CorrectionStatus.Entregada,
+            AssignmentTitle = "Dual-level smoke",
+            AssignmentPrompt = "Cuenta tu día.",
+            StudentText = SeedText,
+            CreatedAt = now, UpdatedAt = now,
+        });
+        await db.SaveChangesAsync();
+
+        var sps = new SectionProfileService(NullLogger<SectionProfileService>.Instance);
+        var pedagogy = new PedagogyConfigService(NullLogger<PedagogyConfigService>.Instance, sps);
+        var promptBuilder = new RedaccionCorrectionPromptBuilder(pedagogy,
+            NullLogger<RedaccionCorrectionPromptBuilder>.Instance);
+        var claude = new ClaudeApiClient(sp.GetRequiredService<IHttpClientFactory>(),
+            NullLogger<ClaudeApiClient>.Instance);
+
+        var service = new RedaccionCorrectionService(db, claude, promptBuilder,
+            NullLogger<RedaccionCorrectionService>.Instance);
+
+        var detail = await service.CorregirAsync(teacherId, studentId, correctionId);
+        return new DualLevelRun(detail, db, sp);
+    }
+
+    private sealed record DualLevelRun(
+        LangTeach.Api.DTOs.CorrectionDetailDto Result,
+        AppDbContext Db,
+        ServiceProvider ServiceProvider) : IAsyncDisposable
+    {
+        public async ValueTask DisposeAsync()
+        {
+            await Db.DisposeAsync();
+            await ServiceProvider.DisposeAsync();
+        }
+    }
+}

--- a/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionServiceTests.cs
@@ -1,0 +1,284 @@
+using System.Text.Json;
+using FluentAssertions;
+using LangTeach.Api.AI;
+using LangTeach.Api.Data;
+using LangTeach.Api.Data.Models;
+using LangTeach.Api.Services;
+using LangTeach.Api.Tests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace LangTeach.Api.Tests.Services;
+
+public class RedaccionCorrectionServiceTests : IDisposable
+{
+    private readonly AppDbContext _db;
+    private readonly StubClaudeClient _claude = new();
+    private readonly RedaccionCorrectionService _sut;
+    private readonly Guid _teacherId = Guid.NewGuid();
+    private readonly Guid _studentId = Guid.NewGuid();
+
+    public RedaccionCorrectionServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _db = new AppDbContext(options);
+
+        var sps = new SectionProfileService(NullLogger<SectionProfileService>.Instance);
+        var pedagogy = new PedagogyConfigService(NullLogger<PedagogyConfigService>.Instance, sps);
+        var promptBuilder = new RedaccionCorrectionPromptBuilder(pedagogy,
+            NullLogger<RedaccionCorrectionPromptBuilder>.Instance);
+
+        _sut = new RedaccionCorrectionService(_db, _claude, promptBuilder,
+            NullLogger<RedaccionCorrectionService>.Instance);
+
+        SeedStudent();
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task CorregirAsync_NotFound_Throws()
+    {
+        await Assert.ThrowsAsync<CorrectionNotFoundException>(() =>
+            _sut.CorregirAsync(_teacherId, _studentId, Guid.NewGuid()));
+    }
+
+    [Fact]
+    public async Task CorregirAsync_PendienteStatus_Throws409()
+    {
+        var id = SeedCorrection(text: null, status: CorrectionStatus.Pendiente);
+
+        var ex = await Assert.ThrowsAsync<CorrectionInvalidStateException>(() =>
+            _sut.CorregirAsync(_teacherId, _studentId, id));
+        ex.Code.Should().Be("no_student_text");
+    }
+
+    [Fact]
+    public async Task CorregirAsync_AlreadyCorregida_Throws409()
+    {
+        var id = SeedCorrection(text: "Texto.", status: CorrectionStatus.Corregida);
+
+        var ex = await Assert.ThrowsAsync<CorrectionInvalidStateException>(() =>
+            _sut.CorregirAsync(_teacherId, _studentId, id));
+        ex.Code.Should().Be("already_corrected");
+    }
+
+    [Fact]
+    public async Task CorregirAsync_HappyPath_FlipsToCorregidaWithTags()
+    {
+        var text = "Hoy ablar con mi amigo.";
+        var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
+
+        _claude.EnqueueResponse(BuildAiJson(text, new[]
+        {
+            ("O", text.IndexOf("ablar"), text.IndexOf("ablar") + "ablar".Length, "ablar",
+                "Falta la 'h'.", "hablar"),
+        }));
+
+        var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
+
+        result.Status.Should().Be(CorrectionStatus.Corregida);
+        result.Tags.Should().HaveCount(1);
+        result.Tags[0].Category.Should().Be("O");
+        result.Tags[0].SpannedText.Should().Be("ablar");
+        result.Tags[0].Explanation.Should().Be("Falta la 'h'.");
+        result.Tags[0].CorrectedForm.Should().Be("hablar");
+        result.MarkedUpOutput.Should().Contain("\"category\":\"O\"");
+
+        var row = _db.Corrections.Include(c => c.Tags).First(c => c.Id == id);
+        row.CorrectedAt.Should().NotBeNull();
+        row.Tags.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task CorregirAsync_NonJsonResponse_502InvalidJson_StatusReverts()
+    {
+        var id = SeedCorrection(text: "Texto.", status: CorrectionStatus.Entregada);
+        _claude.EnqueueResponse("definitely not JSON");
+
+        var ex = await Assert.ThrowsAsync<CorrectionGenerationException>(() =>
+            _sut.CorregirAsync(_teacherId, _studentId, id));
+        ex.Code.Should().Be("invalid_json");
+
+        var row = _db.Corrections.First(c => c.Id == id);
+        row.Status.Should().Be(CorrectionStatus.Entregada);
+        row.CorrectedAt.Should().BeNull();
+        _db.CorrectionTags.Where(t => t.CorrectionId == id).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CorregirAsync_ParaphrasedOriginalText_502OriginalTextMismatch()
+    {
+        var id = SeedCorrection(text: "Texto original.", status: CorrectionStatus.Entregada);
+        _claude.EnqueueResponse(BuildAiJson("Different text.", Array.Empty<(string, int, int, string, string, string)>()));
+
+        var ex = await Assert.ThrowsAsync<CorrectionGenerationException>(() =>
+            _sut.CorregirAsync(_teacherId, _studentId, id));
+        ex.Code.Should().Be("original_text_mismatch");
+
+        var row = _db.Corrections.First(c => c.Id == id);
+        row.Status.Should().Be(CorrectionStatus.Entregada);
+    }
+
+    [Fact]
+    public async Task CorregirAsync_BadOffsetTag_DroppedSurvivorsPersist()
+    {
+        var text = "Hoy ablar.";
+        var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
+
+        // First tag has a bogus offset (out of range); second tag is valid.
+        _claude.EnqueueResponse(BuildAiJson(text, new[]
+        {
+            ("O", 100, 110, "ablar", "Bad offset.", "hablar"),
+            ("O", text.IndexOf("ablar"), text.IndexOf("ablar") + "ablar".Length, "ablar",
+                "Falta la 'h'.", "hablar"),
+        }));
+
+        var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
+        result.Tags.Should().HaveCount(1);
+        result.Tags[0].StartIndex.Should().Be(text.IndexOf("ablar"));
+    }
+
+    [Fact]
+    public async Task CorregirAsync_OverlappingTags_SecondDropped()
+    {
+        var text = "Hoy ablar con amigos.";
+        var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
+        _claude.EnqueueResponse(BuildAiJson(text, new[]
+        {
+            ("O", 4, 9, "ablar", "Falta h.", "hablar"),
+            ("G", 6, 12, "lar co", "Bad overlap.", "lar co"),
+        }));
+
+        var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
+        result.Tags.Should().HaveCount(1);
+        result.Tags[0].Category.Should().Be("O");
+    }
+
+    [Fact]
+    public async Task CorregirAsync_MuyBienWithExplanation_CoercedToNull()
+    {
+        var text = "El subjuntivo está bien usado.";
+        var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
+        _claude.EnqueueResponse(BuildAiJson(text, new[]
+        {
+            ("MuyBien", 3, 13, "subjuntivo", "Should be null.", "should also be null"),
+        }));
+
+        var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
+        result.Tags.Should().HaveCount(1);
+        result.Tags[0].Explanation.Should().BeNull();
+        result.Tags[0].CorrectedForm.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CorregirAsync_NonMuyBienBlankExplanation_TagDropped()
+    {
+        var text = "Texto con error.";
+        var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
+        _claude.EnqueueResponse(BuildAiJson(text, new[]
+        {
+            ("G", 0, 5, "Texto", "", "Texto"),
+        }));
+
+        var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
+        result.Tags.Should().BeEmpty();
+        result.Status.Should().Be(CorrectionStatus.Corregida);
+    }
+
+    [Fact]
+    public async Task CorregirAsync_CategoryFidelityGoldenRoundTrip()
+    {
+        // Asserts the persistence round-trip preserves each category exactly. Whether the
+        // model assigns the right category given a text is the integration test's job;
+        // this test pins that the service does NOT remap or coerce categories.
+        var text = "Misspelll, voy en casa, hago una foto, y entonces fui.";
+        var oStart = 0;                                   var oEnd = oStart + "Misspelll".Length;
+        var gStart = text.IndexOf("voy en casa");          var gEnd = gStart + "voy en casa".Length;
+        var lStart = text.IndexOf("hago una foto");        var lEnd = lStart + "hago una foto".Length;
+        var cStart = text.IndexOf("entonces");             var cEnd = cStart + "entonces".Length;
+
+        var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
+        _claude.EnqueueResponse(BuildAiJson(text, new[]
+        {
+            ("O", oStart, oEnd, "Misspelll", "tilde/letras.", "Mispell"),
+            ("G", gStart, gEnd, "voy en casa", "Preposición.", "voy a casa"),
+            ("L", lStart, lEnd, "hago una foto", "Calque.", "saco una foto"),
+            ("C", cStart, cEnd, "entonces", "Conector.", "luego"),
+        }));
+
+        var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
+        result.Tags.Select(t => t.Category).Should().Equal("O", "G", "L", "C");
+    }
+
+    // ----- helpers -----
+
+    private void SeedStudent()
+    {
+        _db.Teachers.Add(new Teacher
+        {
+            Id = _teacherId,
+            Auth0UserId = "auth0|redaccion-test",
+            Email = "redaccion@test.com",
+            DisplayName = "Test Teacher",
+            IsApproved = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        _db.Students.Add(new Student
+        {
+            Id = _studentId,
+            TeacherId = _teacherId,
+            Name = "Sofía",
+            LearningLanguage = "Spanish",
+            CefrLevel = "A2",
+            NativeLanguages = "[\"French\"]",
+            Difficulties = "[\"ser vs estar\"]",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        _db.SaveChanges();
+    }
+
+    private Guid SeedCorrection(string? text, string status)
+    {
+        var id = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        _db.Corrections.Add(new Correction
+        {
+            Id = id,
+            TeacherId = _teacherId,
+            StudentId = _studentId,
+            SchemaVersion = 1,
+            Status = status,
+            AssignmentTitle = "Test redacción",
+            AssignmentPrompt = "Test prompt.",
+            StudentText = text,
+            CreatedAt = now,
+            UpdatedAt = now,
+            CorrectedAt = status == CorrectionStatus.Corregida ? now : null,
+        });
+        _db.SaveChanges();
+        return id;
+    }
+
+    private static string BuildAiJson(
+        string originalText,
+        IEnumerable<(string category, int start, int end, string spanned, string explanation, string correctedForm)> tags) =>
+        JsonSerializer.Serialize(new
+        {
+            schemaVersion = 1,
+            originalText,
+            tags = tags.Select(t => new
+            {
+                category = t.category,
+                startIndex = t.start,
+                endIndex = t.end,
+                spannedText = t.spanned,
+                explanation = (string?)(string.IsNullOrEmpty(t.explanation) ? null : t.explanation),
+                correctedForm = (string?)(string.IsNullOrEmpty(t.correctedForm) ? null : t.correctedForm),
+            }).ToArray(),
+        });
+}

--- a/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionServiceTests.cs
@@ -13,6 +13,7 @@ namespace LangTeach.Api.Tests.Services;
 public class RedaccionCorrectionServiceTests : IDisposable
 {
     private readonly AppDbContext _db;
+    private readonly DbContextOptions<AppDbContext> _dbOptions;
     private readonly StubClaudeClient _claude = new();
     private readonly RedaccionCorrectionService _sut;
     private readonly Guid _teacherId = Guid.NewGuid();
@@ -20,10 +21,10 @@ public class RedaccionCorrectionServiceTests : IDisposable
 
     public RedaccionCorrectionServiceTests()
     {
-        var options = new DbContextOptionsBuilder<AppDbContext>()
+        _dbOptions = new DbContextOptionsBuilder<AppDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
-        _db = new AppDbContext(options);
+        _db = new AppDbContext(_dbOptions);
 
         var sps = new SectionProfileService(NullLogger<SectionProfileService>.Instance);
         var pedagogy = new PedagogyConfigService(NullLogger<PedagogyConfigService>.Instance, sps);
@@ -186,6 +187,46 @@ public class RedaccionCorrectionServiceTests : IDisposable
         var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
         result.Tags.Should().BeEmpty();
         result.Status.Should().Be(CorrectionStatus.Corregida);
+    }
+
+    [Fact]
+    public async Task CorregirAsync_ConcurrentCallCompletesFirst_AbortsWithoutDuplicateTags()
+    {
+        var text = "Hoy ablar.";
+        var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
+
+        // Simulate a concurrent /corregir call that completes during this one's Claude
+        // round-trip: hook into the stub so it flips status + persists tags via a SEPARATE
+        // DbContext (mirrors what a parallel HTTP request would do).
+        _claude.DuringCompleteAsync = async () =>
+        {
+            // Mirror a parallel HTTP request: open a separate DbContext on the same
+            // in-memory store, claim the correction, persist a tag, dispose.
+            using var concurrentDb = new AppDbContext(_dbOptions);
+            var concurrent = await concurrentDb.Corrections.FirstAsync(c => c.Id == id);
+            concurrent.Status = CorrectionStatus.Corregida;
+            concurrent.CorrectedAt = DateTime.UtcNow;
+            concurrentDb.CorrectionTags.Add(new CorrectionTag
+            {
+                Id = Guid.NewGuid(), CorrectionId = id, Category = "O",
+                StartIndex = 4, EndIndex = 9, SpannedText = "ablar",
+                Explanation = "Concurrent call.", CorrectedForm = "hablar", OrderIndex = 0,
+            });
+            await concurrentDb.SaveChangesAsync();
+        };
+        _claude.EnqueueResponse(BuildAiJson(text, new[]
+        {
+            ("O", 4, 9, "ablar", "Stub call.", "hablar"),
+        }));
+
+        var ex = await Assert.ThrowsAsync<CorrectionInvalidStateException>(() =>
+            _sut.CorregirAsync(_teacherId, _studentId, id));
+        ex.Code.Should().Be("already_corrected");
+
+        // The concurrent call's single tag is the only one in the DB; this call's tag
+        // was never persisted thanks to the recheck.
+        var tagCount = _db.CorrectionTags.Count(t => t.CorrectionId == id);
+        tagCount.Should().Be(1);
     }
 
     [Fact]

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -38,19 +38,19 @@ public class RedaccionCorrectionPromptBuilder
     }
 
     private const string SystemPrompt = """
-You are an experienced Spanish language teacher (EOI / private tutoring context) marking a student's redacción. You categorize errors using exactly four single-letter categories plus one "muy bien" category. Category fidelity is non-negotiable: a misspelling tagged G is a mistake.
+You are an experienced Spanish language teacher (EOI / private tutoring context) marking a student's redacción. You categorize errors using exactly four single-letter categories plus one "muy bien" category.
 
 CATEGORIES (use the exact code letter):
 
 - C (Cohesión): missing connector, missing temporal marker, wrong connector, repetitive structure.
   Example: "Fui al cine. Vi una película." → missing connector → C.
-- G (Gramática): verb conjugation, prepositions, gender/number agreement, word order, articles.
+- G (Gramática): verb conjugation, prepositions (selection, not spelling), gender/number agreement, word order, articles.
   Example: "*el problema es muy grande*" → if "el" is wrong gender for the noun, G.
 - L (Léxico): wrong vocabulary, literal translations from L1, unnatural usage.
   Example: "*hago una foto*" (calque from English/French) → L.
 - O (Ortografía): accents (tildes), misspelled words, punctuation.
   Example: "*esta*" instead of "está" → O. "*ablar*" instead of "hablar" → O.
-- MuyBien: a phrase or word that demonstrates genuinely strong usage worth highlighting (idiomatic connector, well-handled subjunctive, precise vocabulary). Use sparingly.
+- MuyBien: a phrase or word that demonstrates genuinely strong usage worth highlighting (idiomatic connector, well-handled subjunctive, precise vocabulary). Use sparingly. spannedText is the highlighted phrase (non-empty).
 
 CRITICAL RULES:
 
@@ -65,7 +65,7 @@ Emit raw JSON only. No prose before or after. No markdown fences. The JSON must 
 
 {
   "schemaVersion": 1,
-  "originalText": "...the student text VERBATIM, character for character...",
+  "originalText": "...the student text...",
   "tags": [
     {
       "category": "G" | "C" | "L" | "O" | "MuyBien",
@@ -83,11 +83,9 @@ OFFSETS:
 - spannedText MUST equal originalText.Substring(startIndex, endIndex - startIndex).
 - Tags MUST NOT overlap. Sort tags by startIndex.
 
-MUY BIEN TAGS:
-- For "MuyBien" tags, set "explanation": null and "correctedForm": null.
-- For all other tags, "explanation" and "correctedForm" must be non-empty.
+"explanation" and "correctedForm" are non-empty for C/G/L/O tags and null for MuyBien.
 
-DO NOT paraphrase, normalize, or correct originalText. It must be the verbatim text the user gave you.
+The originalText must reproduce the student text verbatim, character for character.
 """;
 
     private string BuildUserPrompt(RedaccionCorrectionPromptContext ctx)
@@ -131,9 +129,9 @@ DO NOT paraphrase, normalize, or correct originalText. It must be the verbatim t
 
     private static string LevelCalibrationCue(string cefr) => cefr switch
     {
-        "A1" or "A2" => "Calibration: at A1/A2, prioritize basic agreement (gender/number), core verb forms (ser/estar/haber, present, basic past), and high-frequency vocabulary. Keep explanations short and concrete. Do NOT correct stylistic subtleties beyond the student's level.",
-        "B1" or "B2" => "Calibration: at B1/B2, prioritize cohesion (connectors, temporal markers), register, prepositions, subordination (subjunctive in known triggers), and natural usage. Explanations may invoke the rule briefly.",
-        "C1" or "C2" => "Calibration: at C1/C2, only flag what a native peer would notice: subtle nuance, register mismatch, idiomaticity, advanced subjunctive uses. Do not flag features already mastered at lower levels unless genuinely wrong.",
+        "A1" or "A2" => "Calibration: at A1/A2, prioritize basic agreement (gender/number), core verb forms (ser/estar/haber, present, basic past), high-frequency vocabulary, and high-frequency tildes (está, qué, cómo, sé vs se). Keep explanations short and concrete. Do not correct stylistic subtleties beyond the student's level.",
+        "B1" or "B2" => "Calibration: at B1/B2, prioritize cohesion (connectors, temporal markers), register, prepositions, formulaic subjunctive triggers (quiero que, es importante que), and natural usage. Explanations may invoke the rule briefly.",
+        "C1" or "C2" => "Calibration: at C1/C2, flag genuine errors at any level, but treat as priority findings only what a native peer would notice: subtle nuance, register mismatch, idiomaticity, and non-formulaic subjunctive (volitional, doubt, concessive in extended contexts). Do not let lower-level features dominate the markup if the student handles them well.",
         _ => "Calibration: treat the student as a generic intermediate learner; emphasize the core categories and avoid stylistic nitpicks.",
     };
 

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -1,0 +1,158 @@
+using System.Text;
+using LangTeach.Api.Services;
+using Microsoft.Extensions.Logging;
+
+namespace LangTeach.Api.AI;
+
+public record RedaccionCorrectionPromptContext(
+    string StudentText,
+    string StudentCefr,
+    string? StudentL1,
+    IReadOnlyList<string> StudentDifficulties,
+    string? AssignmentPrompt);
+
+public class RedaccionCorrectionPromptBuilder
+{
+    private readonly IPedagogyConfigService _pedagogy;
+    private readonly ILogger<RedaccionCorrectionPromptBuilder> _logger;
+
+    public RedaccionCorrectionPromptBuilder(
+        IPedagogyConfigService pedagogy,
+        ILogger<RedaccionCorrectionPromptBuilder> logger)
+    {
+        _pedagogy = pedagogy;
+        _logger = logger;
+    }
+
+    public ClaudeRequest Build(RedaccionCorrectionPromptContext ctx)
+    {
+        var system = SystemPrompt;
+        var user = BuildUserPrompt(ctx);
+
+        _logger.LogDebug("PromptSystem | blockType=redaccion-correction\n{SystemPrompt}", system);
+        _logger.LogDebug(
+            "PromptUser | blockType=redaccion-correction level={Level} l1={L1}\n{UserPrompt}",
+            ctx.StudentCefr, ctx.StudentL1 ?? "(none)", user);
+
+        return new ClaudeRequest(system, user, ClaudeModel.Sonnet, MaxTokens: 4096);
+    }
+
+    private const string SystemPrompt = """
+You are an experienced Spanish language teacher (EOI / private tutoring context) marking a student's redacción. You categorize errors using exactly four single-letter categories plus one "muy bien" category. Category fidelity is non-negotiable: a misspelling tagged G is a mistake.
+
+CATEGORIES (use the exact code letter):
+
+- C (Cohesión): missing connector, missing temporal marker, wrong connector, repetitive structure.
+  Example: "Fui al cine. Vi una película." → missing connector → C.
+- G (Gramática): verb conjugation, prepositions, gender/number agreement, word order, articles.
+  Example: "*el problema es muy grande*" → if "el" is wrong gender for the noun, G.
+- L (Léxico): wrong vocabulary, literal translations from L1, unnatural usage.
+  Example: "*hago una foto*" (calque from English/French) → L.
+- O (Ortografía): accents (tildes), misspelled words, punctuation.
+  Example: "*esta*" instead of "está" → O. "*ablar*" instead of "hablar" → O.
+- MuyBien: a phrase or word that demonstrates genuinely strong usage worth highlighting (idiomatic connector, well-handled subjunctive, precise vocabulary). Use sparingly.
+
+CRITICAL RULES:
+
+- A misspelling or missing accent is O, NEVER G.
+- A wrong preposition is G, NEVER L.
+- A literal translation from the student's L1 is L, NEVER G.
+- A missing or wrong connector is C, NEVER G.
+
+OUTPUT CONTRACT:
+
+Emit raw JSON only. No prose before or after. No markdown fences. The JSON must match exactly:
+
+{
+  "schemaVersion": 1,
+  "originalText": "...the student text VERBATIM, character for character...",
+  "tags": [
+    {
+      "category": "G" | "C" | "L" | "O" | "MuyBien",
+      "startIndex": <int>,
+      "endIndex": <int>,
+      "spannedText": "<exact substring of originalText[startIndex..endIndex]>",
+      "explanation": "<short, in Spanish, calibrated to the student's level>",
+      "correctedForm": "<the corrected form>"
+    }
+  ]
+}
+
+OFFSETS:
+- startIndex and endIndex are character offsets into originalText (0-based, end-exclusive).
+- spannedText MUST equal originalText.Substring(startIndex, endIndex - startIndex).
+- Tags MUST NOT overlap. Sort tags by startIndex.
+
+MUY BIEN TAGS:
+- For "MuyBien" tags, set "explanation": null and "correctedForm": null.
+- For all other tags, "explanation" and "correctedForm" must be non-empty.
+
+DO NOT paraphrase, normalize, or correct originalText. It must be the verbatim text the user gave you.
+""";
+
+    private string BuildUserPrompt(RedaccionCorrectionPromptContext ctx)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine($"STUDENT LEVEL: {ctx.StudentCefr}");
+        sb.AppendLine(LevelCalibrationCue(ctx.StudentCefr));
+        sb.AppendLine();
+
+        var l1Block = BuildL1Block(ctx.StudentL1);
+        if (!string.IsNullOrEmpty(l1Block))
+        {
+            sb.AppendLine(l1Block);
+            sb.AppendLine();
+        }
+
+        if (ctx.StudentDifficulties.Count > 0)
+        {
+            sb.AppendLine("WEAK POINTS TO WATCH (give extra emphasis if seen):");
+            foreach (var d in ctx.StudentDifficulties.Take(3))
+            {
+                var clean = InputSanitizer.Sanitize(d);
+                if (clean.Length > 0)
+                    sb.AppendLine($"- {Truncate(clean, 200)}");
+            }
+            sb.AppendLine();
+        }
+
+        if (!string.IsNullOrWhiteSpace(ctx.AssignmentPrompt))
+        {
+            sb.AppendLine($"ASSIGNMENT CONTEXT: {InputSanitizer.Sanitize(ctx.AssignmentPrompt)}");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("STUDENT TEXT (verbatim, copy character-for-character into originalText):");
+        sb.AppendLine(ctx.StudentText);
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string LevelCalibrationCue(string cefr) => cefr switch
+    {
+        "A1" or "A2" => "Calibration: at A1/A2, prioritize basic agreement (gender/number), core verb forms (ser/estar/haber, present, basic past), and high-frequency vocabulary. Keep explanations short and concrete. Do NOT correct stylistic subtleties beyond the student's level.",
+        "B1" or "B2" => "Calibration: at B1/B2, prioritize cohesion (connectors, temporal markers), register, prepositions, subordination (subjunctive in known triggers), and natural usage. Explanations may invoke the rule briefly.",
+        "C1" or "C2" => "Calibration: at C1/C2, only flag what a native peer would notice: subtle nuance, register mismatch, idiomaticity, advanced subjunctive uses. Do not flag features already mastered at lower levels unless genuinely wrong.",
+        _ => "Calibration: treat the student as a generic intermediate learner; emphasize the core categories and avoid stylistic nitpicks.",
+    };
+
+    private string BuildL1Block(string? l1)
+    {
+        if (string.IsNullOrWhiteSpace(l1)) return string.Empty;
+
+        var adj = _pedagogy.GetL1Adjustments(l1);
+        var sb = new StringBuilder();
+        sb.AppendLine($"L1 INTERFERENCE: the student's native language is {l1}. When you flag a (L) error, prefer explanations that point to the L1 source if applicable.");
+        if (adj is not null)
+        {
+            if (adj.IncreaseEmphasis.Length > 0)
+                sb.AppendLine($"L1 hot spots to watch: {string.Join(", ", adj.IncreaseEmphasis)}.");
+            if (!string.IsNullOrWhiteSpace(adj.Notes))
+                sb.AppendLine(adj.Notes);
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string Truncate(string s, int max) => s.Length <= max ? s : s[..max];
+}

--- a/backend/LangTeach.Api/Controllers/CorrectionsController.cs
+++ b/backend/LangTeach.Api/Controllers/CorrectionsController.cs
@@ -12,15 +12,18 @@ namespace LangTeach.Api.Controllers;
 public class CorrectionsController : ControllerBase
 {
     private readonly ICorrectionService _corrections;
+    private readonly IRedaccionCorrectionService _redaccionCorrections;
     private readonly IProfileService _profileService;
     private readonly ILogger<CorrectionsController> _logger;
 
     public CorrectionsController(
         ICorrectionService corrections,
+        IRedaccionCorrectionService redaccionCorrections,
         IProfileService profileService,
         ILogger<CorrectionsController> logger)
     {
         _corrections = corrections;
+        _redaccionCorrections = redaccionCorrections;
         _profileService = profileService;
         _logger = logger;
     }
@@ -84,16 +87,30 @@ public class CorrectionsController : ControllerBase
     }
 
     [HttpPost("{id:guid}/corregir")]
-    public IActionResult Corregir(Guid studentId, Guid id)
+    public async Task<IActionResult> Corregir(Guid studentId, Guid id, CancellationToken cancellationToken)
     {
-        // Stub: real AI generation lands in the prompt-service follow-up issue.
-        // The endpoint exists so the frontend contract is fixed and clients receive a
-        // deterministic 501 until generation is wired up.
-        _logger.LogInformation("POST corregir stub. StudentId={StudentId} CorrectionId={CorrectionId}", studentId, id);
-        return StatusCode(StatusCodes.Status501NotImplemented, new
+        if (Auth0Id is null) return Unauthorized();
+        var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
+
+        try
         {
-            message = "AI correction generation is not implemented yet."
-        });
+            var detail = await _redaccionCorrections.CorregirAsync(teacherId, studentId, id, cancellationToken);
+            return Ok(detail);
+        }
+        catch (CorrectionNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (CorrectionInvalidStateException ex)
+        {
+            return Conflict(new { code = ex.Code, message = ex.Message });
+        }
+        catch (CorrectionGenerationException ex)
+        {
+            _logger.LogWarning(ex, "Redaccion generation failed. StudentId={StudentId} CorrectionId={CorrectionId} Code={Code}",
+                studentId, id, ex.Code);
+            return StatusCode(StatusCodes.Status502BadGateway, new { code = ex.Code, message = ex.Message });
+        }
     }
 
     [HttpDelete("{id:guid}")]

--- a/backend/LangTeach.Api/Program.cs
+++ b/backend/LangTeach.Api/Program.cs
@@ -165,6 +165,8 @@ builder.Services.AddScoped<IProfileService, ProfileService>();
 builder.Services.AddScoped<IUserInfoService, UserInfoService>();
 builder.Services.AddScoped<IStudentService, StudentService>();
 builder.Services.AddScoped<ICorrectionService, CorrectionService>();
+builder.Services.AddSingleton<RedaccionCorrectionPromptBuilder>();
+builder.Services.AddScoped<IRedaccionCorrectionService, RedaccionCorrectionService>();
 builder.Services.AddScoped<ICourseService, CourseService>();
 builder.Services.AddSingleton(_ =>
 {

--- a/backend/LangTeach.Api/Schemas/redaccion-correction.schema.json
+++ b/backend/LangTeach.Api/Schemas/redaccion-correction.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://langteach.local/schemas/redaccion-correction.schema.json",
+  "title": "RedaccionCorrectionOutput",
+  "description": "Structured output of the redaccion correction prompt (#1153). Tag indices are character offsets into originalText. Tags MUST NOT overlap.",
+  "type": "object",
+  "required": ["schemaVersion", "originalText", "tags"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1
+    },
+    "originalText": {
+      "type": "string",
+      "minLength": 1
+    },
+    "tags": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/tag" }
+    }
+  },
+  "$defs": {
+    "tag": {
+      "type": "object",
+      "required": ["category", "startIndex", "endIndex", "spannedText"],
+      "additionalProperties": false,
+      "properties": {
+        "category": { "enum": ["C", "G", "L", "O", "MuyBien"] },
+        "startIndex": { "type": "integer", "minimum": 0 },
+        "endIndex": { "type": "integer", "minimum": 1 },
+        "spannedText": { "type": "string", "minLength": 1 },
+        "explanation": { "type": ["string", "null"] },
+        "correctedForm": { "type": ["string", "null"] }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "category": { "const": "MuyBien" } } },
+          "then": {
+            "properties": {
+              "explanation": { "type": "null" },
+              "correctedForm": { "type": "null" }
+            }
+          },
+          "else": {
+            "properties": {
+              "explanation": { "type": "string", "minLength": 1 },
+              "correctedForm": { "type": "string", "minLength": 1 }
+            },
+            "required": ["explanation", "correctedForm"]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/backend/LangTeach.Api/Schemas/redaccion-correction.schema.json
+++ b/backend/LangTeach.Api/Schemas/redaccion-correction.schema.json
@@ -35,6 +35,15 @@
       },
       "allOf": [
         {
+          "$comment": "Tag spans must be strictly positive length (endIndex > startIndex). The C# validator enforces this; this schema entry documents the contract for downstream consumers.",
+          "if": { "required": ["startIndex", "endIndex"] },
+          "then": {
+            "properties": {
+              "endIndex": { "exclusiveMinimum": { "$data": "1/startIndex" } }
+            }
+          }
+        },
+        {
           "if": { "properties": { "category": { "const": "MuyBien" } } },
           "then": {
             "properties": {

--- a/backend/LangTeach.Api/Services/CorrectionDtoMapper.cs
+++ b/backend/LangTeach.Api/Services/CorrectionDtoMapper.cs
@@ -1,0 +1,30 @@
+using LangTeach.Api.Data.Models;
+using LangTeach.Api.DTOs;
+
+namespace LangTeach.Api.Services;
+
+/// <summary>
+/// Shared Correction → CorrectionDetailDto mapping. Used by CorrectionService
+/// (CRUD lifecycle) and RedaccionCorrectionService (post-generation read-back).
+/// </summary>
+internal static class CorrectionDtoMapper
+{
+    public static CorrectionDetailDto ToDetail(Correction c, IEnumerable<CorrectionTag> tags) =>
+        new(
+            c.Id,
+            c.StudentId,
+            c.SchemaVersion,
+            c.Status,
+            c.AssignmentTitle,
+            c.AssignmentPrompt,
+            c.StudentText,
+            c.MarkedUpOutput,
+            tags.OrderBy(t => t.OrderIndex)
+                .Select(t => new CorrectionTagDto(
+                    t.Category, t.SpannedText, t.StartIndex, t.EndIndex,
+                    t.Explanation, t.CorrectedForm, t.OrderIndex))
+                .ToList(),
+            c.CreatedAt,
+            c.UpdatedAt,
+            c.CorrectedAt);
+}

--- a/backend/LangTeach.Api/Services/CorrectionService.cs
+++ b/backend/LangTeach.Api/Services/CorrectionService.cs
@@ -152,19 +152,5 @@ public class CorrectionService : ICorrectionService
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 
     private static CorrectionDetailDto ToDetail(Correction c, IEnumerable<CorrectionTag> tags) =>
-        new(
-            c.Id,
-            c.StudentId,
-            c.SchemaVersion,
-            c.Status,
-            c.AssignmentTitle,
-            c.AssignmentPrompt,
-            c.StudentText,
-            c.MarkedUpOutput,
-            tags.OrderBy(t => t.OrderIndex)
-                .Select(t => new CorrectionTagDto(t.Category, t.SpannedText, t.StartIndex, t.EndIndex, t.Explanation, t.CorrectedForm, t.OrderIndex))
-                .ToList(),
-            c.CreatedAt,
-            c.UpdatedAt,
-            c.CorrectedAt);
+        CorrectionDtoMapper.ToDetail(c, tags);
 }

--- a/backend/LangTeach.Api/Services/IRedaccionCorrectionService.cs
+++ b/backend/LangTeach.Api/Services/IRedaccionCorrectionService.cs
@@ -1,0 +1,33 @@
+using LangTeach.Api.DTOs;
+
+namespace LangTeach.Api.Services;
+
+public interface IRedaccionCorrectionService
+{
+    Task<CorrectionDetailDto> CorregirAsync(
+        Guid teacherId, Guid studentId, Guid correctionId, CancellationToken cancellationToken = default);
+}
+
+public class CorrectionNotFoundException : Exception
+{
+    public CorrectionNotFoundException() : base("Correction not found.") { }
+}
+
+public class CorrectionInvalidStateException : Exception
+{
+    public string Code { get; }
+    public CorrectionInvalidStateException(string code, string message) : base(message)
+    {
+        Code = code;
+    }
+}
+
+public class CorrectionGenerationException : Exception
+{
+    public string Code { get; }
+    public CorrectionGenerationException(string code, string message, Exception? inner = null)
+        : base(message, inner)
+    {
+        Code = code;
+    }
+}

--- a/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
+++ b/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
@@ -152,19 +152,22 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
 
         // Reload tags through the tracked context so DTO ordering is stable.
         var persistedTags = correction.Tags.OrderBy(t => t.OrderIndex).ToList();
-        return ToDetail(correction, persistedTags);
+        return CorrectionDtoMapper.ToDetail(correction, persistedTags);
     }
 
     private static RedaccionCorrectionPromptContext BuildPromptContext(Correction correction, Student student)
     {
-        var sanitizedText = correction.StudentText ?? string.Empty;
+        // StudentText is preserved verbatim (no InputSanitizer call): tag offsets must
+        // address the same string the model echoes back as originalText. Sanitization
+        // happens at write time on POST /corrections (DTO layer); we trust what's in DB.
+        var studentText = correction.StudentText ?? string.Empty;
         var cefr = CefrLevelNormalizer.Normalize(student.CefrLevel);
 
         var l1 = ParseFirstString(student.NativeLanguages);
         var difficulties = ParseStringArray(student.Difficulties);
 
         return new RedaccionCorrectionPromptContext(
-            StudentText: sanitizedText,
+            StudentText: studentText,
             StudentCefr: cefr,
             StudentL1: l1,
             StudentDifficulties: difficulties,
@@ -296,23 +299,6 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
 
         return nonOverlapping;
     }
-
-    private static CorrectionDetailDto ToDetail(Correction c, IEnumerable<CorrectionTag> tags) =>
-        new(
-            c.Id,
-            c.StudentId,
-            c.SchemaVersion,
-            c.Status,
-            c.AssignmentTitle,
-            c.AssignmentPrompt,
-            c.StudentText,
-            c.MarkedUpOutput,
-            tags.OrderBy(t => t.OrderIndex)
-                .Select(t => new CorrectionTagDto(t.Category, t.SpannedText, t.StartIndex, t.EndIndex, t.Explanation, t.CorrectedForm, t.OrderIndex))
-                .ToList(),
-            c.CreatedAt,
-            c.UpdatedAt,
-            c.CorrectedAt);
 
     // Internal DTO mirroring redaccion-correction.schema.json. Exposed as a record so tests
     // can construct fixture payloads against the same shape the production code parses.

--- a/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
+++ b/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
@@ -119,6 +119,25 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
 
         var validatedTags = ValidateAndOrderTags(dto.Tags ?? [], sentText, correctionId);
 
+        // TOCTOU guard: a concurrent /corregir call could have completed during our Claude
+        // round-trip. Re-check the persisted status before writing tags to avoid duplicate
+        // tag rows (last-write-wins on the parent row is acceptable; duplicate child rows
+        // are not). True atomicity requires a Corrigiendo state + DB-level claim, which
+        // needs a migration; deferred to a follow-up. See plan/code-review-backlog.md.
+        var freshStatus = await _db.Corrections
+            .AsNoTracking()
+            .Where(c => c.Id == correctionId)
+            .Select(c => c.Status)
+            .FirstOrDefaultAsync(cancellationToken);
+        if (freshStatus != CorrectionStatus.Entregada)
+        {
+            _logger.LogWarning(
+                "Redaccion correction: another request completed first (status now {Status}). Discarding this run. CorrectionId={CorrectionId}",
+                freshStatus, correctionId);
+            throw new CorrectionInvalidStateException("already_corrected",
+                "Another request completed this correction concurrently.");
+        }
+
         var now = DateTime.UtcNow;
         correction.MarkedUpOutput = stripped;
         correction.Status = CorrectionStatus.Corregida;

--- a/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
+++ b/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
@@ -1,0 +1,331 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LangTeach.Api.AI;
+using LangTeach.Api.Data;
+using LangTeach.Api.Data.Models;
+using LangTeach.Api.DTOs;
+using LangTeach.Api.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace LangTeach.Api.Services;
+
+public class RedaccionCorrectionService : IRedaccionCorrectionService
+{
+    private readonly AppDbContext _db;
+    private readonly IClaudeClient _claude;
+    private readonly RedaccionCorrectionPromptBuilder _promptBuilder;
+    private readonly ILogger<RedaccionCorrectionService> _logger;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+    };
+
+    public RedaccionCorrectionService(
+        AppDbContext db,
+        IClaudeClient claude,
+        RedaccionCorrectionPromptBuilder promptBuilder,
+        ILogger<RedaccionCorrectionService> logger)
+    {
+        _db = db;
+        _claude = claude;
+        _promptBuilder = promptBuilder;
+        _logger = logger;
+    }
+
+    public async Task<CorrectionDetailDto> CorregirAsync(
+        Guid teacherId, Guid studentId, Guid correctionId, CancellationToken cancellationToken = default)
+    {
+        var correction = await _db.Corrections
+            .Include(c => c.Tags)
+            .FirstOrDefaultAsync(
+                c => c.Id == correctionId
+                  && c.TeacherId == teacherId
+                  && c.StudentId == studentId
+                  && c.DeletedAt == null,
+                cancellationToken);
+
+        if (correction is null)
+            throw new CorrectionNotFoundException();
+
+        if (correction.Status == CorrectionStatus.Pendiente)
+            throw new CorrectionInvalidStateException("no_student_text",
+                "Cannot correct a redacción before student text is provided.");
+        if (correction.Status == CorrectionStatus.Corregida)
+            throw new CorrectionInvalidStateException("already_corrected",
+                "This redacción has already been corrected.");
+        if (correction.Status != CorrectionStatus.Entregada)
+            throw new CorrectionInvalidStateException("invalid_status",
+                $"Unexpected status: {correction.Status}.");
+
+        // Correction has no Student navigation (AppDbContext configures HasOne<Student>() with no nav).
+        // Load the student separately to access CefrLevel / NativeLanguages / Difficulties.
+        var student = await _db.Students.FirstOrDefaultAsync(
+            s => s.Id == studentId && s.TeacherId == teacherId && !s.IsDeleted, cancellationToken)
+            ?? throw new CorrectionNotFoundException();
+
+        var ctx = BuildPromptContext(correction, student);
+        var request = _promptBuilder.Build(ctx);
+
+        ClaudeResponse response;
+        try
+        {
+            response = await _claude.CompleteAsync(request, cancellationToken);
+        }
+        catch (ClaudeRateLimitException ex)
+        {
+            throw new CorrectionGenerationException("upstream_error", ex.Message, ex);
+        }
+        catch (ClaudeApiException ex)
+        {
+            throw new CorrectionGenerationException("upstream_error", ex.Message, ex);
+        }
+
+        var raw = response.Content;
+        var stripped = ContentJsonHelper.StripFences(raw);
+        if (string.IsNullOrWhiteSpace(stripped))
+        {
+            _logger.LogWarning("Redaccion correction: empty/blank Claude response. CorrectionId={CorrectionId}", correctionId);
+            throw new CorrectionGenerationException("invalid_json", "Claude returned empty content.");
+        }
+
+        RedaccionCorrectionDto? dto;
+        try
+        {
+            dto = JsonSerializer.Deserialize<RedaccionCorrectionDto>(stripped, JsonOpts);
+        }
+        catch (JsonException ex)
+        {
+            var excerpt = stripped.Length > 200 ? stripped[..200] + "..." : stripped;
+            _logger.LogWarning(ex, "Redaccion correction: failed to parse JSON. CorrectionId={CorrectionId} Excerpt={Excerpt}",
+                correctionId, excerpt);
+            throw new CorrectionGenerationException("invalid_json", "Claude response did not parse as the expected JSON shape.", ex);
+        }
+
+        if (dto is null || dto.SchemaVersion != 1)
+            throw new CorrectionGenerationException("invalid_json", "Claude response is missing or has an unsupported schemaVersion.");
+
+        var sentText = ctx.StudentText;
+        if (!string.Equals(dto.OriginalText, sentText, StringComparison.Ordinal))
+        {
+            _logger.LogWarning(
+                "Redaccion correction: originalText mismatch (model paraphrased input). CorrectionId={CorrectionId} SentLen={SentLen} ReturnedLen={ReturnedLen}",
+                correctionId, sentText.Length, dto.OriginalText?.Length ?? 0);
+            throw new CorrectionGenerationException(
+                "original_text_mismatch",
+                "Claude returned a paraphrased originalText; tag offsets cannot be trusted.");
+        }
+
+        var validatedTags = ValidateAndOrderTags(dto.Tags ?? [], sentText, correctionId);
+
+        var now = DateTime.UtcNow;
+        correction.MarkedUpOutput = stripped;
+        correction.Status = CorrectionStatus.Corregida;
+        correction.CorrectedAt = now;
+        correction.UpdatedAt = now;
+        correction.SchemaVersion = 1;
+
+        for (var i = 0; i < validatedTags.Count; i++)
+        {
+            var t = validatedTags[i];
+            _db.CorrectionTags.Add(new CorrectionTag
+            {
+                Id = Guid.NewGuid(),
+                CorrectionId = correction.Id,
+                Category = t.Category,
+                StartIndex = t.StartIndex,
+                EndIndex = t.EndIndex,
+                SpannedText = t.SpannedText,
+                Explanation = t.Explanation,
+                CorrectedForm = t.CorrectedForm,
+                OrderIndex = i,
+            });
+        }
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Redaccion correction generated. CorrectionId={CorrectionId} TeacherId={TeacherId} StudentId={StudentId} Cefr={Cefr} L1={L1} TagCount={TagCount} ModelTokens={InputTokens}/{OutputTokens}",
+            correction.Id, teacherId, studentId, ctx.StudentCefr, ctx.StudentL1 ?? "(none)",
+            validatedTags.Count, response.InputTokens, response.OutputTokens);
+
+        // Reload tags through the tracked context so DTO ordering is stable.
+        var persistedTags = correction.Tags.OrderBy(t => t.OrderIndex).ToList();
+        return ToDetail(correction, persistedTags);
+    }
+
+    private static RedaccionCorrectionPromptContext BuildPromptContext(Correction correction, Student student)
+    {
+        var sanitizedText = correction.StudentText ?? string.Empty;
+        var cefr = CefrLevelNormalizer.Normalize(student.CefrLevel);
+
+        var l1 = ParseFirstString(student.NativeLanguages);
+        var difficulties = ParseStringArray(student.Difficulties);
+
+        return new RedaccionCorrectionPromptContext(
+            StudentText: sanitizedText,
+            StudentCefr: cefr,
+            StudentL1: l1,
+            StudentDifficulties: difficulties,
+            AssignmentPrompt: correction.AssignmentPrompt);
+    }
+
+    private static string? ParseFirstString(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind == JsonValueKind.Array && doc.RootElement.GetArrayLength() > 0)
+            {
+                var first = doc.RootElement[0];
+                if (first.ValueKind == JsonValueKind.String)
+                {
+                    var v = first.GetString();
+                    return string.IsNullOrWhiteSpace(v) ? null : v.Trim();
+                }
+            }
+        }
+        catch (JsonException) { /* fall through */ }
+        return null;
+    }
+
+    private static IReadOnlyList<string> ParseStringArray(string json)
+    {
+        var result = new List<string>();
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var el in doc.RootElement.EnumerateArray())
+                {
+                    if (el.ValueKind == JsonValueKind.String)
+                    {
+                        var v = el.GetString();
+                        if (!string.IsNullOrWhiteSpace(v))
+                            result.Add(v.Trim());
+                    }
+                    else if (el.ValueKind == JsonValueKind.Object && el.TryGetProperty("description", out var desc))
+                    {
+                        // Difficulties may also be stored as objects with a description field.
+                        var v = desc.GetString();
+                        if (!string.IsNullOrWhiteSpace(v))
+                            result.Add(v.Trim());
+                    }
+                }
+            }
+        }
+        catch (JsonException) { /* fall through */ }
+        return result;
+    }
+
+    private List<RedaccionCorrectionTagDto> ValidateAndOrderTags(
+        IReadOnlyList<RedaccionCorrectionTagDto> rawTags, string originalText, Guid correctionId)
+    {
+        var kept = new List<RedaccionCorrectionTagDto>(rawTags.Count);
+        var len = originalText.Length;
+
+        foreach (var tag in rawTags)
+        {
+            if (string.IsNullOrEmpty(tag.Category) || !CorrectionTagCategory.IsValid(tag.Category))
+            {
+                _logger.LogWarning("Drop tag: invalid category '{Category}'. CorrectionId={CorrectionId}", tag.Category, correctionId);
+                continue;
+            }
+            if (tag.StartIndex < 0 || tag.EndIndex <= tag.StartIndex || tag.EndIndex > len)
+            {
+                _logger.LogWarning(
+                    "Drop tag: bad offsets [{Start},{End}) against text length {Len}. CorrectionId={CorrectionId}",
+                    tag.StartIndex, tag.EndIndex, len, correctionId);
+                continue;
+            }
+            var actualSpan = originalText.Substring(tag.StartIndex, tag.EndIndex - tag.StartIndex);
+            if (!string.Equals(actualSpan, tag.SpannedText, StringComparison.Ordinal))
+            {
+                _logger.LogWarning(
+                    "Drop tag: spannedText '{Sent}' does not match originalText[{Start},{End}) = '{Actual}'. CorrectionId={CorrectionId}",
+                    tag.SpannedText, tag.StartIndex, tag.EndIndex, actualSpan, correctionId);
+                continue;
+            }
+
+            string? explanation = tag.Explanation;
+            string? correctedForm = tag.CorrectedForm;
+
+            if (tag.Category == CorrectionTagCategory.MuyBien)
+            {
+                if (!string.IsNullOrWhiteSpace(explanation) || !string.IsNullOrWhiteSpace(correctedForm))
+                {
+                    _logger.LogWarning(
+                        "MuyBien tag had non-null explanation/correctedForm; coercing to null. CorrectionId={CorrectionId}",
+                        correctionId);
+                }
+                explanation = null;
+                correctedForm = null;
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(explanation) || string.IsNullOrWhiteSpace(correctedForm))
+                {
+                    _logger.LogWarning(
+                        "Drop tag: category {Category} requires non-empty explanation and correctedForm. CorrectionId={CorrectionId}",
+                        tag.Category, correctionId);
+                    continue;
+                }
+            }
+
+            kept.Add(tag with { Explanation = explanation, CorrectedForm = correctedForm });
+        }
+
+        kept.Sort((a, b) => a.StartIndex.CompareTo(b.StartIndex));
+
+        var nonOverlapping = new List<RedaccionCorrectionTagDto>(kept.Count);
+        var lastEnd = 0;
+        foreach (var tag in kept)
+        {
+            if (tag.StartIndex < lastEnd)
+            {
+                _logger.LogWarning(
+                    "Drop tag: overlaps prior tag (start {Start} < lastEnd {LastEnd}). CorrectionId={CorrectionId}",
+                    tag.StartIndex, lastEnd, correctionId);
+                continue;
+            }
+            nonOverlapping.Add(tag);
+            lastEnd = tag.EndIndex;
+        }
+
+        return nonOverlapping;
+    }
+
+    private static CorrectionDetailDto ToDetail(Correction c, IEnumerable<CorrectionTag> tags) =>
+        new(
+            c.Id,
+            c.StudentId,
+            c.SchemaVersion,
+            c.Status,
+            c.AssignmentTitle,
+            c.AssignmentPrompt,
+            c.StudentText,
+            c.MarkedUpOutput,
+            tags.OrderBy(t => t.OrderIndex)
+                .Select(t => new CorrectionTagDto(t.Category, t.SpannedText, t.StartIndex, t.EndIndex, t.Explanation, t.CorrectedForm, t.OrderIndex))
+                .ToList(),
+            c.CreatedAt,
+            c.UpdatedAt,
+            c.CorrectedAt);
+
+    // Internal DTO mirroring redaccion-correction.schema.json. Exposed as a record so tests
+    // can construct fixture payloads against the same shape the production code parses.
+    public record RedaccionCorrectionDto(
+        [property: JsonPropertyName("schemaVersion")] int SchemaVersion,
+        [property: JsonPropertyName("originalText")] string OriginalText,
+        [property: JsonPropertyName("tags")] IReadOnlyList<RedaccionCorrectionTagDto>? Tags);
+
+    public record RedaccionCorrectionTagDto(
+        [property: JsonPropertyName("category")] string Category,
+        [property: JsonPropertyName("startIndex")] int StartIndex,
+        [property: JsonPropertyName("endIndex")] int EndIndex,
+        [property: JsonPropertyName("spannedText")] string SpannedText,
+        [property: JsonPropertyName("explanation")] string? Explanation,
+        [property: JsonPropertyName("correctedForm")] string? CorrectedForm);
+}

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -73,3 +73,16 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 ## #1152 (Sophy review notes, APPROVE with follow-ups)
 - Pre-prompt-service: add a CHECK constraint or service-level guard so Status/Category writes are restricted to the string-constant sets. Today only CorrectionService writes; risk surfaces when the AI service starts pushing values directly. Land before #PROMPT_SERVICE issue.
 - Sprint-level decision: pick a soft-delete convention (DeletedAt timestamp vs IsDeleted bool) and either fold Corrections back or migrate the rest. Should not leave both patterns drifting.
+
+## #1153 (Architecture review notes, PASS WITH NOTES)
+- StubClaudeClient (test helper) and SequentialClaudeClient (CurriculumGenerationServiceTests-local) overlap in scope. Consider consolidating into a single shared `Helpers/` test double. Functional difference is real (singleton-suitable for WebAppFactory vs unit-test-local), but the API surfaces should converge to one class.
+
+## #1153 (Sophy review notes, APPROVE with follow-ups)
+- Externalize category definitions (C/G/L/O/MuyBien names, definitions, anti-pattern rules) from `RedaccionCorrectionPromptBuilder.SystemPrompt` to `data/pedagogy/correction-categories.json`. Drives the prompt from `CorrectionTagCategory` + JSON description map; eliminates duplicate truth between code enum and prompt text.
+- Externalize per-CEFR-band calibration cues (`LevelCalibrationCue`) to `data/pedagogy/` (new `correction-calibration.json` or extend `prompt-fragments.json`). Pedagogical voice should be editable without redeploy.
+- Document the relationship between `Correction.MarkedUpOutput` (verbatim AI JSON, audit) and `CorrectionTag` rows (queryable truth) in the `Correction` entity XML doc so future maintainers don't try to "clean it up".
+- The published JSON Schema at `backend/LangTeach.Api/Schemas/redaccion-correction.schema.json` is reference-only; C# field validation in `ValidateAndOrderTags` is the enforcement layer. Either wire schema validation in or document the schema as reference-only.
+
+## #1153 (Prompt-health review notes, NEEDS CLEANUP — partially addressed)
+- Findings #3-#6 (MuyBien null discipline, "VERBATIM" duplication, "DO NOT paraphrase" negative-bloat, opening "category fidelity is non-negotiable" sentence) addressed inline in the same PR.
+- Findings #1 and #2 (offset bounds + non-overlap + span-match instructions) deferred: the service drops bad tags rather than coercing, so the model still benefits from explicit guidance to maximize useful output. Re-evaluate if a future iteration adds offset autocorrection.

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -86,3 +86,7 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 ## #1153 (Prompt-health review notes, NEEDS CLEANUP — partially addressed)
 - Findings #3-#6 (MuyBien null discipline, "VERBATIM" duplication, "DO NOT paraphrase" negative-bloat, opening "category fidelity is non-negotiable" sentence) addressed inline in the same PR.
 - Findings #1 and #2 (offset bounds + non-overlap + span-match instructions) deferred: the service drops bad tags rather than coercing, so the model still benefits from explicit guidance to maximize useful output. Re-evaluate if a future iteration adds offset autocorrection.
+
+## #1153 (CodeRabbit findings, partially addressed)
+- **Schema (Minor):** Added `endIndex > startIndex` cross-field constraint to `redaccion-correction.schema.json`. Schema is reference-only; C# `ValidateAndOrderTags` is the runtime enforcement layer.
+- **TOCTOU race on /corregir (Major) — partially addressed:** Added a fresh-status recheck in `RedaccionCorrectionService.CorregirAsync` between Claude's response and the SaveChanges. Closes the duplicate-tag-rows half of the race. Does NOT prevent both concurrent calls from invoking Claude (double cost). True atomic claim requires either (a) a `Corrigiendo` enum value + DB CHECK constraint update + flip-and-save before the LLM call, or (b) a `RowVersion`/`[Timestamp]` concurrency token on `Correction`. Both options need a migration. Defer until the frontend exposes the corregir button to a multi-tab/double-click vector — for v1, the UI debounces and the blast radius is bounded.

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -8,6 +8,7 @@ Out-of-scope observations logged by agents during implementation. Each row is so
 | #1065 | 2026-05-04 | low | Todo trigger phrases ("añade un teaching todo", etc.) duplicated in two PromptService.cs blocks; should be extracted to data/atelier/intent-triggers.json in a future cleanup (Sophy) |
 | #1065 | 2026-05-04 | low | CreateTeachingTodoDto.DueDate is string? while sibling CreateTeacherFollowupRequest.DueDate is DateOnly?; inconsistent binding strategy for same entity field (arch review) |
 | #smoke-hardening | 2026-05-04 | low | "Apply" button in Atelier Assistant proposal flow not smoke-testable without real audio; #1065 fix end-to-end unconfirmed |
+| #1153 | 2026-05-08 | low | `frontend/src/pages/StudentForm.test.tsx > "includes identity fields in form submission"` is flaky under parallel vitest load (1 fail in full run, 72/72 pass when isolated). Pre-existing — unrelated to redacciones. |
 
 *Cleared 2026-04-22 during UI Redesign & Student Profile Polish sprint close. Actionable entries batched into: #833 (bug batch), #834 (seeder gaps), #835 (e2e session-log rewrite), #836 (ScenarioSeeder Hans B1), #837 (deduplication), #838 (session title from web UI), #839 (debug log privacy), #840 (Edit Student UX), #841 (stale closure + LogSession pre-populate). Already-tracked entries removed (referenced #737/#707/#644/#714/#715/#716/#683/#741/#742/#756/#809/#657). Dismissed entries removed (defensive-only, intentional, or resolved).*
 


### PR DESCRIPTION
Closes #1153.

## Summary

- Wires up `POST /api/students/{studentId}/corrections/{id}/corregir` to generate a structured marked-up correction via Claude Sonnet, replacing the 501 stub from #1152.
- New `RedaccionCorrectionPromptBuilder` (separate from PromptService — different lifecycle, no SectionProfile machinery applies) with verbatim category definitions (C/G/L/O/MuyBien), anti-pattern rules, CEFR-relative calibration cues, L1 interference reuse via `IPedagogyConfigService.GetL1Adjustments`, tracked-difficulties block, and assignment context.
- New `RedaccionCorrectionService`: load + Claude call + validate (offset bounds, span-text round-trip, MuyBien null discipline, overlap drop) + transactional persistence (status→Corregida, tag rows, MarkedUpOutput).
- Controller maps 404 (not found), 409 (no_student_text / already_corrected), 502 (invalid_json / original_text_mismatch / upstream_error). 502 leaves status reverted so the teacher can retry.
- Published JSON Schema at `backend/LangTeach.Api/Schemas/redaccion-correction.schema.json`.
- Shared `CorrectionDtoMapper.ToDetail` extracted so both correction services reuse one mapper.
- `prior-findings.md` updated for Teacher QA tracking.

## Test plan

- [x] `dotnet test` — 1317 pass, 7 opt-in real-Claude tests skipped.
- [x] `RedaccionCorrectionPromptBuilderTests`: L1 / difficulties / assignment / CEFR cue presence + absence.
- [x] `RedaccionCorrectionServiceTests` — 11 cases incl. state guards, happy path, invalid_json with status revert, paraphrase rejection, bad-offset drop, overlap drop, MuyBien coercion, blank-explanation drop, category fidelity round-trip.
- [x] `CorrectionsControllerTests` — corregir 200/409/502 + cold-paste flow end-to-end.
- [x] `RedaccionCorrectionDualLevelTests` — `[SkipIfNoClaudeApiKey]` opt-in real-Claude moat test (A2 vs B2 must differ; "ablar" must be tagged O).
- [x] qa-verify: PASS WITH GAPS (single gap is no automated runtime schema validation; field-level C# validation is the enforcement layer; logged to backlog).
- [x] architecture-reviewer: PASS WITH NOTES — duplicate `ToDetail` extracted, misleading variable renamed, StubClaudeClient/SequentialClaudeClient consolidation deferred to backlog.
- [x] sophy: APPROVE WITH FOLLOW-UPS — externalize categories + CEFR cues to `data/pedagogy/` deferred to backlog.
- [x] prompt-health: NEEDS CLEANUP → addressed (4 of 6 findings inline; 2 deferred with rationale to backlog).
- [x] pedagogy: ADJUST → SOUND after revisions (G preposition disambiguation, MuyBien spannedText non-empty, A1/A2 tildes, B1/B2 formulaic subjunctive, C1/C2 priority-vs-flag wording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added writing assignment correction feature that provides personalized feedback based on student proficiency level (CEFR) and native language.
  * Corrections include structured tagging of errors across multiple categories with explanations and suggested corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->