### PR TITLE
docs(#1176): design system correction annotation patterns + color reconciliation

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerExportTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerExportTests.cs
@@ -138,9 +138,9 @@ public class CorrectionsControllerExportTests
         using var doc = WordprocessingDocument.Open(stream, isEditable: false);
         var runs = doc.MainDocumentPart!.Document.Body!.Descendants<Run>().ToList();
 
-        // The seeded correction has one O-category tag on "ablar" -> emerald 059669
+        // The seeded correction has one O-category tag on "ablar" -> emerald-500 10B981 (DS §11.16)
         var coloredRun = runs.FirstOrDefault(r =>
-            r.RunProperties?.Color?.Val?.Value == "059669"
+            r.RunProperties?.Color?.Val?.Value == "10B981"
             && r.RunProperties?.Bold is not null);
         coloredRun.Should().NotBeNull("the docx must include the colored bold run for the O tag");
 

--- a/backend/LangTeach.Api.Tests/Services/CorrectionDocxExportServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/CorrectionDocxExportServiceTests.cs
@@ -25,7 +25,7 @@ public class CorrectionDocxExportServiceTests
     [Fact]
     public void Generate_WithErrorTag_RendersBoldColoredRunPlusItalicParenthetical()
     {
-        // "ablar" missing 'h' at index 4 -> O (Ortografía, emerald 059669)
+        // "ablar" missing 'h' at index 4 -> O (Ortografía, emerald-500 10B981, DS §11.16)
         const string text = "Hoy ablar con mi amigo.";
         var tag = new CorrectionTagDto("O", "ablar", 4, 9, "Falta la 'h'.", "hablar", 0);
         var detail = MakeDetail(text, [tag]);
@@ -38,7 +38,7 @@ public class CorrectionDocxExportServiceTests
 
         var spannedRun = runs[spannedRunIdx];
         spannedRun.RunProperties!.Bold.Should().NotBeNull();
-        spannedRun.RunProperties.Color!.Val!.Value.Should().Be("059669");
+        spannedRun.RunProperties.Color!.Val!.Value.Should().Be("10B981");
 
         (spannedRunIdx + 1).Should().BeLessThan(runs.Count,
             "error-tagged span must be followed by its parenthetical run");

--- a/backend/LangTeach.Api/Services/CorrectionDocxExport/CorrectionDocxExportService.cs
+++ b/backend/LangTeach.Api/Services/CorrectionDocxExport/CorrectionDocxExportService.cs
@@ -8,15 +8,15 @@ namespace LangTeach.Api.Services.CorrectionDocxExport;
 
 public class CorrectionDocxExportService : ICorrectionDocxExportService
 {
-    // Provisional category color hex values (no '#'), matching the design-system
-    // §11.13 color family for on-screen rendering. Frontend issue #1155 will pin
-    // the canonical map; if it picks different tones, update both sides together.
+    // Category underline colors (no '#'), matching the canonical palette in
+    // design-system.md §11.16 and frontend/src/lib/correction-colors.ts.
+    // Keep both in sync: update correction-colors.ts and this map together.
     private static readonly IReadOnlyDictionary<string, string> CategoryColors = new Dictionary<string, string>
     {
-        [CorrectionTagCategory.Cohesion]   = "4F46E5", // indigo-600
-        [CorrectionTagCategory.Gramatica]  = "B45309", // amber-700 (warm)
-        [CorrectionTagCategory.Lexico]     = "D97706", // amber-600
-        [CorrectionTagCategory.Ortografia] = "059669", // emerald-600
+        [CorrectionTagCategory.Cohesion]   = "6366F1", // indigo-500
+        [CorrectionTagCategory.Gramatica]  = "F97316", // orange-500
+        [CorrectionTagCategory.Lexico]     = "F59E0B", // amber-500
+        [CorrectionTagCategory.Ortografia] = "10B981", // emerald-500
     };
 
     private const string MetadataGray = "6B7280"; // gray-500

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -580,3 +580,63 @@ Reference implementation: `AtelierAssistantPanel.tsx` panel header.
 - Date input style: `text-sm font-inter border border-zinc-200 rounded-md px-2 py-0.5 text-zinc-700 focus:outline-none focus:ring-2 focus:ring-indigo-300`.
 
 Reference implementation: `ProposalCard.tsx` (newSession date input, `NewStudentFields.tsx`).
+
+### 11.15 Correction Status Pill
+
+Displays the workflow state of a Redacción (student writing correction). Used in the correction list row (RedaccionesTab) and the correction detail header (RedaccionDetail).
+
+**Anatomy:** `inline-flex items-center rounded-full px-2.5 py-1 text-[0.6875rem] font-semibold uppercase tracking-wide` — no border, no shadow, no background pattern.
+
+**Persistent states (driven by `CorrectionStatus`):**
+
+| State | Classes | Meaning |
+|-------|---------|---------|
+| Pendiente | `bg-zinc-100 text-zinc-700` | Student has not submitted the text yet |
+| Entregada | `bg-indigo-50 text-indigo-700` | Text received, waiting for teacher to correct |
+| Corregida | `bg-emerald-50 text-emerald-800` | AI correction complete |
+
+**Transient states (local UI only, not persisted):**
+
+| State | Classes | Extra |
+|-------|---------|-------|
+| Corrigiendo | `bg-amber-50 text-amber-800` | Animated pulse dot `h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse` |
+| Error | `bg-red-50 text-red-800` | None |
+
+**Placement:** right-aligned in the header row alongside the page title or list row title. Never inline within body copy.
+
+Reference implementations: `RedaccionDetail.tsx` `StatusPill`, `RedaccionesTab.tsx` `STATUS_BADGE`.
+
+### 11.16 Error Annotation Span (C/G/L/O Chip)
+
+Used in the marked-up correction body to highlight student errors by category. Each span wraps the original student text with a colored underline and a superscript category chip. Clicking opens a Popover with the explanation and corrected form.
+
+**Category color palette** — canonical source is `frontend/src/lib/correction-colors.ts`. These values must match the backend docx export (see `CorrectionDocxExportService.CategoryColors`).
+
+| Category | Label | Underline | Chip bg | Chip text | Hex (for docx) |
+|----------|-------|-----------|---------|-----------|----------------|
+| C | Cohesión | `decoration-indigo-500` | `bg-indigo-100` | `text-indigo-700` | `#6366F1` |
+| G | Gramática | `decoration-orange-500` | `bg-orange-100` | `text-orange-700` | `#F97316` |
+| L | Léxico | `decoration-amber-500` | `bg-amber-100` | `text-amber-700` | `#F59E0B` |
+| O | Ortografía | `decoration-emerald-500` | `bg-emerald-100` | `text-emerald-700` | `#10B981` |
+
+**Span anatomy:**
+- Underline: `underline decoration-2 underline-offset-4` in the category color. `hover:decoration-[3px]` on mouse-over.
+- No background fill on the text itself — only the underline carries the category color.
+- Chip: `<sup>` element, `h-3.5 min-w-3.5 rounded-sm px-0.5 text-[0.6rem] font-semibold leading-none` in the category chip classes. Letter only (C/G/L/O), no full label.
+
+**Trigger behavior:** click to open Popover, not hover. Hover only thickens the underline. The Popover shows the category label, the original spanned text in a blockquote, the explanation, and the corrected form when present.
+
+**Never use:** a background fill on the annotated word span. The color lives in the underline and chip only.
+
+Reference implementations: `TaggedSpan.tsx`, `correction-colors.ts`.
+
+### 11.17 Muy Bien Inline Highlight
+
+Used alongside error annotation spans (§11.16) to mark stretches of text that the AI judged as exemplary.
+
+- **Element:** `<strong className="font-semibold text-zinc-900">`
+- **No underline.** No chip. No popover. No color accent.
+- **When to use:** only when the AI explicitly marks a span as `MuyBien` category. Never apply manually or for editorial emphasis.
+- **When NOT to use:** for error categories (use §11.16 instead), for general bold emphasis in body copy, or for teacher-authored comments.
+
+Reference implementation: `MarkedUpText.tsx` `renderPiece`.

--- a/frontend/src/components/student/RedaccionesTab.tsx
+++ b/frontend/src/components/student/RedaccionesTab.tsx
@@ -24,9 +24,9 @@ interface RedaccionesTabProps {
 }
 
 const STATUS_BADGE: Record<CorrectionStatus, string> = {
-  Pendiente: 'bg-amber-100 text-amber-700',
-  Entregada: 'bg-indigo-100 text-indigo-700',
-  Corregida: 'bg-emerald-100 text-emerald-700',
+  Pendiente: 'bg-zinc-100 text-zinc-700',
+  Entregada: 'bg-indigo-50 text-indigo-700',
+  Corregida: 'bg-emerald-50 text-emerald-800',
 }
 
 const TITLE_MAX = 200
@@ -244,7 +244,7 @@ function CorrectionCard({
           <div className="mt-1 flex items-center gap-2">
             <span
               className={`text-[10px] font-bold tracking-widest uppercase px-2 py-0.5 rounded-md ${
-                isGenerating ? 'bg-amber-100 text-amber-700 animate-pulse' : STATUS_BADGE[status]
+                isGenerating ? 'bg-amber-50 text-amber-800 animate-pulse' : STATUS_BADGE[status]
               }`}
               data-testid={`redaccion-status-${id}`}
             >

--- a/frontend/src/components/student/RedaccionesTab.tsx
+++ b/frontend/src/components/student/RedaccionesTab.tsx
@@ -243,7 +243,7 @@ function CorrectionCard({
           </p>
           <div className="mt-1 flex items-center gap-2">
             <span
-              className={`text-[10px] font-bold tracking-widest uppercase px-2 py-0.5 rounded-md ${
+              className={`text-[0.6875rem] font-semibold tracking-wide uppercase px-2.5 py-0.5 rounded-full ${
                 isGenerating ? 'bg-amber-50 text-amber-800 animate-pulse' : STATUS_BADGE[status]
               }`}
               data-testid={`redaccion-status-${id}`}

--- a/frontend/src/pages/RedaccionDetail.tsx
+++ b/frontend/src/pages/RedaccionDetail.tsx
@@ -202,7 +202,7 @@ function StatusPill({ status, viewState }: StatusPillProps) {
   }
   const palette: Record<typeof status, string> = {
     Pendiente: 'bg-zinc-100 text-zinc-700',
-    Entregada: 'bg-blue-50 text-blue-800',
+    Entregada: 'bg-indigo-50 text-indigo-700',
     Corregida: 'bg-emerald-50 text-emerald-800',
   }
   return (

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -90,6 +90,9 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 ## #1157 (Architecture review notes, PASS WITH NOTES)
 - `RunCorregirAsync` in `RedaccionCorrectionDualLevelTests.cs` is a near-copy of the same method in `RedaccionCorrectionVerbatimTests.cs`. Pre-existing duplication (the skeleton copied the pattern). Extract to a shared `Helpers/CorrectionTestHarness` static helper when a third AI integration test adds the same setup.
 
+## #1176 (Architecture review notes, PASS WITH NOTES)
+- **RedaccionesTab `isGenerating` pill anatomy**: list-view transient state uses full-pill `animate-pulse` rather than the discrete `h-1.5 w-1.5` dot defined in DS §11.15. Restructuring the `<span>` to `<span className="inline-flex items-center gap-1.5">` with a sibling dot element would match the spec exactly. Low risk; the animated pill is a reasonable compact-list equivalent. Revisit if the list view gains the full pill component from the detail view.
+
 ## #1153 (CodeRabbit findings, partially addressed)
 - **Schema (Minor):** Added `endIndex > startIndex` cross-field constraint to `redaccion-correction.schema.json`. Schema is reference-only; C# `ValidateAndOrderTags` is the runtime enforcement layer.
 - **TOCTOU race on /corregir (Major) — partially addressed:** Added a fresh-status recheck in `RedaccionCorrectionService.CorregirAsync` between Claude's response and the SaveChanges. Closes the duplicate-tag-rows half of the race. Does NOT prevent both concurrent calls from invoking Claude (double cost). True atomic claim requires either (a) a `Corrigiendo` enum value + DB CHECK constraint update + flip-and-save before the LLM call, or (b) a `RowVersion`/`[Timestamp]` concurrency token on `Correction`. Both options need a migration. Defer until the frontend exposes the corregir button to a multi-tab/double-click vector — for v1, the UI debounces and the blast radius is bounded.


### PR DESCRIPTION
Closes #1176

## Summary

- Adds `docs/design-system.md` §11.15 (correction status pill), §11.16 (error annotation span / C/G/L/O chip), §11.17 (muy bien inline bold)
- Canonicalizes status pill color palette across `RedaccionesTab` and `RedaccionDetail` (the two screens used different colors for the same states)
- Updates `CorrectionDocxExportService.CategoryColors` to match the frontend underline colors in `correction-colors.ts` (Gramática was amber-700 but frontend uses orange-500; all four categories were one Tailwind tone off)
- Updates test assertions in two test files to reflect corrected hex values

## Color changes

| State / Category | Before | After |
|---|---|---|
| Status: Pendiente (list) | `bg-amber-100 text-amber-700` | `bg-zinc-100 text-zinc-700` |
| Status: Entregada (list) | `bg-indigo-100 text-indigo-700` | `bg-indigo-50 text-indigo-700` |
| Status: Corregida (list) | `bg-emerald-100 text-emerald-700` | `bg-emerald-50 text-emerald-800` |
| Status: Entregada (detail) | `bg-blue-50 text-blue-800` | `bg-indigo-50 text-indigo-700` |
| Docx C (Cohesion) | `4F46E5` (indigo-600) | `6366F1` (indigo-500) |
| Docx G (Gramatica) | `B45309` (amber-700) | `F97316` (orange-500) |
| Docx L (Lexico) | `D97706` (amber-600) | `F59E0B` (amber-500) |
| Docx O (Ortografia) | `059669` (emerald-600) | `10B981` (emerald-500) |

## Test plan

- [x] `npm test` — 1747 tests pass
- [x] `dotnet test` — all API tests pass (updated two hex assertions)
- [x] `review-ui` agent — PASS; correction detail and Redacciones tab render correctly
- [x] `qa-verify` — PASS
- [x] `architecture-reviewer` — PASS WITH NOTES (notes logged to code-review-backlog.md)

## Reviewer table

| Reviewer | Finding | Action |
|---|---|---|
| qa-verify | PASS | — |
| architecture-reviewer | rounded-md vs rounded-full shape inconsistency | Fixed (updated list badge to rounded-full) |
| architecture-reviewer | isGenerating dot vs full-pill animate-pulse | Deferred — logged to code-review-backlog.md |
| review-ui | PASS (gap note: C/G/L/O not documented) | Dismissed — §11.16 in this PR documents exactly that; agent didn't read updated DS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Unified and refined correction status badge colors across the entire application for improved visual consistency.
  * Updated the color palette for all correction status indicators, including delivery status and error highlighting.
  * Enhanced the styling of correction badges and indicators to align with the application's design system.
  * Synchronized exported document colors with the frontend color scheme for a cohesive user experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1179)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->