### PR TITLE
fix(#1212): add minimum-span rule so correction marks the erroneous word, not its surrounding phrase

### DIFF
--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -99,6 +99,12 @@ OFFSETS (read carefully — accented characters cause silent errors if you count
 - spannedText MUST equal the student text at [startIndex, endIndex).
 - If spannedText would appear more than once in the student text, choose a longer or more specific span that is unique. Tags whose spannedText cannot be located unambiguously will be dropped.
 - Tags MUST NOT overlap. Sort tags by startIndex.
+- spannedText MUST be the minimum substring that is itself erroneous: the specific word or
+  morpheme to replace, not its surrounding context. For a verb error, span the verb only.
+  For a missing accent, span the word only. Never span a surrounding phrase.
+  Example: in "Los libros son interesante", spannedText must be "interesante" (the wrong
+  adjective) and correctedForm must be "interesantes" -- not "Los libros son interesante"
+  or any larger span.
 """;
 
     private string BuildUserPrompt(RedaccionCorrectionPromptContext ctx)

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -101,9 +101,10 @@ OFFSETS (read carefully — accented characters cause silent errors if you count
 - Tags MUST NOT overlap. Sort tags by startIndex.
 - spannedText MUST be the minimum substring that is itself erroneous: the specific word or
   morpheme to replace, not its surrounding context. For a verb error, span the verb only.
-  For a missing accent, span the word only. Never span a surrounding phrase.
+  For a missing accent, span the word only. Never span a surrounding phrase (unless a wider
+  span is required for uniqueness per the rule above).
   Example: in "Los libros son interesante", spannedText must be "interesante" (the wrong
-  adjective) and correctedForm must be "interesantes" -- not "Los libros son interesante"
+  adjective) and correctedForm must be "interesantes", not "Los libros son interesante"
   or any larger span.
 """;
 


### PR DESCRIPTION
## Summary

- Adds a minimum-span rule to the OFFSETS block in `RedaccionCorrectionPromptBuilder.cs` instructing the model to span only the erroneous word/morpheme, not the surrounding context phrase.
- Clarifies that widening for uniqueness (existing rule) takes precedence when needed.
- Example uses a gender-agreement error (interesante/interesantes) to keep the new rule independent from the ser/estar rule added in #1210.

## Root cause

The OFFSETS instructions were too vague: "Decide which substring to mark." For relational errors the model reasoned about the enclosing phrase, picked its start as the anchor, and set spannedText to the leading adverb/noun instead of the erroneous verb.

## Test plan

- [x] All 14 `RedaccionCorrectionPromptBuilderTests` pass
- [x] Build verify PASS (dotnet test, npm test, npm build, npm lint all pass)
- [x] Live browser verify (e2e stack, Ana Visual student):
  - "Aquí esta bastante común comer tres veces al día" -> "esta" highlighted G, correctedForm "es" (not "Aquí") PASS
  - "La musica es bonita" -> "musica" highlighted O only PASS
  - "Los libros son interesante" -> "interesante" highlighted G, correctedForm "interesantes" PASS

Closes #1212

🤖 Generated with [Claude Code](https://claude.com/claude-code)