### PR TITLE
fix(#1175): rescue correction tags dropped near accented characters

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs
@@ -129,6 +129,18 @@ public class RedaccionCorrectionPromptBuilderTests
         marker1.Should().NotBe(marker2);
     }
 
+    [Fact]
+    public void Build_SystemPromptInstructsIndexOfOffsetDerivation()
+    {
+        // Issue #1175: the OFFSETS section must instruct the model to use string search
+        // (indexOf) to derive startIndex, NOT counting forward from position 0. Counting
+        // is unreliable near accented chars (é, ó, á, ñ). Removing this instruction
+        // re-opens the silent tag-drop bug.
+        var req = _builder.Build(MakeCtx("B1"));
+        req.SystemPrompt.Should().Contain("indexOf", "OFFSETS must reference indexOf/string-search derivation");
+        req.SystemPrompt.Should().Contain("accented", "OFFSETS must warn about accented characters");
+    }
+
     private static RedaccionCorrectionPromptContext MakeCtx(string cefr) =>
         new("Texto.", cefr, null, Array.Empty<string>(), null);
 }

--- a/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerTests.cs
@@ -395,6 +395,53 @@ public class CorrectionsControllerTests
         resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
+    [Fact]
+    public async Task Corregir_WithAccentedTextAndOffsetDrift_RescuesTagsNotDropped()
+    {
+        // Simulates the Unicode boundary drift bug (issue #1175): model reports correct
+        // spannedText but wrong startIndex/endIndex due to miscounting near é/ó/á chars.
+        // The backend rescue in ValidateAndOrderTags must fix the offsets and keep the tag.
+        var text = "Ayer él fue al café y después tuvo problemas con las preposiciones también. Él está muy cansado.";
+        var (client, studentId) = await SetupAsync("auth0|corr-unicode-rescue");
+        var created = await CreateCorrectionAsync(client, studentId, new CreateCorrectionRequest
+        {
+            AssignmentTitle = "Unicode rescue test",
+            StudentText = text,
+        });
+
+        var realIdx = text.IndexOf("café", StringComparison.Ordinal);
+        var driftedIdx = realIdx + 2; // simulate +2 byte-offset drift from the accented 'é' in "él"
+
+        _factory.ClaudeStub.Reset();
+        _factory.ClaudeStub.EnqueueResponse(System.Text.Json.JsonSerializer.Serialize(new
+        {
+            schemaVersion = 1,
+            originalText = text,
+            tags = new[]
+            {
+                new
+                {
+                    category = "O",
+                    startIndex = driftedIdx,
+                    endIndex = driftedIdx + "café".Length,
+                    spannedText = "café",
+                    explanation = "Ejemplo de tilde correcta; sirve para probar el rescate de offsets.",
+                    correctedForm = "café",
+                }
+            }
+        }));
+
+        var resp = await client.PostAsync(
+            $"/api/students/{studentId}/corrections/{created.Id}/corregir",
+            content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var detail = await resp.Content.ReadFromJsonAsync<CorrectionDetailDto>();
+        detail!.Tags.Should().HaveCount(1, "tag with correct spannedText must be rescued despite offset drift");
+        detail.Tags[0].SpannedText.Should().Be("café");
+        detail.Tags[0].StartIndex.Should().Be(realIdx, "rescue must fix startIndex to the true position");
+    }
+
     // --- helpers ---
 
     private async Task<(HttpClient client, Guid studentId)> SetupAsync(string auth0Id, string? email = null)

--- a/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerTests.cs
@@ -242,6 +242,25 @@ public class CorrectionsControllerTests
             tags = Array.Empty<object>(),
         });
 
