### PR TITLE
fix(#1192): async Corregir -- drawer closes immediately, Corrigiendo status persisted with polling

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerTests.cs
@@ -190,6 +190,7 @@ public class CorrectionsControllerTests
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
         var detail = await resp.Content.ReadFromJsonAsync<CorrectionDetailDto>();
         detail!.Status.Should().Be("Corrigiendo");
+        _factory.ClaudeStub.CompleteCallCount.Should().Be(0, "idempotent path must not trigger a second AI call");
     }
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerTests.cs
@@ -88,7 +88,7 @@ public class CorrectionsControllerTests
     }
 
     [Fact]
-    public async Task Corregir_OnEntregada_FlipsToCorregidaWithTags()
+    public async Task Corregir_OnEntregada_ReturnsCorrigiendoImmediately_ThenFlipsToCorregida()
     {
         var (client, studentId) = await SetupAsync("auth0|corr-corregir-ok");
         var text = "Hoy ablar con mi amigo.";
@@ -105,9 +105,13 @@ public class CorrectionsControllerTests
             $"/api/students/{studentId}/corrections/{created.Id}/corregir",
             content: null);
 
+        // Endpoint returns immediately with Corrigiendo; background task fires asynchronously.
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
-        var detail = await resp.Content.ReadFromJsonAsync<CorrectionDetailDto>();
-        detail!.Status.Should().Be("Corregida");
+        var immediate = await resp.Content.ReadFromJsonAsync<CorrectionDetailDto>();
+        immediate!.Status.Should().Be("Corrigiendo");
+
+        // Background task (stub: synchronous, no network) should complete within a few hundred ms.
+        var detail = await WaitForCorrectionStatusAsync(client, studentId, created.Id, "Corregida");
         detail.CorrectedAt.Should().NotBeNull();
         detail.Tags.Should().HaveCount(1);
         detail.Tags[0].Category.Should().Be("O");
@@ -150,6 +154,9 @@ public class CorrectionsControllerTests
             content: null);
         first.StatusCode.Should().Be(HttpStatusCode.OK);
 
+        // Wait for the background task to flip status to Corregida before the second call.
+        await WaitForCorrectionStatusAsync(client, studentId, created.Id, "Corregida");
+
         var second = await client.PostAsync(
             $"/api/students/{studentId}/corrections/{created.Id}/corregir",
             content: null);
@@ -157,8 +164,39 @@ public class CorrectionsControllerTests
     }
 
     [Fact]
-    public async Task Corregir_OnInvalidJson_Returns502()
+    public async Task Corregir_OnCorrigiendo_Returns200Idempotent()
     {
+        var (client, studentId) = await SetupAsync("auth0|corr-corregir-idempotent");
+        var text = "El niño juega en el parque.";
+        var created = await CreateCorrectionAsync(client, studentId, new CreateCorrectionRequest
+        {
+            AssignmentTitle = "Idempotent test",
+            StudentText = text,
+        });
+
+        // Force Corrigiendo status directly via DB.
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<LangTeach.Api.Data.AppDbContext>();
+            var row = db.Corrections.First(c => c.Id == created.Id);
+            row.Status = LangTeach.Api.Data.Models.CorrectionStatus.Corrigiendo;
+            db.SaveChanges();
+        }
+
+        var resp = await client.PostAsync(
+            $"/api/students/{studentId}/corrections/{created.Id}/corregir",
+            content: null);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var detail = await resp.Content.ReadFromJsonAsync<CorrectionDetailDto>();
+        detail!.Status.Should().Be("Corrigiendo");
+    }
+
+    [Fact]
+    public async Task Corregir_OnEntregada_ReturnsCorrigiendoEvenWhenAiFails()
+    {
+        // Endpoint fires background task and returns immediately. AI failure is silent;
+        // staleness recovery (60s) eventually resets to Entregada on the next GET.
         var (client, studentId) = await SetupAsync("auth0|corr-corregir-badjson");
         var created = await CreateCorrectionAsync(client, studentId, new CreateCorrectionRequest
         {
@@ -172,13 +210,37 @@ public class CorrectionsControllerTests
         var resp = await client.PostAsync(
             $"/api/students/{studentId}/corrections/{created.Id}/corregir",
             content: null);
-        resp.StatusCode.Should().Be(HttpStatusCode.BadGateway);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var detail = await resp.Content.ReadFromJsonAsync<CorrectionDetailDto>();
+        detail!.Status.Should().Be("Corrigiendo");
+    }
 
-        // Status reverts (was never committed): row remains Entregada, retryable.
-        using var scope = _factory.Services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<LangTeach.Api.Data.AppDbContext>();
-        var row = db.Corrections.First(c => c.Id == created.Id);
-        row.Status.Should().Be(LangTeach.Api.Data.Models.CorrectionStatus.Entregada);
+    [Fact]
+    public async Task List_StaleCorrigiendo_RevetsToEntregada()
+    {
+        // When a Corrigiendo record is older than 60 seconds (background task failed silently),
+        // the next GET /corrections resets it to Entregada so the teacher can retry.
+        var (client, studentId) = await SetupAsync("auth0|corr-staleness");
+        var created = await CreateCorrectionAsync(client, studentId, new CreateCorrectionRequest
+        {
+            AssignmentTitle = "Staleness test",
+            StudentText = "Texto para comprobar el mecanismo de staleness.",
+        });
+
+        // Force Corrigiendo with an old UpdatedAt to simulate a stuck background task.
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<LangTeach.Api.Data.AppDbContext>();
+            var row = db.Corrections.First(c => c.Id == created.Id);
+            row.Status = LangTeach.Api.Data.Models.CorrectionStatus.Corrigiendo;
+            row.UpdatedAt = DateTime.UtcNow.AddMinutes(-2);
+            db.SaveChanges();
+        }
+
+        var listResp = await client.GetAsync($"/api/students/{studentId}/corrections");
+        listResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var list = await listResp.Content.ReadFromJsonAsync<List<CorrectionSummaryDto>>();
+        list!.Should().ContainSingle(c => c.Id == created.Id && c.Status == "Entregada");
     }
 
     [Fact]
@@ -207,8 +269,11 @@ public class CorrectionsControllerTests
             $"/api/students/{studentId}/corrections/{detail.Id}/corregir",
             content: null);
         corregirResp.StatusCode.Should().Be(HttpStatusCode.OK);
-        var corrected = await corregirResp.Content.ReadFromJsonAsync<CorrectionDetailDto>();
-        corrected!.Status.Should().Be("Corregida");
+        var immediate = await corregirResp.Content.ReadFromJsonAsync<CorrectionDetailDto>();
+        immediate!.Status.Should().Be("Corrigiendo");
+
+        var corrected = await WaitForCorrectionStatusAsync(client, studentId, detail.Id, "Corregida");
+        corrected.Status.Should().Be("Corregida");
     }
 
     private static string BuildSampleAiJson(string originalText)
@@ -439,13 +504,54 @@ public class CorrectionsControllerTests
             content: null);
 
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
-        var detail = await resp.Content.ReadFromJsonAsync<CorrectionDetailDto>();
-        detail!.Tags.Should().HaveCount(1, "tag with correct spannedText must be rescued despite offset drift");
+        var detail = await WaitForCorrectionStatusAsync(client, studentId, created.Id, "Corregida");
+        detail.Tags.Should().HaveCount(1, "tag with correct spannedText must be rescued despite offset drift");
         detail.Tags[0].SpannedText.Should().Be("café");
         detail.Tags[0].StartIndex.Should().Be(realIdx, "rescue must fix startIndex to the true position");
     }
 
+    [Fact]
+    public async Task Patch_StudentTextOnCorrigiendo_Returns400()
+    {
+        var (client, studentId) = await SetupAsync("auth0|corr-locked-corrigiendo");
+        var created = await CreateCorrectionAsync(client, studentId, new CreateCorrectionRequest
+        {
+            AssignmentTitle = "Corrigiendo lock test",
+            StudentText = "Original text.",
+        });
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<LangTeach.Api.Data.AppDbContext>();
+            var row = db.Corrections.First(c => c.Id == created.Id);
+            row.Status = LangTeach.Api.Data.Models.CorrectionStatus.Corrigiendo;
+            db.SaveChanges();
+        }
+
+        var resp = await client.PatchAsJsonAsync(
+            $"/api/students/{studentId}/corrections/{created.Id}",
+            new UpdateCorrectionRequest { StudentText = "Edited while corrigiendo." });
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
     // --- helpers ---
+
+    private async Task<CorrectionDetailDto> WaitForCorrectionStatusAsync(
+        HttpClient client, Guid studentId, Guid correctionId, string expectedStatus,
+        int maxWaitMs = 5000, int pollIntervalMs = 50)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(maxWaitMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            var r = await client.GetAsync($"/api/students/{studentId}/corrections/{correctionId}");
+            r.EnsureSuccessStatusCode();
+            var d = await r.Content.ReadFromJsonAsync<CorrectionDetailDto>();
+            if (d!.Status == expectedStatus) return d;
+            await Task.Delay(pollIntervalMs);
+        }
+        throw new TimeoutException(
+            $"Correction {correctionId} did not reach status '{expectedStatus}' within {maxWaitMs}ms.");
+    }
 
     private async Task<(HttpClient client, Guid studentId)> SetupAsync(string auth0Id, string? email = null)
     {

--- a/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerTests.cs
@@ -183,6 +183,8 @@ public class CorrectionsControllerTests
             db.SaveChanges();
         }
 
+        _factory.ClaudeStub.Reset();
+
         var resp = await client.PostAsync(
             $"/api/students/{studentId}/corrections/{created.Id}/corregir",
             content: null);
@@ -208,12 +210,19 @@ public class CorrectionsControllerTests
         _factory.ClaudeStub.Reset();
         _factory.ClaudeStub.EnqueueResponse("This is not JSON at all.");
 
