### PR TITLE
fix(#1188,#1189): two-section docx export and auto-generate title when blank

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerExportTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerExportTests.cs
@@ -138,14 +138,16 @@ public class CorrectionsControllerExportTests
         using var doc = WordprocessingDocument.Open(stream, isEditable: false);
         var runs = doc.MainDocumentPart!.Document.Body!.Descendants<Run>().ToList();
 
-        // The seeded correction has one O-category tag on "ablar" -> emerald-500 10B981 (DS §11.16)
+        // Section 1: O-category tag "ablar" -> emerald-500 10B981, underlined (not bold)
         var coloredRun = runs.FirstOrDefault(r =>
             r.RunProperties?.Color?.Val?.Value == "10B981"
-            && r.RunProperties?.Bold is not null);
-        coloredRun.Should().NotBeNull("the docx must include the colored bold run for the O tag");
+            && r.RunProperties?.Underline is not null);
+        coloredRun.Should().NotBeNull("the docx must include the underlined colored run for the O tag");
 
         var allText = string.Concat(runs.SelectMany(r => r.Descendants<Text>()).Select(t => t.Text));
-        allText.Should().Contain("(O) corrección:");
+        allText.Should().NotContain("(O) corrección:", "old inline parenthetical format must not appear");
+        // Section 2: numbered corrections list
+        allText.Should().Contain("[O]");
         allText.Should().Contain("hablar");
     }
 

--- a/backend/LangTeach.Api.Tests/Services/CorrectionDocxExportServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/CorrectionDocxExportServiceTests.cs
@@ -23,7 +23,7 @@ public class CorrectionDocxExportServiceTests
     }
 
     [Fact]
-    public void Generate_WithErrorTag_RendersBoldColoredRunPlusItalicParenthetical()
+    public void Generate_WithErrorTag_RendersUnderlinedColoredRunWithSuperscriptAndCorrectionSection()
     {
         // "ablar" missing 'h' at index 4 -> O (Ortografía, emerald-500 10B981, DS §11.16)
         const string text = "Hoy ablar con mi amigo.";
@@ -33,21 +33,29 @@ public class CorrectionDocxExportServiceTests
         var bytes = _svc.Generate(detail, "Gavin");
         var (texts, runs) = ReadAllRuns(bytes);
 
+        // Section 1: spanned text is underlined + colored, no bold
         var spannedRunIdx = texts.FindIndex(t => t == "ablar");
         spannedRunIdx.Should().BeGreaterThanOrEqualTo(0, "spanned text should appear as its own run");
 
         var spannedRun = runs[spannedRunIdx];
-        spannedRun.RunProperties!.Bold.Should().NotBeNull();
+        spannedRun.RunProperties!.Bold.Should().BeNull("error spans are underlined, not bold");
         spannedRun.RunProperties.Color!.Val!.Value.Should().Be("10B981");
+        spannedRun.RunProperties.Underline.Should().NotBeNull();
 
-        (spannedRunIdx + 1).Should().BeLessThan(runs.Count,
-            "error-tagged span must be followed by its parenthetical run");
-        var parenRun = runs[spannedRunIdx + 1];
-        parenRun.RunProperties!.Italic.Should().NotBeNull();
-        var parenText = parenRun.Descendants<Text>().Single().Text;
-        parenText.Should().StartWith(" (O) corrección:");
-        parenText.Should().Contain("hablar");
-        parenText.Should().Contain("Falta la 'h'.");
+        // Immediately followed by a superscript run "1"
+        (spannedRunIdx + 1).Should().BeLessThan(runs.Count, "span must be followed by superscript");
+        var supRun = runs[spannedRunIdx + 1];
+        supRun.RunProperties!.VerticalTextAlignment!.Val!.Value.Should().Be(VerticalPositionValues.Superscript);
+        string.Concat(supRun.Descendants<Text>().Select(t => t.Text)).Should().Be("1");
+
+        // No inline parenthetical text
+        var combined = string.Concat(texts);
+        combined.Should().NotContain("(O) corrección:");
+
+        // Section 2: numbered correction entry appears somewhere in document
+        combined.Should().Contain("[O]");
+        combined.Should().Contain("hablar");
+        combined.Should().Contain("Falta la 'h'.");
     }
 
     [Fact]
