### PR TITLE
feat(#1185): replace Atelier no-session banner with inline session picker

### DIFF
--- a/e2e/tests/visual/atelier-1165-no-session-guard.visual.spec.ts
+++ b/e2e/tests/visual/atelier-1165-no-session-guard.visual.spec.ts
@@ -46,16 +46,19 @@ test('@visual atelier-1165 no-session-banner visible on student profile', async 
   await expect(page.locator('[data-testid="proposals-list"]')).toBeVisible({ timeout: UI_TIMEOUT })
   await page.waitForLoadState('networkidle', { timeout: UI_TIMEOUT })
 
-  // The no-session banner must be present
-  const banner = page.locator('[data-testid="no-session-banner"]')
+  // The session picker banner must be present
+  const banner = page.locator('[data-testid="session-picker-banner"]')
   await expect(banner).toBeVisible({ timeout: UI_TIMEOUT })
+
+  // "+ New session" row must be present
+  await expect(page.locator('[data-testid="session-picker-new"]')).toBeVisible({ timeout: UI_TIMEOUT })
 
   // At least one Apply button must be disabled (session-type proposals)
   const disabledApplyBtns = page.locator('[data-testid^="apply-btn-"]:disabled')
   expect(await disabledApplyBtns.count()).toBeGreaterThan(0)
 
   await banner.scrollIntoViewIfNeeded()
-  await page.screenshot({ path: 'screenshots/atelier-1165-no-session-banner.png', fullPage: true })
+  await page.screenshot({ path: 'screenshots/atelier-1165-session-picker-banner.png', fullPage: true })
 
   expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)
   await context.close()

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type ElementType } from 'react'
+import { useState, useEffect, useCallback, type ElementType } from 'react'
 import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth0 } from '@auth0/auth0-react'
 import { useQuery } from '@tanstack/react-query'