+    private static string BuildDriftedOffsetAiJson(string originalText, string spannedText, int driftedStartIndex) =>
+        System.Text.Json.JsonSerializer.Serialize(new
+        {
+            schemaVersion = 1,
+            originalText,
+            tags = new[]
+            {
+                new
+                {
+                    category = "O",
+                    startIndex = driftedStartIndex,
+                    endIndex = driftedStartIndex + spannedText.Length,
+                    spannedText,
+                    explanation = "Ejemplo de tilde correcta; sirve para probar el rescate de offsets.",
+                    correctedForm = spannedText,
+                }
+            }
+        });
+
     [Fact]
     public async Task List_ExcludesSoftDeleted()
     {
@@ -413,23 +432,7 @@ public class CorrectionsControllerTests
         var driftedIdx = realIdx + 2; // simulate +2 byte-offset drift from the accented 'é' in "él"
 
         _factory.ClaudeStub.Reset();
-        _factory.ClaudeStub.EnqueueResponse(System.Text.Json.JsonSerializer.Serialize(new
-        {
-            schemaVersion = 1,
-            originalText = text,
-            tags = new[]
-            {
-                new
-                {
-                    category = "O",
-                    startIndex = driftedIdx,
-                    endIndex = driftedIdx + "café".Length,
-                    spannedText = "café",
-                    explanation = "Ejemplo de tilde correcta; sirve para probar el rescate de offsets.",
-                    correctedForm = "café",
-                }
-            }
-        }));
+        _factory.ClaudeStub.EnqueueResponse(BuildDriftedOffsetAiJson(text, "café", driftedIdx));
 
         var resp = await client.PostAsync(
             $"/api/students/{studentId}/corrections/{created.Id}/corregir",

--- a/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionDualLevelTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionDualLevelTests.cs
@@ -74,6 +74,34 @@ public class RedaccionCorrectionDualLevelTests
         b2Ablar!.Category.Should().Be("O", "misspelling must be tagged O, not another category");
     }
 
+    /// <summary>
+    /// Issue #1175 guard: B1 text with 5+ accented characters in the first 100 characters must
+    /// produce at least 5 tags. Before the fix, Unicode offset drift caused tags to be silently
+    /// dropped, producing far fewer than the expected count.
+    /// </summary>
+    [SkipIfNoClaudeApiKey]
+    public async Task B1_AccentedText_TagCountNotTruncated()
+    {
+        // 5+ accented chars in the first 100 chars: é(él), ó(estudió), é(después), é(También), é(café)
+        // Deliberate B1 errors: "hago" (G-tense), "Y luego...Y luego" (C-connector), "dependen en" (G-prep)
+        const string accentedB1Text =
+            "Ayer él estudió mucho, pero después tuvo muchos problemas con las preposiciones. " +
+            "También hago una foto de mis amigos en el café. " +
+            "Y luego fuimos a casa. Y luego volvimos al centro. " +
+            "Todos dependen en sus familias para organizar estas actividades juntos.";
+
+        // Verify the constraint: at least 4 accented chars in the first 100 chars.
+        var first100 = accentedB1Text.Length >= 100 ? accentedB1Text[..100] : accentedB1Text;
+        var accentCount = first100.Count(c => "áéíóúàèìòùäëïöüâêîôûñÁÉÍÓÚÀÈÌÒÙÄËÏÖÜÂÊÎÔÛÑ".Contains(c));
+        accentCount.Should().BeGreaterThanOrEqualTo(4, "test text must have 4+ accented chars in first 100 chars");
+
+        await using var run = await RunCorregirAsync(accentedB1Text, "B1", "English");
+
+        run.Result.Tags.Should().HaveCountGreaterThanOrEqualTo(5,
+            "a B1 text with multiple clear errors and accented chars must not have tags silently truncated. "
+            + $"Tags found: {string.Join(", ", run.Result.Tags.Select(t => $"[{t.Category}] \"{t.SpannedText}\""))}");
+    }
+
     private static IEnumerable<string> CategoryDistribution(IEnumerable<LangTeach.Api.DTOs.CorrectionTagDto> tags) =>
         tags.GroupBy(t => t.Category).Select(g => $"{g.Key}:{g.Count()}").OrderBy(s => s);
 

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -91,7 +91,7 @@ OFFSETS (read carefully — accented characters cause silent errors if you count
   3. Locate spannedText inside originalText using a forward string search (like indexOf / find), starting from position 0.
   4. Set startIndex to the result of that search. Set endIndex = startIndex + length(spannedText).
 - spannedText MUST equal originalText.Substring(startIndex, endIndex - startIndex).
-- If spannedText appears more than once in originalText, use the first occurrence.
+- If spannedText would appear more than once in originalText, choose a longer or more specific span that is unique. Tags whose spannedText cannot be located unambiguously will be dropped.
 - Tags MUST NOT overlap. Sort tags by startIndex.
 
 "explanation" and "correctedForm" are non-empty for C/G/L/O tags and null for MuyBien.

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -82,9 +82,16 @@ Emit raw JSON only. No prose before or after. No markdown fences. The JSON must 
   ]
 }
 
