### PR TITLE
fix(#1151): assert disabled FAB instead of clicking it on no-student screen

### DIFF
--- a/e2e/tests/visual/atelier-1029-new-session-proposal.visual.spec.ts
+++ b/e2e/tests/visual/atelier-1029-new-session-proposal.visual.spec.ts
@@ -65,29 +65,10 @@ test('@visual atelier-1029 new-session-proposal-no-student', async ({ browser })
   await expect(page.locator('h1')).toBeVisible({ timeout: NAV_TIMEOUT })
   await page.waitForLoadState('networkidle', { timeout: UI_TIMEOUT })
 
-  // Open assistant panel
+  // Assert FAB is disabled — product invariant: no student context means the assistant cannot be opened
   const assistantBtn = page.locator('[data-testid="open-assistant-btn"]').first()
-  await assistantBtn.click()
-  await expect(page.locator('[data-testid="assistant-panel"]')).toBeVisible({ timeout: UI_TIMEOUT })
-
-  // Submit scheduling text
-  const input = page.locator('[data-testid="assistant-input"]')
-  await input.fill('La semana que viene hagamos el subjuntivo. [schedule-new-session]')
-  await page.locator('[data-testid="assistant-send-btn"]').click()
-
-  // Wait for proposals; scroll to newSession card
-  await expect(page.locator('[data-testid="proposals-list"]')).toBeVisible({ timeout: UI_TIMEOUT })
-  await page.waitForLoadState('networkidle', { timeout: UI_TIMEOUT })
-
-  // Assert newSession card disabled state before screenshotting
-  const dateInput2 = page.locator('[data-testid^="session-date-input-"]').first()
-  await expect(dateInput2).toBeVisible({ timeout: UI_TIMEOUT })
-  await dateInput2.scrollIntoViewIfNeeded()
-
-  // Verify Apply is disabled and helper text is present
-  const applyBtnLocator = page.locator('[data-testid^="apply-btn-"]').filter({ hasText: /apply/i }).first()
-  await expect(applyBtnLocator).toBeDisabled({ timeout: UI_TIMEOUT })
-  await expect(page.getByText("Open from a student's screen to schedule a session")).toBeVisible({ timeout: UI_TIMEOUT })
+  await expect(assistantBtn).toBeVisible({ timeout: UI_TIMEOUT })
+  await expect(assistantBtn).toBeDisabled({ timeout: UI_TIMEOUT })
 
   await page.screenshot({ path: 'screenshots/atelier-1029-new-session-proposal-no-student.png', fullPage: true })
 

--- a/e2e/tests/visual/atelier-1029-new-session-proposal.visual.spec.ts
+++ b/e2e/tests/visual/atelier-1029-new-session-proposal.visual.spec.ts
@@ -69,6 +69,7 @@ test('@visual atelier-1029 new-session-proposal-no-student', async ({ browser })
   const assistantBtn = page.locator('[data-testid="open-assistant-btn"]').first()
   await expect(assistantBtn).toBeVisible({ timeout: UI_TIMEOUT })
   await expect(assistantBtn).toBeDisabled({ timeout: UI_TIMEOUT })
+  await expect(assistantBtn).toHaveAttribute('aria-disabled', 'true')
 
   await page.screenshot({ path: 'screenshots/atelier-1029-new-session-proposal-no-student.png', fullPage: true })
 

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -3,6 +3,7 @@
 Out-of-scope observations logged by agents during implementation. Each row is something an agent noticed but did not fix because it was outside the current task's scope. These get batched into future GitHub issues by the PM.
 
 | Source issue | Date | Severity | Observation |
+| #1151 | 2026-05-09 | P3:nice | Apply-disabled + "Open from a student's screen" helper text invariant has no e2e coverage; was in the no-student spec but can only be tested from a student context (panel open) -- needs a new spec |
 | #smoke-hardening | 2026-05-04 | medium | `/dashboard` route renders blank white page; correct route is `/` - sidebar link uses `/` but direct navigation to `/dashboard` silently fails |
 | #1065 | 2026-05-04 | low | CreateTeachingTodoDto.DueDate lacks [RegularExpression] format attribute; invalid dates accepted at model-binding boundary and silently become null (Sophy) |
 | #1065 | 2026-05-04 | low | Todo trigger phrases ("añade un teaching todo", etc.) duplicated in two PromptService.cs blocks; should be extracted to data/atelier/intent-triggers.json in a future cleanup (Sophy) |


### PR DESCRIPTION
## Summary
- Removes the `.click()` call on the `open-assistant-btn` FAB in the no-student visual spec, which always timed out because the button is `aria-disabled="true"` on the dashboard
- Replaces it with `toBeDisabled()` assertions, covering the actual product invariant: the assistant FAB is disabled when no student context is present
- This unblocks the `visual-onboarding` Playwright project, which has `dependencies: ['visual']`

## Test plan
- [ ] Build verify passes (dotnet test, npm test, npm lint, npm build all pass)
- [ ] The `@visual atelier-1029 new-session-proposal-no-student` spec no longer times out
- [ ] The `visual-onboarding` project runs after `visual` completes successfully

Closes #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage for the new session proposal feature to properly validate assistant button behavior in no-student scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->