@@ -141,6 +141,10 @@ export default function AppShell() {
   const atelierEnabled = isAtelierEnabled(location.pathname)
   const assistantOpen = userWantsOpen && atelierEnabled
 
+  const navigate = useNavigate()
+  const [pickerSessionId, setPickerSessionId] = useState<string | null>(null)
+  const effectiveSessionId = pickerSessionId ?? sessionId
+
   const { data: studentData } = useQuery({
     queryKey: ['student', studentId],
     queryFn: () => getStudent(studentId!),
@@ -148,13 +152,21 @@ export default function AppShell() {
     select: (s) => s.name,
   })
 
-  const assistant = useAtelierAssistant(studentId, sessionId)
+  const handleAfterSessionApply = useCallback((appliedSessionId: string) => {
+    setPickerSessionId(null)
+    if (studentId) {
+      navigate(`/students/${studentId}/sessions/${appliedSessionId}/edit`)
+    }
+  }, [studentId, navigate])
+
+  const assistant = useAtelierAssistant(studentId, effectiveSessionId, handleAfterSessionApply)
 
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => {
     setDrawerOpen(false)
     if (!isAtelierEnabled(location.pathname)) {
       setUserWantsOpen(false)
+      setPickerSessionId(null)
       assistant.reset()
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -176,14 +188,7 @@ export default function AppShell() {
     ? user.name.split(' ').map((n: string) => n[0]).join('').toUpperCase().slice(0, 2)
     : '?'
 
-  const navigate = useNavigate()
   const toggleAssistant = () => { if (atelierEnabled) setUserWantsOpen(open => !open) }
-
-  function handleNavigateToSession() {
-    if (studentId && assistant.suggestedSessionId) {
-      navigate(`/students/${studentId}/sessions/${assistant.suggestedSessionId}/edit`)
-    }
-  }
 
   return (
     <div className="flex h-screen overflow-hidden bg-[#FBF8FF]">
@@ -306,8 +311,8 @@ export default function AppShell() {
       {/* Atelier Assistant panel */}
       <AtelierAssistantPanel
         open={assistantOpen}
-        onClose={() => { setUserWantsOpen(false); assistant.reset() }}
-        onCloseDiscarding={() => { setUserWantsOpen(false); assistant.reset() }}
+        onClose={() => { setUserWantsOpen(false); setPickerSessionId(null); assistant.reset() }}
+        onCloseDiscarding={() => { setUserWantsOpen(false); setPickerSessionId(null); assistant.reset() }}
         studentName={studentData}
         transcription={assistant.transcription}
         processing={assistant.processing}
@@ -322,9 +327,8 @@ export default function AppShell() {
         onDismissAll={assistant.dismissAll}
         onEditPayload={assistant.onEditPayload}
         studentId={studentId}
-        sessionId={sessionId}
-        suggestedSessionId={assistant.suggestedSessionId}
-        onNavigateToSession={handleNavigateToSession}
+        sessionId={effectiveSessionId}
+        onSelectSession={setPickerSessionId}
       />
     </div>
   )

--- a/frontend/src/components/AtelierAssistantPanel.test.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, act, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi, describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import AtelierAssistantPanel from './AtelierAssistantPanel'
 import type { VoiceNote } from '@/api/voiceNotes'
 import type { ProposalWithStatus } from '@/hooks/useAtelierAssistant'
@@ -59,6 +61,11 @@ vi.mock('@/api/assistant', async () => {
   return { ...actual, submitVoiceFeedback: vi.fn().mockResolvedValue(undefined) }
 })
 
+// sessionLogs API mock
+vi.mock('@/api/sessionLogs', () => ({
+  listSessions: vi.fn().mockResolvedValue([]),
+}))
+
 const SAMPLE_NOTE: VoiceNote = {
   id: 'note-1',
   originalFileName: 'recording.webm',
@@ -96,9 +103,18 @@ const defaultProps = {
   onEditPayload: vi.fn(),
 }
 
-function renderPanel(overrides: Partial<typeof defaultProps> & { studentId?: string | null; sessionId?: string | null; suggestedSessionId?: string | null; onNavigateToSession?: () => void } = {}) {
+function wrapWithProviders(ui: React.ReactElement) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+function renderPanel(overrides: Partial<typeof defaultProps> & { studentId?: string | null; sessionId?: string | null; onSelectSession?: (id: string) => void } = {}) {
   const props = { ...defaultProps, ...overrides }
-  return { ...render(<AtelierAssistantPanel {...props} />), props }
+  return { ...render(wrapWithProviders(<AtelierAssistantPanel {...props} />)), props }
 }
 
 function makeProposal(overrides: Partial<ProposalWithStatus> = {}): ProposalWithStatus {
@@ -358,16 +374,16 @@ describe('AtelierAssistantPanel', () => {
   it('input value is cleared when panel closes and reopens', async () => {
     const user = userEvent.setup()
     const props = { ...defaultProps }
-    const { rerender } = render(<AtelierAssistantPanel {...props} />)
+    const { rerender } = render(wrapWithProviders(<AtelierAssistantPanel {...props} />))
 
     const input = screen.getByTestId('assistant-input')
     await user.type(input, 'some text')
     expect((input as HTMLInputElement).value).toBe('some text')
 
     // Close panel
-    rerender(<AtelierAssistantPanel {...props} open={false} />)
+    rerender(wrapWithProviders(<AtelierAssistantPanel {...props} open={false} />))
     // Reopen panel
-    rerender(<AtelierAssistantPanel {...props} open={true} />)
+    rerender(wrapWithProviders(<AtelierAssistantPanel {...props} open={true} />))
 
     expect((screen.getByTestId('assistant-input') as HTMLInputElement).value).toBe('')
   })
@@ -376,15 +392,15 @@ describe('AtelierAssistantPanel', () => {
     const user = userEvent.setup()
     mockGetUserMedia.mockRejectedValueOnce(Object.assign(new Error('denied'), { name: 'NotAllowedError' }))
     const props = { ...defaultProps }
-    const { rerender } = render(<AtelierAssistantPanel {...props} />)
+    const { rerender } = render(wrapWithProviders(<AtelierAssistantPanel {...props} />))
 
     // Trigger permission denied
     await user.click(screen.getByTestId('mic-btn'))
     await waitFor(() => expect(screen.getByTestId('mic-permission-error')).toBeInTheDocument())
 
     // Close and reopen
-    rerender(<AtelierAssistantPanel {...props} open={false} />)
-    rerender(<AtelierAssistantPanel {...props} open={true} />)
+    rerender(wrapWithProviders(<AtelierAssistantPanel {...props} open={false} />))
+    rerender(wrapWithProviders(<AtelierAssistantPanel {...props} open={true} />))
 
     // Must show idle empty state, not permission error
     expect(screen.queryByTestId('mic-permission-error')).not.toBeInTheDocument()
@@ -395,7 +411,7 @@ describe('AtelierAssistantPanel', () => {
     vi.useFakeTimers()
     mockUpload.mockRejectedValue(new Error('network'))
     const props = { ...defaultProps }
-    const { rerender } = render(<AtelierAssistantPanel {...props} />)
+    const { rerender } = render(wrapWithProviders(<AtelierAssistantPanel {...props} />))
 
     await act(async () => { fireEvent.click(screen.getByTestId('mic-btn')) })
     act(() => { vi.advanceTimersByTime(2000) })
@@ -405,8 +421,8 @@ describe('AtelierAssistantPanel', () => {
     expect(await screen.findByTestId('upload-error')).toBeInTheDocument()
 
     // Close and reopen
-    rerender(<AtelierAssistantPanel {...props} open={false} />)
-    rerender(<AtelierAssistantPanel {...props} open={true} />)
+    rerender(wrapWithProviders(<AtelierAssistantPanel {...props} open={false} />))
+    rerender(wrapWithProviders(<AtelierAssistantPanel {...props} open={true} />))
 
     // Must show idle input row, not error state
     expect(screen.queryByTestId('upload-error')).not.toBeInTheDocument()
@@ -709,75 +725,81 @@ describe('AtelierAssistantPanel', () => {
     })
   })
 
-  // ---- no-session context banner ----------------------------------------------
+  // ---- session picker banner -------------------------------------------------
 
-  describe('no-session context banner', () => {
+  describe('session picker banner', () => {
     const sessionProposal = makeProposal({ id: 'sp1', type: 'session', field: 'title', label: 'Session Title', oldValue: null, newValue: 'Past Perfect' })
 
-    it('shows banner when session proposals exist and sessionId is null', () => {
+    it('shows picker when session proposals exist and sessionId is null', () => {
       renderPanel({
         transcription: 'Past perfect class',
         proposals: [sessionProposal],
         sessionId: null,
       })
-      expect(screen.getByTestId('no-session-banner')).toBeInTheDocument()
+      expect(screen.getByTestId('session-picker-banner')).toBeInTheDocument()
+      expect(screen.getByTestId('session-picker-new')).toBeInTheDocument()
     })
 
-    it('does not show banner when sessionId is present', () => {
+    it('does not show picker when sessionId is present', () => {
       renderPanel({
         transcription: 'Past perfect class',
         proposals: [sessionProposal],
         sessionId: 'session-1',
       })
-      expect(screen.queryByTestId('no-session-banner')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('session-picker-banner')).not.toBeInTheDocument()
     })
 
-    it('does not show banner when no session-type proposals exist', () => {
+    it('does not show picker when no session-type proposals exist', () => {
       const studentProposal = makeProposal({ type: 'student' })
       renderPanel({
         transcription: 'Past perfect class',
         proposals: [studentProposal],
         sessionId: null,
       })
-      expect(screen.queryByTestId('no-session-banner')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('session-picker-banner')).not.toBeInTheDocument()
     })
 
-    it('shows "Open matched session" button when suggestedSessionId is provided', () => {
-      const onNavigate = vi.fn()
-      renderPanel({
-        transcription: 'Past perfect class',
-        proposals: [sessionProposal],
-        sessionId: null,
-        suggestedSessionId: 'session-xyz',
-        onNavigateToSession: onNavigate,
-      })
-      const btn = screen.getByTestId('open-matched-session-btn')
-      expect(btn).toBeInTheDocument()
-    })
-
-    it('calls onNavigateToSession when "Open matched session" is clicked', async () => {
+    it('calls onSelectSession when a session row is clicked', async () => {
+      const { listSessions } = await import('@/api/sessionLogs')
+      const mockedList = vi.mocked(listSessions)
+      mockedList.mockResolvedValueOnce([{
+        id: 'session-abc',
+        studentId: 'student-1',
+        sessionDate: '2026-04-28',
+        title: 'Pretérito indefinido',
+        isCancelled: false,
+        createdAt: '2026-04-28T10:00:00Z',
+        updatedAt: '2026-04-28T10:00:00Z',
+        plannedContent: null, actualContent: null, homeworkAssigned: null,
+        previousHomeworkStatus: 0, previousHomeworkStatusName: 'NotApplicable',
+        nextSessionTopics: null, generalNotes: null, levelReassessmentSkill: null,
+        levelReassessmentLevel: null, linkedLessonId: null, topicTags: '[]',
+        status: 1, statusName: 'Confirmed', mentionedDifficultyPairs: '[]',
+        suggestedDifficulties: '[]', duration: null, hasVoiceNote: false,
+      }])
+      const onSelect = vi.fn()
       const user = userEvent.setup()
-      const onNavigate = vi.fn()
       renderPanel({
         transcription: 'Past perfect class',
         proposals: [sessionProposal],
         sessionId: null,
-        suggestedSessionId: 'session-xyz',
-        onNavigateToSession: onNavigate,
+        studentId: 'student-1',
+        onSelectSession: onSelect,
       })
-      await user.click(screen.getByTestId('open-matched-session-btn'))
-      expect(onNavigate).toHaveBeenCalledOnce()
+      await waitFor(() => expect(screen.getByTestId('session-picker-row-session-abc')).toBeInTheDocument())
+      await user.click(screen.getByTestId('session-picker-row-session-abc'))
+      expect(onSelect).toHaveBeenCalledWith('session-abc')
     })
 
-    it('does not show "Open matched session" button when suggestedSessionId is absent', () => {
+    it('shows only "+ New session" when student has no sessions', () => {
       renderPanel({
         transcription: 'Past perfect class',
         proposals: [sessionProposal],
         sessionId: null,
-        suggestedSessionId: null,
+        studentId: 'student-1',
       })
-      expect(screen.getByTestId('no-session-banner')).toBeInTheDocument()
-      expect(screen.queryByTestId('open-matched-session-btn')).not.toBeInTheDocument()
+      expect(screen.getByTestId('session-picker-new')).toBeInTheDocument()
+      expect(screen.queryByTestId(/^session-picker-row-/)).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { Sparkles, X, Send, Mic, Square, Loader2, AlertCircle, ThumbsUp, ThumbsDown, ExternalLink } from 'lucide-react'
+import { Sparkles, X, Send, Mic, Square, Loader2, AlertCircle, ThumbsUp, ThumbsDown, Plus, CalendarDays } from 'lucide-react'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
 import { Input } from '@/components/ui/input'
 import { uploadVoiceNote } from '@/api/voiceNotes'
@@ -10,6 +10,10 @@ import { submitVoiceFeedback } from '@/api/assistant'
 import { MAX_RECORDING_SECONDS, WARN_REMAINING_SECONDS } from '@/lib/recordingLimits'
 import { formatDuration } from '@/lib/formatDuration'
 import { BRAND_NAME } from '@/lib/brand'
+import { useQuery } from '@tanstack/react-query'
+import { listSessions } from '@/api/sessionLogs'
+import { useNavigate } from 'react-router-dom'
+import { formatMonthDay } from '@/utils/formatDate'
 
 const MIN_DURATION_S = 1
 
@@ -49,8 +53,7 @@ interface Props {
   onEditPayload?: (id: string, payload: import('@/api/assistant').NewStudentData | import('@/api/assistant').NewSessionData | Record<string, unknown>) => void
   studentId?: string | null
   sessionId?: string | null
-  suggestedSessionId?: string | null
-  onNavigateToSession?: () => void
+  onSelectSession?: (sessionId: string) => void
 }
 
 export default function AtelierAssistantPanel({
@@ -72,9 +75,27 @@ export default function AtelierAssistantPanel({
   onEditPayload,
   studentId,
   sessionId,
-  suggestedSessionId,
-  onNavigateToSession,
+  onSelectSession,
 }: Props) {
+  const navigate = useNavigate()
+  const sessionContextMissing = !sessionId
+  const hasSessionProposalsWithoutContext = sessionContextMissing && proposals.some(p => p.type === 'session' && (p.status === 'proposed' || p.status === 'error'))
+
+  const { data: recentSessions } = useQuery({
+    queryKey: ['sessions', studentId],
+    queryFn: () => listSessions(studentId!),
+    enabled: !!studentId && hasSessionProposalsWithoutContext,
+    select: (sessions) =>
+      [...sessions]
+        .filter(s => !s.isCancelled)
+        .sort((a, b) => {
+          const da = new Date(a.sessionDate ?? a.createdAt).getTime()
+          const db = new Date(b.sessionDate ?? b.createdAt).getTime()
+          return db - da
+        })
+        .slice(0, 3),
+  })
+
   const [inputValue, setInputValue] = useState('')
   const [pendingClose, setPendingClose] = useState(false)
   const [currentVoiceNoteId, setCurrentVoiceNoteId] = useState<string | null>(null)
@@ -271,9 +292,10 @@ export default function AtelierAssistantPanel({
   const noHardware = hookError === 'no-hardware'
   const permissionDenied = hookError === 'permission-denied'
   const pendingProposals = proposals.filter(p => p.status === 'proposed')
-  const sessionContextMissing = !sessionId
-  const hasSessionProposalsWithoutContext = sessionContextMissing && pendingProposals.some(p => p.type === 'session')
-  const applyAllBlocked = !studentId && pendingProposals.some(p => p.type === 'newSession')
+  const applyAllBlocked = (
+    (!studentId && pendingProposals.some(p => p.type === 'newSession')) ||
+    (hasSessionProposalsWithoutContext && pendingProposals.every(p => p.type === 'session'))
+  )
 
   return (
     <Sheet open={open} onOpenChange={handleSheetOpenChange}>
@@ -416,22 +438,39 @@ export default function AtelierAssistantPanel({
                   <div className="space-y-3" data-testid="proposals-list">
                     {hasSessionProposalsWithoutContext && (
                       <div
-                        className="flex flex-col gap-2 px-3 py-2.5 rounded-xl bg-violet-50 border border-violet-100"
-                        data-testid="no-session-banner"
+                        className="flex flex-col gap-1.5 px-3 py-2.5 rounded-xl bg-violet-50 border border-violet-100"
+                        data-testid="session-picker-banner"
                       >
-                        <p className="text-xs font-inter text-violet-700 leading-snug">
-                          These session notes need an open session. Open a session to apply them.
+                        <p className="text-xs font-inter text-violet-700 leading-snug mb-1">
+                          Choose a session to apply these notes to:
                         </p>
-                        {suggestedSessionId && onNavigateToSession && (
-                          <button
-                            onClick={onNavigateToSession}
-                            className="flex items-center gap-1.5 self-start text-xs font-inter font-semibold text-violet-700 hover:text-violet-900 hover:underline transition-colors"
-                            data-testid="open-matched-session-btn"
-                          >
-                            <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
-                            Open matched session
-                          </button>
-                        )}
+                        <button
+                          onClick={() => studentId && navigate(`/students/${studentId}/sessions/new`)}
+                          className="flex items-center gap-2 px-2.5 py-2 rounded-lg text-xs font-inter font-semibold text-indigo-600 hover:bg-indigo-50 transition-colors text-left"
+                          data-testid="session-picker-new"
+                        >
+                          <Plus className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                          New session
+                        </button>
+                        {(recentSessions ?? []).map(session => {
+                          const dateLabel = session.sessionDate
+                            ? formatMonthDay(session.sessionDate)
+                            : session.createdAt
+                              ? formatMonthDay(session.createdAt)
+                              : null
+                          const title = session.title ?? 'Session'
+                          return (
+                            <button
+                              key={session.id}
+                              onClick={() => onSelectSession?.(session.id)}
+                              className="flex items-center gap-2 px-2.5 py-2 rounded-lg text-xs font-inter text-zinc-600 hover:bg-violet-100 transition-colors text-left"
+                              data-testid={`session-picker-row-${session.id}`}
+                            >
+                              <CalendarDays className="h-3.5 w-3.5 shrink-0 text-zinc-400" aria-hidden="true" />
+                              <span className="truncate">{dateLabel ? `${dateLabel} — ` : ''}{title}</span>
+                            </button>
+                          )
+                        })}
                       </div>
                     )}
                     <div className="space-y-2">

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -438,7 +438,7 @@ export default function AtelierAssistantPanel({
                   <div className="space-y-3" data-testid="proposals-list">
                     {hasSessionProposalsWithoutContext && (
                       <div
-                        className="flex flex-col gap-1.5 px-3 py-2.5 rounded-xl bg-violet-50 border border-violet-100"
+                        className="flex flex-col gap-1.5 px-3 py-2.5 rounded-xl bg-violet-50"
                         data-testid="session-picker-banner"
                       >
                         <p className="text-xs font-inter text-violet-700 leading-snug mb-1">

--- a/frontend/src/hooks/useAtelierAssistant.test.ts
+++ b/frontend/src/hooks/useAtelierAssistant.test.ts
@@ -541,32 +541,6 @@ describe('useAtelierAssistant', () => {
     expect(result.current.proposals[0].status).toBe('error')
   })
 
-  it('submit: captures suggestedSessionId from propose response when sessionId is null', async () => {
-    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[1]], sessionLogId: 'session-xyz' })
-    const { result } = renderHook(() => useAtelierAssistant('student-1', null), { wrapper: makeWrapper() })
-    act(() => { result.current.submit('text') })
-    await act(async () => { await vi.runAllTimersAsync() })
-    expect(result.current.suggestedSessionId).toBe('session-xyz')
-  })
-
-  it('submit: does not capture suggestedSessionId when sessionId is already in scope', async () => {
-    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[1]], sessionLogId: 'session-xyz' })
-    const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'), { wrapper: makeWrapper() })
-    act(() => { result.current.submit('text') })
-    await act(async () => { await vi.runAllTimersAsync() })
-    expect(result.current.suggestedSessionId).toBeNull()
-  })
-
-  it('reset: clears suggestedSessionId', async () => {
-    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[1]], sessionLogId: 'session-xyz' })
-    const { result } = renderHook(() => useAtelierAssistant('student-1', null), { wrapper: makeWrapper() })
-    act(() => { result.current.submit('text') })
-    await act(async () => { await vi.runAllTimersAsync() })
-    expect(result.current.suggestedSessionId).toBe('session-xyz')
-    act(() => { result.current.reset() })
-    expect(result.current.suggestedSessionId).toBeNull()
-  })
-
   it('applyAll: skips session proposals when sessionId is null', async () => {
     mockPropose.mockResolvedValueOnce({ proposals: sampleProposals })
     mockApplyStudent.mockResolvedValueOnce(undefined)

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -199,7 +199,7 @@ export function useAtelierAssistant(
       } else if (proposal.type === 'session' && studentId && sessionId) {
         await queryClient.invalidateQueries({ queryKey: ['session', studentId, sessionId] })
         await queryClient.invalidateQueries({ queryKey: ['sessions', studentId] })
-        onAfterSessionApply?.(sessionId)
+        Promise.resolve(onAfterSessionApply?.(sessionId)).catch(() => { /* proposal already applied; swallow */ })
       } else if (proposal.type === 'newStudent') {
         await queryClient.invalidateQueries({ queryKey: ['students'] })
       } else if (proposal.type === 'newSession' && studentId) {

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -28,7 +28,6 @@ export interface AtelierAssistantState {
   transcription: string | null
   processing: boolean
   proposals: ProposalWithStatus[]
-  suggestedSessionId: string | null
 }
 
 export interface AtelierAssistantActions {
@@ -46,12 +45,12 @@ export interface AtelierAssistantActions {
 export function useAtelierAssistant(
   studentId: string | null,
   sessionId: string | null,
+  onAfterSessionApply?: (sessionId: string) => void,
 ): AtelierAssistantState & AtelierAssistantActions {
   const queryClient = useQueryClient()
   const [transcription, setTranscription] = useState<string | null>(null)
   const [processing, setProcessing] = useState(false)
   const [proposals, setProposals] = useState<ProposalWithStatus[]>([])
-  const [suggestedSessionId, setSuggestedSessionId] = useState<string | null>(null)
   const undoTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
   const applyingIdsRef = useRef<Set<string>>(new Set())
   const generationRef = useRef(0)
@@ -78,13 +77,12 @@ export function useAtelierAssistant(
     const hasPending = proposalsRef.current.some(p => p.status === 'proposed')
     if (!hasPending) setProposals([])
     try {
-      const { proposals: raw, sessionLogId } = await proposeAssistant(
+      const { proposals: raw } = await proposeAssistant(
         text,
         studentId ?? undefined,
         sessionId ?? undefined,
       )
       if (generationRef.current !== gen) return
-      if (!sessionId && sessionLogId) setSuggestedSessionId(sessionLogId)
       if (!hasPending) {
         setProposals(raw.map(p => ({ ...p, status: 'proposed', undoVisible: false })))
       } else {
@@ -201,6 +199,7 @@ export function useAtelierAssistant(
       } else if (proposal.type === 'session' && studentId && sessionId) {
         await queryClient.invalidateQueries({ queryKey: ['session', studentId, sessionId] })
         await queryClient.invalidateQueries({ queryKey: ['sessions', studentId] })
+        onAfterSessionApply?.(sessionId)
       } else if (proposal.type === 'newStudent') {
         await queryClient.invalidateQueries({ queryKey: ['students'] })
       } else if (proposal.type === 'newSession' && studentId) {
@@ -216,7 +215,7 @@ export function useAtelierAssistant(
     } finally {
       applyingIdsRef.current.delete(id)
     }
-  }, [studentId, sessionId, updateProposal, queryClient])
+  }, [studentId, sessionId, updateProposal, queryClient, onAfterSessionApply])
 
   const dismiss = useCallback((id: string) => {
     updateProposal(id, { status: 'dismissed', undoVisible: true })
@@ -273,14 +272,12 @@ export function useAtelierAssistant(
     setTranscription(null)
     setProcessing(false)
     setProposals([])
-    setSuggestedSessionId(null)
   }, [])
 
   return {
     transcription,
     processing,
     proposals,
-    suggestedSessionId,
     submit,
     apply,
     dismiss,

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -3,6 +3,7 @@
 Out-of-scope observations logged by agents during implementation. Each row is something an agent noticed but did not fix because it was outside the current task's scope. These get batched into future GitHub issues by the PM.
 
 | Source issue | Date | Severity | Observation |
+| #1185 | 2026-05-09 | low | Atelier session picker (inline pick-list inside AI proposals area) has no design system spec; picker rows use ghost-button style with hover-bg but no selected/active state defined -- needs Vera discussion before pattern is reused |
 | #smoke-text-correction | 2026-05-09 | low | Atelier assistant extracted phantom profile data (profession "Engineer", country "Spain", interests "Travel, Cooking") from a session note that contained none of that information -- extraction model may be hallucinating updates from prior context rather than the current transcript |
 | #1181 | 2026-05-09 | low | CorrectionDrawer footer pairs "Cancelar" ghost button with primary "Guardar" on the same row; violates design-system §5 (destructive/secondary actions should be separated from primary). Pre-existing, not introduced by this PR. |
 | #1151 | 2026-05-09 | P3:nice | Apply-disabled + "Open from a student's screen" helper text invariant has no e2e coverage; was in the no-student spec but can only be tested from a student context (panel open) -- needs a new spec |


### PR DESCRIPTION
## Summary

- Replaces the "Open matched session" link in the Atelier panel with an inline session picker: a "New session" row (Plus icon, indigo) plus up to 3 most-recent sessions (date + title, CalendarDays icon)
- Tapping a session row sets `pickerSessionId` in AppShell dynamically; `effectiveSessionId` propagates to the hook so session proposal Apply buttons activate immediately without navigation
- After any session proposal is applied, `handleAfterSessionApply` navigates to the session edit view and clears the picker override; panel stays open
- "New session" row navigates to the new session form; proposals survive (hook state persists while Atelier is enabled)
- Empty student scenario: picker shows only "New session" row, no error
- Removed `suggestedSessionId` state from hook and `onNavigateToSession` prop from panel (both replaced by the new picker architecture)

## Architecture

- `AppShell`: adds `pickerSessionId` state, `effectiveSessionId = pickerSessionId ?? sessionId`, `handleAfterSessionApply` (useCallback), passes `onSelectSession` to panel
- `useAtelierAssistant`: optional third param `onAfterSessionApply` called after session proposal apply succeeds
- `AtelierAssistantPanel`: `useQuery(listSessions)` gated on `hasSessionProposalsWithoutContext`; `useNavigate` for "New session" routing; sort uses `getTime()`; date format via shared `formatMonthDay`

## Test plan

- [ ] Open any student profile (not inside a session), open Atelier, submit: "Hoy repasamos el pretérito indefinido, mandé redacción de tarea."
- [ ] Verify violet banner shows "New session" row + 2-3 recent session rows (date + title)
- [ ] Tap a session row -- Apply buttons on session cards activate, no navigation
- [ ] Tap Apply on a session card -- field saves, page navigates to session edit view, panel stays open
- [ ] Open a student with no sessions -- banner shows only "New session"
- [ ] Tap "New session" -- new session form opens, proposals still in panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session-picker banner in the Atelier assistant panel allowing users to select from recent sessions or create a new session.

* **Refactor**
  * Updated session selection flow in the assistant panel to improve the user experience when managing session context.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1186)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->