@@ -71,7 +79,8 @@ public class CorrectionDocxExportServiceTests
         var nextRun = spannedIdx + 1 < runs.Count ? runs[spannedIdx + 1] : null;
         if (nextRun is not null)
         {
-            nextRun.RunProperties?.Italic.Should().BeNull("MuyBien must NOT be followed by an italic parenthetical");
+            nextRun.RunProperties?.VerticalTextAlignment.Should().BeNull("MuyBien must NOT be followed by a superscript ref");
+            nextRun.RunProperties?.Italic.Should().BeNull("MuyBien must NOT be followed by a parenthetical");
         }
     }
 
@@ -173,7 +182,7 @@ public class CorrectionDocxExportServiceTests
         var bytes = _svc.Generate(detail, "Test");
         bytes.Should().NotBeEmpty();
         var (texts, _) = ReadAllRuns(bytes);
-        string.Concat(texts).Should().NotContain("(G) corrección:");
+        string.Concat(texts).Should().NotContain("[G]", "out-of-bounds tag should be skipped entirely");
     }
 
     // --- helpers ---

--- a/backend/LangTeach.Api/Services/CorrectionDocxExport/CorrectionDocxExportService.cs
+++ b/backend/LangTeach.Api/Services/CorrectionDocxExport/CorrectionDocxExportService.cs
@@ -70,10 +70,7 @@ public class CorrectionDocxExportService : ICorrectionDocxExportService
             .OrderBy(t => t.StartIndex)
             .ToList();
 
-        var errorTags = tags.Where(t => t.Category != CorrectionTagCategory.MuyBien).ToList();
-        var refNumbers = errorTags
-            .Select((tag, i) => (tag, refNum: i + 1))
-            .ToDictionary(x => x.tag, x => x.refNum);
+        var renderedErrorTags = new List<CorrectionTagDto>();
 
         var currentParagraph = new Paragraph();
         body.AppendChild(currentParagraph);
@@ -89,7 +86,12 @@ public class CorrectionDocxExportService : ICorrectionDocxExportService
             {
                 AppendTextWithLineBreaks(body, ref currentParagraph, text.Substring(cursor, tag.StartIndex - cursor), runFactory: PlainRun);
             }
-            var refNum = refNumbers.TryGetValue(tag, out var n) ? n : (int?)null;
+            int? refNum = null;
+            if (tag.Category != CorrectionTagCategory.MuyBien)
+            {
+                renderedErrorTags.Add(tag);
+                refNum = renderedErrorTags.Count;
+            }
             AppendTaggedSpan(currentParagraph, tag, refNum);
             cursor = tag.EndIndex;
         }
@@ -101,9 +103,12 @@ public class CorrectionDocxExportService : ICorrectionDocxExportService
 
         AppendSeparator(body);
 
-        if (errorTags.Count > 0)
+        if (renderedErrorTags.Count > 0)
         {
-            AppendCorrectionsSection(body, errorTags, refNumbers);
+            var refNumbers = renderedErrorTags
+                .Select((tag, i) => (tag, refNum: i + 1))
+                .ToDictionary(x => x.tag, x => x.refNum);
+            AppendCorrectionsSection(body, renderedErrorTags, refNumbers);
         }
     }
 

--- a/backend/LangTeach.Api/Services/CorrectionDocxExport/CorrectionDocxExportService.cs
+++ b/backend/LangTeach.Api/Services/CorrectionDocxExport/CorrectionDocxExportService.cs
@@ -70,6 +70,11 @@ public class CorrectionDocxExportService : ICorrectionDocxExportService
             .OrderBy(t => t.StartIndex)
             .ToList();
 
