### PR TITLE
fix(#1182): docx download URL mismatch and AppShell session nav missing /edit

### DIFF
--- a/frontend/src/api/corrections.ts
+++ b/frontend/src/api/corrections.ts
@@ -91,7 +91,7 @@ export async function downloadCorrectionDocx(
   filenameHint: string,
 ): Promise<void> {
   const response = await apiClient.get<Blob>(
-    `/api/students/${studentId}/corrections/${id}/docx`,
+    `/api/students/${studentId}/corrections/${id}/export.docx`,
     { responseType: 'blob' },
   )
   const fallback = `${sanitizeFilename(filenameHint)}.docx`

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -181,7 +181,7 @@ export default function AppShell() {
 
   function handleNavigateToSession() {
     if (studentId && assistant.suggestedSessionId) {
-      navigate(`/students/${studentId}/sessions/${assistant.suggestedSessionId}`)
+      navigate(`/students/${studentId}/sessions/${assistant.suggestedSessionId}/edit`)
     }
   }
 


### PR DESCRIPTION
Closes #1182

## Summary
- `frontend/src/api/corrections.ts`: frontend called `/corrections/{id}/docx` but the backend route is `/corrections/{id}/export.docx` -- 404 on every download
- `frontend/src/components/AppShell.tsx`: `handleNavigateToSession` navigated to `/students/${studentId}/sessions/${suggestedSessionId}` (no `/edit`), causing React router to find no match and render a blank page

## Test plan
- [ ] Open Ana Visual > Redacciones > open seeded CORREGIDA card > click "Descargar .docx" -- file downloads, opens in Word with colored corrections
- [ ] Open any student > submit Atelier note from outside a session > click "Open matched session" in warning banner -- session edit view loads, no blank page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized the correction document export functionality by updating to an improved endpoint infrastructure, ensuring more reliable and consistent file downloads throughout the application.
  * Enhanced the suggested session workflow by modifying navigation to direct users directly to edit mode, streamlining your experience and eliminating unnecessary intermediate navigation steps.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1183)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->