### PR TITLE
feat: add ClaudeModel.Opus with temperature guard

### DIFF
--- a/backend/LangTeach.Api/AI/ClaudeApiClient.cs
+++ b/backend/LangTeach.Api/AI/ClaudeApiClient.cs
@@ -14,6 +14,7 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
     {
         [ClaudeModel.Haiku]  = "claude-haiku-4-5-20251001",
         [ClaudeModel.Sonnet] = "claude-sonnet-4-6",
+        [ClaudeModel.Opus]   = "claude-opus-4-7",
     };
 
     public async Task<ClaudeResponse> CompleteAsync(ClaudeRequest request, CancellationToken ct = default)
@@ -191,7 +192,8 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
             ["stream"]     = stream,
             ["messages"]   = messages,
         };
-        if (request.Temperature is not null)
+        // temperature is deprecated for Opus 4 -- omit it entirely for that model family.
+        if (request.Temperature is not null && request.Model != ClaudeModel.Opus)
             body["temperature"] = request.Temperature;
         return body;
     }

--- a/backend/LangTeach.Api/AI/IClaudeClient.cs
+++ b/backend/LangTeach.Api/AI/IClaudeClient.cs
@@ -24,4 +24,4 @@ public record ClaudeResponse(
     int OutputTokens
 );
 
-public enum ClaudeModel { Haiku, Sonnet }
+public enum ClaudeModel { Haiku, Sonnet, Opus }


### PR DESCRIPTION
## Summary

- Adds `ClaudeModel.Opus` to the enum and maps it to `claude-opus-4-7` in `ClaudeApiClient`
- Guards against the 400 error when passing `temperature` to Opus 4 (deprecated parameter for this model family)
- Pass 1 correction prompt stays on Sonnet; Opus is available for future use

Tested 2026-05-10: switching Pass 1 to Opus produced worse results (false MuyBien positives, no improvement on ser/estar detection). Reverted to Sonnet. Infrastructure kept for future experimentation.

## Test plan

- [ ] `dotnet build` passes
- [ ] No existing tests broken (no behavioural change -- Pass 1 still uses Sonnet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)