-OFFSETS:
-- startIndex and endIndex are character offsets into originalText (0-based, end-exclusive).
+OFFSETS (read carefully — accented characters cause silent errors if you count positions):
+- startIndex and endIndex are Unicode character offsets into originalText (0-based, end-exclusive).
+- DO NOT derive offsets by counting characters forward from the start of the text. Counting is unreliable near accented characters (é, ó, á, ñ, ü, etc.) because your internal position tracking may not match the host's character indices.
+- CORRECT procedure for every tag:
+  1. Decide which substring of originalText to mark; that substring is spannedText.
+  2. Write the explanation.
+  3. Locate spannedText inside originalText using a forward string search (like indexOf / find), starting from position 0.
+  4. Set startIndex to the result of that search. Set endIndex = startIndex + length(spannedText).
 - spannedText MUST equal originalText.Substring(startIndex, endIndex - startIndex).
+- If spannedText appears more than once in originalText, use the first occurrence.
 - Tags MUST NOT overlap. Sort tags by startIndex.
 
 "explanation" and "correctedForm" are non-empty for C/G/L/O tags and null for MuyBien.

--- a/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
+++ b/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
@@ -293,8 +293,9 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
         var kept = new List<RedaccionCorrectionTagDto>(rawTags.Count);
         var len = originalText.Length;
 
