### PR TITLE
feat(#1196): thumbs up/down feedback on corrections

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerTests.cs
@@ -616,6 +616,20 @@ public class CorrectionsControllerTests
         second.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 
+    [Fact]
+    public async Task SubmitFeedback_OtherTeachersCorrection_Returns404()
+    {
+        var (clientA, studentA) = await SetupAsync("auth0|corr-feedback-rls-a", "feedback-rls-a@example.com");
+        var correction = await CreateCorrectionAsync(clientA, studentA, new CreateCorrectionRequest { AssignmentTitle = "Owner A" });
+
+        var (clientB, _) = await SetupAsync("auth0|corr-feedback-rls-b", "feedback-rls-b@example.com");
+
+        var resp = await clientB.PostAsJsonAsync(
+            $"/api/students/{studentA}/corrections/{correction.Id}/feedback",
+            new { rating = "up" });
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
     private async Task<CorrectionDetailDto> WaitForCorrectionStatusAsync(
         HttpClient client, Guid studentId, Guid correctionId, string expectedStatus,
         int maxWaitMs = 5000, int pollIntervalMs = 50, DateTime? stopWhenUpdatedAtAdvances = null)

--- a/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/CorrectionsControllerTests.cs
@@ -546,6 +546,76 @@ public class CorrectionsControllerTests
 
     // --- helpers ---
 
+    [Fact]
+    public async Task SubmitFeedback_UpRating_Returns204()
+    {
+        var (client, studentId) = await SetupAsync("auth0|corr-feedback-up");
+        var correction = await CreateCorrectionAsync(client, studentId, new CreateCorrectionRequest { AssignmentTitle = "Feedback Up" });
+
+        var resp = await client.PostAsJsonAsync(
+            $"/api/students/{studentId}/corrections/{correction.Id}/feedback",
+            new { rating = "up" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task SubmitFeedback_DownRatingWithReason_Returns204()
+    {
+        var (client, studentId) = await SetupAsync("auth0|corr-feedback-down");
+        var correction = await CreateCorrectionAsync(client, studentId, new CreateCorrectionRequest { AssignmentTitle = "Feedback Down" });
+
+        var resp = await client.PostAsJsonAsync(
+            $"/api/students/{studentId}/corrections/{correction.Id}/feedback",
+            new { rating = "down", reason = "El tag 3 es léxico, no gramática." });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task SubmitFeedback_UnknownCorrectionId_Returns404()
+    {
+        var (client, _) = await SetupAsync("auth0|corr-feedback-404");
+        var fakeStudentId = Guid.NewGuid();
+        var fakeCorrectionId = Guid.NewGuid();
+
+        var resp = await client.PostAsJsonAsync(
+            $"/api/students/{fakeStudentId}/corrections/{fakeCorrectionId}/feedback",
+            new { rating = "up" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task SubmitFeedback_InvalidRating_Returns400()
+    {
+        var (client, studentId) = await SetupAsync("auth0|corr-feedback-bad-rating");
+        var correction = await CreateCorrectionAsync(client, studentId, new CreateCorrectionRequest { AssignmentTitle = "Bad Rating" });
+
+        var resp = await client.PostAsJsonAsync(
+            $"/api/students/{studentId}/corrections/{correction.Id}/feedback",
+            new { rating = "maybe" });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task SubmitFeedback_DoubleSubmit_IsIdempotent()
+    {
+        var (client, studentId) = await SetupAsync("auth0|corr-feedback-upsert");
+        var correction = await CreateCorrectionAsync(client, studentId, new CreateCorrectionRequest { AssignmentTitle = "Upsert Test" });
+
+        var first = await client.PostAsJsonAsync(
+            $"/api/students/{studentId}/corrections/{correction.Id}/feedback",
+            new { rating = "up" });
+        first.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var second = await client.PostAsJsonAsync(
+            $"/api/students/{studentId}/corrections/{correction.Id}/feedback",
+            new { rating = "down", reason = "Revised opinion." });
+        second.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
     private async Task<CorrectionDetailDto> WaitForCorrectionStatusAsync(
         HttpClient client, Guid studentId, Guid correctionId, string expectedStatus,
         int maxWaitMs = 5000, int pollIntervalMs = 50, DateTime? stopWhenUpdatedAtAdvances = null)

--- a/backend/LangTeach.Api/Controllers/CorrectionsController.cs
+++ b/backend/LangTeach.Api/Controllers/CorrectionsController.cs
@@ -164,7 +164,7 @@ public class CorrectionsController : ControllerBase
         if (!ModelState.IsValid) return BadRequest(ModelState);
 
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
-        var result = await _feedbackService.SubmitForCorrectionAsync(teacherId, id, request.Rating, request.Reason, cancellationToken);
+        var result = await _feedbackService.SubmitForCorrectionAsync(teacherId, studentId, id, request.Rating, request.Reason, cancellationToken);
 
         return result switch
         {

--- a/backend/LangTeach.Api/Controllers/CorrectionsController.cs
+++ b/backend/LangTeach.Api/Controllers/CorrectionsController.cs
@@ -19,6 +19,7 @@ public class CorrectionsController : ControllerBase
     private readonly IRedaccionCorrectionService _redaccionCorrections;
     private readonly ICorrectionDocxExportService _docxExport;
     private readonly IProfileService _profileService;
+    private readonly IAssistantFeedbackService _feedbackService;
     private readonly ILogger<CorrectionsController> _logger;
 
     private const string DocxContentType =
@@ -29,12 +30,14 @@ public class CorrectionsController : ControllerBase
         IRedaccionCorrectionService redaccionCorrections,
         ICorrectionDocxExportService docxExport,
         IProfileService profileService,
+        IAssistantFeedbackService feedbackService,
         ILogger<CorrectionsController> logger)
     {
         _corrections = corrections;
         _redaccionCorrections = redaccionCorrections;
         _docxExport = docxExport;
         _profileService = profileService;
+        _feedbackService = feedbackService;
         _logger = logger;
     }
 
@@ -152,6 +155,22 @@ public class CorrectionsController : ControllerBase
         Response.Headers.ContentDisposition = disposition.ToString();
 
         return File(bytes, DocxContentType);
+    }
+
+    [HttpPost("{id:guid}/feedback")]
+    public async Task<IActionResult> SubmitFeedback(Guid studentId, Guid id, [FromBody] CorrectionFeedbackRequest request, CancellationToken cancellationToken)
+    {
+        if (Auth0Id is null) return Unauthorized();
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
+        var result = await _feedbackService.SubmitForCorrectionAsync(teacherId, id, request.Rating, request.Reason, cancellationToken);
+
+        return result switch
+        {
+            CorrectionFeedbackResult.CorrectionNotFound => NotFound(),
+            _ => NoContent(),
+        };
     }
 
     [HttpDelete("{id:guid}")]

--- a/backend/LangTeach.Api/DTOs/CorrectionDtos.cs
+++ b/backend/LangTeach.Api/DTOs/CorrectionDtos.cs
@@ -58,3 +58,12 @@ public class UpdateCorrectionRequest
     [MaxLength(CreateCorrectionRequest.StudentTextMaxLength)]
     public string? StudentText { get; set; }
 }
+
+public class CorrectionFeedbackRequest
+{
+    [Required, RegularExpression("^(up|down)$", ErrorMessage = "Rating must be 'up' or 'down'.")]
+    public string Rating { get; set; } = "";
+
+    [MaxLength(2000)]
+    public string? Reason { get; set; }
+}

--- a/backend/LangTeach.Api/Data/AppDbContext.cs
+++ b/backend/LangTeach.Api/Data/AppDbContext.cs
@@ -314,6 +314,17 @@ public class AppDbContext : DbContext
              .HasForeignKey(f => f.VoiceNoteId)
              .IsRequired(false)
              .OnDelete(DeleteBehavior.NoAction);
+            // Same cascade-path constraint as VoiceNote: Teacher→Correction→AssistantTurnFeedback
+            // would conflict with Teacher→AssistantTurnFeedback cascade. NoAction used; application
+            // code is responsible for cleanup if a Correction is hard-deleted.
+            e.HasOne<Correction>()
+             .WithMany()
+             .HasForeignKey(f => f.CorrectionId)
+             .IsRequired(false)
+             .OnDelete(DeleteBehavior.NoAction);
+            e.HasIndex(f => new { f.CorrectionId, f.TeacherId })
+             .IsUnique()
+             .HasFilter("[CorrectionId] IS NOT NULL");
             e.Property(f => f.Rating).HasMaxLength(4).IsRequired();
             e.Property(f => f.Reason).HasMaxLength(2000);
         });

--- a/backend/LangTeach.Api/Data/Models/AssistantTurnFeedback.cs
+++ b/backend/LangTeach.Api/Data/Models/AssistantTurnFeedback.cs
@@ -5,6 +5,7 @@ public class AssistantTurnFeedback
     public Guid Id { get; set; }
     public Guid TeacherId { get; set; }
     public Guid? VoiceNoteId { get; set; }
+    public Guid? CorrectionId { get; set; }
     /// <summary>Snapshot of the student context at submit time. Intentionally no FK — reconstruction after deletion is impossible.</summary>
     public Guid? StudentId { get; set; }
     /// <summary>Snapshot of the session context at submit time. Intentionally no FK — reconstruction after deletion is impossible.</summary>

--- a/backend/LangTeach.Api/Migrations/20260510033309_AddCorrectionIdToAssistantTurnFeedback.Designer.cs
+++ b/backend/LangTeach.Api/Migrations/20260510033309_AddCorrectionIdToAssistantTurnFeedback.Designer.cs
@@ -4,6 +4,7 @@ using LangTeach.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LangTeach.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510033309_AddCorrectionIdToAssistantTurnFeedback")]
+    partial class AddCorrectionIdToAssistantTurnFeedback
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/LangTeach.Api/Migrations/20260510033309_AddCorrectionIdToAssistantTurnFeedback.cs
+++ b/backend/LangTeach.Api/Migrations/20260510033309_AddCorrectionIdToAssistantTurnFeedback.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LangTeach.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCorrectionIdToAssistantTurnFeedback : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "CorrectionId",
+                table: "AssistantTurnFeedbacks",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AssistantTurnFeedbacks_CorrectionId_TeacherId",
+                table: "AssistantTurnFeedbacks",
+                columns: new[] { "CorrectionId", "TeacherId" },
+                unique: true,
+                filter: "[CorrectionId] IS NOT NULL");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AssistantTurnFeedbacks_Corrections_CorrectionId",
+                table: "AssistantTurnFeedbacks",
+                column: "CorrectionId",
+                principalTable: "Corrections",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AssistantTurnFeedbacks_Corrections_CorrectionId",
+                table: "AssistantTurnFeedbacks");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AssistantTurnFeedbacks_CorrectionId_TeacherId",
+                table: "AssistantTurnFeedbacks");
+
+            migrationBuilder.DropColumn(
+                name: "CorrectionId",
+                table: "AssistantTurnFeedbacks");
+        }
+    }
+}

--- a/backend/LangTeach.Api/Services/AssistantFeedbackService.cs
+++ b/backend/LangTeach.Api/Services/AssistantFeedbackService.cs
@@ -74,13 +74,14 @@ public class AssistantFeedbackService : IAssistantFeedbackService
 
     public async Task<CorrectionFeedbackResult> SubmitForCorrectionAsync(
         Guid teacherId,
+        Guid studentId,
         Guid correctionId,
         string rating,
         string? reason,
         CancellationToken ct)
     {
         var correctionExists = await _db.Corrections
-            .AnyAsync(c => c.Id == correctionId && c.TeacherId == teacherId, ct);
+            .AnyAsync(c => c.Id == correctionId && c.TeacherId == teacherId && c.StudentId == studentId, ct);
         if (!correctionExists)
             return CorrectionFeedbackResult.CorrectionNotFound;
 

--- a/backend/LangTeach.Api/Services/AssistantFeedbackService.cs
+++ b/backend/LangTeach.Api/Services/AssistantFeedbackService.cs
@@ -72,6 +72,56 @@ public class AssistantFeedbackService : IAssistantFeedbackService
         return AssistantFeedbackResult.Saved;
     }
 
+    public async Task<CorrectionFeedbackResult> SubmitForCorrectionAsync(
+        Guid teacherId,
+        Guid correctionId,
+        string rating,
+        string? reason,
+        CancellationToken ct)
+    {
+        var correctionExists = await _db.Corrections
+            .AnyAsync(c => c.Id == correctionId && c.TeacherId == teacherId, ct);
+        if (!correctionExists)
+            return CorrectionFeedbackResult.CorrectionNotFound;
+
+        var now = DateTime.UtcNow;
+
+        var existing = await _db.AssistantTurnFeedbacks
+            .FirstOrDefaultAsync(f => f.CorrectionId == correctionId && f.TeacherId == teacherId, ct);
+
+        if (existing is not null)
+        {
+            existing.Rating = rating;
+            existing.Reason = reason;
+            existing.UpdatedAt = now;
+        }
+        else
+        {
+            _db.AssistantTurnFeedbacks.Add(new AssistantTurnFeedback
+            {
+                Id = Guid.NewGuid(),
+                TeacherId = teacherId,
+                CorrectionId = correctionId,
+                Rating = rating,
+                Reason = reason,
+                ProposalsJson = "",
+                CreatedAt = now,
+                UpdatedAt = now,
+            });
+        }
+
+        try
+        {
+            await _db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex) when (existing is null && IsSqlServerUniqueViolation(ex))
+        {
+            // Concurrent double-tap; unique constraint honoured.
+        }
+
+        return CorrectionFeedbackResult.Saved;
+    }
+
     // SQL Server error codes: 2601 = unique index violation, 2627 = unique constraint violation.
     private static bool IsSqlServerUniqueViolation(DbUpdateException ex) =>
         ex.InnerException is SqlException { Number: 2601 or 2627 };

--- a/backend/LangTeach.Api/Services/IAssistantFeedbackService.cs
+++ b/backend/LangTeach.Api/Services/IAssistantFeedbackService.cs
@@ -26,6 +26,7 @@ public interface IAssistantFeedbackService
 
     Task<CorrectionFeedbackResult> SubmitForCorrectionAsync(
         Guid teacherId,
+        Guid studentId,
         Guid correctionId,
         string rating,
         string? reason,

--- a/backend/LangTeach.Api/Services/IAssistantFeedbackService.cs
+++ b/backend/LangTeach.Api/Services/IAssistantFeedbackService.cs
@@ -6,6 +6,12 @@ public enum AssistantFeedbackResult
     VoiceNoteNotFound,
 }
 
+public enum CorrectionFeedbackResult
+{
+    Saved,
+    CorrectionNotFound,
+}
+
 public interface IAssistantFeedbackService
 {
     Task<AssistantFeedbackResult> SubmitAsync(
@@ -16,5 +22,12 @@ public interface IAssistantFeedbackService
         Guid? studentId,
         Guid? sessionLogId,
         string proposalsJson,
+        CancellationToken ct);
+
+    Task<CorrectionFeedbackResult> SubmitForCorrectionAsync(
+        Guid teacherId,
+        Guid correctionId,
+        string rating,
+        string? reason,
         CancellationToken ct);
 }

--- a/frontend/src/api/corrections.ts
+++ b/frontend/src/api/corrections.ts
@@ -100,6 +100,19 @@ export async function downloadCorrectionDocx(
   triggerBlobDownload(response, fallback)
 }
 
+export interface CorrectionFeedbackRequest {
+  rating: 'up' | 'down'
+  reason?: string | null
+}
+
+export async function submitCorrectionFeedback(
+  studentId: string,
+  correctionId: string,
+  body: CorrectionFeedbackRequest,
+): Promise<void> {
+  await apiClient.post(`/api/students/${studentId}/corrections/${correctionId}/feedback`, body)
+}
+
 function sanitizeFilename(value: string): string {
   return value.replace(/[^a-zA-Z0-9-_.\s]/g, '').trim() || 'correccion'
 }

--- a/frontend/src/pages/RedaccionDetail.tsx
+++ b/frontend/src/pages/RedaccionDetail.tsx
@@ -1,11 +1,12 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { ArrowLeft, Download, Loader2, RefreshCw } from 'lucide-react'
+import { ArrowLeft, Download, Loader2, RefreshCw, ThumbsDown, ThumbsUp } from 'lucide-react'
 import {
   corregirCorrection,
   downloadCorrectionDocx,
   getCorrection,
+  submitCorrectionFeedback,
   type CorrectionDetail,
 } from '../api/corrections'
 import { Button } from '@/components/ui/button'
@@ -169,7 +170,91 @@ export default function RedaccionDetail() {
           ) : (
             <MarkedUpText studentText={data.studentText} tags={data.tags} />
           )}