+        var errorTags = tags.Where(t => t.Category != CorrectionTagCategory.MuyBien).ToList();
+        var refNumbers = errorTags
+            .Select((tag, i) => (tag, refNum: i + 1))
+            .ToDictionary(x => x.tag, x => x.refNum);
+
         var currentParagraph = new Paragraph();
         body.AppendChild(currentParagraph);
 
@@ -84,7 +89,8 @@ public class CorrectionDocxExportService : ICorrectionDocxExportService
             {
                 AppendTextWithLineBreaks(body, ref currentParagraph, text.Substring(cursor, tag.StartIndex - cursor), runFactory: PlainRun);
             }
-            AppendTaggedSpan(currentParagraph, tag);
+            var refNum = refNumbers.TryGetValue(tag, out var n) ? n : (int?)null;
+            AppendTaggedSpan(currentParagraph, tag, refNum);
             cursor = tag.EndIndex;
         }
 
@@ -92,9 +98,16 @@ public class CorrectionDocxExportService : ICorrectionDocxExportService
         {
             AppendTextWithLineBreaks(body, ref currentParagraph, text.Substring(cursor), runFactory: PlainRun);
         }
+
+        AppendSeparator(body);
+
+        if (errorTags.Count > 0)
+        {
+            AppendCorrectionsSection(body, errorTags, refNumbers);
+        }
     }
 
-    private static void AppendTaggedSpan(Paragraph paragraph, CorrectionTagDto tag)
+    private static void AppendTaggedSpan(Paragraph paragraph, CorrectionTagDto tag, int? refNum)
     {
         if (tag.Category == CorrectionTagCategory.MuyBien)
         {
@@ -103,12 +116,40 @@ public class CorrectionDocxExportService : ICorrectionDocxExportService
         }
 
         var color = CategoryColors.TryGetValue(tag.Category, out var hex) ? hex : "000000";
-        paragraph.AppendChild(BoldColoredRun(tag.SpannedText, color));
-        paragraph.AppendChild(ItalicGrayRun(BuildParenthetical(tag)));
+        paragraph.AppendChild(UnderlinedColoredRun(tag.SpannedText, color));
+        if (refNum.HasValue)
+        {
+            paragraph.AppendChild(SuperscriptRun(refNum.Value.ToString()));
+        }
     }
 
-    internal static string BuildParenthetical(CorrectionTagDto tag) =>
-        $" ({tag.Category}) corrección: \"{tag.CorrectedForm}\" — {tag.Explanation}.";
+    private static void AppendSeparator(Body body)
+    {
+        body.AppendChild(new Paragraph());
+        var hrPara = new Paragraph();
+        var hrProps = new ParagraphProperties();
+        var pBorders = new ParagraphBorders();
+        pBorders.AppendChild(new BottomBorder { Val = BorderValues.Single, Size = 6, Space = 1, Color = "E5E7EB" });
+        hrProps.AppendChild(pBorders);
+        hrPara.AppendChild(hrProps);
+        body.AppendChild(hrPara);
+        body.AppendChild(new Paragraph());
+    }
+
+    private static void AppendCorrectionsSection(Body body, List<CorrectionTagDto> errorTags, Dictionary<CorrectionTagDto, int> refNumbers)
+    {
+        body.AppendChild(BuildParagraph(runs: new[] { BoldRun("Correcciones", sizeHalfPoints: 26) }));
+        body.AppendChild(new Paragraph());
+
+        foreach (var tag in errorTags)
+        {
+            var num = refNumbers[tag];
+            var correctedForm = tag.CorrectedForm ?? string.Empty;
+            var explanation = tag.Explanation ?? string.Empty;
+            var entry = $"{num}. [{tag.Category}] \"{tag.SpannedText}\" → \"{correctedForm}\" — {explanation}";
+            body.AppendChild(BuildParagraph(runs: new[] { PlainRun(entry) }));
+        }
+    }
 
     private static void AppendTextWithLineBreaks(Body body, ref Paragraph current, string text, Func<string, Run> runFactory)
     {
@@ -147,9 +188,15 @@ public class CorrectionDocxExportService : ICorrectionDocxExportService
         return BuildRun(text, props);
     }
 
