### PR TITLE
fix(#1165): Atelier Assistant no-session context guard

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/AssistantControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/AssistantControllerTests.cs
@@ -638,6 +638,82 @@ public class AssistantControllerTests
             p.Type == "student" && p.Field == "cefrLevel");
     }
 
+    [Fact]
+    public async Task Propose_WithStudentAndNoSessionId_ReturnsSessionLogId()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        var teacher = new Teacher
+        {
+            Id = Guid.NewGuid(),
+            Auth0UserId = "auth0|assistant-session-log-id",
+            Email = "assistant-session-log-id@example.com",
+            DisplayName = "Session LogId Test Teacher",
+            IsApproved = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        db.Teachers.Add(teacher);
+
+        var student = new Student
+        {
+            Id = Guid.NewGuid(),
+            TeacherId = teacher.Id,
+            Name = "Ana",
+            LearningLanguage = "Spanish",
+            CefrLevel = "A2",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        db.Students.Add(student);
+
+        var session = new SessionLog
+        {
+            Id = Guid.NewGuid(),
+            TeacherId = teacher.Id,
+            StudentId = student.Id,
+            SessionDate = DateTime.UtcNow.AddDays(-1),
+            PreviousHomeworkStatus = HomeworkStatus.NotApplicable,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        db.SessionLogs.Add(session);
+        await db.SaveChangesAsync();
+
+        var client = _factory.CreateAuthenticatedClient("auth0|assistant-session-log-id", "assistant-session-log-id@example.com");
+        var request = new AssistantProposeRequest
+        {
+            Text = "We worked on past perfect.",
+            StudentId = student.Id,
+        };
+        var response = await client.PostAsJsonAsync("/api/assistant/propose", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<AssistantProposeResponse>();
+        body.Should().NotBeNull();
+        body!.SessionLogId.Should().Be(session.Id);
+    }
+
+    [Fact]
+    public async Task Propose_WithStudentAndNoSessions_ReturnsNullSessionLogId()
+    {
+        var (client, studentId) = await SeedTeacherWithStudent(
+            "auth0|assistant-no-sessions", "assistant-no-sessions@example.com");
+
+        var request = new AssistantProposeRequest
+        {
+            Text = "We worked on past perfect.",
+            StudentId = studentId,
+        };
+        var response = await client.PostAsJsonAsync("/api/assistant/propose", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<AssistantProposeResponse>();
+        body.Should().NotBeNull();
+        body!.SessionLogId.Should().BeNull();
+    }
+
     // TC-19: "sube el nivel de conversación a B1" → student proposal skillLevel.speaking = "B1"
     [Fact]
     public async Task Propose_TC19_SpeakingLevelRaised_EmitsSkillLevelSpeakingProposal()

--- a/backend/LangTeach.Api/Controllers/AssistantController.cs
+++ b/backend/LangTeach.Api/Controllers/AssistantController.cs
@@ -206,7 +206,18 @@ public class AssistantController : ControllerBase
                 payloadElement));
         }
 
-        return Ok(new AssistantProposeResponse(proposals, request.VoiceNoteId));
+        Guid? suggestedSessionLogId = null;
+        if (student != null && !request.SessionId.HasValue)
+        {
+            var sessions = await _sessionLogService.ListAsync(teacherId, student.Id, ct);
+            suggestedSessionLogId = sessions
+                .Where(s => !s.IsCancelled)
+                .OrderByDescending(s => s.SessionDate ?? s.CreatedAt)
+                .Select(s => (Guid?)s.Id)
+                .FirstOrDefault();
+        }
+
+        return Ok(new AssistantProposeResponse(proposals, request.VoiceNoteId, suggestedSessionLogId));
     }
 
     [HttpPost("voice-notes/{voiceNoteId:guid}/feedback")]

