### PR TITLE
fix(#1146): redirect /dashboard to / to prevent blank white page

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,11 +1,33 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import Dashboard from './pages/Dashboard'
-import { MemoryRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
+import App from './App'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 vi.mock('./api/students', () => ({ getStudents: vi.fn(() => new Promise(() => {})) }))
 vi.mock('./api/lessons', () => ({ getLessons: vi.fn(() => new Promise(() => {})) }))
+vi.mock('./api/corrections', () => ({ getCorrections: vi.fn(() => new Promise(() => {})) }))
+vi.mock('@auth0/auth0-react', () => ({
+  useAuth0: () => ({
+    isAuthenticated: true,
+    isLoading: false,
+    user: { name: 'Test', email: 'test@example.com' },
+    loginWithRedirect: vi.fn(),
+    logout: vi.fn(),
+    getAccessTokenSilently: vi.fn(),
+  }),
+}))
+vi.mock('./hooks/useProfile', () => ({
+  useProfile: () => ({
+    data: { hasCompletedOnboarding: true },
+    isLoading: false,
+  }),
+}))
+vi.mock('./lib/apiClient', () => ({
+  apiClient: {},
+  setupAuthInterceptor: vi.fn(() => () => {}),
+}))
 
 function wrapper(ui: React.ReactElement) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
@@ -28,16 +50,21 @@ function LocationDisplay() {
   return <div data-testid="location">{location.pathname}</div>
 }
 
+vi.mock('./components/AppShell', () => ({
+  default: () => {
+    const { Outlet } = require('react-router-dom')
+    return <Outlet />
+  },
+}))
+
 describe('/dashboard redirect', () => {
-  it('redirects /dashboard to /', () => {
+  it('redirects /dashboard to / in the real App route table', () => {
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     render(
       <QueryClientProvider client={client}>
         <MemoryRouter initialEntries={['/dashboard']}>
-          <Routes>
-            <Route path="/" element={<LocationDisplay />} />
-            <Route path="/dashboard" element={<Navigate to="/" replace />} />
-          </Routes>
+          <App />
+          <LocationDisplay />
         </MemoryRouter>
       </QueryClientProvider>
     )

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import Dashboard from './pages/Dashboard'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 vi.mock('./api/students', () => ({ getStudents: vi.fn(() => new Promise(() => {})) }))
@@ -20,5 +20,27 @@ describe('Dashboard', () => {
   it('renders the dashboard skeleton while loading', () => {
     wrapper(<Dashboard />)
     expect(screen.getByTestId('dashboard-skeleton')).toBeInTheDocument()
+  })
+})
+
+function LocationDisplay() {
+  const location = useLocation()
+  return <div data-testid="location">{location.pathname}</div>
+}
+
+describe('/dashboard redirect', () => {
+  it('redirects /dashboard to /', () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/dashboard']}>
+          <Routes>
+            <Route path="/" element={<LocationDisplay />} />
+            <Route path="/dashboard" element={<Navigate to="/" replace />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+    expect(screen.getByTestId('location').textContent).toBe('/')
   })
 })

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import Dashboard from './pages/Dashboard'
 import App from './App'
-import { MemoryRouter, useLocation } from 'react-router-dom'
+import { MemoryRouter, Outlet, useLocation } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 vi.mock('./api/students', () => ({ getStudents: vi.fn(() => new Promise(() => {})) }))
@@ -51,10 +51,7 @@ function LocationDisplay() {
 }
 
 vi.mock('./components/AppShell', () => ({
-  default: () => {
-    const { Outlet } = require('react-router-dom')
-    return <Outlet />
-  },
+  default: () => <Outlet />,
 }))
 
 describe('/dashboard redirect', () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { Routes, Route } from 'react-router-dom'
+import { Routes, Route, Navigate } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useAuth0 } from '@auth0/auth0-react'
 import { apiClient, setupAuthInterceptor } from './lib/apiClient'
@@ -63,6 +63,7 @@ export default function App() {
               <Route element={<ProtectedRoute><OnboardingGuard /></ProtectedRoute>}>
                 <Route element={<AppShell />}>
                   <Route path="/" element={<Dashboard />} />
+                  <Route path="/dashboard" element={<Navigate to="/" replace />} />
                   <Route path="/settings" element={<Settings />} />
                   <Route path="/students" element={<Students />} />
                   <Route path="/students/new" element={<StudentForm />} />


### PR DESCRIPTION
Fixes #1146

## Summary
- Adds `<Route path="/dashboard" element={<Navigate to="/" replace />} />` inside the authenticated AppShell route group in App.tsx
- The `replace` prop prevents `/dashboard` from entering the browser history stack
- Adds a unit test that exercises the real App route table (with auth/profile mocked) to verify the redirect wires correctly

## Test plan
- [ ] Unit test passes: `npx vitest run src/App.test.tsx` (2 tests)
- [ ] Build verify PASS (all stages green)
- [ ] UI review PASS: `/dashboard` redirected to `/`, sidebar regression clean
- [ ] Architecture review PASS: `Navigate replace` pattern consistent with OnboardingGuard

🤖 Generated with [Claude Code](https://claude.com/claude-code)