+        var preCallTime = created.UpdatedAt;
+
         var resp = await client.PostAsync(
             $"/api/students/{studentId}/corrections/{created.Id}/corregir",
             content: null);
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
         var detail = await resp.Content.ReadFromJsonAsync<CorrectionDetailDto>();
         detail!.Status.Should().Be("Corrigiendo");
+
+        // Wait for the background task to consume the stub response (bad JSON).
+        // This prevents the stub queue from racing with the next test in the collection.
+        await WaitForCorrectionStatusAsync(client, studentId, created.Id, "Corrigiendo",
+            maxWaitMs: 2000, stopWhenUpdatedAtAdvances: preCallTime);
     }
 
     [Fact]
@@ -539,19 +548,23 @@ public class CorrectionsControllerTests
 
     private async Task<CorrectionDetailDto> WaitForCorrectionStatusAsync(
         HttpClient client, Guid studentId, Guid correctionId, string expectedStatus,
-        int maxWaitMs = 5000, int pollIntervalMs = 50)
+        int maxWaitMs = 5000, int pollIntervalMs = 50, DateTime? stopWhenUpdatedAtAdvances = null)
     {
         var deadline = DateTime.UtcNow.AddMilliseconds(maxWaitMs);
+        string? lastStatus = null;
         while (DateTime.UtcNow < deadline)
         {
             var r = await client.GetAsync($"/api/students/{studentId}/corrections/{correctionId}");
             r.EnsureSuccessStatusCode();
             var d = await r.Content.ReadFromJsonAsync<CorrectionDetailDto>();
-            if (d!.Status == expectedStatus) return d;
+            lastStatus = d!.Status;
+            if (d.Status == expectedStatus) return d;
+            if (stopWhenUpdatedAtAdvances.HasValue && d.UpdatedAt > stopWhenUpdatedAtAdvances.Value)
+                return d;
             await Task.Delay(pollIntervalMs);
         }
         throw new TimeoutException(
-            $"Correction {correctionId} did not reach status '{expectedStatus}' within {maxWaitMs}ms.");
+            $"Correction {correctionId} did not reach status '{expectedStatus}' within {maxWaitMs}ms (last seen: '{lastStatus}').");
     }
 
     private async Task<(HttpClient client, Guid studentId)> SetupAsync(string auth0Id, string? email = null)

--- a/backend/LangTeach.Api.Tests/Helpers/FakeServiceScopeFactory.cs
+++ b/backend/LangTeach.Api.Tests/Helpers/FakeServiceScopeFactory.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LangTeach.Api.Tests.Helpers;
+
+/// <summary>
+/// A minimal IServiceScopeFactory for unit tests. Creates scopes backed by a fixed
+/// IServiceProvider, so background Task.Run work (e.g. fire-and-forget corrections)
+/// can resolve the same stub/mock dependencies the test registered.
+/// </summary>
+public sealed class FakeServiceScopeFactory : IServiceScopeFactory
+{
+    private readonly IServiceProvider _provider;
+
+    public FakeServiceScopeFactory(IServiceProvider provider) => _provider = provider;
+
+    public IServiceScope CreateScope() => new FakeScope(_provider);
+
+    private sealed class FakeScope : IServiceScope
+    {
+        public IServiceProvider ServiceProvider { get; }
+        public FakeScope(IServiceProvider provider) => ServiceProvider = provider;
+        public void Dispose() { }
+    }
+}

--- a/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionDualLevelTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionDualLevelTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using LangTeach.Api.AI;
 using LangTeach.Api.Data;
 using LangTeach.Api.Data.Models;
+using LangTeach.Api.DTOs;
 using LangTeach.Api.Services;
 using LangTeach.Api.Tests.Helpers;
 using Microsoft.EntityFrameworkCore;
@@ -185,10 +186,32 @@ public class RedaccionCorrectionDualLevelTests
         var claude = new ClaudeApiClient(sp.GetRequiredService<IHttpClientFactory>(),
             NullLogger<ClaudeApiClient>.Instance);
 
-        var service = new RedaccionCorrectionService(db, claude, promptBuilder,
+        var scopeServices = new ServiceCollection();
+        scopeServices.AddSingleton<AppDbContext>(_ => new AppDbContext(dbOptions));
+        scopeServices.AddSingleton<IClaudeClient>(claude);
+        scopeServices.AddSingleton(promptBuilder);
+        scopeServices.AddLogging();
+        var scopeFactory = new FakeServiceScopeFactory(scopeServices.BuildServiceProvider());
+
+        var service = new RedaccionCorrectionService(db, scopeFactory, promptBuilder,
             NullLogger<RedaccionCorrectionService>.Instance);
 
-        var detail = await service.CorregirAsync(teacherId, studentId, correctionId);
+        await service.CorregirAsync(teacherId, studentId, correctionId);
+
+        var deadline = DateTime.UtcNow.AddSeconds(120);
+        CorrectionDetailDto? detail = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            using var check = new AppDbContext(dbOptions);
+            var row = check.Corrections.Include(c => c.Tags).FirstOrDefault(c => c.Id == correctionId);
+            if (row?.Status == "Corregida")
+            {
+                detail = CorrectionDtoMapper.ToDetail(row, row.Tags);
+                break;
+            }
+            await Task.Delay(500);
+        }
+        if (detail is null) throw new TimeoutException($"Correction {correctionId} never reached Corregida in 120s.");
         return new DualLevelRun(detail, db, sp);
     }
 

--- a/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionServiceTests.cs
@@ -6,6 +6,7 @@ using LangTeach.Api.Data.Models;
 using LangTeach.Api.Services;
 using LangTeach.Api.Tests.Helpers;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace LangTeach.Api.Tests.Services;
@@ -31,7 +32,19 @@ public class RedaccionCorrectionServiceTests : IDisposable
         var promptBuilder = new RedaccionCorrectionPromptBuilder(pedagogy,
             NullLogger<RedaccionCorrectionPromptBuilder>.Instance);
 
-        _sut = new RedaccionCorrectionService(_db, _claude, promptBuilder,
+        // Build a FakeServiceScopeFactory so Task.Run inside CorregirAsync can resolve
+        // AppDbContext (backed by the same in-memory store) and the stub Claude client.
+        // Transient AppDbContext ensures the background task gets a fresh context per use,
+        // avoiding change-tracker conflicts with the test's primary _db instance.
+        var scopeServices = new ServiceCollection();
+        scopeServices.AddTransient<AppDbContext>(_ => new AppDbContext(_dbOptions));
+        scopeServices.AddSingleton<IClaudeClient>(_claude);
+        scopeServices.AddSingleton(promptBuilder);
+        scopeServices.AddLogging();
+        var scopeProvider = scopeServices.BuildServiceProvider();
+        var scopeFactory = new FakeServiceScopeFactory(scopeProvider);
+
+        _sut = new RedaccionCorrectionService(_db, scopeFactory, promptBuilder,
             NullLogger<RedaccionCorrectionService>.Instance);
 
         SeedStudent();
@@ -67,7 +80,7 @@ public class RedaccionCorrectionServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task CorregirAsync_HappyPath_FlipsToCorregidaWithTags()
+    public async Task CorregirAsync_HappyPath_ReturnsCorrigiendoThenFlipsToCorregidaWithTags()
     {
         var text = "Hoy ablar con mi amigo.";
         var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
@@ -79,53 +92,55 @@ public class RedaccionCorrectionServiceTests : IDisposable
         }));
 
         var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
+        result.Status.Should().Be(CorrectionStatus.Corrigiendo);
 
-        result.Status.Should().Be(CorrectionStatus.Corregida);
-        result.Tags.Should().HaveCount(1);
-        result.Tags[0].Category.Should().Be("O");
-        result.Tags[0].SpannedText.Should().Be("ablar");
-        result.Tags[0].Explanation.Should().Be("Falta la 'h'.");
-        result.Tags[0].CorrectedForm.Should().Be("hablar");
-        result.MarkedUpOutput.Should().Contain("\"category\":\"O\"");
+        // Background task (stub: synchronous) completes quickly.
+        var row = await WaitForDbStatusAsync(id, CorrectionStatus.Corregida);
 
-        var row = _db.Corrections.Include(c => c.Tags).First(c => c.Id == id);
         row.CorrectedAt.Should().NotBeNull();
         row.Tags.Should().HaveCount(1);
+        row.Tags.First().Category.Should().Be("O");
+        row.Tags.First().SpannedText.Should().Be("ablar");
     }
 
     [Fact]
-    public async Task CorregirAsync_NonJsonResponse_502InvalidJson_StatusReverts()
+    public async Task CorregirAsync_NonJsonResponse_ReturnsCorrigiendoAndBackgroundFailsSilently()
     {
         var id = SeedCorrection(text: "Texto.", status: CorrectionStatus.Entregada);
         _claude.EnqueueResponse("definitely not JSON");
 
-        var ex = await Assert.ThrowsAsync<CorrectionGenerationException>(() =>
-            _sut.CorregirAsync(_teacherId, _studentId, id));
-        ex.Code.Should().Be("invalid_json");
+        var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
+        result.Status.Should().Be(CorrectionStatus.Corrigiendo);
 
-        var row = _db.Corrections.First(c => c.Id == id);
-        row.Status.Should().Be(CorrectionStatus.Entregada);
+        // Give the background task time to run and fail; it logs the error and leaves
+        // status as Corrigiendo (staleness recovery resets after 60 seconds on next GET).
+        await Task.Delay(300);
+
+        using var check = new AppDbContext(_dbOptions);
+        var row = check.Corrections.First(c => c.Id == id);
+        row.Status.Should().Be(CorrectionStatus.Corrigiendo, "background task failed silently; staleness recovery resets after 60s");
         row.CorrectedAt.Should().BeNull();
-        _db.CorrectionTags.Where(t => t.CorrectionId == id).Should().BeEmpty();
+        check.CorrectionTags.Where(t => t.CorrectionId == id).Should().BeEmpty();
     }
 
     [Fact]
