### PR TITLE
fix(#1200, #1201): session start time in new-session payload; Apply All blocked until session picked

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/AssistantControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/AssistantControllerTests.cs
@@ -547,6 +547,32 @@ public class AssistantControllerTests
     }
 
     [Fact]
+    public async Task Propose_WithSchedulingIntentAndTime_CombinesDateAndTimeInPayload()
+    {
+        // When SessionStartTime is non-null, the controller must combine date + time into an ISO datetime.
+        // StubReflectionExtractionService returns date "2026-05-19" and time "09:00" for [schedule-new-session].
+        var (client, studentId) = await SeedTeacherWithStudent(
+            "auth0|assistant-new-session-with-time", "assistant-new-session-with-time@example.com");
+
+        var request = new AssistantProposeRequest
+        {
+            Text = "La clase de hoy de las 9:00 fue bien. [schedule-new-session]",
+            StudentId = studentId,
+        };
+        var response = await client.PostAsJsonAsync("/api/assistant/propose", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<AssistantProposeResponse>();
+        body.Should().NotBeNull();
+        var newSessionProposal = body!.Proposals.FirstOrDefault(p => p.Type == "newSession");
+        newSessionProposal.Should().NotBeNull();
+
+        var payloadDoc = System.Text.Json.JsonDocument.Parse(newSessionProposal!.Payload!.Value.GetRawText());
+        var sessionDate = payloadDoc.RootElement.GetProperty("sessionDate").GetString();
+        sessionDate.Should().Be("2026-05-19T09:00");
+    }
+
+    [Fact]
     public async Task Propose_WithoutSchedulingIntent_DoesNotEmitNewSessionProposal()
     {
         // Normal reflection text without "[schedule-new-session]" trigger → no newSession proposal.

--- a/backend/LangTeach.Api/Controllers/AssistantController.cs
+++ b/backend/LangTeach.Api/Controllers/AssistantController.cs
@@ -193,7 +193,10 @@ public class AssistantController : ControllerBase
 
         if (reflectionExtraction.ProposedNewSession is { } proposed)
         {
-            var sessionDate = proposed.Date ?? DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd");
+            var dateOnly = proposed.Date ?? DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd");
+            var sessionDate = reflectionExtraction.SessionStartTime is { } t
+                ? $"{dateOnly}T{t}"
+                : dateOnly;
             var newSessionPayload = new { title = proposed.Title, sessionDate };
             var payloadElement = JsonSerializer.SerializeToElement(newSessionPayload, camelCaseOpts);
             proposals.Add(new ProposalDto(

--- a/backend/LangTeach.Api/Services/StubReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/StubReflectionExtractionService.cs
@@ -20,7 +20,9 @@ public class StubReflectionExtractionService : IReflectionExtractionService
         var isNewSession = !hasOpenSession &&
             (text.Contains("[schedule-new-session]") || text.Contains("[schedule-new-session-no-date]"));
         var newSessionTitle = isNewSession ? "[Extracted] New Session Title" : null;
-        var newSessionDate = isNewSession && text.Contains("[schedule-new-session]") ? "2026-05-19" : null;
+        var isNoDateTrigger = text.Contains("[schedule-new-session-no-date]");
+        var newSessionDate = isNewSession && !isNoDateTrigger ? "2026-05-19" : null;
+        var newSessionStartTime = isNewSession && !isNoDateTrigger ? "09:00" : null;
 
         return Task.FromResult(new ExtractedReflectionDto(
             WhatWasCovered: isNewSession ? null : new ExtractedTextFieldDto("[Extracted] What was covered", ExtractionMode.Replace),
@@ -40,7 +42,7 @@ public class StubReflectionExtractionService : IReflectionExtractionService
             DurationMinutes: null,
             IsCancelled: null,
             DifficultiesWorkedOn: [],
-            SessionStartTime: "09:00",
+            SessionStartTime: newSessionStartTime ?? (isNewSession ? null : "09:00"),
             ProposedNewSession: newSessionTitle is not null ? new ProposedNewSession(newSessionTitle, newSessionDate) : null
         ));
     }

--- a/frontend/src/components/AtelierAssistantPanel.test.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.test.tsx
@@ -725,6 +725,35 @@ describe('AtelierAssistantPanel', () => {
     })
   })
 
+  // ---- Apply All Remaining blocked when session picker active ----------------
+
+  describe('applyAllBlocked when session picker active', () => {
+    const sessionProposal = makeProposal({ id: 'sp1', type: 'session', field: 'title', label: 'Session Title', oldValue: null, newValue: 'Past Perfect' })
+    const todoProposal = makeProposal({ id: 'tp1', type: 'todo', field: 'todo', label: 'Teaching Todo', oldValue: null, newValue: 'Practice subjunctive' })
+
+    it('disables Apply All when session proposals exist and no session selected, even with mixed proposals', () => {
+      renderPanel({
+        transcription: 'Past perfect class',
+        proposals: [sessionProposal, todoProposal],
+        sessionId: null,
+        studentId: 'student-1',
+      })
+      const btn = screen.getByTestId('apply-all-btn')
+      expect(btn).toBeDisabled()
+    })
+
+    it('enables Apply All once a session is selected', () => {
+      renderPanel({
+        transcription: 'Past perfect class',
+        proposals: [sessionProposal, todoProposal],
+        sessionId: 'session-1',
+        studentId: 'student-1',
+      })
+      const btn = screen.getByTestId('apply-all-btn')
+      expect(btn).not.toBeDisabled()
+    })
+  })
+
   // ---- session picker banner -------------------------------------------------
 
   describe('session picker banner', () => {

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -297,7 +297,7 @@ export default function AtelierAssistantPanel({
   const pendingProposals = proposals.filter(p => p.status === 'proposed')
   const applyAllBlocked = (
     (!studentId && pendingProposals.some(p => p.type === 'newSession')) ||
-    (hasSessionProposalsWithoutContext && pendingProposals.every(p => p.type === 'session'))
+    hasSessionProposalsWithoutContext
   )
 
   return (

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -123,3 +123,5 @@ Pre-existing (unrelated to PR):
 ## #1192 -- Corregir race condition (CodeRabbit, 2026-05-10)
 
 The read-then-write in CorregirAsync (check Status == Entregada, then set Corrigiendo) lacks atomic compare-and-swap. Two concurrent requests on the same correction can both observe Entregada and spawn duplicate background AI tasks. The TOCTOU guard in RunCorrectionInScopeAsync prevents duplicate tag rows, but two Claude calls can still fire. Fix: add [Timestamp] RowVersion to Correction entity + catch DbUpdateConcurrencyException in CorregirAsync.
+
+| #1200/#1201 | 2026-05-10 | arch | Low | `AssistantController` lines 196-200: date+time combination logic belongs in `ReflectionExtractionService` (pre-existing violation, diff extends it; not blocking) |


### PR DESCRIPTION
## Summary

- **#1200 (backend)**: `AssistantController` now combines `SessionStartTime` with the proposed date into a full ISO datetime (`YYYY-MM-DDTHH:MM`) when `SessionStartTime` is non-null. Previously the extracted start time was silently dropped and new sessions saved with time 00:00.
- **#1201 (frontend)**: `applyAllBlocked` now triggers whenever `hasSessionProposalsWithoutContext` is true, not only when every pending proposal is session-type. This ensures "Apply All Remaining" is disabled any time the session picker is visible and no session has been selected yet, even when mixed proposal types are present (e.g. session + todo).

## Test plan

- [x] New backend integration test `Propose_WithSchedulingIntentAndTime_CombinesDateAndTimeInPayload` asserts `sessionDate == "2026-05-19T09:00"`
- [x] Existing `Propose_WithSchedulingIntentButNoDate_DefaultsPayloadDateToToday` still passes (stub updated to return null `SessionStartTime` for no-date trigger)
- [x] New frontend tests: "disables Apply All when session proposals exist and no session selected, even with mixed proposals" and "enables Apply All once a session is selected"
- [x] Build verify: all 26 backend + 62 frontend tests pass
- [x] UI review: PASS (Apply All correctly disabled with session picker visible, individual session cards greyed out, non-session cards remain active)

Closes #1200
Closes #1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session proposals now intelligently combine date and time fields into a single ISO datetime format when scheduling.

* **Bug Fixes**
  * Fixed "Apply All Remaining" button to correctly disable when session proposals exist without a selected session context.

* **Tests**
  * Added integration tests for date/time combination in scheduling proposals.
  * Added test coverage for "Apply All Remaining" button state management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1202)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->