+          <CorrectionFeedback studentId={studentId!} correctionId={correctionId!} />
         </>
+      )}
+    </div>
+  )
+}
+
+type FeedbackState = 'idle' | 'down-open' | 'submitting' | 'done'
+
+interface CorrectionFeedbackProps {
+  studentId: string
+  correctionId: string
+}
+
+function CorrectionFeedback({ studentId, correctionId }: CorrectionFeedbackProps) {
+  const [state, setState] = useState<FeedbackState>('idle')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  async function submit(rating: 'up' | 'down', reason?: string) {
+    setState('submitting')
+    try {
+      await submitCorrectionFeedback(studentId, correctionId, { rating, reason: reason || null })
+      setState('done')
+    } catch (err) {
+      logger.error('CorrectionFeedback', 'submit failed', err)
+      setState('idle')
+    }
+  }
+
+  if (state === 'done') {
+    return (
+      <p className="text-sm text-zinc-500" role="status">
+        Gracias por tu feedback.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {state !== 'down-open' && (
+        <div className="flex items-center gap-3">
+          <button
+            aria-label="Positivo"
+            disabled={state === 'submitting'}
+            onClick={() => submit('up')}
+            className="text-zinc-400 transition-colors hover:text-emerald-600 disabled:opacity-50"
+          >
+            <ThumbsUp className="h-5 w-5" />
+          </button>
+          <button
+            aria-label="Mejorable"
+            disabled={state === 'submitting'}
+            onClick={() => setState('down-open')}
+            className="text-zinc-400 transition-colors hover:text-red-500 disabled:opacity-50"
+          >
+            <ThumbsDown className="h-5 w-5" />
+          </button>
+          {state === 'submitting' && <Loader2 className="h-4 w-4 animate-spin text-zinc-400" />}
+        </div>
+      )}
+      {state === 'down-open' && (
+        <div className="flex items-center gap-2">
+          <input
+            ref={inputRef}
+            type="text"
+            autoFocus
+            maxLength={500}
+            placeholder="¿Qué mejorarías?"
+            className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-400"
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => submit('down', inputRef.current?.value?.trim())}
+          >
+            Enviar
+          </Button>
+          <button
+            aria-label="Cancelar"
+            onClick={() => setState('idle')}
+            className="text-xs text-zinc-400 hover:text-zinc-600"
+          >
+            Cancelar
+          </button>
+        </div>
       )}
     </div>
   )

--- a/frontend/src/pages/RedaccionDetail.tsx
+++ b/frontend/src/pages/RedaccionDetail.tsx
@@ -10,6 +10,7 @@ import {
   type CorrectionDetail,
 } from '../api/corrections'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
 import { MarkedUpText } from '@/components/corrections/MarkedUpText'
 import { logger } from '../lib/logger'
@@ -177,7 +178,7 @@ export default function RedaccionDetail() {
   )
 }
 