--- a/backend/LangTeach.Api/DTOs/AssistantDtos.cs
+++ b/backend/LangTeach.Api/DTOs/AssistantDtos.cs
@@ -45,7 +45,7 @@ public record ProposalDto(
     JsonElement? NewStudentPayload = null
 );
 
-public record AssistantProposeResponse(List<ProposalDto> Proposals, Guid? VoiceNoteId = null);
+public record AssistantProposeResponse(List<ProposalDto> Proposals, Guid? VoiceNoteId = null, Guid? SessionLogId = null);
 
 public class PatchStudentRequest
 {

--- a/e2e/tests/visual/atelier-1165-no-session-guard.visual.spec.ts
+++ b/e2e/tests/visual/atelier-1165-no-session-guard.visual.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test'
+import { createMockAuthContext } from '../../helpers/auth-helper'
+import { setupMockTeacher } from '../../helpers/mock-teacher-helper'
+import { NAV_TIMEOUT, UI_TIMEOUT } from '../../helpers/timeouts'
+import * as fs from 'fs'
+
+test.beforeAll(async ({ browser }) => {
+  const ctx = await createMockAuthContext(browser)
+  const page = await ctx.newPage()
+  await setupMockTeacher(page)
+  await page.close()
+  await ctx.close()
+})
+
+// When teacher opens the assistant from a student profile (no session in scope)
+// and submits a note that produces session proposals, the panel must show the
+// no-session-context banner and disable Apply on session-type cards.
+test('@visual atelier-1165 no-session-banner visible on student profile', async ({ browser }) => {
+  fs.mkdirSync('screenshots', { recursive: true })
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  const consoleErrors: string[] = []
+  page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()) })
+
+  // Navigate to Ana Visual's student overview (no session in scope)
+  await page.goto('/students')
+  await expect(page.locator('h1')).toBeVisible({ timeout: NAV_TIMEOUT })
+  await page.waitForLoadState('networkidle', { timeout: UI_TIMEOUT })
+  const anaLink = page.getByText('Ana Visual').first()
+  await anaLink.click()
+  await expect(page.locator('[data-testid="student-detail-name"]')).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.waitForLoadState('networkidle', { timeout: UI_TIMEOUT })
+
+  // Open the Atelier Assistant panel
+  const assistantBtn = page.locator('[data-testid="open-assistant-btn"]').first()
+  await assistantBtn.click()
+  await expect(page.locator('[data-testid="assistant-panel"]')).toBeVisible({ timeout: UI_TIMEOUT })
+
+  // Submit a regular session-reflection note (no [schedule-new-session] trigger)
+  // The stub will produce session-type proposals (title, actualContent, etc.)
+  const input = page.locator('[data-testid="assistant-input"]')
+  await input.fill('Hoy trabajamos el pretérito imperfecto con Ana. Hicimos ejercicios de conversación.')
+  await page.locator('[data-testid="assistant-send-btn"]').click()
+
+  // Wait for proposals
+  await expect(page.locator('[data-testid="proposals-list"]')).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.waitForLoadState('networkidle', { timeout: UI_TIMEOUT })
+
+  // The no-session banner must be present
+  const banner = page.locator('[data-testid="no-session-banner"]')
+  await expect(banner).toBeVisible({ timeout: UI_TIMEOUT })
+
+  // At least one session-type Apply button must be disabled
+  const sessionApplyBtns = page.locator('[data-testid^="apply-btn-"]')
+  const count = await sessionApplyBtns.count()
+  expect(count).toBeGreaterThan(0)
+  const firstApplyBtn = sessionApplyBtns.first()
+  await expect(firstApplyBtn).toBeDisabled()
+
+  await banner.scrollIntoViewIfNeeded()
+  await page.screenshot({ path: 'screenshots/atelier-1165-no-session-banner.png', fullPage: true })
+
+  expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)
+  await context.close()
+})

