### PR TITLE
fix(#1207): remove originalText echo, add CorreccionFallida status

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs
@@ -116,17 +116,16 @@ public class RedaccionCorrectionPromptBuilderTests
     [Fact]
     public void Build_WrapsStudentTextInVerbatimMarkers()
     {
-        // Defense in depth alongside temperature=0: explicit delimiters + a "byte-for-byte"
-        // instruction make it harder for the model to silently smooth the echo. Markers use
-        // a per-request nonce ("STUDENT_TEXT_VERBATIM_<guid>") so they cannot collide with
-        // user-controlled student text.
+        // Markers use a per-request nonce ("STUDENT_TEXT_VERBATIM_<guid>") so they cannot
+        // collide with user-controlled student text. The label tells the model that tag
+        // offsets must reference this text exactly.
         var ctx = MakeCtx() with { StudentText = "Hoy ablar con mi amigo." };
         var prompt = _builder.Build(ctx).UserPrompt;
 
         prompt.Should().MatchRegex("<<<STUDENT_TEXT_VERBATIM_[0-9a-f]{32}>>>");
         prompt.Should().MatchRegex("<<</STUDENT_TEXT_VERBATIM_[0-9a-f]{32}>>>");
         prompt.Should().Contain("Hoy ablar con mi amigo.");
-        prompt.Should().Contain("byte-for-byte");
+        prompt.Should().Contain("offsets must reference this text exactly");
     }
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionServiceTests.cs
@@ -88,7 +88,7 @@ public class RedaccionCorrectionServiceTests : IDisposable
         var text = "Hoy ablar con mi amigo.";
         var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
 
-        _claude.EnqueueResponse(BuildAiJson(text, new[]
+        _claude.EnqueueResponse(BuildAiJson(new[]
         {
             ("O", text.IndexOf("ablar"), text.IndexOf("ablar") + "ablar".Length, "ablar",
                 "Falta la 'h'.", "hablar"),
@@ -107,7 +107,7 @@ public class RedaccionCorrectionServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task CorregirAsync_NonJsonResponse_ReturnsCorrigiendoAndBackgroundFailsSilently()
+    public async Task CorregirAsync_NonJsonResponse_SetsCorreccionFallida()
     {
         var id = SeedCorrection(text: "Texto.", status: CorrectionStatus.Entregada);
         _claude.EnqueueResponse("definitely not JSON");
@@ -115,63 +115,33 @@ public class RedaccionCorrectionServiceTests : IDisposable
         var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
         result.Status.Should().Be(CorrectionStatus.Corrigiendo);
 
-        // Give the background task time to run and fail; it logs the error and leaves
-        // status as Corrigiendo (staleness recovery resets after 60 seconds on next GET).
-        await Task.Delay(300);
+        await Task.Delay(500);
 
         using var check = new AppDbContext(_dbOptions);
         var row = check.Corrections.First(c => c.Id == id);
-        row.Status.Should().Be(CorrectionStatus.Corrigiendo, "background task failed silently; staleness recovery resets after 60s");
+        row.Status.Should().Be(CorrectionStatus.CorreccionFallida, "background task must surface the failure explicitly");
         row.CorrectedAt.Should().BeNull();
         check.CorrectionTags.Where(t => t.CorrectionId == id).Should().BeEmpty();
     }
 
     [Fact]
-    public async Task CorregirAsync_ParaphrasedOriginalText_BothAttempts_BackgroundTaskFailsSilently()
+    public async Task CorregirAsync_BadSchemaVersion_SetsCorreccionFallida()
     {
-        // Issue #1166: when BOTH attempts paraphrase, background task logs and leaves Corrigiendo.
+        // When the model returns a response with an unsupported schemaVersion,
+        // the background task must surface CorreccionFallida rather than failing silently.
         var id = SeedCorrection(text: "Texto original.", status: CorrectionStatus.Entregada);
-        _claude.EnqueueResponse(BuildAiJson("Different text.", Array.Empty<(string, int, int, string, string, string)>()));
-        _claude.EnqueueResponse(BuildAiJson("Yet another paraphrase.", Array.Empty<(string, int, int, string, string, string)>()));
+        _claude.EnqueueResponse("""{"schemaVersion":99,"tags":[]}""");
 
         var result = await _sut.CorregirAsync(_teacherId, _studentId, id);
         result.Status.Should().Be(CorrectionStatus.Corrigiendo);
 
-        await Task.Delay(300);
+        await Task.Delay(500);
 
-        _claude.CompleteCallCount.Should().Be(2, "the service must retry exactly once before giving up");
-        using var check2 = new AppDbContext(_dbOptions);
-        var row2 = check2.Corrections.First(c => c.Id == id);
-        row2.Status.Should().Be(CorrectionStatus.Corrigiendo, "background task failed silently; staleness recovery resets after 60s");
-        check2.CorrectionTags.Where(t => t.CorrectionId == id).Should().BeEmpty();
-    }
-
-    [Fact]
-    public async Task CorregirAsync_ParaphrasedThenVerbatim_RetrySucceeds()
-    {
-        // Issue #1166: a single paraphrased response triggers exactly one retry; if the
-        // second attempt echoes verbatim, the correction succeeds without surfacing an
-        // error to the teacher.
-        var text = "Hoy ablar con mi amigo.";
-        var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
-
-        // First call: paraphrased originalText (model "fixed" the typo while echoing)
-        _claude.EnqueueResponse(BuildAiJson("Hoy hablar con mi amigo.", Array.Empty<(string, int, int, string, string, string)>()));
-        // Second call: verbatim originalText with the expected O tag on "ablar"
-        _claude.EnqueueResponse(BuildAiJson(text, new[]
-        {
-            ("O", text.IndexOf("ablar"), text.IndexOf("ablar") + "ablar".Length, "ablar",
-                "Falta la 'h'.", "hablar"),
-        }));
-
-        var immediate = await _sut.CorregirAsync(_teacherId, _studentId, id);
-        immediate.Status.Should().Be(CorrectionStatus.Corrigiendo);
-
-        var row = await WaitForDbStatusAsync(id, CorrectionStatus.Corregida);
-
-        _claude.CompleteCallCount.Should().Be(3, "two Pass 1 calls (first paraphrased, second verbatim) plus one Pass 2 level-filter call");
-        row.Tags.Should().HaveCount(1);
-        row.Tags.First().SpannedText.Should().Be("ablar");
+        _claude.CompleteCallCount.Should().Be(1, "no retry loop -- single call");
+        using var check = new AppDbContext(_dbOptions);
+        var row = check.Corrections.First(c => c.Id == id);
+        row.Status.Should().Be(CorrectionStatus.CorreccionFallida, "background task must surface the failure explicitly");
+        check.CorrectionTags.Where(t => t.CorrectionId == id).Should().BeEmpty();
     }
 
     [Fact]
@@ -181,7 +151,7 @@ public class RedaccionCorrectionServiceTests : IDisposable
         var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
 
         // First tag has a bogus offset (out of range); second tag is valid.
-        _claude.EnqueueResponse(BuildAiJson(text, new[]
+        _claude.EnqueueResponse(BuildAiJson(new[]
         {
             ("O", 100, 110, "ablar", "Bad offset.", "hablar"),
             ("O", text.IndexOf("ablar"), text.IndexOf("ablar") + "ablar".Length, "ablar",
@@ -200,7 +170,7 @@ public class RedaccionCorrectionServiceTests : IDisposable
     {
         var text = "Hoy ablar con amigos.";
         var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
-        _claude.EnqueueResponse(BuildAiJson(text, new[]
+        _claude.EnqueueResponse(BuildAiJson(new[]
         {
             ("O", 4, 9, "ablar", "Falta h.", "hablar"),
             ("G", 6, 12, "lar co", "Bad overlap.", "lar co"),
@@ -218,7 +188,7 @@ public class RedaccionCorrectionServiceTests : IDisposable
     {
         var text = "El subjuntivo está bien usado.";
         var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
-        _claude.EnqueueResponse(BuildAiJson(text, new[]
+        _claude.EnqueueResponse(BuildAiJson(new[]
         {
             ("MuyBien", 3, 13, "subjuntivo", "Should be null.", "should also be null"),
         }));
@@ -236,7 +206,7 @@ public class RedaccionCorrectionServiceTests : IDisposable
     {
         var text = "Texto con error.";
         var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
-        _claude.EnqueueResponse(BuildAiJson(text, new[]
+        _claude.EnqueueResponse(BuildAiJson(new[]
         {
             ("G", 0, 5, "Texto", "", "Texto"),
         }));
@@ -273,7 +243,7 @@ public class RedaccionCorrectionServiceTests : IDisposable
             });
             await concurrentDb.SaveChangesAsync();
         };
-        _claude.EnqueueResponse(BuildAiJson(text, new[]
+        _claude.EnqueueResponse(BuildAiJson(new[]
         {
             ("O", 4, 9, "ablar", "Stub call.", "hablar"),
         }));
@@ -306,7 +276,7 @@ public class RedaccionCorrectionServiceTests : IDisposable
         var cStart = text.IndexOf("entonces");             var cEnd = cStart + "entonces".Length;
 
         var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
-        _claude.EnqueueResponse(BuildAiJson(text, new[]
+        _claude.EnqueueResponse(BuildAiJson(new[]
         {
             ("O", oStart, oEnd, "Misspelll", "tilde/letras.", "Mispell"),
             ("G", gStart, gEnd, "voy en casa", "Preposición.", "voy a casa"),
@@ -398,12 +368,10 @@ public class RedaccionCorrectionServiceTests : IDisposable
     }
 
     private static string BuildAiJson(
-        string originalText,
         IEnumerable<(string category, int start, int end, string spanned, string explanation, string correctedForm)> tags) =>
         JsonSerializer.Serialize(new
         {
             schemaVersion = 1,
-            originalText,
             tags = tags.Select(t => new
             {
                 category = t.category,

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -33,10 +33,9 @@ public class RedaccionCorrectionPromptBuilder
             "PromptUser | blockType=redaccion-correction l1={L1}\n{UserPrompt}",
             ctx.StudentL1 ?? "(none)", user);
 
-        // temperature=0: the verbatim originalText echo is non-negotiable; default sampling
-        // (1.0) leads the model to silently smooth typos and normalize punctuation while
-        // copying the student text into originalText, which then fails the strict ordinal
-        // guard in RedaccionCorrectionService. Sonnet 4.6 still supports temperature.
+        // temperature=0: deterministic offset generation -- spannedText must locate uniquely
+        // via indexOf in the student text; sampling variation leads the model to rephrase
+        // spannedText, breaking the rescue logic in ValidateAndOrderTags.
         return new ClaudeRequest(system, user, ClaudeModel.Sonnet, MaxTokens: 4096, Temperature: 0);
     }
 
@@ -90,7 +89,7 @@ OFFSETS (read carefully — accented characters cause silent errors if you count
   2. Write the explanation.
   3. Locate spannedText inside the student text using a forward string search (like indexOf / find), starting from position 0.
   4. Set startIndex to the result of that search. Set endIndex = startIndex + length(spannedText).
-- spannedText MUST equal studentText.Substring(startIndex, endIndex - startIndex).
+- spannedText MUST equal the student text at [startIndex, endIndex).
 - If spannedText would appear more than once in the student text, choose a longer or more specific span that is unique. Tags whose spannedText cannot be located unambiguously will be dropped.
 - Tags MUST NOT overlap. Sort tags by startIndex.
 """;
@@ -133,7 +132,7 @@ OFFSETS (read carefully — accented characters cause silent errors if you count
         while (ctx.StudentText.Contains(marker, StringComparison.Ordinal))
             marker = "STUDENT_TEXT_VERBATIM_" + Guid.NewGuid().ToString("N");
 
-        sb.AppendLine($"STUDENT TEXT (copy byte-for-byte into originalText; see OUTPUT CONTRACT for why; the text appears between the <<<{marker}>>> ... <<</{marker}>>> marker lines below):");
+        sb.AppendLine($"STUDENT TEXT (your tag offsets must reference this text exactly; see OUTPUT CONTRACT; the text appears between the <<<{marker}>>> ... <<</{marker}>>> marker lines below):");
         sb.AppendLine($"<<<{marker}>>>");
         sb.AppendLine(ctx.StudentText);
         sb.AppendLine($"<<</{marker}>>>");

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -68,13 +68,12 @@ Emit raw JSON only. No prose before or after. No markdown fences. The JSON must 
 
 {
   "schemaVersion": 1,
-  "originalText": "...the student text...",
   "tags": [
     {
       "category": "G" | "C" | "L" | "O",
       "startIndex": <int>,
       "endIndex": <int>,
-      "spannedText": "<exact substring of originalText[startIndex..endIndex]>",
+      "spannedText": "<exact substring of the student text at [startIndex..endIndex]>",
       "explanation": "<short, in Spanish>",
       "correctedForm": "<the corrected form>"
     }
@@ -84,18 +83,16 @@ Emit raw JSON only. No prose before or after. No markdown fences. The JSON must 
 "explanation" and "correctedForm" are always non-empty for every tag.
 
 OFFSETS (read carefully — accented characters cause silent errors if you count positions):
-- startIndex and endIndex are Unicode character offsets into originalText (0-based, end-exclusive).
+- startIndex and endIndex are Unicode character offsets into the student text between the markers (0-based, end-exclusive).
 - DO NOT derive offsets by counting characters forward from the start of the text. Counting is unreliable near accented characters (é, ó, á, ñ, ü, etc.) because your internal position tracking may not match the host's character indices.
 - CORRECT procedure for every tag:
-  1. Decide which substring of originalText to mark; that substring is spannedText.
+  1. Decide which substring of the student text to mark; that substring is spannedText.
   2. Write the explanation.
-  3. Locate spannedText inside originalText using a forward string search (like indexOf / find), starting from position 0.
+  3. Locate spannedText inside the student text using a forward string search (like indexOf / find), starting from position 0.
   4. Set startIndex to the result of that search. Set endIndex = startIndex + length(spannedText).
-- spannedText MUST equal originalText.Substring(startIndex, endIndex - startIndex).
-- If spannedText would appear more than once in originalText, choose a longer or more specific span that is unique. Tags whose spannedText cannot be located unambiguously will be dropped.
+- spannedText MUST equal studentText.Substring(startIndex, endIndex - startIndex).
+- If spannedText would appear more than once in the student text, choose a longer or more specific span that is unique. Tags whose spannedText cannot be located unambiguously will be dropped.
 - Tags MUST NOT overlap. Sort tags by startIndex.
-
-Copy the student text byte-for-byte into the originalText field, preserving every typo, missing accent, and punctuation mark exactly as written between the STUDENT_TEXT_VERBATIM_... marker lines in the user prompt. Do not normalize or rewrite. The errors and irregularities are precisely the signal we are here to mark - if you silently "fix" them during the echo, the corresponding tags lose their anchor and the correction is unusable.
 """;
 
     private string BuildUserPrompt(RedaccionCorrectionPromptContext ctx)

--- a/backend/LangTeach.Api/Data/AppDbContext.cs
+++ b/backend/LangTeach.Api/Data/AppDbContext.cs
@@ -377,7 +377,7 @@ public class AppDbContext : DbContext
         {
             e.ToTable(t => t.HasCheckConstraint(
                 "CK_Corrections_Status",
-                "Status COLLATE Latin1_General_100_BIN2 IN ('Pendiente', 'Entregada', 'Corrigiendo', 'Corregida')"));
+                "Status COLLATE Latin1_General_100_BIN2 IN ('Pendiente', 'Entregada', 'Corrigiendo', 'Corregida', 'CorreccionFallida')"));
             e.HasKey(c => c.Id);
             e.HasIndex(c => new { c.TeacherId, c.DeletedAt });
             e.HasIndex(c => new { c.StudentId, c.DeletedAt });

--- a/backend/LangTeach.Api/Data/Models/CorrectionStatus.cs
+++ b/backend/LangTeach.Api/Data/Models/CorrectionStatus.cs
@@ -10,7 +10,9 @@ public static class CorrectionStatus
     public const string Entregada = "Entregada";
     public const string Corrigiendo = "Corrigiendo";
     public const string Corregida = "Corregida";
+    public const string CorreccionFallida = "CorreccionFallida";
 
     public static bool IsValid(string value) =>
-        value == Pendiente || value == Entregada || value == Corrigiendo || value == Corregida;
+        value == Pendiente || value == Entregada || value == Corrigiendo
+        || value == Corregida || value == CorreccionFallida;
 }

--- a/backend/LangTeach.Api/Migrations/20260510120000_AddCorreccionFallidaStatus.Designer.cs
+++ b/backend/LangTeach.Api/Migrations/20260510120000_AddCorreccionFallidaStatus.Designer.cs
@@ -4,6 +4,7 @@ using LangTeach.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LangTeach.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510120000_AddCorreccionFallidaStatus")]
+    partial class AddCorreccionFallidaStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/LangTeach.Api/Migrations/20260510120000_AddCorreccionFallidaStatus.cs
+++ b/backend/LangTeach.Api/Migrations/20260510120000_AddCorreccionFallidaStatus.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LangTeach.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCorreccionFallidaStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_Corrections_Status",
+                table: "Corrections");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_Corrections_Status",
+                table: "Corrections",
+                sql: "Status COLLATE Latin1_General_100_BIN2 IN ('Pendiente', 'Entregada', 'Corrigiendo', 'Corregida', 'CorreccionFallida')");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_Corrections_Status",
+                table: "Corrections");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_Corrections_Status",
+                table: "Corrections",
+                sql: "Status COLLATE Latin1_General_100_BIN2 IN ('Pendiente', 'Entregada', 'Corrigiendo', 'Corregida')");
+        }
+    }
+}

--- a/backend/LangTeach.Api/Schemas/redaccion-correction.schema.json
+++ b/backend/LangTeach.Api/Schemas/redaccion-correction.schema.json
@@ -2,18 +2,14 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://langteach.local/schemas/redaccion-correction.schema.json",
   "title": "RedaccionCorrectionOutput",
-  "description": "Structured output of the redaccion correction prompt (#1153). Tag indices are character offsets into originalText. Tags MUST NOT overlap.",
+  "description": "Structured output of the redaccion correction prompt (#1153). Tag indices are character offsets into the stored StudentText. Tags MUST NOT overlap.",
   "type": "object",
-  "required": ["schemaVersion", "originalText", "tags"],
+  "required": ["schemaVersion", "tags"],
   "additionalProperties": false,
   "properties": {
     "schemaVersion": {
       "type": "integer",
       "const": 1
-    },
-    "originalText": {
-      "type": "string",
-      "minLength": 1
     },
     "tags": {
       "type": "array",

--- a/backend/LangTeach.Api/Services/CorrectionService.cs
+++ b/backend/LangTeach.Api/Services/CorrectionService.cs
@@ -133,9 +133,9 @@ public class CorrectionService : ICorrectionService
 
             var trimmed = string.IsNullOrWhiteSpace(request.StudentText) ? null : request.StudentText;
             correction.StudentText = trimmed;
-            if (trimmed is not null && correction.Status == CorrectionStatus.Pendiente)
+            if (trimmed is not null && correction.Status is CorrectionStatus.Pendiente or CorrectionStatus.CorreccionFallida)
                 correction.Status = CorrectionStatus.Entregada;
-            else if (trimmed is null && correction.Status == CorrectionStatus.Entregada)
+            else if (trimmed is null && correction.Status is CorrectionStatus.Entregada or CorrectionStatus.CorreccionFallida)
                 correction.Status = CorrectionStatus.Pendiente;
         }
 

--- a/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
+++ b/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
@@ -58,7 +58,7 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
         if (correction.Status == CorrectionStatus.Corregida)
             throw new CorrectionInvalidStateException("already_corrected",
                 "This redacción has already been corrected.");
-        if (correction.Status != CorrectionStatus.Entregada)
+        if (correction.Status is not CorrectionStatus.Entregada and not CorrectionStatus.CorreccionFallida)
             throw new CorrectionInvalidStateException("invalid_status",
                 $"Unexpected status: {correction.Status}.");
 
@@ -83,9 +83,28 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
             }
             catch (Exception ex)
             {
-                (scopeLogger ?? outerLogger).LogError(ex,
-                    "Background correction failed silently; row stays Corrigiendo until CorrectionService.ListAsync staleness sweep resets it to Entregada. CorrectionId={CorrectionId} TeacherId={TeacherId} StudentId={StudentId}",
+                var errLogger = scopeLogger ?? outerLogger;
+                errLogger.LogError(ex,
+                    "Background correction failed; setting CorreccionFallida. CorrectionId={CorrectionId} TeacherId={TeacherId} StudentId={StudentId}",
                     correctionId, teacherId, studentId);
+                try
+                {
+                    using var failScope = _scopeFactory.CreateScope();
+                    var failDb = failScope.ServiceProvider.GetRequiredService<AppDbContext>();
+                    var failRow = await failDb.Corrections
+                        .FirstOrDefaultAsync(c => c.Id == correctionId && c.DeletedAt == null);
+                    if (failRow is not null && failRow.Status == CorrectionStatus.Corrigiendo)
+                    {
+                        failRow.Status = CorrectionStatus.CorreccionFallida;
+                        failRow.UpdatedAt = DateTime.UtcNow;
+                        await failDb.SaveChangesAsync();
+                    }
+                }
+                catch (Exception saveEx)
+                {
+                    errLogger.LogError(saveEx,
+                        "Failed to persist CorreccionFallida status. CorrectionId={CorrectionId}", correctionId);
+                }
             }
         });
 
@@ -134,56 +153,30 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
         var request = promptBuilder.Build(ctx);
         var sentText = ctx.StudentText.TrimEnd();
 
-        const int MaxAttempts = 2;
-        ClaudeResponse response = null!;
-        string? stripped = null;
-        RedaccionCorrectionDto dto = null!;
-        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+        var response = await claude.CompleteAsync(request, CancellationToken.None);
+
+        var raw = response.Content;
+        var stripped = ContentJsonHelper.StripFences(raw);
+        if (string.IsNullOrWhiteSpace(stripped))
         {
-            response = await claude.CompleteAsync(request, CancellationToken.None);
+            logger.LogWarning("Background correction: empty/blank Claude response. CorrectionId={CorrectionId}", correctionId);
+            throw new InvalidOperationException("Claude returned empty content.");
+        }
 
-            var raw = response.Content;
-            stripped = ContentJsonHelper.StripFences(raw);
-            if (string.IsNullOrWhiteSpace(stripped))
-            {
-                logger.LogWarning("Background correction: empty/blank Claude response. CorrectionId={CorrectionId}", correctionId);
-                throw new InvalidOperationException("Claude returned empty content.");
-            }
-
-            RedaccionCorrectionDto? parsed;
-            try
-            {
-                parsed = JsonSerializer.Deserialize<RedaccionCorrectionDto>(stripped, JsonOpts);
-            }
-            catch (JsonException ex)
-            {
-                var excerpt = stripped.Length > 200 ? stripped[..200] + "..." : stripped;
-                logger.LogWarning(ex, "Background correction: failed to parse JSON. CorrectionId={CorrectionId} Excerpt={Excerpt}",
-                    correctionId, excerpt);
-                throw new InvalidOperationException("Claude response did not parse as the expected JSON shape.", ex);
-            }
-
+        RedaccionCorrectionDto dto;
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<RedaccionCorrectionDto>(stripped, JsonOpts);
             if (parsed is null || parsed.SchemaVersion != 1)
                 throw new InvalidOperationException("Claude response is missing or has an unsupported schemaVersion.");
-
-            if (string.Equals(parsed.OriginalText, sentText, StringComparison.Ordinal))
-            {
-                dto = parsed;
-                break;
-            }
-
-            if (attempt < MaxAttempts)
-            {
-                logger.LogWarning(
-                    "Background correction: originalText mismatch on attempt {Attempt}/{MaxAttempts}; retrying once. CorrectionId={CorrectionId} SentLen={SentLen} ReturnedLen={ReturnedLen}",
-                    attempt, MaxAttempts, correctionId, sentText.Length, parsed.OriginalText?.Length ?? 0);
-                continue;
-            }
-
-            logger.LogWarning(
-                "Background correction: originalText mismatch after {MaxAttempts} attempts. CorrectionId={CorrectionId} SentLen={SentLen} ReturnedLen={ReturnedLen}",
-                MaxAttempts, correctionId, sentText.Length, parsed.OriginalText?.Length ?? 0);
-            throw new InvalidOperationException("Claude returned a paraphrased originalText; tag offsets cannot be trusted.");
+            dto = parsed;
+        }
+        catch (JsonException ex)
+        {
+            var excerpt = stripped.Length > 200 ? stripped[..200] + "..." : stripped;
+            logger.LogWarning(ex, "Background correction: failed to parse JSON. CorrectionId={CorrectionId} Excerpt={Excerpt}",
+                correctionId, excerpt);
+            throw new InvalidOperationException("Claude response did not parse as the expected JSON shape.", ex);
         }
 
         var validatedTags = ValidateAndOrderTags(dto.Tags ?? [], sentText, correctionId, logger);
@@ -519,7 +512,6 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
     // can construct fixture payloads against the same shape the production code parses.
     public record RedaccionCorrectionDto(
         [property: JsonPropertyName("schemaVersion")] int SchemaVersion,
-        [property: JsonPropertyName("originalText")] string OriginalText,
         [property: JsonPropertyName("tags")] IReadOnlyList<RedaccionCorrectionTagDto>? Tags);
 
     public record RedaccionCorrectionTagDto(

--- a/frontend/src/api/corrections.ts
+++ b/frontend/src/api/corrections.ts
@@ -1,7 +1,7 @@
 import { apiClient } from '../lib/apiClient'
 import { triggerBlobDownload } from '../lib/downloadBlob'
 
-export type CorrectionStatus = 'Pendiente' | 'Entregada' | 'Corrigiendo' | 'Corregida'
+export type CorrectionStatus = 'Pendiente' | 'Entregada' | 'Corrigiendo' | 'Corregida' | 'CorreccionFallida'
 export type CorrectionTagCategory = 'C' | 'G' | 'L' | 'O' | 'MuyBien'
 
 export interface CorrectionSummary {

--- a/frontend/src/components/student/RedaccionesTab.tsx
+++ b/frontend/src/components/student/RedaccionesTab.tsx
@@ -28,6 +28,15 @@ const STATUS_BADGE: Record<CorrectionStatus, string> = {
   Entregada: 'bg-indigo-50 text-indigo-700',
   Corrigiendo: 'bg-amber-50 text-amber-800',
   Corregida: 'bg-emerald-50 text-emerald-800',
+  CorreccionFallida: 'bg-red-50 text-red-700',
+}
+
+const STATUS_LABEL: Record<CorrectionStatus, string> = {
+  Pendiente: 'Pendiente',
+  Entregada: 'Entregada',
+  Corrigiendo: 'Corrigiendo',
+  Corregida: 'Corregida',
+  CorreccionFallida: 'Error al corregir',
 }
 
 const TITLE_MAX = 200
@@ -211,7 +220,8 @@ function CorrectionCard({
   const { id, assignmentTitle, status, createdAt } = correction
   const isCorregida = status === 'Corregida'
   const isCorrigiendo = status === 'Corrigiendo'
-  const showCorregir = status === 'Entregada'
+  const isFallida = status === 'CorreccionFallida'
+  const showCorregir = status === 'Entregada' || isFallida
 
   function openDetail() {
     navigate(`/students/${studentId}/redacciones/${id}`)
@@ -240,7 +250,8 @@ function CorrectionCard({
               data-testid={`redaccion-status-${id}`}
             >
               {isCorrigiendo && <span className="h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse" />}
-              {status}
+              {isFallida && <span className="h-1.5 w-1.5 rounded-full bg-red-500" />}
+              {STATUS_LABEL[status]}
             </span>
             <span className="text-xs text-zinc-400" data-testid={`redaccion-date-${id}`}>
               {relativeTime(createdAt)}
@@ -257,7 +268,7 @@ function CorrectionCard({
               onClick={onCorregir}
               data-testid={`redaccion-corregir-${id}`}
             >
-              Corregir
+              {isFallida ? 'Reintentar' : 'Corregir'}
             </Button>
           )}
           {!isCorregida && !isCorrigiendo && (

--- a/frontend/src/pages/RedaccionDetail.tsx
+++ b/frontend/src/pages/RedaccionDetail.tsx
@@ -82,6 +82,7 @@ export default function RedaccionDetail() {
   const isCorregida = data.status === 'Corregida'
   const isEntregada = data.status === 'Entregada'
   const isPendiente = data.status === 'Pendiente'
+  const isFallida = data.status === 'CorreccionFallida'
 
   return (
     <div className="mx-auto w-full max-w-3xl space-y-6 p-6">
@@ -121,6 +122,18 @@ export default function RedaccionDetail() {
         <p className="text-sm text-zinc-600">
           Esta redacción aún está pendiente. El estudiante todavía no ha entregado el texto.
         </p>
+      )}
+
+      {isFallida && data.studentText && (
+        <div className="space-y-4">
+          <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800">
+            La corrección automática no se pudo completar. Puedes volver a intentarlo.
+          </div>
+          <ReadingColumn text={data.studentText} />
+          <Button onClick={() => corregir.mutate()} disabled={corregir.isPending}>
+            Reintentar corrección
+          </Button>
+        </div>
       )}
 
       {isEntregada && data.studentText && viewState === 'idle' && (
@@ -294,12 +307,14 @@ function StatusPill({ status, viewState }: StatusPillProps) {
     Entregada: 'bg-indigo-50 text-indigo-700',
     Corrigiendo: 'bg-amber-50 text-amber-800',
     Corregida: 'bg-emerald-50 text-emerald-800',
+    CorreccionFallida: 'bg-red-50 text-red-700',
   }
+  const label = status === 'CorreccionFallida' ? 'Error al corregir' : status
   return (
     <span
       className={`inline-flex items-center rounded-full px-2.5 py-1 text-[0.6875rem] font-semibold uppercase tracking-wide ${palette[status]}`}
     >
-      {status}
+      {label}
     </span>
   )
 }

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -8,6 +8,9 @@ Out-of-scope observations logged by agents during implementation. Each row is so
 | #1203 | 2026-05-10 | low | Sophy: ser/estar worked examples and register-mismatch examples are hardcoded in C# SystemPrompt literals. Long-term they belong in JSON config alongside grammar scope data. |
 | #1203 | 2026-05-10 | low | Prompt health: redundant verbatim-echo rationale appears twice in Pass 1 prompt (line 84 and line 98 paragraph). Minor cleanup opportunity. |
 | #1192 | 2026-05-09 | low | No dedicated test asserting `refetchInterval` is 3000ms when Corrigiendo cards exist -- only behavior-level coverage via component test |
+| #1207 | 2026-05-10 | low | Arch: STATUS_BADGE (CSS) and status label are split across two Record maps in RedaccionesTab.tsx; RedaccionDetail.tsx has its own parallel palette Record. Should unify into a shared constants file as statuses grow. |
+| #1207 | 2026-05-10 | low | Code: CorreccionFallida failure tests use Task.Delay(500) instead of the existing WaitForDbStatusAsync polling helper; could be flaky on slow CI. |
+| #1207 | 2026-05-10 | low | Code: RedaccionDetail.tsx Reintentar button missing data-testid (inconsistent with RedaccionesTab.tsx pattern). |
 | #1192 | 2026-05-09 | low | Corrigiendo badge with amber pulse dot not visually verified (no seeded Corrigiendo correction in Ana Visual's data; would need a dedicated seed) |
 | #1185 | 2026-05-09 | low | Atelier session picker (inline pick-list inside AI proposals area) has no design system spec; picker rows use ghost-button style with hover-bg but no selected/active state defined -- needs Vera discussion before pattern is reused |
 | #smoke-text-correction | 2026-05-09 | low | Atelier assistant extracted phantom profile data (profession "Engineer", country "Spain", interests "Travel, Cooking") from a session note that contained none of that information -- extraction model may be hallucinating updates from prior context rather than the current transcript |


### PR DESCRIPTION
Fixes #1207

## Root cause

After #1203 removed `STUDENT LEVEL` and `LevelCalibrationCue` from the Pass 1 prompt, Sonnet 4.6 (temperature=0) deterministically dropped the letter sign-off (`\n\nUn saludo,\nGavin`, 18 chars) when echoing `originalText`. The echo check threw `InvalidOperationException: Claude returned a paraphrased originalText`, leaving the record in `Corrigiendo` until the 60s staleness sweep reset it to `Entregada`.

## Solution (discussed with Sophy)

**Part 1 -- Remove `originalText` echo**

The echo was never the real protection -- `spannedText` is. `ValidateAndOrderTags` already checks `studentText.Substring(startIndex, endIndex-startIndex) == spannedText` and rescues drift offsets via `indexOf`. The echo added complexity and fragility without correctness guarantees. Removing it eliminates the failure, shrinks output tokens, and simplifies the service.

**Part 2 -- Add `CorreccionFallida` status**

Failures were silent (log + 60s staleness reset). Now the catch block sets `CorreccionFallida` explicitly and saves. The teacher sees a red "Error al corregir" badge with a "Reintentar" button. Staleness sweep still handles crash recovery (abandoned `Corrigiendo` rows).

## Changes

- `RedaccionCorrectionPromptBuilder.cs` -- remove `originalText` from output contract; update offset instructions
- `redaccion-correction.schema.json` -- remove `originalText` field
- `RedaccionCorrectionService.cs` -- delete echo comparison loop; catch block sets `CorreccionFallida`; accept `CorreccionFallida` as retry source state
- `RedaccionCorrectionDto` -- remove `OriginalText` property
- `CorrectionStatus.cs` + `AppDbContext.cs` -- add `CorreccionFallida` constant and check constraint
- Migration `20260510120000_AddCorreccionFallidaStatus` -- update DB constraint
- `CorrectionService.cs` -- allow text edits from `CorreccionFallida`; status transitions to `Entregada`/`Pendiente`
- Frontend -- `CorrectionStatus` type, `STATUS_LABEL` map, red badge, `Reintentar` button, error state in `RedaccionDetail`

## Live test

```
[11:46:13 INF] Background correction completed. CorrectionId=986ac4ed...
  Cefr=A1 L1=English TagCount=11 FilteredOut=3 ModelTokens=1396/1952
```

DB: `Status=Corregida, CorrectedAt=2026-05-10 11:46:13, TagCount=11`. Card flipped to CORREGIDA without page reload.

## Test plan

- [ ] All 1380 backend tests pass
- [ ] All 1754 frontend tests pass
- [ ] Build verify: PASS
- [ ] QA-verify: PASS
- [ ] Live correction reaches `Corregida` within 30s (confirmed above)
- [ ] DB confirmed `Status=Corregida` with non-null `CorrectedAt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Failed Correction" status with retry capability; users can now re-attempt correction of failed items.

* **Bug Fixes**
  * Improved error handling when AI correction fails; corrections no longer remain stuck in processing state.
  * Strengthened validation of AI responses for accuracy.

* **User Interface**
  * Added visual indicator (red dot) for failed corrections on assignment cards.
  * Added "Retry" button for failed corrections; label changes to "Reintentar" when applicable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1209)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->