-    public async Task CorregirAsync_ParaphrasedOriginalText_BothAttempts_502OriginalTextMismatch()
+    public async Task CorregirAsync_ParaphrasedOriginalText_BothAttempts_BackgroundTaskFailsSilently()
     {
-        // Issue #1166: when BOTH attempts paraphrase, the service surfaces the mismatch.
+        // Issue #1166: when BOTH attempts paraphrase, background task logs and leaves Corrigiendo.
         var id = SeedCorrection(text: "Texto original.", status: CorrectionStatus.Entregada);
         _claude.EnqueueResponse(BuildAiJson("Different text.", Array.Empty<(string, int, int, string, string, string)>()));
         _claude.EnqueueResponse(BuildAiJson("Yet another paraphrase.", Array.Empty<(string, int, int, string, string, string)>()));
 
-        var ex = await Assert.ThrowsAsync<CorrectionGenerationException>(() =>
-            _sut.CorregirAsync(_teacherId, _studentId, id));
-        ex.Code.Should().Be("original_text_mismatch");
+        var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
+        result.Status.Should().Be(CorrectionStatus.Corrigiendo);
+
+        await Task.Delay(300);
 
         _claude.CompleteCallCount.Should().Be(2, "the service must retry exactly once before giving up");
-
-        var row = _db.Corrections.First(c => c.Id == id);
-        row.Status.Should().Be(CorrectionStatus.Entregada);
-        _db.CorrectionTags.Where(t => t.CorrectionId == id).Should().BeEmpty();
+        using var check2 = new AppDbContext(_dbOptions);
+        var row2 = check2.Corrections.First(c => c.Id == id);
+        row2.Status.Should().Be(CorrectionStatus.Corrigiendo, "background task failed silently; staleness recovery resets after 60s");
+        check2.CorrectionTags.Where(t => t.CorrectionId == id).Should().BeEmpty();
     }
 
     [Fact]
@@ -146,12 +161,14 @@ public class RedaccionCorrectionServiceTests : IDisposable
                 "Falta la 'h'.", "hablar"),
         }));
 
-        var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
+        var immediate = await _sut.CorregirAsync(_teacherId, _studentId, id);
+        immediate.Status.Should().Be(CorrectionStatus.Corrigiendo);
 
-        result.Status.Should().Be(CorrectionStatus.Corregida);
-        result.Tags.Should().HaveCount(1);
-        result.Tags[0].SpannedText.Should().Be("ablar");
+        var row = await WaitForDbStatusAsync(id, CorrectionStatus.Corregida);
+
         _claude.CompleteCallCount.Should().Be(2, "the service must call Claude twice when the first attempt paraphrased");
+        row.Tags.Should().HaveCount(1);
+        row.Tags.First().SpannedText.Should().Be("ablar");
     }
 
     [Fact]
@@ -168,9 +185,11 @@ public class RedaccionCorrectionServiceTests : IDisposable
                 "Falta la 'h'.", "hablar"),
         }));
 
-        var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
-        result.Tags.Should().HaveCount(1);
-        result.Tags[0].StartIndex.Should().Be(text.IndexOf("ablar"));
+        await _sut.CorregirAsync(_teacherId, _studentId, id);
+        var row = await WaitForDbStatusAsync(id, CorrectionStatus.Corregida);
+
+        row.Tags.Should().HaveCount(1);
+        row.Tags.First().StartIndex.Should().Be(text.IndexOf("ablar"));
     }
 
     [Fact]
@@ -184,9 +203,11 @@ public class RedaccionCorrectionServiceTests : IDisposable
             ("G", 6, 12, "lar co", "Bad overlap.", "lar co"),
         }));
 
-        var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
-        result.Tags.Should().HaveCount(1);
-        result.Tags[0].Category.Should().Be("O");
+        await _sut.CorregirAsync(_teacherId, _studentId, id);
+        var row = await WaitForDbStatusAsync(id, CorrectionStatus.Corregida);
+
+        row.Tags.Should().HaveCount(1);
+        row.Tags.First().Category.Should().Be("O");
     }
 
     [Fact]
@@ -199,10 +220,12 @@ public class RedaccionCorrectionServiceTests : IDisposable
             ("MuyBien", 3, 13, "subjuntivo", "Should be null.", "should also be null"),
         }));
 
-        var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
-        result.Tags.Should().HaveCount(1);
-        result.Tags[0].Explanation.Should().BeNull();
-        result.Tags[0].CorrectedForm.Should().BeNull();
+        await _sut.CorregirAsync(_teacherId, _studentId, id);
+        var row = await WaitForDbStatusAsync(id, CorrectionStatus.Corregida);
+
+        row.Tags.Should().HaveCount(1);
+        row.Tags.First().Explanation.Should().BeNull();
+        row.Tags.First().CorrectedForm.Should().BeNull();
     }
 
     [Fact]
@@ -215,9 +238,11 @@ public class RedaccionCorrectionServiceTests : IDisposable
             ("G", 0, 5, "Texto", "", "Texto"),
         }));
 
-        var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
-        result.Tags.Should().BeEmpty();
-        result.Status.Should().Be(CorrectionStatus.Corregida);
+        await _sut.CorregirAsync(_teacherId, _studentId, id);
+        var row = await WaitForDbStatusAsync(id, CorrectionStatus.Corregida);
+
+        row.Tags.Should().BeEmpty();
+        row.Status.Should().Be(CorrectionStatus.Corregida);
     }
 
     [Fact]
@@ -250,12 +275,17 @@ public class RedaccionCorrectionServiceTests : IDisposable
             ("O", 4, 9, "ablar", "Stub call.", "hablar"),
         }));
 
-        var ex = await Assert.ThrowsAsync<CorrectionInvalidStateException>(() =>
-            _sut.CorregirAsync(_teacherId, _studentId, id));
-        ex.Code.Should().Be("already_corrected");
+        // CorregirAsync sets to Corrigiendo and fires background task. The DuringCompleteAsync
+        // hook runs inside the background task, sets status to Corregida, then the TOCTOU
+        // guard in RunCorrectionInScopeAsync sees Corregida (not Corrigiendo) and discards.
+        var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
+        result.Status.Should().Be(CorrectionStatus.Corrigiendo);
+
+        // Wait for background task to run and discard.
+        await Task.Delay(300);
 
         // The concurrent call's single tag is the only one in the DB; this call's tag
-        // was never persisted thanks to the recheck.
+        // was never persisted thanks to the TOCTOU guard.
         var tagCount = _db.CorrectionTags.Count(t => t.CorrectionId == id);
         tagCount.Should().Be(1);
     }
@@ -281,11 +311,39 @@ public class RedaccionCorrectionServiceTests : IDisposable
             ("C", cStart, cEnd, "entonces", "Conector.", "luego"),
         }));
 
+        await _sut.CorregirAsync(_teacherId, _studentId, id);
+        var row = await WaitForDbStatusAsync(id, CorrectionStatus.Corregida);
+
+        row.Tags.OrderBy(t => t.OrderIndex).Select(t => t.Category).Should().Equal("O", "G", "L", "C");
+    }
+
+    [Fact]
+    public async Task CorregirAsync_OnCorrigiendo_ReturnsExistingRecordIdempotent()
+    {
+        var id = SeedCorrection(text: "Texto.", status: CorrectionStatus.Corrigiendo);
+
         var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
-        result.Tags.Select(t => t.Category).Should().Equal("O", "G", "L", "C");
+        result.Status.Should().Be(CorrectionStatus.Corrigiendo);
+        _claude.CompleteCallCount.Should().Be(0, "no AI call should be made for idempotent Corrigiendo");
     }
 
     // ----- helpers -----
+
+    private async Task<Correction> WaitForDbStatusAsync(Guid correctionId, string expectedStatus,
+        int maxWaitMs = 3000, int pollIntervalMs = 30)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(maxWaitMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            using var check = new AppDbContext(_dbOptions);
+            var row = check.Corrections.Include(c => c.Tags).FirstOrDefault(c => c.Id == correctionId);
+            if (row?.Status == expectedStatus)
+                return row;
+            await Task.Delay(pollIntervalMs);
+        }
+        throw new TimeoutException(
+            $"Correction {correctionId} did not reach status '{expectedStatus}' within {maxWaitMs}ms.");
+    }
 
     private void SeedStudent()
     {

--- a/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionVerbatimTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionVerbatimTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using LangTeach.Api.AI;
 using LangTeach.Api.Data;
 using LangTeach.Api.Data.Models;
+using LangTeach.Api.DTOs;
 using LangTeach.Api.Services;
 using LangTeach.Api.Tests.Helpers;
 using Microsoft.EntityFrameworkCore;
@@ -147,10 +148,34 @@ public class RedaccionCorrectionVerbatimTests
         var claude = new ClaudeApiClient(sp.GetRequiredService<IHttpClientFactory>(),
             NullLogger<ClaudeApiClient>.Instance);
 
-        var service = new RedaccionCorrectionService(db, claude, promptBuilder,
+        // Build a scope factory so the background Task.Run can resolve fresh dependencies.
+        var scopeServices = new ServiceCollection();
+        scopeServices.AddSingleton<AppDbContext>(_ => new AppDbContext(dbOptions));
+        scopeServices.AddSingleton<IClaudeClient>(claude);
+        scopeServices.AddSingleton(promptBuilder);
+        scopeServices.AddLogging();
+        var scopeFactory = new FakeServiceScopeFactory(scopeServices.BuildServiceProvider());
+
+        var service = new RedaccionCorrectionService(db, scopeFactory, promptBuilder,
             NullLogger<RedaccionCorrectionService>.Instance);
 
-        var detail = await service.CorregirAsync(teacherId, studentId, correctionId);
+        await service.CorregirAsync(teacherId, studentId, correctionId);
+
+        // Background task calls the real Claude API; poll until completed (up to 120s).
+        var deadline = DateTime.UtcNow.AddSeconds(120);
+        CorrectionDetailDto? detail = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            using var check = new AppDbContext(dbOptions);
+            var row = check.Corrections.Include(c => c.Tags).FirstOrDefault(c => c.Id == correctionId);
+            if (row?.Status == "Corregida")
+            {
+                detail = CorrectionDtoMapper.ToDetail(row, row.Tags);
+                break;
+            }
+            await Task.Delay(500);
+        }
+        if (detail is null) throw new TimeoutException($"Correction {correctionId} never reached Corregida in 120s.");
         return new CorrectionRun(detail, db, sp);
     }
 