-    private static Run BoldColoredRun(string text, string colorHex)
+    private static Run UnderlinedColoredRun(string text, string colorHex)
     {
-        var props = new RunProperties(new Bold(), new Color { Val = colorHex });
+        var props = new RunProperties(new Color { Val = colorHex }, new Underline { Val = UnderlineValues.Single });
+        return BuildRun(text, props);
+    }
+
+    private static Run SuperscriptRun(string text)
+    {
+        var props = new RunProperties(new VerticalTextAlignment { Val = VerticalPositionValues.Superscript });
         return BuildRun(text, props);
     }
 
@@ -157,12 +204,6 @@ public class CorrectionDocxExportService : ICorrectionDocxExportService
     {
         var props = new RunProperties(new Italic());
         if (sizeHalfPoints is int sz) props.AppendChild(new FontSize { Val = sz.ToString() });
-        return BuildRun(text, props);
-    }
-
-    private static Run ItalicGrayRun(string text)
-    {
-        var props = new RunProperties(new Italic(), new Color { Val = MetadataGray });
         return BuildRun(text, props);
     }
 

--- a/frontend/src/components/student/RedaccionesTab.test.tsx
+++ b/frontend/src/components/student/RedaccionesTab.test.tsx
@@ -138,6 +138,22 @@ describe('RedaccionesTab', () => {
     expect(save).not.toBeDisabled()
   })
 
