### PR TITLE
fix(ux): remove Atelier overlay blur so content stays readable (#1234)

### DIFF
--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -305,6 +305,7 @@ export default function AtelierAssistantPanel({
       <SheetContent
         data-testid="assistant-panel"
         className="right-0 left-auto w-[380px] max-w-full flex flex-col p-0 backdrop-blur-[12px] bg-white/80 shadow-[0_8px_40px_0_rgb(26_27_34_/_0.12)] data-open:slide-in-from-right data-closed:slide-out-to-right"
+        overlayClassName="bg-transparent supports-backdrop-filter:backdrop-blur-none"
       >
         {/* Header */}
         <div className="flex items-center px-5 py-4 gap-2 shrink-0">

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -32,12 +32,13 @@ function SheetOverlay({
 
 function SheetContent({
   className,
+  overlayClassName,
   children,
   ...props
-}: DialogPrimitive.Popup.Props) {
+}: DialogPrimitive.Popup.Props & { overlayClassName?: string }) {
   return (
     <DialogPrimitive.Portal>
-      <SheetOverlay />
+      <SheetOverlay className={overlayClassName} />
       <DialogPrimitive.Popup
         data-slot="sheet-content"
         className={cn(


### PR DESCRIPTION
## Summary

- Adds optional `overlayClassName` prop to `SheetContent` in `sheet.tsx`, forwarded directly to `SheetOverlay`
- `AtelierAssistantPanel` passes `overlayClassName="bg-transparent supports-backdrop-filter:backdrop-blur-none"` to neutralise the visual overlay while keeping it as a click-catcher (dismiss-on-outside-click preserved)
- All other `SheetContent` consumers (AppShell nav drawer) are unaffected -- they pass no `overlayClassName` so the default blur/dim behaviour is unchanged

Fixes #1234. Reported by Jordi.

## Root cause

`SheetOverlay` applied `bg-black/10 supports-backdrop-filter:backdrop-blur-xs` to the full page when the Atelier panel opened. There was no way to opt out of this per-instance. The fix adds an escape hatch via `overlayClassName` without changing the base component defaults.

## Test plan

- [x] Build verify: all checks pass (npm build, npm test 105/105, dotnet build, dotnet test, lint)
- [x] Live verify: student profile content (skill bars, session notes, name/level) fully legible with panel open; no blur, no dim
- [x] Click outside panel closes it (overlay click-catcher preserved)
- [x] Regression: AppShell mobile drawer still shows default dim/blur overlay
- [x] qa-verify: PASS WITH GAPS (gaps: no unit tests for the new prop -- acceptable for a 4-line CSS className change)
- [x] Code review: PASS
- [x] UI review: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)