### PR TITLE
fix(#1150): navigation helper race causes Sprint Reviewer timeout

### DIFF
--- a/.claude/skills/teacher-qa/playwright/helpers/navigation.ts
+++ b/.claude/skills/teacher-qa/playwright/helpers/navigation.ts
@@ -199,21 +199,22 @@ export async function ensureStudentHasSessionLog(
 ): Promise<void> {
   const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5175'
 
-  // Check existing sessions via the summary endpoint.
-  // Attach the response listener BEFORE goto so it is bound to a stable
-  // promise reference before navigation kicks off the request.
-  const summaryResponsePromise = page.waitForResponse(
+  // Attach the response listener BEFORE goto so the listener is active
+  // before the page fires the request.
+  const sessionsResponsePromise = page.waitForResponse(
     resp =>
-      resp.url().includes(`/api/students/${studentId}/sessions/summary`) &&
+      resp.url().includes(`/api/students/${studentId}/sessions`) &&
+      !resp.url().includes('/extract') &&
+      resp.request().method() === 'GET' &&
       resp.status() === 200 &&
       resp.request().resourceType() === 'xhr',
     { timeout: 15000 }
   )
   await page.goto(`${baseURL}/students/${studentId}?tab=sessions`)
-  const summaryResponse = await summaryResponsePromise
+  const sessionsResponse = await sessionsResponsePromise
 
-  const summary: { totalSessions?: number } = await summaryResponse.json()
-  if ((summary.totalSessions ?? 0) > 0) return
+  const sessions: unknown[] = await sessionsResponse.json()
+  if (sessions.length > 0) return
 
   // No sessions — create a minimal confirmed one via the log-session UI
   await page.goto(`${baseURL}/students/${studentId}/log-session`)

--- a/.claude/skills/teacher-qa/playwright/helpers/navigation.ts
+++ b/.claude/skills/teacher-qa/playwright/helpers/navigation.ts
@@ -199,17 +199,18 @@ export async function ensureStudentHasSessionLog(
 ): Promise<void> {
   const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5175'
 
-  // Check existing sessions via the summary endpoint
-  const [summaryResponse] = await Promise.all([
-    page.waitForResponse(
-      resp =>
-        resp.url().includes(`/api/students/${studentId}/sessions/summary`) &&
-        resp.status() === 200 &&
-        resp.request().resourceType() === 'xhr',
-      { timeout: 10000 }
-    ),
-    page.goto(`${baseURL}/students/${studentId}?tab=sessions`),
-  ])
+  // Check existing sessions via the summary endpoint.
+  // Attach the response listener BEFORE goto so it is bound to a stable
+  // promise reference before navigation kicks off the request.
+  const summaryResponsePromise = page.waitForResponse(
+    resp =>
+      resp.url().includes(`/api/students/${studentId}/sessions/summary`) &&
+      resp.status() === 200 &&
+      resp.request().resourceType() === 'xhr',
+    { timeout: 15000 }
+  )
+  await page.goto(`${baseURL}/students/${studentId}?tab=sessions`)
+  const summaryResponse = await summaryResponsePromise
 
   const summary: { totalSessions?: number } = await summaryResponse.json()
   if ((summary.totalSessions ?? 0) > 0) return

--- a/.claude/skills/teacher-qa/playwright/helpers/navigation.ts
+++ b/.claude/skills/teacher-qa/playwright/helpers/navigation.ts
@@ -216,18 +216,20 @@ export async function ensureStudentHasSessionLog(
   const sessions: unknown[] = await sessionsResponse.json()
   if (sessions.length > 0) return
 
-  // No sessions — create a minimal confirmed one via the log-session UI
-  await page.goto(`${baseURL}/students/${studentId}/log-session`)
-  await page.locator('[data-testid="log-session-page"]').waitFor({ state: 'visible', timeout: 15000 })
-
-  // Wait for autosave to create the Draft session before clicking Done
-  await page.waitForResponse(
+  // No sessions — create a minimal confirmed one via the log-session UI.
+  // Attach the autosave POST listener BEFORE goto so it captures the
+  // response even if autosave fires during initial page load.
+  const autosavePromise = page.waitForResponse(
     resp =>
       resp.url().includes(`/api/students/${studentId}/sessions`) &&
+      !resp.url().includes('/extract') &&
       resp.request().method() === 'POST' &&
       resp.status() === 201,
-    { timeout: 15000 }
+    { timeout: 30000 }
   )
+  await page.goto(`${baseURL}/students/${studentId}/log-session`)
+  await page.locator('[data-testid="log-session-page"]').waitFor({ state: 'visible', timeout: 15000 })
+  await autosavePromise
 
   await page.click('[data-testid="done-btn"]')
 

--- a/.claude/skills/teacher-qa/playwright/helpers/navigation.ts
+++ b/.claude/skills/teacher-qa/playwright/helpers/navigation.ts
@@ -217,24 +217,14 @@ export async function ensureStudentHasSessionLog(
   if (sessions.length > 0) return
 
   // No sessions — create a minimal confirmed one via the log-session UI.
-  // Attach the autosave POST listener BEFORE goto so it captures the
-  // response even if autosave fires during initial page load.
-  const autosavePromise = page.waitForResponse(
-    resp =>
-      resp.url().includes(`/api/students/${studentId}/sessions`) &&
-      !resp.url().includes('/extract') &&
-      resp.request().method() === 'POST' &&
-      resp.status() === 201,
-    { timeout: 30000 }
-  )
+  // Clicking Done triggers saveNow() which POSTs the session and redirects.
   await page.goto(`${baseURL}/students/${studentId}/log-session`)
   await page.locator('[data-testid="log-session-page"]').waitFor({ state: 'visible', timeout: 15000 })
-  await autosavePromise
 
   await page.click('[data-testid="done-btn"]')
 
   // Wait until redirected away from the log-session page
-  await page.waitForURL(`${baseURL}/students/${studentId}**`, { timeout: 15000 })
+  await page.waitForURL(`${baseURL}/students/${studentId}**`, { timeout: 30000 })
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixed `ensureStudentHasSessionLog` in `.claude/skills/teacher-qa/playwright/helpers/navigation.ts` which was causing Sprint Reviewer persona to time out during Teacher QA
- Root cause: helper waited for a `/sessions/summary` endpoint that does not exist (frontend fetches `GET /api/students/{id}/sessions` instead)
- Secondary fix: removed dead `waitForResponse` for the autosave POST which only fires on user interaction, not on page load. Simplified to navigate, click Done, wait for redirect
- Applied listener-before-goto pattern and bumped timeouts to 15s/30s as safety net

## Acceptance verified

- Sprint Reviewer persona completes without timeout (64s generation, 5 sections, all artifacts captured)
- No product code changes, helper-only

## Test plan

- [x] Sprint Reviewer persona passes via `teacher-qa sprint`
- [x] `dotnet build` + `dotnet test` pass
- [x] `npm lint` + `npm build` pass
- [x] `npm test` (1696/1696 pass; pre-existing StudentForm flakes pass in isolation)

Closes #1150

🤖 Generated with [Claude Code](https://claude.com/claude-code)