+  it('submitting create form with blank title auto-generates Redacción YYYY-MM-DD', async () => {
+    vi.mocked(correctionsApi.listCorrections).mockResolvedValue([])
+    vi.mocked(correctionsApi.createCorrection).mockResolvedValue({ ...detail, id: 'new' })
+    wrapper(<RedaccionesTab studentId={STUDENT_ID} />)
+
+    fireEvent.click(await screen.findByTestId('redacciones-empty-cta'))
+    // leave title blank, just click save
+    fireEvent.click(screen.getByTestId('correction-drawer-save'))
+
+    await waitFor(() => {
+      const call = vi.mocked(correctionsApi.createCorrection).mock.calls[0]
+      const body = call[1] as { assignmentTitle?: string }
+      expect(body.assignmentTitle).toMatch(/^Redacción \d{4}-\d{2}-\d{2}$/)
+    })
+  })
+
   it('submitting create form calls createCorrection with trimmed title and optional fields', async () => {
     vi.mocked(correctionsApi.listCorrections).mockResolvedValue([])
     vi.mocked(correctionsApi.createCorrection).mockResolvedValue({

--- a/frontend/src/components/student/RedaccionesTab.test.tsx
+++ b/frontend/src/components/student/RedaccionesTab.test.tsx
@@ -128,16 +128,13 @@ describe('RedaccionesTab', () => {
     )
   })
 
-  it('create form requires title (Save disabled until typed)', async () => {
+  it('create form Save is enabled even with blank title', async () => {
     vi.mocked(correctionsApi.listCorrections).mockResolvedValue([])
     wrapper(<RedaccionesTab studentId={STUDENT_ID} />)
 
     fireEvent.click(await screen.findByTestId('redacciones-empty-cta'))
 
     const save = screen.getByTestId('correction-drawer-save')
-    expect(save).toBeDisabled()
-
-    fireEvent.change(screen.getByTestId('correction-drawer-title'), { target: { value: 'Carta' } })
     expect(save).not.toBeDisabled()
   })
 

--- a/frontend/src/components/student/RedaccionesTab.tsx
+++ b/frontend/src/components/student/RedaccionesTab.tsx
@@ -334,7 +334,8 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved }: CorrectionDra
   const trimmedTitle = title.trim()
   const titleValid = trimmedTitle.length > 0 && trimmedTitle.length <= TITLE_MAX
   const studentTextLocked = isEdit && statusFromLoad === 'Corregida'
-  const canSave = titleValid && !isSaving && (!isEdit || hydrated)
+  const titleOk = isEdit ? titleValid : trimmedTitle.length <= TITLE_MAX
+  const canSave = titleOk && !isSaving && (!isEdit || hydrated)
 
   const isPendienteEdit = isEdit && statusFromLoad === 'Pendiente'
   const hasText = text.trim().length > 0
@@ -366,8 +367,10 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved }: CorrectionDra
         }
         await updateCorrection(studentId, editId as string, body)
       } else {
+        const today = new Date().toISOString().split('T')[0]
+        const effectiveTitle = trimmedTitle || `Redacción ${today}`
         const newCorrection = await createCorrection(studentId, {
-          assignmentTitle: trimmedTitle,
+          assignmentTitle: effectiveTitle,
           assignmentPrompt: prompt.length > 0 ? prompt : null,
           studentText: text.length > 0 ? text : null,
         })

--- a/frontend/src/components/student/RedaccionesTab.tsx
+++ b/frontend/src/components/student/RedaccionesTab.tsx
@@ -367,7 +367,8 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved }: CorrectionDra
         }
         await updateCorrection(studentId, editId as string, body)
       } else {
-        const today = new Date().toISOString().split('T')[0]
+        const now = new Date()
+        const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
         const effectiveTitle = trimmedTitle || `Redacción ${today}`
         const newCorrection = await createCorrection(studentId, {
           assignmentTitle: effectiveTitle,


### PR DESCRIPTION
## Summary

- **#1188**: Replaces the inline parenthetical correction format in the `.docx` export with a standard two-section layout: student text with colored underlined spans and superscript reference numbers (Section 1), followed by a horizontal rule and a numbered corrections list (Section 2). Mirrors how a teacher marks a paper by hand.
- **#1189**: Allows teacher to submit a new redacción with a blank title. Title auto-generates as "Redacción YYYY-MM-DD" before the API call. The Corregir button no longer requires a title to be enabled on the create form.

## Changes

**Backend (`CorrectionDocxExportService.cs`):**
- `AppendCorrectedBody`: assigns superscript ref numbers to error tags, calls new `AppendSeparator` + `AppendCorrectionsSection`
- `AppendTaggedSpan`: underlined+colored run + superscript ref (was bold+colored + italic parenthetical)
- Removed: `BoldColoredRun`, `ItalicGrayRun`, `BuildParenthetical`
- Added: `UnderlinedColoredRun`, `SuperscriptRun`, `AppendSeparator`, `AppendCorrectionsSection`

**Frontend (`RedaccionesTab.tsx`):**
- `titleOk` guard: create path allows blank title (`trimmedTitle.length <= TITLE_MAX`); edit path still requires non-empty title
- `handleSave`: `effectiveTitle = trimmedTitle || "Redacción YYYY-MM-DD"` for new corrections

## Test plan

- [ ] Backend: 1352 tests pass (0 failures); updated `CorrectionDocxExportServiceTests` and `CorrectionsControllerExportTests` for new two-section assertions
- [ ] Frontend: 1747 tests pass; updated "create form requires title" test; added test asserting auto-generated title matches `Redacción YYYY-MM-DD` pattern
- [ ] Download `.docx` for Ana Visual's seeded correction: text reads cleanly with underlines and superscripts; numbered corrections list appears below the rule; no parenthetical interruptions inside the text
- [ ] Open Nueva redacción drawer: Corregir button enabled without typing a title; submit with blank title produces card titled "Redacción 2026-05-09"

Closes #1188, Closes #1189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-generates correction titles with date format (Redacción YYYY-MM-DD) when submitted blank.
  * Added corrections reference section in exported documents listing all corrections with reference numbers.

* **Bug Fixes**
  * Updated correction display formatting in exported documents from bold parentheticals to underlined text with superscript reference numbers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1190)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->