-        foreach (var tag in rawTags)
+        foreach (var rawTag in rawTags)
         {
+            var tag = rawTag;
             if (string.IsNullOrEmpty(tag.Category) || !CorrectionTagCategory.IsValid(tag.Category))
             {
                 _logger.LogWarning("Drop tag: invalid category '{Category}'. CorrectionId={CorrectionId}", tag.Category, correctionId);
@@ -310,10 +311,29 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
             var actualSpan = originalText.Substring(tag.StartIndex, tag.EndIndex - tag.StartIndex);
             if (!string.Equals(actualSpan, tag.SpannedText, StringComparison.Ordinal))
             {
+                // Rescue: the model reported valid-range offsets but the substring doesn't match.
+                // This is the Unicode boundary drift pattern (model miscounts chars near é/ó/á/ñ).
+                // Locate spannedText by string search; fix offsets if the match is unambiguous.
+                var foundAt = originalText.IndexOf(tag.SpannedText, StringComparison.Ordinal);
+                if (foundAt < 0)
+                {
+                    _logger.LogWarning(
+                        "Drop tag: spannedText '{Spanned}' not found in originalText (model hallucinated span). CorrectionId={CorrectionId}",
+                        tag.SpannedText, correctionId);
+                    continue;
+                }
+                var secondAt = originalText.IndexOf(tag.SpannedText, foundAt + 1, StringComparison.Ordinal);
+                if (secondAt >= 0)
+                {
+                    _logger.LogWarning(
+                        "Drop tag: spannedText '{Spanned}' is ambiguous (found at {First} and {Second}); cannot rescue. CorrectionId={CorrectionId}",
+                        tag.SpannedText, foundAt, secondAt, correctionId);
+                    continue;
+                }
                 _logger.LogWarning(
-                    "Drop tag: spannedText '{Sent}' does not match originalText[{Start},{End}) = '{Actual}'. CorrectionId={CorrectionId}",
-                    tag.SpannedText, tag.StartIndex, tag.EndIndex, actualSpan, correctionId);
-                continue;
+                    "Rescue tag: Unicode offset drift; spannedText '{Spanned}' relocated from model-reported [{Start},{End}) to [{Fixed},{FixedEnd}). CorrectionId={CorrectionId}",
+                    tag.SpannedText, tag.StartIndex, tag.EndIndex, foundAt, foundAt + tag.SpannedText.Length, correctionId);
+                tag = tag with { StartIndex = foundAt, EndIndex = foundAt + tag.SpannedText.Length };
             }
 
             string? explanation = tag.Explanation;

--- a/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
+++ b/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
@@ -311,6 +311,12 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
             var actualSpan = originalText.Substring(tag.StartIndex, tag.EndIndex - tag.StartIndex);
             if (!string.Equals(actualSpan, tag.SpannedText, StringComparison.Ordinal))
             {
+                if (string.IsNullOrEmpty(tag.SpannedText))
+                {
+                    _logger.LogWarning(
+                        "Drop tag: spannedText is null or empty. CorrectionId={CorrectionId}", correctionId);
+                    continue;
+                }
                 // Rescue: the model reported valid-range offsets but the substring doesn't match.
                 // This is the Unicode boundary drift pattern (model miscounts chars near é/ó/á/ñ).
                 // Locate spannedText by string search; fix offsets if the match is unambiguous.

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -93,3 +93,11 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 ## #1153 (CodeRabbit findings, partially addressed)
 - **Schema (Minor):** Added `endIndex > startIndex` cross-field constraint to `redaccion-correction.schema.json`. Schema is reference-only; C# `ValidateAndOrderTags` is the runtime enforcement layer.
 - **TOCTOU race on /corregir (Major) — partially addressed:** Added a fresh-status recheck in `RedaccionCorrectionService.CorregirAsync` between Claude's response and the SaveChanges. Closes the duplicate-tag-rows half of the race. Does NOT prevent both concurrent calls from invoking Claude (double cost). True atomic claim requires either (a) a `Corrigiendo` enum value + DB CHECK constraint update + flip-and-save before the LLM call, or (b) a `RowVersion`/`[Timestamp]` concurrency token on `Correction`. Both options need a migration. Defer until the frontend exposes the corregir button to a multi-tab/double-click vector — for v1, the UI debounces and the blast radius is bounded.
+
+## #1175 prompt-health finding (minor, deferred)
+
+`RedaccionCorrectionPromptBuilder.cs` SystemPrompt:
+
+"Tags MUST NOT overlap. Sort tags by startIndex." -- redundant with service-layer enforcement
+(`ValidateAndOrderTags` sorts by StartIndex and drops overlapping tags). The instruction is
+net-positive model guidance but wastes tokens. Consider trimming in a future prompt-health pass.


### PR DESCRIPTION
Fixes #1175

## Summary

- **Prompt hardening**: The OFFSETS section of the correction system prompt now instructs Sonnet 4.6 to derive `startIndex`/`endIndex` by locating `spannedText` via string search (indexOf) rather than counting characters forward from position 0. Counting is unreliable near accented characters (é, ó, á, ñ). Ambiguous spans (spannedText appears twice) are flagged for the model to choose a more specific span.
- **Backend rescue**: `ValidateAndOrderTags` now attempts `IndexOf(spannedText)` when the model's reported offsets are valid-range but the substring doesn't match. If the match is unambiguous the offsets are fixed and the tag is kept; ambiguous or missing spans are still dropped. Logged as "Rescue tag" warning for observability.
- **Tests**: stub-based integration test (AC#2, always runs) + opt-in live API smoke test (AC#1, `AI_INTEGRATION_TESTS=1`) + prompt assertion test (AC#3).

## Root cause

Sonnet 4.6 miscounts character positions near accented characters, likely conflating UTF-8 byte offsets with UTF-16 character indices. In C# all accented Spanish characters (é, ó, á, ñ) are single `char` values, so the model's reported positions are off by 1--2 per accented character encountered before the tag. `ValidateAndOrderTags` previously dropped any tag whose substring didn't match, with no teacher-visible indication.

## Test plan

- [ ] `dotnet test --filter "FullyQualifiedName~Corregir_WithAccentedTextAndOffsetDrift"` passes (rescue test)
- [ ] `dotnet test --filter "FullyQualifiedName~Build_SystemPromptInstructs"` passes (prompt assertion)
- [ ] Browser: open Gavin's student profile > Redacciones > new correction > paste _"Ayer él estudió mucho, pero después tuvo problemas con las preposiciones también. Él está muy cansado."_ > Corregir > at least 3 underlined spans appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of accented characters in text corrections, ensuring tags are preserved even when offset indices drift slightly.
  * Enhanced tag offset recovery mechanism to search for and correct misplaced tags while maintaining text accuracy.

* **Tests**
  * Added comprehensive test coverage for accented text processing and offset drift scenarios across correction pipeline.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1178)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->