--- a/backend/LangTeach.Api/Controllers/CorrectionsController.cs
+++ b/backend/LangTeach.Api/Controllers/CorrectionsController.cs
@@ -115,12 +115,6 @@ public class CorrectionsController : ControllerBase
         {
             return Conflict(new { code = ex.Code, message = ex.Message });
         }
-        catch (CorrectionGenerationException ex)
-        {
-            _logger.LogWarning(ex, "Redaccion generation failed. StudentId={StudentId} CorrectionId={CorrectionId} Code={Code}",
-                studentId, id, ex.Code);
-            return StatusCode(StatusCodes.Status502BadGateway, new { code = ex.Code, message = ex.Message });
-        }
     }
 
     [HttpGet("{id:guid}/export.docx")]

--- a/backend/LangTeach.Api/Data/AppDbContext.cs
+++ b/backend/LangTeach.Api/Data/AppDbContext.cs
@@ -366,7 +366,7 @@ public class AppDbContext : DbContext
         {
             e.ToTable(t => t.HasCheckConstraint(
                 "CK_Corrections_Status",
-                "Status COLLATE Latin1_General_100_BIN2 IN ('Pendiente', 'Entregada', 'Corregida')"));
+                "Status COLLATE Latin1_General_100_BIN2 IN ('Pendiente', 'Entregada', 'Corrigiendo', 'Corregida')"));
             e.HasKey(c => c.Id);
             e.HasIndex(c => new { c.TeacherId, c.DeletedAt });
             e.HasIndex(c => new { c.StudentId, c.DeletedAt });

--- a/backend/LangTeach.Api/Data/Models/CorrectionStatus.cs
+++ b/backend/LangTeach.Api/Data/Models/CorrectionStatus.cs
@@ -8,8 +8,9 @@ public static class CorrectionStatus
 {
     public const string Pendiente = "Pendiente";
     public const string Entregada = "Entregada";
+    public const string Corrigiendo = "Corrigiendo";
     public const string Corregida = "Corregida";
 
     public static bool IsValid(string value) =>
-        value == Pendiente || value == Entregada || value == Corregida;
+        value == Pendiente || value == Entregada || value == Corrigiendo || value == Corregida;
 }

--- a/backend/LangTeach.Api/Migrations/20260509000000_AddCorrigiendoStatus.Designer.cs
+++ b/backend/LangTeach.Api/Migrations/20260509000000_AddCorrigiendoStatus.Designer.cs
@@ -4,6 +4,7 @@ using LangTeach.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LangTeach.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260509000000_AddCorrigiendoStatus")]
+    partial class AddCorrigiendoStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/LangTeach.Api/Migrations/20260509000000_AddCorrigiendoStatus.cs
+++ b/backend/LangTeach.Api/Migrations/20260509000000_AddCorrigiendoStatus.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LangTeach.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCorrigiendoStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_Corrections_Status",
+                table: "Corrections");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_Corrections_Status",
+                table: "Corrections",
+                sql: "Status COLLATE Latin1_General_100_BIN2 IN ('Pendiente', 'Entregada', 'Corrigiendo', 'Corregida')");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_Corrections_Status",
+                table: "Corrections");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_Corrections_Status",
+                table: "Corrections",
+                sql: "Status COLLATE Latin1_General_100_BIN2 IN ('Pendiente', 'Entregada', 'Corregida')");
+        }
+    }
+}

--- a/backend/LangTeach.Api/Services/CorrectionService.cs
+++ b/backend/LangTeach.Api/Services/CorrectionService.cs
@@ -23,6 +23,27 @@ public class CorrectionService : ICorrectionService
         if (!await StudentBelongsToTeacherAsync(teacherId, studentId, cancellationToken))
             return null;
 
+        // Staleness recovery: a background AI task that failed silently leaves the
+        // correction stuck in Corrigiendo. After 60 seconds we revert to Entregada
+        // so the teacher can retry via the Corregir button.
+        var staleThreshold = DateTime.UtcNow.AddSeconds(-60);
+        var stale = await _db.Corrections
+            .Where(c => c.TeacherId == teacherId && c.StudentId == studentId
+                     && c.DeletedAt == null
+                     && c.Status == CorrectionStatus.Corrigiendo
+                     && c.UpdatedAt < staleThreshold)
+            .ToListAsync(cancellationToken);
+        if (stale.Count > 0)
+        {
+            var now = DateTime.UtcNow;
+            foreach (var s in stale)
+            {
+                s.Status = CorrectionStatus.Entregada;
+                s.UpdatedAt = now;
+            }
+            await _db.SaveChangesAsync(cancellationToken);
+        }
+
         var rows = await _db.Corrections
             .Where(c => c.TeacherId == teacherId && c.StudentId == studentId && c.DeletedAt == null)
             .OrderByDescending(c => c.CreatedAt)
@@ -106,7 +127,7 @@ public class CorrectionService : ICorrectionService
         {
             // StudentText is locked once the correction is Corregida; the markup tags reference
             // character offsets that would no longer match.
-            if (correction.Status == CorrectionStatus.Corregida)
+            if (correction.Status == CorrectionStatus.Corregida || correction.Status == CorrectionStatus.Corrigiendo)
                 throw new CorrectionStudentTextLockedException();
 
             var trimmed = string.IsNullOrWhiteSpace(request.StudentText) ? null : request.StudentText;

--- a/backend/LangTeach.Api/Services/CorrectionService.cs
+++ b/backend/LangTeach.Api/Services/CorrectionService.cs
@@ -24,9 +24,10 @@ public class CorrectionService : ICorrectionService
             return null;
 
         // Staleness recovery: a background AI task that failed silently leaves the
-        // correction stuck in Corrigiendo. After 60 seconds we revert to Entregada
-        // so the teacher can retry via the Corregir button.
-        var staleThreshold = DateTime.UtcNow.AddSeconds(-60);
+        // correction stuck in Corrigiendo. After StaleCorrigiendoSeconds we revert to
+        // Entregada so the teacher can retry. Must exceed p99 Claude latency (~30s).
+        const int StaleCorrigiendoSeconds = 60;
+        var staleThreshold = DateTime.UtcNow.AddSeconds(-StaleCorrigiendoSeconds);
         var stale = await _db.Corrections
             .Where(c => c.TeacherId == teacherId && c.StudentId == studentId
                      && c.DeletedAt == null

--- a/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
+++ b/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
@@ -80,7 +80,7 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
             catch (Exception ex)
             {
                 logger.LogError(ex,
-                    "Background correction failed silently. CorrectionId={CorrectionId} TeacherId={TeacherId} StudentId={StudentId}",
+                    "Background correction failed silently; row stays Corrigiendo until CorrectionService.ListAsync staleness sweep resets it to Entregada. CorrectionId={CorrectionId} TeacherId={TeacherId} StudentId={StudentId}",
                     correctionId, teacherId, studentId);
             }
         });