-type FeedbackState = 'idle' | 'down-open' | 'submitting' | 'done'
+type FeedbackInputState = 'idle' | 'down-open'
 
 interface CorrectionFeedbackProps {
   studentId: string
@@ -185,21 +186,21 @@ interface CorrectionFeedbackProps {
 }
 
 function CorrectionFeedback({ studentId, correctionId }: CorrectionFeedbackProps) {
-  const [state, setState] = useState<FeedbackState>('idle')
+  const [inputState, setInputState] = useState<FeedbackInputState>('idle')
   const inputRef = useRef<HTMLInputElement>(null)
 
-  async function submit(rating: 'up' | 'down', reason?: string) {
-    setState('submitting')
-    try {
-      await submitCorrectionFeedback(studentId, correctionId, { rating, reason: reason || null })
-      setState('done')
-    } catch (err) {
-      logger.error('CorrectionFeedback', 'submit failed', err)
-      setState('idle')
-    }
+  const mutation = useMutation({
+    mutationFn: (body: { rating: 'up' | 'down'; reason?: string | null }) =>
+      submitCorrectionFeedback(studentId, correctionId, body),
+    onError: (err) => logger.error('CorrectionFeedback', 'submit failed', err),
+  })
+
+  function handleDown() {
+    const reason = inputRef.current?.value?.trim() || undefined
+    mutation.mutate({ rating: 'down', reason: reason ?? null })
   }
 
-  if (state === 'done') {
+  if (mutation.isSuccess) {
     return (
       <p className="text-sm text-zinc-500" role="status">
         Gracias por tu feedback.
@@ -209,47 +210,50 @@ function CorrectionFeedback({ studentId, correctionId }: CorrectionFeedbackProps
 
   return (
     <div className="space-y-2">
-      {state !== 'down-open' && (
+      {inputState !== 'down-open' && (
         <div className="flex items-center gap-3">
           <button
             aria-label="Positivo"
-            disabled={state === 'submitting'}
-            onClick={() => submit('up')}
+            disabled={mutation.isPending}
+            onClick={() => mutation.mutate({ rating: 'up' })}
             className="text-zinc-400 transition-colors hover:text-emerald-600 disabled:opacity-50"
           >
-            <ThumbsUp className="h-5 w-5" />
+            <ThumbsUp className="h-4 w-4" />
           </button>
           <button
             aria-label="Mejorable"
-            disabled={state === 'submitting'}
-            onClick={() => setState('down-open')}
+            disabled={mutation.isPending}
+            onClick={() => setInputState('down-open')}
             className="text-zinc-400 transition-colors hover:text-red-500 disabled:opacity-50"
           >
-            <ThumbsDown className="h-5 w-5" />
+            <ThumbsDown className="h-4 w-4" />
           </button>
-          {state === 'submitting' && <Loader2 className="h-4 w-4 animate-spin text-zinc-400" />}
+          {mutation.isPending && <Loader2 className="h-4 w-4 animate-spin text-zinc-400" />}
         </div>
       )}
-      {state === 'down-open' && (
+      {inputState === 'down-open' && (
         <div className="flex items-center gap-2">
-          <input
+          <Input
             ref={inputRef}
-            type="text"
             autoFocus
             maxLength={500}
             placeholder="¿Qué mejorarías?"
-            className="flex-1 rounded-md border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-400"
+            disabled={mutation.isPending}
+            onKeyDown={(e) => e.key === 'Enter' && handleDown()}
+            className="flex-1 h-8 text-sm"
           />
           <Button
             size="sm"
-            variant="outline"
-            onClick={() => submit('down', inputRef.current?.value?.trim())}
+            variant="ghost"
+            disabled={mutation.isPending}
+            onClick={handleDown}
           >
             Enviar
           </Button>
           <button
             aria-label="Cancelar"
-            onClick={() => setState('idle')}
+            disabled={mutation.isPending}
+            onClick={() => setInputState('idle')}
             className="text-xs text-zinc-400 hover:text-zinc-600"
           >
             Cancelar


### PR DESCRIPTION
Closes #1196

## Summary

- Adds nullable `CorrectionId` FK to `AssistantTurnFeedback` (filtered unique index `WHERE [CorrectionId] IS NOT NULL`; no cascade; no nav property -- same snapshot philosophy as `VoiceNoteId`)
- New `POST /api/students/{studentId}/corrections/{id}/feedback` endpoint accepts `{ rating: "up"|"down", reason?: string }` and upserts the feedback row (teacher-scoped, 404 if not owned)
- `CorrectionFeedback` component in `RedaccionDetail` shows thumbs up/down below the corrections section; up submits immediately, down reveals an inline text input with Enter-to-submit; both show "Gracias por tu feedback." on success

## Test plan

- [ ] Open any CORREGIDA correction -- thumbs up/down visible below corrections
- [ ] Tap thumbs up -- "Gracias por tu feedback." replaces icons, no navigation
- [ ] Tap thumbs down -- inline text input appears (no modal, no overlay)
- [ ] Type "El tag 3 es léxico, no gramática" + Enviar -- "Gracias" confirmation appears
- [ ] Check DB: `AssistantTurnFeedback` has row with `CorrectionId` set, `Rating = "down"`, `Reason` as typed
- [ ] Pressing Enter in the down-thumb input also submits
- [ ] Another teacher's correction returns 404 (cross-tenant RLS test in suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added feedback submission capability for all completed corrections, allowing users to rate them as helpful (up) or unhelpful (down) with optional written comments for any negative ratings.
  * Integrated feedback interface directly within the correction details view with real-time submission status tracking, comprehensive error handling, and success confirmation messaging upon completion.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1198)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->