### PR TITLE
fix(#1187): + New session sets picker intent instead of navigating

### DIFF
--- a/frontend/src/components/AtelierAssistantPanel.test.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.test.tsx
@@ -801,5 +801,30 @@ describe('AtelierAssistantPanel', () => {
       expect(screen.getByTestId('session-picker-new')).toBeInTheDocument()
       expect(screen.queryByTestId(/^session-picker-row-/)).not.toBeInTheDocument()
     })
+
+    it('calls onSelectSession("new") when "+ New session" is clicked, does not navigate', async () => {
+      const onSelect = vi.fn()
+      const user = userEvent.setup()
+      renderPanel({
+        transcription: 'Past perfect class',
+        proposals: [sessionProposal],
+        sessionId: null,
+        studentId: 'student-1',
+        onSelectSession: onSelect,
+      })
+      await user.click(screen.getByTestId('session-picker-new'))
+      expect(onSelect).toHaveBeenCalledWith('new')
+    })
+
+    it('keeps banner visible and shows check mark when sessionId is "new"', () => {
+      renderPanel({
+        transcription: 'Past perfect class',
+        proposals: [sessionProposal],
+        sessionId: 'new',
+        studentId: 'student-1',
+      })
+      expect(screen.getByTestId('session-picker-banner')).toBeInTheDocument()
+      expect(screen.getByTestId('session-picker-new')).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { Sparkles, X, Send, Mic, Square, Loader2, AlertCircle, ThumbsUp, ThumbsDown, Plus, CalendarDays } from 'lucide-react'
+import { Sparkles, X, Send, Mic, Square, Loader2, AlertCircle, ThumbsUp, ThumbsDown, Plus, CalendarDays, Check } from 'lucide-react'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
 import { Input } from '@/components/ui/input'
 import { uploadVoiceNote } from '@/api/voiceNotes'
@@ -12,7 +12,6 @@ import { formatDuration } from '@/lib/formatDuration'
 import { BRAND_NAME } from '@/lib/brand'
 import { useQuery } from '@tanstack/react-query'
 import { listSessions } from '@/api/sessionLogs'
-import { useNavigate } from 'react-router-dom'
 import { formatMonthDay } from '@/utils/formatDate'
 
 const MIN_DURATION_S = 1
@@ -77,14 +76,18 @@ export default function AtelierAssistantPanel({
   sessionId,
   onSelectSession,
 }: Props) {
-  const navigate = useNavigate()
   const sessionContextMissing = !sessionId
-  const hasSessionProposalsWithoutContext = sessionContextMissing && proposals.some(p => p.type === 'session' && (p.status === 'proposed' || p.status === 'error'))
+  const newSessionSelected = sessionId === 'new'
+  const hasSessionProposals = proposals.some(p => p.type === 'session' && (p.status === 'proposed' || p.status === 'error'))
+  const hasSessionProposalsWithoutContext = sessionContextMissing && hasSessionProposals
+  // Show the session picker whenever there are session proposals and no real session is selected yet
+  // (includes the 'new' selection state so the teacher can see / change their choice)
+  const showSessionPicker = (sessionContextMissing || newSessionSelected) && hasSessionProposals
 
   const { data: recentSessions } = useQuery({
     queryKey: ['sessions', studentId],
     queryFn: () => listSessions(studentId!),
-    enabled: !!studentId && hasSessionProposalsWithoutContext,
+    enabled: !!studentId && showSessionPicker,
     select: (sessions) =>
       [...sessions]
         .filter(s => !s.isCancelled)
@@ -436,7 +439,7 @@ export default function AtelierAssistantPanel({
                   </p>
                 ) : (
                   <div className="space-y-3" data-testid="proposals-list">
-                    {hasSessionProposalsWithoutContext && (
+                    {showSessionPicker && (
                       <div
                         className="flex flex-col gap-1.5 px-3 py-2.5 rounded-xl bg-violet-50"
                         data-testid="session-picker-banner"
@@ -445,11 +448,14 @@ export default function AtelierAssistantPanel({
                           Choose a session to apply these notes to:
                         </p>
                         <button
-                          onClick={() => studentId && navigate(`/students/${studentId}/sessions/new`)}
-                          className="flex items-center gap-2 px-2.5 py-2 rounded-lg text-xs font-inter font-semibold text-indigo-600 hover:bg-indigo-50 transition-colors text-left"
+                          onClick={() => onSelectSession?.('new')}
+                          className={`flex items-center gap-2 px-2.5 py-2 rounded-lg text-xs font-inter font-semibold transition-colors text-left ${newSessionSelected ? 'text-indigo-700 bg-indigo-100' : 'text-indigo-600 hover:bg-indigo-50'}`}
                           data-testid="session-picker-new"
                         >
-                          <Plus className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                          {newSessionSelected
+                            ? <Check className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                            : <Plus className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                          }
                           New session
                         </button>
                         {(recentSessions ?? []).map(session => {

--- a/frontend/src/hooks/useAtelierAssistant.test.ts
+++ b/frontend/src/hooks/useAtelierAssistant.test.ts
@@ -23,8 +23,13 @@ vi.mock('../api/students', () => ({
   createStudent: vi.fn(),
 }))
 
+vi.mock('../api/sessionLogs', () => ({
+  createSession: vi.fn(),
+}))
+
 import * as assistantApi from '../api/assistant'
 import * as studentsApi from '../api/students'
+import * as sessionLogsApi from '../api/sessionLogs'
 
 const mockPropose = vi.mocked(assistantApi.proposeAssistant)
 const mockApplyStudent = vi.mocked(assistantApi.applyStudentProposal)
@@ -33,6 +38,7 @@ const mockApplySession = vi.mocked(assistantApi.applySessionProposal)
 const mockApplyTodo = vi.mocked(assistantApi.applyTodoProposal)
 const mockApplyNewSession = vi.mocked(assistantApi.applyNewSessionProposal)
 const mockCreateStudent = vi.mocked(studentsApi.createStudent)
+const mockCreateSession = vi.mocked(sessionLogsApi.createSession)
 
 const sampleProposals = [
   { id: 'p1', type: 'student' as const, field: 'cefrLevel', label: 'CEFR Level', oldValue: 'A2', newValue: 'B1' },
@@ -539,6 +545,42 @@ describe('useAtelierAssistant', () => {
     await act(async () => { await result.current.apply('p2') })
     expect(mockApplySession).not.toHaveBeenCalled()
     expect(result.current.proposals[0].status).toBe('error')
+  })
+
+  it('apply: session proposal with sessionId "new" creates a session then applies', async () => {
+    const fakeSession = { id: 'created-123', studentId: 'student-1', sessionDate: '2026-05-09', title: 'Session', isCancelled: false, createdAt: '', updatedAt: '', plannedContent: null, actualContent: null, homeworkAssigned: null, previousHomeworkStatus: 0, previousHomeworkStatusName: 'NotApplicable' as const, nextSessionTopics: null, generalNotes: null, levelReassessmentSkill: null, levelReassessmentLevel: null, linkedLessonId: null, topicTags: '[]', status: 1, statusName: 'Confirmed' as const, mentionedDifficultyPairs: '[]', suggestedDifficulties: '[]', duration: null, hasVoiceNote: false }
+    mockCreateSession.mockResolvedValueOnce(fakeSession)
+    mockApplySession.mockResolvedValueOnce(undefined)
+    const onAfterSessionApply = vi.fn()
+
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[1]] })
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'new', onAfterSessionApply), { wrapper: makeWrapper() })
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    await act(async () => { await result.current.apply('p2') })
+    expect(mockCreateSession).toHaveBeenCalledWith('student-1', expect.objectContaining({ title: 'Session', previousHomeworkStatus: 'NotApplicable' }))
+    expect(mockApplySession).toHaveBeenCalledWith('student-1', 'created-123', 'title', 'Past Perfect')
+    expect(result.current.proposals[0].status).toBe('applied')
+    expect(onAfterSessionApply).toHaveBeenCalledWith('created-123')
+  })
+
+  it('applyAll with sessionId "new" reuses the same created session for all session proposals', async () => {
+    const sessionProp2 = { id: 'p4', type: 'session' as const, field: 'generalNotes', label: 'Notes', oldValue: null, newValue: 'Reviewed past perfect' }
+    const fakeSession = { id: 'created-456', studentId: 'student-1', sessionDate: '2026-05-09', title: 'Session', isCancelled: false, createdAt: '', updatedAt: '', plannedContent: null, actualContent: null, homeworkAssigned: null, previousHomeworkStatus: 0, previousHomeworkStatusName: 'NotApplicable' as const, nextSessionTopics: null, generalNotes: null, levelReassessmentSkill: null, levelReassessmentLevel: null, linkedLessonId: null, topicTags: '[]', status: 1, statusName: 'Confirmed' as const, mentionedDifficultyPairs: '[]', suggestedDifficulties: '[]', duration: null, hasVoiceNote: false }
+    mockCreateSession.mockResolvedValueOnce(fakeSession)
+    mockApplySession.mockResolvedValue(undefined)
+
+    mockPropose.mockResolvedValueOnce({ proposals: [sampleProposals[1], sessionProp2] })
+    const { result } = renderHook(() => useAtelierAssistant('student-1', 'new'), { wrapper: makeWrapper() })
+    act(() => { result.current.submit('text') })
+    await act(async () => { await vi.runAllTimersAsync() })
+
+    await act(async () => { await result.current.applyAll() })
+    expect(mockCreateSession).toHaveBeenCalledTimes(1)
+    expect(mockApplySession).toHaveBeenCalledTimes(2)
+    expect(mockApplySession).toHaveBeenCalledWith('student-1', 'created-456', 'title', 'Past Perfect')
+    expect(mockApplySession).toHaveBeenCalledWith('student-1', 'created-456', 'generalNotes', 'Reviewed past perfect')
   })
 
   it('applyAll: skips session proposals when sessionId is null', async () => {

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -14,6 +14,7 @@ import {
 // Re-export so consumers don't need to import from api/assistant directly
 export type { NewSessionData, NewStudentData }
 import { createStudent } from '../api/students'
+import { createSession } from '../api/sessionLogs'
 import { normalizeLanguage, normalizeLanguages } from '../lib/extractionNormalizer'
 
 export type ProposalStatus = 'proposed' | 'applying' | 'applied' | 'dismissed' | 'error'
@@ -57,6 +58,8 @@ export function useAtelierAssistant(
   // Ref keeps apply/applyAll free of stale closure on proposals
   const proposalsRef = useRef<ProposalWithStatus[]>([])
   useEffect(() => { proposalsRef.current = proposals }, [proposals])
+  // Tracks the session created when sessionId === 'new', so applyAll reuses one session
+  const newlyCreatedSessionRef = useRef<string | null>(null)
 
   // Clear all undo timers on unmount to prevent memory leaks
   useEffect(() => {
@@ -139,6 +142,16 @@ export function useAtelierAssistant(
         } else {
           await applyStudentProposal(studentId, proposal.field, proposal.newValue)
         }
+      } else if (proposal.type === 'session' && studentId && sessionId === 'new') {
+        if (!newlyCreatedSessionRef.current) {
+          const newSession = await createSession(studentId, {
+            title: 'Session',
+            sessionDate: new Date().toISOString().slice(0, 10),
+            previousHomeworkStatus: 'NotApplicable',
+          })
+          newlyCreatedSessionRef.current = newSession.id
+        }
+        await applySessionProposal(studentId, newlyCreatedSessionRef.current!, proposal.field, proposal.newValue)
       } else if (proposal.type === 'session' && studentId && !sessionId) {
         throw new Error('Cannot apply session update: no session is open on this screen.')
       } else if (proposal.type === 'session' && studentId && sessionId) {
@@ -196,6 +209,10 @@ export function useAtelierAssistant(
       // Invalidate relevant queries so the rest of the UI reflects the change
       if (proposal.type === 'student' && studentId) {
         await queryClient.invalidateQueries({ queryKey: ['student', studentId] })
+      } else if (proposal.type === 'session' && studentId && sessionId === 'new' && newlyCreatedSessionRef.current) {
+        const createdId = newlyCreatedSessionRef.current
+        await queryClient.invalidateQueries({ queryKey: ['sessions', studentId] })
+        Promise.resolve(onAfterSessionApply?.(createdId)).catch(() => { /* proposal already applied; swallow */ })
       } else if (proposal.type === 'session' && studentId && sessionId) {
         await queryClient.invalidateQueries({ queryKey: ['session', studentId, sessionId] })
         await queryClient.invalidateQueries({ queryKey: ['sessions', studentId] })
@@ -267,6 +284,7 @@ export function useAtelierAssistant(
   const reset = useCallback(() => {
     generationRef.current++
     applyingIdsRef.current.clear()
+    newlyCreatedSessionRef.current = null
     undoTimers.current.forEach(timer => clearTimeout(timer))
     undoTimers.current.clear()
     setTranscription(null)

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -143,10 +143,13 @@ export function useAtelierAssistant(
           await applyStudentProposal(studentId, proposal.field, proposal.newValue)
         }
       } else if (proposal.type === 'session' && studentId && sessionId === 'new') {
+        // Create one session for this "new" selection; applyAll reuses it via ref
         if (!newlyCreatedSessionRef.current) {
+          const now = new Date()
+          const localDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
           const newSession = await createSession(studentId, {
             title: 'Session',
-            sessionDate: new Date().toISOString().slice(0, 10),
+            sessionDate: localDate,
             previousHomeworkStatus: 'NotApplicable',
           })
           newlyCreatedSessionRef.current = newSession.id

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -60,6 +60,8 @@ export function useAtelierAssistant(
   useEffect(() => { proposalsRef.current = proposals }, [proposals])
   // Tracks the session created when sessionId === 'new', so applyAll reuses one session
   const newlyCreatedSessionRef = useRef<string | null>(null)
+  // In-flight guard: concurrent apply() calls share this promise instead of each calling createSession
+  const creatingSessionPromiseRef = useRef<Promise<string> | null>(null)
 
   // Clear all undo timers on unmount to prevent memory leaks
   useEffect(() => {
@@ -143,16 +145,22 @@ export function useAtelierAssistant(
           await applyStudentProposal(studentId, proposal.field, proposal.newValue)
         }
       } else if (proposal.type === 'session' && studentId && sessionId === 'new') {
-        // Create one session for this "new" selection; applyAll reuses it via ref
+        // Create one session for this "new" selection; concurrent calls share the same promise
         if (!newlyCreatedSessionRef.current) {
-          const now = new Date()
-          const localDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
-          const newSession = await createSession(studentId, {
-            title: 'Session',
-            sessionDate: localDate,
-            previousHomeworkStatus: 'NotApplicable',
-          })
-          newlyCreatedSessionRef.current = newSession.id
+          if (!creatingSessionPromiseRef.current) {
+            const now = new Date()
+            const localDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
+            creatingSessionPromiseRef.current = createSession(studentId, {
+              title: 'Session',
+              sessionDate: localDate,
+              previousHomeworkStatus: 'NotApplicable',
+            }).then(s => {
+              newlyCreatedSessionRef.current = s.id
+              creatingSessionPromiseRef.current = null
+              return s.id
+            })
+          }
+          await creatingSessionPromiseRef.current
         }
         await applySessionProposal(studentId, newlyCreatedSessionRef.current!, proposal.field, proposal.newValue)
       } else if (proposal.type === 'session' && studentId && !sessionId) {
@@ -288,6 +296,7 @@ export function useAtelierAssistant(
     generationRef.current++
     applyingIdsRef.current.clear()
     newlyCreatedSessionRef.current = null
+    creatingSessionPromiseRef.current = null
     undoTimers.current.forEach(timer => clearTimeout(timer))
     undoTimers.current.clear()
     setTranscription(null)


### PR DESCRIPTION
Fixes #1187

## Summary

- `AtelierAssistantPanel`: "+ New session" button now calls `onSelectSession('new')` instead of `navigate(...)`. Removes `useNavigate` from the panel entirely.
- The session picker banner stays visible after selecting "New session" (using `showSessionPicker` condition), with a check mark replacing the plus icon to show the selection.
- `useAtelierAssistant`: when `sessionId === 'new'`, applying a session proposal creates a blank session (today's local date, title "Session"), applies the proposal to it, then calls `onAfterSessionApply` to navigate to the new session edit view in background. A `newlyCreatedSessionRef` ensures Apply All reuses the same session rather than creating one per proposal.
- `AppShell`: no changes needed. `handleAfterSessionApply` already navigates without closing the panel (the target route is Atelier-enabled).

## Test plan

- [x] Unit: "+ New session" button calls `onSelectSession('new')`, not navigate
- [x] Unit: banner stays visible and shows check mark when `sessionId === 'new'`
- [x] Unit: hook creates session + applies proposal when `sessionId === 'new'`
- [x] Unit: Apply All with `sessionId === 'new'` reuses one created session (1 createSession call, 2 applySessionProposal calls)
- [x] 1751 frontend tests passing
- [x] TypeScript clean
- [x] UI review: PASS (rebuilt stack, visual spec confirms picker banner and proposal cards render correctly)

## Review findings

| Reviewer | Finding | Action |
|---|---|---|
| qa-verify | AC2 background-navigation integration untested | Dismissed - unit tests cover all components; AppShell integration is unchanged |
| code review | Hardcoded English "Session" as default title | Deferred - acceptable default for a draft session the teacher will rename |
| code review | UTC date off-by-one | Fixed - use local date computation |
| code review | Orphan session if applySessionProposal fails after createSession | Dismissed - ref allows retry to reuse the same session |
| architecture | createSession bypasses applyNewSessionProposal wrapper in assistant.ts | Dismissed - minor inconsistency; not blocking |
| UI review | No #1187-specific visual spec for post-click check mark state | Dismissed - covered by unit tests and code trace |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * "+ New session" feature now properly creates and applies new sessions with session proposals.
  * Enhanced session picker visibility and display logic based on session context.
  * Better handling when applying multiple proposals to a new session.

* **Bug Fixes**
  * Improved session picker UI behavior when selecting or creating new sessions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1191)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->