### PR TITLE
fix(#1217): raise MaxTokens to 8192 to prevent truncation on long texts

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs
@@ -148,6 +148,14 @@ public class RedaccionCorrectionPromptBuilderTests
     }
 
     [Fact]
+    public void Build_SetsMaxTokensTo8192_ToPreventTruncationOnLongTexts()
+    {
+        // Issue #1217: 4096 was too small for B1+ redacciones; responses were truncated mid-JSON.
+        var req = _builder.Build(MakeCtx());
+        req.MaxTokens.Should().Be(8192);
+    }
+
+    [Fact]
     public void Build_WrapsStudentTextInVerbatimMarkers()
     {
         // Markers use a per-request nonce ("STUDENT_TEXT_VERBATIM_<guid>") so they cannot

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -36,7 +36,7 @@ public class RedaccionCorrectionPromptBuilder
         // temperature=0: deterministic offset generation -- spannedText must locate uniquely
         // via indexOf in the student text; sampling variation leads the model to rephrase
         // spannedText, breaking the rescue logic in ValidateAndOrderTags.
-        return new ClaudeRequest(system, user, ClaudeModel.Sonnet, MaxTokens: 4096, Temperature: 0);
+        return new ClaudeRequest(system, user, ClaudeModel.Sonnet, MaxTokens: 8192, Temperature: 0);
     }
 
     private const string SystemPrompt = """

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -36,6 +36,8 @@ public class RedaccionCorrectionPromptBuilder
         // temperature=0: deterministic offset generation -- spannedText must locate uniquely
         // via indexOf in the student text; sampling variation leads the model to rephrase
         // spannedText, breaking the rescue logic in ValidateAndOrderTags.
+        // MaxTokens 8192: ser/estar tree + minimum-span rule + L1 interference blocks pushed
+        // long-text responses past 4096, truncating mid-JSON (#1217).
         return new ClaudeRequest(system, user, ClaudeModel.Sonnet, MaxTokens: 8192, Temperature: 0);
     }
 


### PR DESCRIPTION
## Summary

- Raises `MaxTokens` from 4096 to 8192 in `RedaccionCorrectionPromptBuilder` to prevent `CorreccionFallida` on realistic B1+ redacciones
- Adds a regression test pinning the value
- Adds rationale comment explaining why 8192 is needed (prompt growth from #1210-#1212)

## Root cause

Recent prompt additions (ser/estar decision tree, minimum-span rule, L1 interference blocks) combined with longer student texts pushed the JSON response past 4096 tokens. The truncated response had no closing `}`, JSON parse failed, and `CorreccionFallida` was set.

## Verify

Tested live with the 150-word "Carta a un extraterrestre" text from the issue. Result: `Corregida` status with 10+ error tags (G and O categories). No truncation.

## Reviewer findings

| Reviewer | Finding | Action |
|---|---|---|
| qa-verify | No unit test for MaxTokens | Fixed: test added |
| architecture-reviewer | PASS | No action needed |
| Sophy | Add rationale comment for MaxTokens choice | Fixed: comment added |
| Sophy | MaxTokens-to-config refactor | Deferred (not a blocker) |
| prompt-health-reviewer | CLEAN (2 minor cosmetic findings in SystemPrompt) | Logged to backlog |

🤖 Generated with [Claude Code](https://claude.com/claude-code)