--- a/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
+++ b/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
@@ -6,13 +6,14 @@ using LangTeach.Api.Data.Models;
 using LangTeach.Api.DTOs;
 using LangTeach.Api.Helpers;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace LangTeach.Api.Services;
 
 public class RedaccionCorrectionService : IRedaccionCorrectionService
 {
     private readonly AppDbContext _db;
-    private readonly IClaudeClient _claude;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly RedaccionCorrectionPromptBuilder _promptBuilder;
     private readonly ILogger<RedaccionCorrectionService> _logger;
 
@@ -24,12 +25,12 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
 
     public RedaccionCorrectionService(
         AppDbContext db,
-        IClaudeClient claude,
+        IServiceScopeFactory scopeFactory,
         RedaccionCorrectionPromptBuilder promptBuilder,
         ILogger<RedaccionCorrectionService> logger)
     {
         _db = db;
-        _claude = claude;
+        _scopeFactory = scopeFactory;
         _promptBuilder = promptBuilder;
         _logger = logger;
     }
@@ -52,6 +53,8 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
         if (correction.Status == CorrectionStatus.Pendiente)
             throw new CorrectionInvalidStateException("no_student_text",
                 "Cannot correct a redacción before student text is provided.");
+        if (correction.Status == CorrectionStatus.Corrigiendo)
+            return CorrectionDtoMapper.ToDetail(correction, correction.Tags);
         if (correction.Status == CorrectionStatus.Corregida)
             throw new CorrectionInvalidStateException("already_corrected",
                 "This redacción has already been corrected.");
@@ -59,64 +62,86 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
             throw new CorrectionInvalidStateException("invalid_status",
                 $"Unexpected status: {correction.Status}.");
 
-        // Correction has no Student navigation (AppDbContext configures HasOne<Student>() with no nav).
-        // Load the student separately to access CefrLevel / NativeLanguages / Difficulties.
-        var student = await _db.Students.FirstOrDefaultAsync(
-            s => s.Id == studentId && s.TeacherId == teacherId && !s.IsDeleted, cancellationToken)
-            ?? throw new CorrectionNotFoundException();
+        correction.Status = CorrectionStatus.Corrigiendo;
+        correction.UpdatedAt = DateTime.UtcNow;
+        await _db.SaveChangesAsync(cancellationToken);
+
+        _ = Task.Run(async () =>
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var claude = scope.ServiceProvider.GetRequiredService<IClaudeClient>();
+            var promptBuilder = scope.ServiceProvider.GetRequiredService<RedaccionCorrectionPromptBuilder>();
+            var logger = scope.ServiceProvider.GetRequiredService<ILogger<RedaccionCorrectionService>>();
+            try
+            {
+                await RunCorrectionInScopeAsync(correctionId, studentId, teacherId, db, claude, promptBuilder, logger);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "Background correction failed silently. CorrectionId={CorrectionId} TeacherId={TeacherId} StudentId={StudentId}",
+                    correctionId, teacherId, studentId);
+            }
+        });
+
+        return CorrectionDtoMapper.ToDetail(correction, correction.Tags);
+    }
+
+    private static async Task RunCorrectionInScopeAsync(
+        Guid correctionId, Guid studentId, Guid teacherId,
+        AppDbContext db, IClaudeClient claude,
+        RedaccionCorrectionPromptBuilder promptBuilder,
+        ILogger logger)
+    {
+        var correction = await db.Corrections
+            .Include(c => c.Tags)
+            .FirstOrDefaultAsync(c => c.Id == correctionId && c.DeletedAt == null);
+
+        if (correction is null)
+        {
+            logger.LogWarning(
+                "Background correction: record not found. CorrectionId={CorrectionId}", correctionId);
+            return;
+        }
+
+        if (correction.Status != CorrectionStatus.Corrigiendo)
+        {
+            logger.LogWarning(
+                "Background correction: unexpected status {Status} (expected Corrigiendo). CorrectionId={CorrectionId}",
+                correction.Status, correctionId);
+            return;
+        }
+
+        var student = await db.Students.FirstOrDefaultAsync(
+            s => s.Id == studentId && s.TeacherId == teacherId && !s.IsDeleted);
+
+        if (student is null)
+        {
+            logger.LogWarning(
+                "Background correction: student not found. CorrectionId={CorrectionId} StudentId={StudentId}",
+                correctionId, studentId);
+            return;
+        }
 
         var ctx = BuildPromptContext(correction, student);
-        var request = _promptBuilder.Build(ctx);
-        // The model treats the text inside the STUDENT_TEXT_VERBATIM markers as ending at the
-        // last non-whitespace character and does NOT echo the trailing newline (the marker on
-        // the next line is its own token boundary). The strict ordinal check therefore compares
-        // against the trim-end-ed version, NOT against ctx.StudentText raw - otherwise a
-        // student submission ending with whitespace produces a false mismatch every time.
-        // ctx.StudentText itself stays raw, and the persisted Correction.StudentText (what the
-        // student wrote) is never modified.
+        var request = promptBuilder.Build(ctx);
         var sentText = ctx.StudentText.TrimEnd();
 
-        // One-shot retry on originalText mismatch only. Sonnet 4.6 occasionally paraphrases
-        // longer inputs even with temperature=0 + delimited markers; a second attempt almost
-        // always succeeds. Other failure codes (invalid_json, upstream_error) propagate
-        // immediately - they are not transient and retrying wastes a round-trip.
         const int MaxAttempts = 2;
         ClaudeResponse response = null!;
         string? stripped = null;
         RedaccionCorrectionDto dto = null!;
         for (var attempt = 1; attempt <= MaxAttempts; attempt++)
         {
-            try
-            {
-                response = await _claude.CompleteAsync(request, cancellationToken);
-            }
-            catch (OperationCanceledException)
-            {
-                // Caller-driven cancellation flows up unchanged.
-                throw;
-            }
-            catch (ClaudeRateLimitException ex)
-            {
-                throw new CorrectionGenerationException("upstream_error", ex.Message, ex);
-            }
-            catch (ClaudeApiException ex)
-            {
-                throw new CorrectionGenerationException("upstream_error", ex.Message, ex);
-            }
-            catch (Exception ex)
-            {
-                // Any other transport / parsing / serialization failure from the Claude
-                // client maps to upstream_error so the controller returns 502 (consistent
-                // with the existing two specific catches), not an unhandled 500.
-                throw new CorrectionGenerationException("upstream_error", ex.Message, ex);
-            }
+            response = await claude.CompleteAsync(request, CancellationToken.None);
 
             var raw = response.Content;
             stripped = ContentJsonHelper.StripFences(raw);
             if (string.IsNullOrWhiteSpace(stripped))
             {
-                _logger.LogWarning("Redaccion correction: empty/blank Claude response. CorrectionId={CorrectionId}", correctionId);
-                throw new CorrectionGenerationException("invalid_json", "Claude returned empty content.");
+                logger.LogWarning("Background correction: empty/blank Claude response. CorrectionId={CorrectionId}", correctionId);
+                throw new InvalidOperationException("Claude returned empty content.");
             }
 
             RedaccionCorrectionDto? parsed;
@@ -127,13 +152,13 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
             catch (JsonException ex)
             {
                 var excerpt = stripped.Length > 200 ? stripped[..200] + "..." : stripped;
-                _logger.LogWarning(ex, "Redaccion correction: failed to parse JSON. CorrectionId={CorrectionId} Excerpt={Excerpt}",
+                logger.LogWarning(ex, "Background correction: failed to parse JSON. CorrectionId={CorrectionId} Excerpt={Excerpt}",
                     correctionId, excerpt);
-                throw new CorrectionGenerationException("invalid_json", "Claude response did not parse as the expected JSON shape.", ex);
+                throw new InvalidOperationException("Claude response did not parse as the expected JSON shape.", ex);
             }
 
             if (parsed is null || parsed.SchemaVersion != 1)
-                throw new CorrectionGenerationException("invalid_json", "Claude response is missing or has an unsupported schemaVersion.");
+                throw new InvalidOperationException("Claude response is missing or has an unsupported schemaVersion.");
 
             if (string.Equals(parsed.OriginalText, sentText, StringComparison.Ordinal))
             {
@@ -143,39 +168,32 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
 
             if (attempt < MaxAttempts)
             {
-                _logger.LogWarning(
-                    "Redaccion correction: originalText mismatch on attempt {Attempt}/{MaxAttempts}; retrying once. CorrectionId={CorrectionId} SentLen={SentLen} ReturnedLen={ReturnedLen}",
+                logger.LogWarning(
+                    "Background correction: originalText mismatch on attempt {Attempt}/{MaxAttempts}; retrying once. CorrectionId={CorrectionId} SentLen={SentLen} ReturnedLen={ReturnedLen}",
                     attempt, MaxAttempts, correctionId, sentText.Length, parsed.OriginalText?.Length ?? 0);
                 continue;
             }
 
-            _logger.LogWarning(
-                "Redaccion correction: originalText mismatch after {MaxAttempts} attempts (model paraphrased input). CorrectionId={CorrectionId} SentLen={SentLen} ReturnedLen={ReturnedLen}",
+            logger.LogWarning(
+                "Background correction: originalText mismatch after {MaxAttempts} attempts. CorrectionId={CorrectionId} SentLen={SentLen} ReturnedLen={ReturnedLen}",
                 MaxAttempts, correctionId, sentText.Length, parsed.OriginalText?.Length ?? 0);
-            throw new CorrectionGenerationException(
-                "original_text_mismatch",
-                "Claude returned a paraphrased originalText; tag offsets cannot be trusted.");
+            throw new InvalidOperationException("Claude returned a paraphrased originalText; tag offsets cannot be trusted.");
         }
 
-        var validatedTags = ValidateAndOrderTags(dto.Tags ?? [], sentText, correctionId);
+        var validatedTags = ValidateAndOrderTags(dto.Tags ?? [], sentText, correctionId, logger);
 
-        // TOCTOU guard: a concurrent /corregir call could have completed during our Claude
-        // round-trip. Re-check the persisted status before writing tags to avoid duplicate
-        // tag rows (last-write-wins on the parent row is acceptable; duplicate child rows
-        // are not). True atomicity requires a Corrigiendo state + DB-level claim, which
-        // needs a migration; deferred to a follow-up. See plan/code-review-backlog.md.
-        var freshStatus = await _db.Corrections
+        // Confirm still Corrigiendo before writing (concurrent /corregir guard).
+        var freshStatus = await db.Corrections
             .AsNoTracking()
             .Where(c => c.Id == correctionId)
             .Select(c => c.Status)
-            .FirstOrDefaultAsync(cancellationToken);
-        if (freshStatus != CorrectionStatus.Entregada)
+            .FirstOrDefaultAsync();
+        if (freshStatus != CorrectionStatus.Corrigiendo)
         {
-            _logger.LogWarning(
-                "Redaccion correction: another request completed first (status now {Status}). Discarding this run. CorrectionId={CorrectionId}",
+            logger.LogWarning(
+                "Background correction: status changed to {Status} during generation; discarding. CorrectionId={CorrectionId}",
                 freshStatus, correctionId);
-            throw new CorrectionInvalidStateException("already_corrected",
-                "Another request completed this correction concurrently.");
+            return;
         }
 
         var now = DateTime.UtcNow;
@@ -188,7 +206,7 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
         for (var i = 0; i < validatedTags.Count; i++)
         {
             var t = validatedTags[i];
-            _db.CorrectionTags.Add(new CorrectionTag
+            db.CorrectionTags.Add(new CorrectionTag
             {
                 Id = Guid.NewGuid(),
                 CorrectionId = correction.Id,
@@ -202,16 +220,12 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
             });
         }
 
-        await _db.SaveChangesAsync(cancellationToken);
+        await db.SaveChangesAsync(CancellationToken.None);
 
-        _logger.LogInformation(
-            "Redaccion correction generated. CorrectionId={CorrectionId} TeacherId={TeacherId} StudentId={StudentId} Cefr={Cefr} L1={L1} TagCount={TagCount} ModelTokens={InputTokens}/{OutputTokens}",
-            correction.Id, teacherId, studentId, ctx.StudentCefr, ctx.StudentL1 ?? "(none)",
+        logger.LogInformation(
+            "Background correction completed. CorrectionId={CorrectionId} TeacherId={TeacherId} StudentId={StudentId} Cefr={Cefr} L1={L1} TagCount={TagCount} ModelTokens={InputTokens}/{OutputTokens}",
+            correctionId, teacherId, studentId, ctx.StudentCefr, ctx.StudentL1 ?? "(none)",
             validatedTags.Count, response.InputTokens, response.OutputTokens);
-
-        // Reload tags through the tracked context so DTO ordering is stable.
-        var persistedTags = correction.Tags.OrderBy(t => t.OrderIndex).ToList();
-        return CorrectionDtoMapper.ToDetail(correction, persistedTags);
     }
 
     private static RedaccionCorrectionPromptContext BuildPromptContext(Correction correction, Student student)
@@ -222,8 +236,8 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
         //
         // The trim-trailing-whitespace concern (the model treats the text as ending at the
         // last non-whitespace character when wrapped in markers and does NOT echo the
-        // trailing newline back) is handled at the equality-check site in CorregirAsync, not
-        // here, so the persisted Correction.StudentText stays exactly what the student wrote.
+        // trailing newline back) is handled at the equality-check site in RunCorrectionInScopeAsync,
+        // not here, so the persisted Correction.StudentText stays exactly what the student wrote.
         var studentText = correction.StudentText ?? string.Empty;
         var cefr = CefrLevelNormalizer.Normalize(student.CefrLevel);
 
@@ -287,8 +301,8 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
         return result;
     }
 
-    private List<RedaccionCorrectionTagDto> ValidateAndOrderTags(
-        IReadOnlyList<RedaccionCorrectionTagDto> rawTags, string originalText, Guid correctionId)
+    private static List<RedaccionCorrectionTagDto> ValidateAndOrderTags(
+        IReadOnlyList<RedaccionCorrectionTagDto> rawTags, string originalText, Guid correctionId, ILogger logger)
     {
         var kept = new List<RedaccionCorrectionTagDto>(rawTags.Count);
         var len = originalText.Length;
@@ -298,12 +312,12 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
             var tag = rawTag;
             if (string.IsNullOrEmpty(tag.Category) || !CorrectionTagCategory.IsValid(tag.Category))
             {
-                _logger.LogWarning("Drop tag: invalid category '{Category}'. CorrectionId={CorrectionId}", tag.Category, correctionId);
+                logger.LogWarning("Drop tag: invalid category '{Category}'. CorrectionId={CorrectionId}", tag.Category, correctionId);
                 continue;
             }
             if (tag.StartIndex < 0 || tag.EndIndex <= tag.StartIndex || tag.EndIndex > len)
             {
-                _logger.LogWarning(
+                logger.LogWarning(
                     "Drop tag: bad offsets [{Start},{End}) against text length {Len}. CorrectionId={CorrectionId}",
                     tag.StartIndex, tag.EndIndex, len, correctionId);
                 continue;
@@ -313,17 +327,14 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
             {
                 if (string.IsNullOrEmpty(tag.SpannedText))
                 {
-                    _logger.LogWarning(
+                    logger.LogWarning(
                         "Drop tag: spannedText is null or empty. CorrectionId={CorrectionId}", correctionId);
                     continue;
                 }
-                // Rescue: the model reported valid-range offsets but the substring doesn't match.
-                // This is the Unicode boundary drift pattern (model miscounts chars near é/ó/á/ñ).
-                // Locate spannedText by string search; fix offsets if the match is unambiguous.
                 var foundAt = originalText.IndexOf(tag.SpannedText, StringComparison.Ordinal);
                 if (foundAt < 0)
                 {
-                    _logger.LogWarning(
+                    logger.LogWarning(
                         "Drop tag: spannedText '{Spanned}' not found in originalText (model hallucinated span). CorrectionId={CorrectionId}",
                         tag.SpannedText, correctionId);
                     continue;
@@ -331,12 +342,12 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
                 var secondAt = originalText.IndexOf(tag.SpannedText, foundAt + 1, StringComparison.Ordinal);
                 if (secondAt >= 0)
                 {
-                    _logger.LogWarning(
+                    logger.LogWarning(
                         "Drop tag: spannedText '{Spanned}' is ambiguous (found at {First} and {Second}); cannot rescue. CorrectionId={CorrectionId}",
                         tag.SpannedText, foundAt, secondAt, correctionId);
                     continue;
                 }
-                _logger.LogWarning(
+                logger.LogWarning(
                     "Rescue tag: Unicode offset drift; spannedText '{Spanned}' relocated from model-reported [{Start},{End}) to [{Fixed},{FixedEnd}). CorrectionId={CorrectionId}",
                     tag.SpannedText, tag.StartIndex, tag.EndIndex, foundAt, foundAt + tag.SpannedText.Length, correctionId);
                 tag = tag with { StartIndex = foundAt, EndIndex = foundAt + tag.SpannedText.Length };
@@ -349,7 +360,7 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
             {
                 if (!string.IsNullOrWhiteSpace(explanation) || !string.IsNullOrWhiteSpace(correctedForm))
                 {
-                    _logger.LogWarning(
+                    logger.LogWarning(
                         "MuyBien tag had non-null explanation/correctedForm; coercing to null. CorrectionId={CorrectionId}",
                         correctionId);
                 }
@@ -360,7 +371,7 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
             {
                 if (string.IsNullOrWhiteSpace(explanation) || string.IsNullOrWhiteSpace(correctedForm))
                 {
-                    _logger.LogWarning(
+                    logger.LogWarning(
                         "Drop tag: category {Category} requires non-empty explanation and correctedForm. CorrectionId={CorrectionId}",
                         tag.Category, correctionId);
                     continue;
@@ -378,7 +389,7 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
         {
             if (tag.StartIndex < lastEnd)
             {
-                _logger.LogWarning(
+                logger.LogWarning(
                     "Drop tag: overlaps prior tag (start {Start} < lastEnd {LastEnd}). CorrectionId={CorrectionId}",
                     tag.StartIndex, lastEnd, correctionId);
                 continue;

--- a/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
+++ b/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
@@ -66,20 +66,23 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
         correction.UpdatedAt = DateTime.UtcNow;
         await _db.SaveChangesAsync(cancellationToken);
 
+        var outerLogger = _logger;
         _ = Task.Run(async () =>
         {
-            using var scope = _scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-            var claude = scope.ServiceProvider.GetRequiredService<IClaudeClient>();
-            var promptBuilder = scope.ServiceProvider.GetRequiredService<RedaccionCorrectionPromptBuilder>();
-            var logger = scope.ServiceProvider.GetRequiredService<ILogger<RedaccionCorrectionService>>();
+            ILogger<RedaccionCorrectionService>? scopeLogger = null;
             try
             {
-                await RunCorrectionInScopeAsync(correctionId, studentId, teacherId, db, claude, promptBuilder, logger);
+                using var scope = _scopeFactory.CreateScope();
+                var sp = scope.ServiceProvider;
+                var db = sp.GetRequiredService<AppDbContext>();
+                var claude = sp.GetRequiredService<IClaudeClient>();
+                var promptBuilder = sp.GetRequiredService<RedaccionCorrectionPromptBuilder>();
+                scopeLogger = sp.GetRequiredService<ILogger<RedaccionCorrectionService>>();
+                await RunCorrectionInScopeAsync(correctionId, studentId, teacherId, db, claude, promptBuilder, scopeLogger);
             }
             catch (Exception ex)
             {
-                logger.LogError(ex,
+                (scopeLogger ?? outerLogger).LogError(ex,
                     "Background correction failed silently; row stays Corrigiendo until CorrectionService.ListAsync staleness sweep resets it to Entregada. CorrectionId={CorrectionId} TeacherId={TeacherId} StudentId={StudentId}",
                     correctionId, teacherId, studentId);
             }

--- a/e2e/tests/visual/student-detail.visual.spec.ts
+++ b/e2e/tests/visual/student-detail.visual.spec.ts
@@ -287,6 +287,8 @@ test('@visual student detail redacciones tab - correction list', async ({ browse
   await expect(page.getByTestId('student-detail-name')).toBeVisible({ timeout: NAV_TIMEOUT })
   await page.getByTestId('tab-redacciones').click()
   await expect(page.getByTestId('redacciones-tab')).toBeVisible({ timeout: UI_TIMEOUT })
+  // Wait for the list to resolve (not the skeleton loading state).
+  await expect(page.getByTestId('redacciones-list').or(page.getByTestId('redacciones-empty'))).toBeVisible({ timeout: UI_TIMEOUT })
   await page.screenshot({ path: 'screenshots/student-detail-redacciones-tab.png', fullPage: true })
 
   expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)

--- a/e2e/tests/visual/student-detail.visual.spec.ts
+++ b/e2e/tests/visual/student-detail.visual.spec.ts
@@ -267,3 +267,28 @@ test('@visual student detail overview tab - with sessions', async ({ browser }) 
   expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)
   await context.close()
 })
+
+test('@visual student detail redacciones tab - correction list', async ({ browser }) => {
+  fs.mkdirSync('screenshots', { recursive: true })
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  const consoleErrors: string[] = []
+  page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()) })
+
+  // Ana Visual has a seeded Corregida correction visible in this tab.
+  const res = await page.request.get(`${API_BASE}/api/students`, { headers: { Authorization: 'Bearer test-token' } })
+  expect(res.ok()).toBeTruthy()
+  const body = await res.json()
+  const students: Array<{ name?: string; id: string }> = Array.isArray(body) ? body : (body.items ?? body.data ?? [])
+  const ana = students.find((s: { name?: string }) => s.name === 'Ana Visual')
+  if (!ana) throw new Error('No "Ana Visual" student found. Run start-visual-stack.sh first.')
+
+  await page.goto(`/students/${ana.id}`)
+  await expect(page.getByTestId('student-detail-name')).toBeVisible({ timeout: NAV_TIMEOUT })
+  await page.getByTestId('tab-redacciones').click()
+  await expect(page.getByTestId('redacciones-tab')).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.screenshot({ path: 'screenshots/student-detail-redacciones-tab.png', fullPage: true })
+
+  expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)
+  await context.close()
+})

--- a/frontend/src/api/corrections.ts
+++ b/frontend/src/api/corrections.ts
@@ -1,7 +1,7 @@
 import { apiClient } from '../lib/apiClient'
 import { triggerBlobDownload } from '../lib/downloadBlob'
 
-export type CorrectionStatus = 'Pendiente' | 'Entregada' | 'Corregida'
+export type CorrectionStatus = 'Pendiente' | 'Entregada' | 'Corrigiendo' | 'Corregida'
 export type CorrectionTagCategory = 'C' | 'G' | 'L' | 'O' | 'MuyBien'
 
 export interface CorrectionSummary {
@@ -79,10 +79,12 @@ export async function deleteCorrection(studentId: string, id: string): Promise<v
   await apiClient.delete(`/api/students/${studentId}/corrections/${id}`)
 }
 
-export async function corregirCorrection(studentId: string, id: string): Promise<void> {
-  await apiClient.post(`/api/students/${studentId}/corrections/${id}/corregir`, null, {
-    timeout: 60_000,
-  })
+export async function corregirCorrection(studentId: string, id: string): Promise<CorrectionDetail> {
+  const res = await apiClient.post<CorrectionDetail>(
+    `/api/students/${studentId}/corrections/${id}/corregir`,
+    null,
+  )
+  return res.data
 }
 
 export async function downloadCorrectionDocx(

--- a/frontend/src/components/student/RedaccionesTab.test.tsx
+++ b/frontend/src/components/student/RedaccionesTab.test.tsx
@@ -91,25 +91,19 @@ describe('RedaccionesTab', () => {
     expect(screen.queryByTestId('redaccion-corregir-c-pend')).not.toBeInTheDocument()
   })
 
-  it('renders Corregir on Entregada cards and shows Generando state when clicked', async () => {
+  it('renders Corregir on Entregada cards; clicking it fires corregirCorrection', async () => {
+    const corrigiendoDetail: CorrectionDetail = {
+      ...detail,
+      id: 'c-ent',
+      status: 'Corrigiendo',
+    }
     vi.mocked(correctionsApi.listCorrections).mockResolvedValue([entregada])
-    let resolveCorregir: () => void = () => {}
-    vi.mocked(correctionsApi.corregirCorrection).mockReturnValue(
-      new Promise<void>((resolve) => {
-        resolveCorregir = resolve
-      }),
-    )
+    vi.mocked(correctionsApi.corregirCorrection).mockResolvedValue(corrigiendoDetail)
     wrapper(<RedaccionesTab studentId={STUDENT_ID} />)
 
     const button = await screen.findByTestId('redaccion-corregir-c-ent')
     fireEvent.click(button)
 
-    await waitFor(() => {
-      expect(screen.getByTestId('redaccion-status-c-ent')).toHaveTextContent('Generando…')
-    })
-    expect(button).toBeDisabled()
-
-    resolveCorregir()
     await waitFor(() => {
       expect(correctionsApi.corregirCorrection).toHaveBeenCalledWith(STUDENT_ID, 'c-ent')
     })
@@ -278,7 +272,7 @@ describe('RedaccionesTab', () => {
   it('create with text: clicking Corregir calls createCorrection then corregirCorrection', async () => {
     vi.mocked(correctionsApi.listCorrections).mockResolvedValue([])
     vi.mocked(correctionsApi.createCorrection).mockResolvedValue({ ...detail, id: 'new-id', status: 'Entregada' })
-    vi.mocked(correctionsApi.corregirCorrection).mockResolvedValue()
+    vi.mocked(correctionsApi.corregirCorrection).mockResolvedValue({ ...detail, id: 'new-id', status: 'Corrigiendo' })
     wrapper(<RedaccionesTab studentId={STUDENT_ID} />)
 
     fireEvent.click(await screen.findByTestId('redacciones-empty-cta'))

--- a/frontend/src/components/student/RedaccionesTab.tsx
+++ b/frontend/src/components/student/RedaccionesTab.tsx
@@ -235,10 +235,10 @@ function CorrectionCard({
           </p>
           <div className="mt-1 flex items-center gap-2">
             <span
-              className={`inline-flex items-center gap-1 text-[0.6875rem] font-semibold tracking-wide uppercase px-2.5 py-0.5 rounded-full ${STATUS_BADGE[status]}`}
+              className={`inline-flex items-center gap-1.5 text-[0.6875rem] font-semibold tracking-wide uppercase px-2.5 py-1 rounded-full ${STATUS_BADGE[status]}`}
               data-testid={`redaccion-status-${id}`}
             >
-              {isCorrigiendo && <Loader2 className="h-3 w-3 animate-spin" />}
+              {isCorrigiendo && <span className="h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse" />}
               {status}
             </span>
             <span className="text-xs text-zinc-400" data-testid={`redaccion-date-${id}`}>

--- a/frontend/src/components/student/RedaccionesTab.tsx
+++ b/frontend/src/components/student/RedaccionesTab.tsx
@@ -26,6 +26,7 @@ interface RedaccionesTabProps {
 const STATUS_BADGE: Record<CorrectionStatus, string> = {
   Pendiente: 'bg-zinc-100 text-zinc-700',
   Entregada: 'bg-indigo-50 text-indigo-700',
+  Corrigiendo: 'bg-amber-50 text-amber-800',
   Corregida: 'bg-emerald-50 text-emerald-800',
 }
 
@@ -40,13 +41,20 @@ export function RedaccionesTab({ studentId }: RedaccionesTabProps) {
     | { mode: 'create' }
     | { mode: 'edit'; id: string }
   >({ mode: 'closed' })
-  const [generatingIds, setGeneratingIds] = useState<Set<string>>(new Set())
-  const [generationError, setGenerationError] = useState<string | null>(null)
+  const [corregirError, setCorregirError] = useState<string | null>(null)
 
   const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ['corrections', studentId],
     queryFn: () => listCorrections(studentId),
   })
+
+  // Poll every 3 seconds while any correction is in Corrigiendo state.
+  useEffect(() => {
+    const hasCorrigiendo = data?.some((c) => c.status === 'Corrigiendo') ?? false
+    if (!hasCorrigiendo) return
+    const id = setInterval(() => { void refetch() }, 3000)
+    return () => clearInterval(id)
+  }, [data, refetch])
 
   function invalidate() {
     queryClient.invalidateQueries({ queryKey: ['corrections', studentId] })
@@ -54,27 +62,19 @@ export function RedaccionesTab({ studentId }: RedaccionesTabProps) {
 
   const corregirMutation = useMutation({
     mutationFn: (id: string) => corregirCorrection(studentId, id),
-    onMutate: (id: string) => {
-      setGenerationError(null)
-      setGeneratingIds((prev) => new Set(prev).add(id))
-    },
-    onError: (err: unknown, id: string) => {
-      setGeneratingIds((prev) => {
-        const next = new Set(prev)
-        next.delete(id)
-        return next
-      })
+    onMutate: () => { setCorregirError(null) },
+    onError: (err: unknown) => {
       const msg =
         (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
         'No se pudo iniciar la corrección.'
-      setGenerationError(msg)
+      setCorregirError(msg)
     },
-    onSuccess: (_, id) => {
-      setGeneratingIds((prev) => {
-        const next = new Set(prev)
-        next.delete(id)
-        return next
-      })
+    onSuccess: (detail) => {
+      queryClient.setQueryData(
+        ['corrections', studentId],
+        (old: CorrectionSummary[] | undefined) =>
+          old?.map((c) => (c.id === detail.id ? { ...c, status: detail.status } : c)) ?? old,
+      )
       invalidate()
     },
   })
@@ -105,15 +105,15 @@ export function RedaccionesTab({ studentId }: RedaccionesTabProps) {
         )}
       </div>
 
-      {generationError && (
+      {corregirError && (
         <div
           className="flex items-start justify-between gap-3 rounded-xl bg-red-50 px-4 py-3 text-sm text-red-700"
           data-testid="redacciones-generation-error"
           role="alert"
         >
-          <span>{generationError}</span>
+          <span>{corregirError}</span>
           <button
-            onClick={() => setGenerationError(null)}
+            onClick={() => setCorregirError(null)}
             aria-label="Descartar"
             className="shrink-0 rounded p-0.5 text-red-500 hover:bg-red-100"
             data-testid="redacciones-generation-error-dismiss"
@@ -174,7 +174,6 @@ export function RedaccionesTab({ studentId }: RedaccionesTabProps) {
               key={c.id}
               correction={c}
               studentId={studentId}
-              isGenerating={generatingIds.has(c.id)}
               onCorregir={() => corregirMutation.mutate(c.id)}
               onEdit={() => openEdit(c.id)}
               onDelete={() => deleteMutation.mutate(c.id)}
@@ -201,7 +200,6 @@ export function RedaccionesTab({ studentId }: RedaccionesTabProps) {
 interface CorrectionCardProps {
   correction: CorrectionSummary
   studentId: string
-  isGenerating: boolean
   onCorregir: () => void
   onEdit: () => void
   onDelete: () => void
@@ -210,7 +208,6 @@ interface CorrectionCardProps {
 function CorrectionCard({
   correction,
   studentId,
-  isGenerating,
   onCorregir,
   onEdit,
   onDelete,
@@ -218,6 +215,7 @@ function CorrectionCard({
   const navigate = useNavigate()
   const { id, assignmentTitle, status, createdAt } = correction
   const isCorregida = status === 'Corregida'
+  const isCorrigiendo = status === 'Corrigiendo'
   const showCorregir = status === 'Entregada'
 
   function openDetail() {
@@ -243,12 +241,11 @@ function CorrectionCard({
           </p>
           <div className="mt-1 flex items-center gap-2">
             <span
-              className={`text-[0.6875rem] font-semibold tracking-wide uppercase px-2.5 py-0.5 rounded-full ${
-                isGenerating ? 'bg-amber-50 text-amber-800 animate-pulse' : STATUS_BADGE[status]
-              }`}
+              className={`inline-flex items-center gap-1 text-[0.6875rem] font-semibold tracking-wide uppercase px-2.5 py-0.5 rounded-full ${STATUS_BADGE[status]}`}
               data-testid={`redaccion-status-${id}`}
             >
-              {isGenerating ? 'Generando…' : status}
+              {isCorrigiendo && <Loader2 className="h-3 w-3 animate-spin" />}
+              {status}
             </span>
             <span className="text-xs text-zinc-400" data-testid={`redaccion-date-${id}`}>
               {relativeTime(createdAt)}
@@ -263,13 +260,12 @@ function CorrectionCard({
             <Button
               size="sm"
               onClick={onCorregir}
-              disabled={isGenerating}
               data-testid={`redaccion-corregir-${id}`}
             >
-              {isGenerating ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Corregir'}
+              Corregir
             </Button>
           )}
-          {!isCorregida && (
+          {!isCorregida && !isCorrigiendo && (
             <Button
               variant={showCorregir ? 'secondary' : 'ghost'}
               size="sm"
@@ -279,7 +275,7 @@ function CorrectionCard({
               Editar
             </Button>
           )}
-          {!isCorregida && (
+          {!isCorregida && !isCorrigiendo && (
             <Button
               variant={showCorregir ? 'secondary' : 'ghost'}
               size="sm"
@@ -304,6 +300,7 @@ interface CorrectionDrawerProps {
 }
 
 function CorrectionDrawer({ studentId, editId, onClose, onSaved }: CorrectionDrawerProps) {
+  const queryClient = useQueryClient()
   const isEdit = editId != null
   const [title, setTitle] = useState('')
   const [prompt, setPrompt] = useState('')
@@ -377,7 +374,12 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved }: CorrectionDra
         })
         if (text.trim().length > 0) {
           try {
-            await corregirCorrection(studentId, newCorrection.id)
+            const detail = await corregirCorrection(studentId, newCorrection.id)
+            queryClient.setQueryData(
+              ['corrections', studentId],
+              (old: CorrectionSummary[] | undefined) =>
+                old?.map((c) => (c.id === detail.id ? { ...c, status: detail.status } : c)) ?? old,
+            )
           } catch {
             // correction was saved as Entregada; corregir can be retried from the card
           }

--- a/frontend/src/components/student/RedaccionesTab.tsx
+++ b/frontend/src/components/student/RedaccionesTab.tsx
@@ -46,15 +46,9 @@ export function RedaccionesTab({ studentId }: RedaccionesTabProps) {
   const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ['corrections', studentId],
     queryFn: () => listCorrections(studentId),
+    refetchInterval: (query) =>
+      query.state.data?.some((c) => c.status === 'Corrigiendo') ? 3000 : false,
   })
-
-  // Poll every 3 seconds while any correction is in Corrigiendo state.
-  useEffect(() => {
-    const hasCorrigiendo = data?.some((c) => c.status === 'Corrigiendo') ?? false
-    if (!hasCorrigiendo) return
-    const id = setInterval(() => { void refetch() }, 3000)
-    return () => clearInterval(id)
-  }, [data, refetch])
 
   function invalidate() {
     queryClient.invalidateQueries({ queryKey: ['corrections', studentId] })

--- a/frontend/src/components/student/RedaccionesTab.tsx
+++ b/frontend/src/components/student/RedaccionesTab.tsx
@@ -185,6 +185,7 @@ export function RedaccionesTab({ studentId }: RedaccionesTabProps) {
             invalidate()
             closeDrawer()
           }}
+          onCorregirError={(msg) => setCorregirError(msg)}
         />
       )}
     </div>
@@ -291,9 +292,10 @@ interface CorrectionDrawerProps {
   editId: string | null
   onClose: () => void
   onSaved: () => void
+  onCorregirError: (msg: string) => void
 }
 
-function CorrectionDrawer({ studentId, editId, onClose, onSaved }: CorrectionDrawerProps) {
+function CorrectionDrawer({ studentId, editId, onClose, onSaved, onCorregirError }: CorrectionDrawerProps) {
   const queryClient = useQueryClient()
   const isEdit = editId != null
   const [title, setTitle] = useState('')
@@ -374,8 +376,13 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved }: CorrectionDra
               (old: CorrectionSummary[] | undefined) =>
                 old?.map((c) => (c.id === detail.id ? { ...c, status: detail.status } : c)) ?? old,
             )
-          } catch {
-            // correction was saved as Entregada; corregir can be retried from the card
+          } catch (corregirErr: unknown) {
+            // Correction was saved as Entregada; close the drawer and surface the error
+            // so the teacher knows AI generation didn't start and can retry from the card.
+            const msg =
+              (corregirErr as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+              'No se pudo iniciar la corrección.'
+            onCorregirError(msg)
           }
         }
       }

--- a/frontend/src/pages/RedaccionDetail.tsx
+++ b/frontend/src/pages/RedaccionDetail.tsx
@@ -203,6 +203,7 @@ function StatusPill({ status, viewState }: StatusPillProps) {
   const palette: Record<typeof status, string> = {
     Pendiente: 'bg-zinc-100 text-zinc-700',
     Entregada: 'bg-indigo-50 text-indigo-700',
+    Corrigiendo: 'bg-amber-50 text-amber-800',
     Corregida: 'bg-emerald-50 text-emerald-800',
   }
   return (

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -119,3 +119,7 @@ convention.
 Pre-existing (unrelated to PR):
 - `BuildSectionConversationPrompt` (L844-847): `forbiddenReasons` injected as negative list alongside positive guidance. Consider surfacing via guidance string instead.
 - `BuildSystemPrompt` (L606-608): second sentence duplicates first ("self-contained" stated twice). Merge to one sentence.
+
+## #1192 -- Corregir race condition (CodeRabbit, 2026-05-10)
+
+The read-then-write in CorregirAsync (check Status == Entregada, then set Corrigiendo) lacks atomic compare-and-swap. Two concurrent requests on the same correction can both observe Entregada and spawn duplicate background AI tasks. The TOCTOU guard in RunCorrectionInScopeAsync prevents duplicate tag rows, but two Claude calls can still fire. Fix: add [Timestamp] RowVersion to Correction entity + catch DbUpdateConcurrencyException in CorregirAsync.

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -3,6 +3,8 @@
 Out-of-scope observations logged by agents during implementation. Each row is something an agent noticed but did not fix because it was outside the current task's scope. These get batched into future GitHub issues by the PM.
 
 | Source issue | Date | Severity | Observation |
+| #1192 | 2026-05-09 | low | No dedicated test asserting `refetchInterval` is 3000ms when Corrigiendo cards exist -- only behavior-level coverage via component test |
+| #1192 | 2026-05-09 | low | Corrigiendo badge with amber pulse dot not visually verified (no seeded Corrigiendo correction in Ana Visual's data; would need a dedicated seed) |
 | #1185 | 2026-05-09 | low | Atelier session picker (inline pick-list inside AI proposals area) has no design system spec; picker rows use ghost-button style with hover-bg but no selected/active state defined -- needs Vera discussion before pattern is reused |
 | #smoke-text-correction | 2026-05-09 | low | Atelier assistant extracted phantom profile data (profession "Engineer", country "Spain", interests "Travel, Cooking") from a session note that contained none of that information -- extraction model may be hallucinating updates from prior context rather than the current transcript |
 | #1181 | 2026-05-09 | low | CorrectionDrawer footer pairs "Cancelar" ghost button with primary "Guardar" on the same row; violates design-system §5 (destructive/secondary actions should be separated from primary). Pre-existing, not introduced by this PR. |


### PR DESCRIPTION
Fixes #1192

## Summary

- **Backend:** `CorregirAsync` now sets status to `Corrigiendo`, returns the card immediately (200), and fires the AI call in a background `Task.Run` using `IServiceScopeFactory`. The drawer no longer hangs for up to 10 seconds.
- **Backend:** New `Corrigiendo` DB status. Migration drops and recreates `CK_Corrections_Status` to include `Corrigiendo`. StudentText locked on `Corrigiendo` (same as `Corregida`).
- **Backend:** Staleness recovery in `ListAsync` -- `Corrigiendo` records with `UpdatedAt` older than 60 seconds (must exceed p99 Claude latency) revert to `Entregada` so the teacher can retry.
- **Backend:** Idempotency -- calling Corregir on an already-`Corrigiendo` card returns the existing record without starting a second AI call.
- **Frontend:** `CorrectionStatus` union adds `Corrigiendo`. Status badge uses amber pill with pulse dot per design-system §11.15. TanStack `refetchInterval` polls every 3s while any card is `Corrigiendo`, stops when none remain. Drawer closes immediately on response.
- **Tests:** All unit/integration tests updated. `FakeServiceScopeFactory` added to test helpers. New visual spec for Redacciones tab list.

## Test plan

- [ ] Open student > Redacciones > Nueva redacción, fill in text, click Corregir -- drawer closes immediately, card shows Corrigiendo with amber pulse dot
- [ ] Navigate away and back -- card still shows Corrigiendo, polling resumes
- [ ] Wait -- card transitions to Corregida automatically (no manual action)
- [ ] Staleness: set `UpdatedAt` on a Corrigiendo record to 2 minutes ago via DB, reload tab -- card shows Entregada with Retry (Corregir button)
- [ ] Click Corregir on a Corrigiendo card -- returns existing record, no duplicate AI call

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "Corrigiendo" status representing corrections currently being processed
  * Correction processing now runs in the background; the endpoint returns immediately with "Corrigiendo" status instead of blocking

* **Improvements**
  * UI automatically polls and updates when corrections finish processing
  * Student text editing is locked while a correction is being processed
  * Automatic recovery of stale processing states to prevent corrections from remaining stuck

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1193)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->