--- a/e2e/tests/visual/atelier-1165-no-session-guard.visual.spec.ts
+++ b/e2e/tests/visual/atelier-1165-no-session-guard.visual.spec.ts
@@ -50,12 +50,9 @@ test('@visual atelier-1165 no-session-banner visible on student profile', async 
   const banner = page.locator('[data-testid="no-session-banner"]')
   await expect(banner).toBeVisible({ timeout: UI_TIMEOUT })
 
-  // At least one session-type Apply button must be disabled
-  const sessionApplyBtns = page.locator('[data-testid^="apply-btn-"]')
-  const count = await sessionApplyBtns.count()
-  expect(count).toBeGreaterThan(0)
-  const firstApplyBtn = sessionApplyBtns.first()
-  await expect(firstApplyBtn).toBeDisabled()
+  // At least one Apply button must be disabled (session-type proposals)
+  const disabledApplyBtns = page.locator('[data-testid^="apply-btn-"]:disabled')
+  expect(await disabledApplyBtns.count()).toBeGreaterThan(0)
 
   await banner.scrollIntoViewIfNeeded()
   await page.screenshot({ path: 'screenshots/atelier-1165-no-session-banner.png', fullPage: true })

--- a/frontend/src/api/assistant.ts
+++ b/frontend/src/api/assistant.ts
@@ -33,6 +33,7 @@ export interface ProposalDto {
 export interface ProposeResponse {
   proposals: ProposalDto[]
   voiceNoteId?: string
+  sessionLogId?: string
 }
 
 export async function proposeAssistant(

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, type ElementType } from 'react'
-import { Link, Outlet, useLocation } from 'react-router-dom'
+import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth0 } from '@auth0/auth0-react'
 import { useQuery } from '@tanstack/react-query'
 import { LayoutDashboard, Users, CalendarDays, BookOpen, GraduationCap, Settings, LogOut, Menu, Sparkles, X } from 'lucide-react'
@@ -176,7 +176,14 @@ export default function AppShell() {
     ? user.name.split(' ').map((n: string) => n[0]).join('').toUpperCase().slice(0, 2)
     : '?'
 
+  const navigate = useNavigate()
   const toggleAssistant = () => { if (atelierEnabled) setUserWantsOpen(open => !open) }
+
+  function handleNavigateToSession() {
+    if (studentId && assistant.suggestedSessionId) {
+      navigate(`/students/${studentId}/sessions/${assistant.suggestedSessionId}`)
+    }
+  }
 
   return (
     <div className="flex h-screen overflow-hidden bg-[#FBF8FF]">
@@ -316,6 +323,8 @@ export default function AppShell() {
         onEditPayload={assistant.onEditPayload}
         studentId={studentId}
         sessionId={sessionId}
+        suggestedSessionId={assistant.suggestedSessionId}
+        onNavigateToSession={handleNavigateToSession}
       />
     </div>
   )

--- a/frontend/src/components/AtelierAssistantPanel.test.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.test.tsx
@@ -96,7 +96,7 @@ const defaultProps = {
   onEditPayload: vi.fn(),
 }
 
-function renderPanel(overrides: Partial<typeof defaultProps> = {}) {
+function renderPanel(overrides: Partial<typeof defaultProps> & { studentId?: string | null; sessionId?: string | null; suggestedSessionId?: string | null; onNavigateToSession?: () => void } = {}) {
   const props = { ...defaultProps, ...overrides }
   return { ...render(<AtelierAssistantPanel {...props} />), props }
 }
@@ -706,6 +706,78 @@ describe('AtelierAssistantPanel', () => {
       vi.useRealTimers()
       await waitFor(() => expect(screen.getByTestId('thumbs-pair')).toBeInTheDocument())
       expect(screen.queryByTestId('feedback-thanks')).not.toBeInTheDocument()
+    })
+  })
+
+  // ---- no-session context banner ----------------------------------------------
+
+  describe('no-session context banner', () => {
+    const sessionProposal = makeProposal({ id: 'sp1', type: 'session', field: 'title', label: 'Session Title', oldValue: null, newValue: 'Past Perfect' })
+
+    it('shows banner when session proposals exist and sessionId is null', () => {
+      renderPanel({
+        transcription: 'Past perfect class',
+        proposals: [sessionProposal],
+        sessionId: null,
+      })
+      expect(screen.getByTestId('no-session-banner')).toBeInTheDocument()
+    })
+
+    it('does not show banner when sessionId is present', () => {
+      renderPanel({
+        transcription: 'Past perfect class',
+        proposals: [sessionProposal],
+        sessionId: 'session-1',
+      })
+      expect(screen.queryByTestId('no-session-banner')).not.toBeInTheDocument()
+    })
+
+    it('does not show banner when no session-type proposals exist', () => {
+      const studentProposal = makeProposal({ type: 'student' })
+      renderPanel({
+        transcription: 'Past perfect class',
+        proposals: [studentProposal],
+        sessionId: null,
+      })
+      expect(screen.queryByTestId('no-session-banner')).not.toBeInTheDocument()
+    })
+
+    it('shows "Open matched session" button when suggestedSessionId is provided', () => {
+      const onNavigate = vi.fn()
+      renderPanel({
+        transcription: 'Past perfect class',
+        proposals: [sessionProposal],
+        sessionId: null,
+        suggestedSessionId: 'session-xyz',
+        onNavigateToSession: onNavigate,
+      })
+      const btn = screen.getByTestId('open-matched-session-btn')
+      expect(btn).toBeInTheDocument()
+    })
+
+    it('calls onNavigateToSession when "Open matched session" is clicked', async () => {
+      const user = userEvent.setup()
+      const onNavigate = vi.fn()
+      renderPanel({
+        transcription: 'Past perfect class',
+        proposals: [sessionProposal],
+        sessionId: null,
+        suggestedSessionId: 'session-xyz',
+        onNavigateToSession: onNavigate,
+      })
+      await user.click(screen.getByTestId('open-matched-session-btn'))
+      expect(onNavigate).toHaveBeenCalledOnce()
+    })
+
+    it('does not show "Open matched session" button when suggestedSessionId is absent', () => {
+      renderPanel({
+        transcription: 'Past perfect class',
+        proposals: [sessionProposal],
+        sessionId: null,
+        suggestedSessionId: null,
+      })
+      expect(screen.getByTestId('no-session-banner')).toBeInTheDocument()
+      expect(screen.queryByTestId('open-matched-session-btn')).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { Sparkles, X, Send, Mic, Square, Loader2, AlertCircle, ThumbsUp, ThumbsDown } from 'lucide-react'
+import { Sparkles, X, Send, Mic, Square, Loader2, AlertCircle, ThumbsUp, ThumbsDown, ExternalLink } from 'lucide-react'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
 import { Input } from '@/components/ui/input'
 import { uploadVoiceNote } from '@/api/voiceNotes'
@@ -49,6 +49,8 @@ interface Props {
   onEditPayload?: (id: string, payload: import('@/api/assistant').NewStudentData | import('@/api/assistant').NewSessionData | Record<string, unknown>) => void
   studentId?: string | null
   sessionId?: string | null
+  suggestedSessionId?: string | null
+  onNavigateToSession?: () => void
 }
 
 export default function AtelierAssistantPanel({
@@ -70,6 +72,8 @@ export default function AtelierAssistantPanel({
   onEditPayload,
   studentId,
   sessionId,
+  suggestedSessionId,
+  onNavigateToSession,
 }: Props) {
   const [inputValue, setInputValue] = useState('')
   const [pendingClose, setPendingClose] = useState(false)
@@ -267,6 +271,8 @@ export default function AtelierAssistantPanel({
   const noHardware = hookError === 'no-hardware'
   const permissionDenied = hookError === 'permission-denied'
   const pendingProposals = proposals.filter(p => p.status === 'proposed')
+  const sessionContextMissing = !sessionId
+  const hasSessionProposalsWithoutContext = sessionContextMissing && pendingProposals.some(p => p.type === 'session')
   const applyAllBlocked = !studentId && pendingProposals.some(p => p.type === 'newSession')
 
   return (
@@ -407,7 +413,28 @@ export default function AtelierAssistantPanel({
                     No updates suggested.
                   </p>
                 ) : (
-                  <div className="space-y-2" data-testid="proposals-list">
+                  <div className="space-y-3" data-testid="proposals-list">
+                    {hasSessionProposalsWithoutContext && (
+                      <div
+                        className="flex flex-col gap-2 px-3 py-2.5 rounded-xl bg-violet-50 border border-violet-100"
+                        data-testid="no-session-banner"
+                      >
+                        <p className="text-xs font-inter text-violet-700 leading-snug">
+                          These session notes need an open session. Open a session to apply them.
+                        </p>
+                        {suggestedSessionId && onNavigateToSession && (
+                          <button
+                            onClick={onNavigateToSession}
+                            className="flex items-center gap-1.5 self-start text-xs font-inter font-semibold text-violet-700 hover:text-violet-900 hover:underline transition-colors"
+                            data-testid="open-matched-session-btn"
+                          >
+                            <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                            Open matched session
+                          </button>
+                        )}
+                      </div>
+                    )}
+                    <div className="space-y-2">
                     {proposals.map(proposal => (
                       <ProposalCard
                         key={proposal.id}
@@ -419,8 +446,10 @@ export default function AtelierAssistantPanel({
                         onModify={onModify}
                         onEditPayload={onEditPayload}
                         studentId={studentId}
+                        sessionContextMissing={sessionContextMissing}
                       />
                     ))}
+                    </div>
                   </div>
                 )}
               </div>

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -435,20 +435,20 @@ export default function AtelierAssistantPanel({
                       </div>
                     )}
                     <div className="space-y-2">
-                    {proposals.map(proposal => (
-                      <ProposalCard
-                        key={proposal.id}
-                        proposal={proposal}
-                        onApply={onApply}
-                        onDismiss={onDismiss}
-                        onUndo={onUndo}
-                        onRetry={onRetry}
-                        onModify={onModify}
-                        onEditPayload={onEditPayload}
-                        studentId={studentId}
-                        sessionContextMissing={sessionContextMissing}
-                      />
-                    ))}
+                      {proposals.map(proposal => (
+                        <ProposalCard
+                          key={proposal.id}
+                          proposal={proposal}
+                          onApply={onApply}
+                          onDismiss={onDismiss}
+                          onUndo={onUndo}
+                          onRetry={onRetry}
+                          onModify={onModify}
+                          onEditPayload={onEditPayload}
+                          studentId={studentId}
+                          sessionContextMissing={sessionContextMissing}
+                        />
+                      ))}
                     </div>
                   </div>
                 )}

--- a/frontend/src/components/assistant/ProposalCard.test.tsx
+++ b/frontend/src/components/assistant/ProposalCard.test.tsx
@@ -339,4 +339,26 @@ describe('ProposalCard', () => {
     expect(lastCall[1].sessionDate).toBe('2026-05-19')
     expect(lastCall[1].title).toBe('Subjunctive')
   })
+
+  it('session type: Apply button is disabled when sessionContextMissing is true', () => {
+    const onApply = vi.fn()
+    renderCard(
+      makeProposal({ type: 'session', field: 'title', label: 'Session Title', oldValue: null, newValue: 'Past Perfect' }),
+      { onApply, sessionContextMissing: true },
+    )
+    const applyBtn = screen.getByTestId('apply-btn-p1')
+    expect(applyBtn).toBeDisabled()
+    fireEvent.click(applyBtn)
+    expect(onApply).not.toHaveBeenCalled()
+  })
+
+  it('session type: Apply button is enabled when sessionContextMissing is false', () => {
+    const onApply = vi.fn()
+    renderCard(
+      makeProposal({ type: 'session', field: 'title', label: 'Session Title', oldValue: null, newValue: 'Past Perfect' }),
+      { onApply, sessionContextMissing: false },
+    )
+    const applyBtn = screen.getByTestId('apply-btn-p1')
+    expect(applyBtn).not.toBeDisabled()
+  })
 })

--- a/frontend/src/components/assistant/ProposalCard.tsx
+++ b/frontend/src/components/assistant/ProposalCard.tsx
@@ -16,6 +16,7 @@ interface Props {
   onModify: (id: string, newValue: string) => void
   onEditPayload?: (id: string, payload: NewStudentData | NewSessionData | Record<string, unknown>) => void
   studentId?: string | null
+  sessionContextMissing?: boolean
 }
 
 const MULTILINE_FIELDS = new Set(
@@ -55,7 +56,7 @@ const TYPE_CONFIG = {
   },
 } as const
 
-export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onRetry, onModify, onEditPayload, studentId }: Props) {
+export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onRetry, onModify, onEditPayload, studentId, sessionContextMissing }: Props) {
   const config = TYPE_CONFIG[proposal.type]
   const { Icon } = config
 
@@ -107,6 +108,7 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
   const isTodo = proposal.type === 'todo'
   const newSessionPayload = isNewSession ? (proposal.payload as NewSessionData | null | undefined) : null
   const newSessionApplyDisabled = isNewSession && !studentId
+  const sessionApplyDisabled = proposal.type === 'session' && !!sessionContextMissing
   const newSessionDateEditable = isNewSession && (proposal.status === 'proposed' || proposal.status === 'error')
   const todoPayload = isTodo ? (proposal.payload as { dueDate?: string | null } | null | undefined) : null
   const todoDateEditable = isTodo && (proposal.status === 'proposed' || proposal.status === 'error')
@@ -261,12 +263,13 @@ export default function ProposalCard({ proposal, onApply, onDismiss, onUndo, onR
           {proposal.status === 'proposed' && !editing && (
             <>
               <button
-                onClick={() => !newSessionApplyDisabled && onApply(proposal.id)}
-                disabled={newSessionApplyDisabled}
+                onClick={() => !newSessionApplyDisabled && !sessionApplyDisabled && onApply(proposal.id)}
+                disabled={newSessionApplyDisabled || sessionApplyDisabled}
                 data-testid={`apply-btn-${proposal.id}`}
+                aria-disabled={newSessionApplyDisabled || sessionApplyDisabled}
                 className={cn(
                   'text-xs font-semibold font-inter px-3 py-1 rounded-lg transition-colors',
-                  newSessionApplyDisabled
+                  (newSessionApplyDisabled || sessionApplyDisabled)
                     ? 'text-zinc-400 bg-zinc-100 cursor-not-allowed'
                     : 'text-white bg-indigo-600 hover:bg-indigo-700'
                 )}

--- a/frontend/src/hooks/useAtelierAssistant.test.ts
+++ b/frontend/src/hooks/useAtelierAssistant.test.ts
@@ -541,6 +541,48 @@ describe('useAtelierAssistant', () => {
     expect(result.current.proposals[0].status).toBe('error')
   })
 
+  it('submit: captures suggestedSessionId from propose response when sessionId is null', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[1]], sessionLogId: 'session-xyz' })
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null), { wrapper: makeWrapper() })
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(result.current.suggestedSessionId).toBe('session-xyz')
+  })
+
+  it('submit: does not capture suggestedSessionId when sessionId is already in scope', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[1]], sessionLogId: 'session-xyz' })
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'), { wrapper: makeWrapper() })
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(result.current.suggestedSessionId).toBeNull()
+  })
+
+  it('reset: clears suggestedSessionId', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[1]], sessionLogId: 'session-xyz' })
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null), { wrapper: makeWrapper() })
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+    expect(result.current.suggestedSessionId).toBe('session-xyz')
+    act(() => { result.current.reset() })
+    expect(result.current.suggestedSessionId).toBeNull()
+  })
+
+  it('applyAll: skips session proposals when sessionId is null', async () => {
+    mockPropose.mockResolvedValueOnce({ proposals: sampleProposals })
+    mockApplyStudent.mockResolvedValueOnce(undefined)
+    mockApplyTodo.mockResolvedValueOnce(undefined)
+    const { result } = renderHook(() => useAtelierAssistant('student-1', null), { wrapper: makeWrapper() })
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    await act(async () => { await result.current.applyAll() })
+    expect(mockApplyStudent).toHaveBeenCalledOnce()
+    expect(mockApplyTodo).toHaveBeenCalledOnce()
+    expect(mockApplySession).not.toHaveBeenCalled()
+    const sessionCard = result.current.proposals.find(p => p.type === 'session')
+    expect(sessionCard?.status).toBe('proposed')
+  })
+
   it('apply: routes skillLevel.writing student proposal to applyStudentProposal with dotted field', async () => {
     const skillProposal = { id: 'psk1', type: 'student' as const, field: 'skillLevel.writing', label: 'Writing Level', oldValue: null, newValue: 'B1' }
     mockPropose.mockResolvedValueOnce({ proposals: [skillProposal] })

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -28,6 +28,7 @@ export interface AtelierAssistantState {
   transcription: string | null
   processing: boolean
   proposals: ProposalWithStatus[]
+  suggestedSessionId: string | null
 }
 
 export interface AtelierAssistantActions {
@@ -50,6 +51,7 @@ export function useAtelierAssistant(
   const [transcription, setTranscription] = useState<string | null>(null)
   const [processing, setProcessing] = useState(false)
   const [proposals, setProposals] = useState<ProposalWithStatus[]>([])
+  const [suggestedSessionId, setSuggestedSessionId] = useState<string | null>(null)
   const undoTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
   const applyingIdsRef = useRef<Set<string>>(new Set())
   const generationRef = useRef(0)
@@ -76,12 +78,13 @@ export function useAtelierAssistant(
     const hasPending = proposalsRef.current.some(p => p.status === 'proposed')
     if (!hasPending) setProposals([])
     try {
-      const { proposals: raw } = await proposeAssistant(
+      const { proposals: raw, sessionLogId } = await proposeAssistant(
         text,
         studentId ?? undefined,
         sessionId ?? undefined,
       )
       if (generationRef.current !== gen) return
+      if (!sessionId && sessionLogId) setSuggestedSessionId(sessionLogId)
       if (!hasPending) {
         setProposals(raw.map(p => ({ ...p, status: 'proposed', undoVisible: false })))
       } else {
@@ -241,11 +244,13 @@ export function useAtelierAssistant(
   }, [updateProposal])
 
   const applyAll = useCallback(async () => {
-    const pending = proposalsRef.current.filter(p => p.status === 'proposed')
+    const pending = proposalsRef.current.filter(p =>
+      p.status === 'proposed' && !(p.type === 'session' && !sessionId)
+    )
     for (const p of pending) {
       await apply(p.id)
     }
-  }, [apply])
+  }, [apply, sessionId])
 
   const dismissAll = useCallback(() => {
     proposalsRef.current.filter(p => p.status === 'proposed').forEach(p => dismiss(p.id))
@@ -268,12 +273,14 @@ export function useAtelierAssistant(
     setTranscription(null)
     setProcessing(false)
     setProposals([])
+    setSuggestedSessionId(null)
   }, [])
 
   return {
     transcription,
     processing,
     proposals,
+    suggestedSessionId,
     submit,
     apply,
     dismiss,

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -8,6 +8,7 @@ Out-of-scope observations logged by agents during implementation. Each row is so
 | #1065 | 2026-05-04 | low | CreateTeachingTodoDto.DueDate lacks [RegularExpression] format attribute; invalid dates accepted at model-binding boundary and silently become null (Sophy) |
 | #1065 | 2026-05-04 | low | Todo trigger phrases ("añade un teaching todo", etc.) duplicated in two PromptService.cs blocks; should be extracted to data/atelier/intent-triggers.json in a future cleanup (Sophy) |
 | #1065 | 2026-05-04 | low | CreateTeachingTodoDto.DueDate is string? while sibling CreateTeacherFollowupRequest.DueDate is DateOnly?; inconsistent binding strategy for same entity field (arch review) |
+| #1165 | 2026-05-09 | low | AssistantProposeRequest uses `SessionId` but AssistantProposeResponse uses `SessionLogId` for the same entity; naming asymmetry in the API contract (Sophy) |
 | #smoke-hardening | 2026-05-04 | low | "Apply" button in Atelier Assistant proposal flow not smoke-testable without real audio; #1065 fix end-to-end unconfirmed |
 | #1153 | 2026-05-08 | low | `frontend/src/pages/StudentForm.test.tsx > "includes identity fields in form submission"` is flaky under parallel vitest load (1 fail in full run, 72/72 pass when isolated). Pre-existing, unrelated to redacciones. |
 | #1155 | 2026-05-08 | low | Correction status pill (CORREGIDA/Entregada/Pendiente) is a new pattern, not covered by design-system.md; needs Vera spec before reuse (review-ui) |


### PR DESCRIPTION
## Summary

- When a teacher records a voice note from a non-session screen (student profile, dashboard), session-type patch cards no longer dead-end with "Cannot apply session update: no session is open on this screen" errors and an unrecoverable state.
- Backend propose response now includes the most recent session ID for the student, enabling a direct navigation CTA.
- A violet banner appears above session proposals when no session is in scope, with an "Open matched session" button that navigates to the session so the teacher can apply.
- Session-type ProposalCard Apply buttons are disabled while no session is in scope, preventing the error state entirely in normal flow.
- `applyAll` skips session proposals silently when `sessionId` is null, so student/todo proposals can still be bulk-applied.

## Changes

**Backend:**
- `AssistantDtos.cs`: add `Guid? SessionLogId = null` to `AssistantProposeResponse`
- `AssistantController.cs`: when student is known but no sessionId in request, call `ListAsync` to find the most recent non-cancelled session and include its ID in the response

**Frontend:**
- `api/assistant.ts`: add `sessionLogId?: string` to `ProposeResponse`
- `hooks/useAtelierAssistant.ts`: store `suggestedSessionId` from the response; skip session proposals in `applyAll` when `sessionId` is null; expose in state
- `components/AppShell.tsx`: pass `suggestedSessionId` and `onNavigateToSession` to panel
- `components/AtelierAssistantPanel.tsx`: violet banner with CTA when session proposals exist without session context; pass `sessionContextMissing` to cards
- `components/assistant/ProposalCard.tsx`: disable Apply on session-type cards when `sessionContextMissing`

## Test plan

- [ ] Open assistant from student profile (no session in URL), submit a note; verify violet banner appears and session-type Apply buttons are greyed out
- [ ] Click "Open matched session" button; verify navigation to session page; verify banner disappears and Apply buttons are active
- [ ] On session detail page, submit a note; verify no banner appears and session proposals can be applied normally (happy path)
- [ ] Submit a note with only student/todo proposals from a no-session screen; verify Apply All works for those cards
- 14 Playwright visual specs pass; 12 new frontend unit tests; 2 new backend integration tests

Closes #1165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant proposals now suggest previously used sessions when no session is currently active.
  * A banner displays when session-related proposals need an active session context.
  * Quick action to open a suggested matched session directly from the assistant panel.

* **Tests**
  * Added integration tests for session suggestion logic.
  * Added visual and unit tests for no-session banner behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->