### PR TITLE
refactor(voice): migrate VoiceUpdateDrawer from PUT to PATCH and extract shared constants (#1236)

### DIFF
--- a/backend/LangTeach.Api/Controllers/StudentsController.cs
+++ b/backend/LangTeach.Api/Controllers/StudentsController.cs
@@ -145,6 +145,16 @@ public class StudentsController : ControllerBase
         if (patch.SkillLevelWriting is not null) request.SkillLevelOverrides["Writing"] = patch.SkillLevelWriting;
         if (patch.SkillLevelSpeaking is not null) request.SkillLevelOverrides["Speaking"] = patch.SkillLevelSpeaking;
         if (patch.SkillLevelListening is not null) request.SkillLevelOverrides["Listening"] = patch.SkillLevelListening;
+        if (patch.OfficialCefrLevel is not null) request.OfficialCefrLevel = patch.OfficialCefrLevel;
+        if (patch.ReasonForStudying is not null) request.ReasonForStudying = patch.ReasonForStudying;
+        if (patch.BirthYear.HasValue) request.BirthYear = patch.BirthYear;
+        if (patch.CityOfResidence is not null) request.CityOfResidence = patch.CityOfResidence;
+        if (patch.NativeLanguages is not null) request.NativeLanguages = patch.NativeLanguages;
+        if (patch.SpokenLanguages is not null) request.SpokenLanguages = patch.SpokenLanguages;
+        if (patch.Interests is not null) request.Interests = patch.Interests;
+        if (patch.ShortTermObjectives is not null) request.ShortTermObjectives = patch.ShortTermObjectives;
+        if (patch.Difficulties is not null) request.Difficulties = patch.Difficulties;
+        if (patch.TeachingTodos is not null) request.TeachingTodos = patch.TeachingTodos;
 
         try
         {

--- a/backend/LangTeach.Api/Controllers/StudentsController.cs
+++ b/backend/LangTeach.Api/Controllers/StudentsController.cs
@@ -149,12 +149,42 @@ public class StudentsController : ControllerBase
         if (patch.ReasonForStudying is not null) request.ReasonForStudying = patch.ReasonForStudying;
         if (patch.BirthYear.HasValue) request.BirthYear = patch.BirthYear;
         if (patch.CityOfResidence is not null) request.CityOfResidence = patch.CityOfResidence;
-        if (patch.NativeLanguages is not null) request.NativeLanguages = patch.NativeLanguages;
-        if (patch.SpokenLanguages is not null) request.SpokenLanguages = patch.SpokenLanguages;
-        if (patch.Interests is not null) request.Interests = patch.Interests;
-        if (patch.ShortTermObjectives is not null) request.ShortTermObjectives = patch.ShortTermObjectives;
-        if (patch.Difficulties is not null) request.Difficulties = patch.Difficulties;
-        if (patch.TeachingTodos is not null) request.TeachingTodos = patch.TeachingTodos;
+        if (patch.NativeLanguages is not null)
+        {
+            if (patch.NativeLanguages.Count > MaxProfileListCount)
+            { ModelState.AddModelError(nameof(patch.NativeLanguages), $"Cannot exceed {MaxProfileListCount} native languages."); return BadRequest(ModelState); }
+            request.NativeLanguages = patch.NativeLanguages;
+        }
+        if (patch.SpokenLanguages is not null)
+        {
+            if (patch.SpokenLanguages.Count > MaxProfileListCount)
+            { ModelState.AddModelError(nameof(patch.SpokenLanguages), $"Cannot exceed {MaxProfileListCount} spoken languages."); return BadRequest(ModelState); }
+            request.SpokenLanguages = patch.SpokenLanguages;
+        }
+        if (patch.Interests is not null)
+        {
+            if (patch.Interests.Count > MaxProfileListCount)
+            { ModelState.AddModelError(nameof(patch.Interests), $"Cannot exceed {MaxProfileListCount} interests."); return BadRequest(ModelState); }
+            request.Interests = patch.Interests;
+        }
+        if (patch.ShortTermObjectives is not null)
+        {
+            if (patch.ShortTermObjectives.Count > MaxProfileListCount)
+            { ModelState.AddModelError(nameof(patch.ShortTermObjectives), $"Cannot exceed {MaxProfileListCount} objectives."); return BadRequest(ModelState); }
+            request.ShortTermObjectives = patch.ShortTermObjectives;
+        }
+        if (patch.Difficulties is not null)
+        {
+            if (patch.Difficulties.Count > MaxProfileListCount)
+            { ModelState.AddModelError(nameof(patch.Difficulties), $"Cannot exceed {MaxProfileListCount} difficulties."); return BadRequest(ModelState); }
+            request.Difficulties = patch.Difficulties;
+        }
+        if (patch.TeachingTodos is not null)
+        {
+            if (patch.TeachingTodos.Count > MaxProfileListCount)
+            { ModelState.AddModelError(nameof(patch.TeachingTodos), $"Cannot exceed {MaxProfileListCount} teaching todos."); return BadRequest(ModelState); }
+            request.TeachingTodos = patch.TeachingTodos;
+        }
 
         try
         {

--- a/backend/LangTeach.Api/DTOs/AssistantDtos.cs
+++ b/backend/LangTeach.Api/DTOs/AssistantDtos.cs
@@ -69,6 +69,25 @@ public class PatchStudentRequest
 
     [MaxLength(10)]
     public string? SkillLevelListening { get; set; }
+
+    // Voice-update path fields (replace semantics when non-null)
+    [RegularExpression(CefrConstants.ValidationPattern, ErrorMessage = "OfficialCefrLevel must be one of: A1, A2, B1, B2, C1, C2.")]
+    public string? OfficialCefrLevel { get; set; }
+
+    [MaxLength(500)]
+    public string? ReasonForStudying { get; set; }
+
+    public int? BirthYear { get; set; }
+
+    [MaxLength(64)]
+    public string? CityOfResidence { get; set; }
+
+    public List<string>? NativeLanguages { get; set; }
+    public List<string>? SpokenLanguages { get; set; }
+    public List<string>? Interests { get; set; }
+    public List<ShortTermObjectiveDto>? ShortTermObjectives { get; set; }
+    public List<DifficultyDto>? Difficulties { get; set; }
+    public List<TeachingTodoDto>? TeachingTodos { get; set; }
 }
 
 public class PatchSessionRequest

--- a/frontend/src/api/students.ts
+++ b/frontend/src/api/students.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '../lib/apiClient'
+import type { VoiceMergePatch } from '../lib/voiceUpdateMerge'
 
 export interface StudentWeaknessItem {
   description: string
@@ -151,21 +152,7 @@ export async function updateStudent(id: string, data: StudentFormData): Promise<
   return res.data
 }
 
-export async function patchStudentVoice(id: string, patch: {
-  cefrLevel?: string
-  officialCefrLevel?: string | null
-  profession?: string | null
-  reasonForStudying?: string | null
-  birthYear?: number | null
-  countryOfResidence?: string | null
-  cityOfResidence?: string | null
-  nativeLanguages?: string[]
-  spokenLanguages?: string[]
-  interests?: string[]
-  shortTermObjectives?: ShortTermObjective[]
-  difficulties?: Difficulty[]
-  teachingTodos?: TeachingTodo[]
-}): Promise<void> {
+export async function patchStudentVoice(id: string, patch: VoiceMergePatch): Promise<void> {
   await apiClient.patch(`/api/students/${id}`, patch)
 }
 

--- a/frontend/src/api/students.ts
+++ b/frontend/src/api/students.ts
@@ -151,6 +151,24 @@ export async function updateStudent(id: string, data: StudentFormData): Promise<
   return res.data
 }
 
+export async function patchStudentVoice(id: string, patch: {
+  cefrLevel?: string
+  officialCefrLevel?: string | null
+  profession?: string | null
+  reasonForStudying?: string | null
+  birthYear?: number | null
+  countryOfResidence?: string | null
+  cityOfResidence?: string | null
+  nativeLanguages?: string[]
+  spokenLanguages?: string[]
+  interests?: string[]
+  shortTermObjectives?: ShortTermObjective[]
+  difficulties?: Difficulty[]
+  teachingTodos?: TeachingTodo[]
+}): Promise<void> {
+  await apiClient.patch(`/api/students/${id}`, patch)
+}
+
 export async function deleteStudent(id: string): Promise<void> {
   await apiClient.delete(`/api/students/${id}`)
 }

--- a/frontend/src/lib/voiceUpdateMerge.ts
+++ b/frontend/src/lib/voiceUpdateMerge.ts
@@ -5,6 +5,25 @@ import type { ExtractedStudentProfile, ExtractedObjective, ExtractedDifficulty }
 
 const DEFAULT_LEARNING_LANGUAGE = 'Spanish'
 
+const FIELD_LABELS: Record<string, string> = {
+  name: 'Name',
+  cefrLevel: 'CEFR Level',
+  officialCefrLevel: 'Official CEFR',
+  profession: 'Profession',
+  reasonForStudying: 'Reason for Studying',
+  birthYear: 'Birth Year',
+  countryOfResidence: 'Country of Residence',
+  cityOfResidence: 'City of Residence',
+  nativeLanguages: 'Native Language',
+  spokenLanguages: 'Spoken Language',
+  interests: 'Interest',
+  shortTermObjectives: 'Short-term Objective',
+  difficulties: 'Difficulty',
+  teachingTodos: 'Idea for Next Class',
+}
+
+const DIFFICULTY_DEFAULTS = { severity: 'medium', trend: 'stable', status: 'Active' } as const
+
 function mergeUnique(existing: string[], incoming: string[]): string[] {
   const result = [...existing]
   for (const x of incoming) {
@@ -64,28 +83,28 @@ export function buildDrawerRows(extracted: ExtractedStudentProfile, student: Stu
     })
   }
 
-  addScalar('cefrLevel', 'CEFR Level', extracted.cefrLevel, student.level.cefrLevel)
-  addScalar('officialCefrLevel', 'Official CEFR', extracted.officialCefrLevel, student.level.officialCefrLevel)
-  addScalar('profession', 'Profession', extracted.profession, student.identity.profession)
-  addScalar('reasonForStudying', 'Reason for Studying', extracted.reasonForStudying, student.profile.reasonForStudying)
-  addScalar('birthYear', 'Birth Year', extracted.birthYear, student.identity.birthYear)
-  addScalar('countryOfResidence', 'Country of Residence', extracted.countryOfResidence, student.identity.countryOfResidence)
-  addScalar('cityOfResidence', 'City of Residence', extracted.cityOfResidence, student.identity.cityOfResidence)
+  addScalar('cefrLevel', FIELD_LABELS.cefrLevel, extracted.cefrLevel, student.level.cefrLevel)
+  addScalar('officialCefrLevel', FIELD_LABELS.officialCefrLevel, extracted.officialCefrLevel, student.level.officialCefrLevel)
+  addScalar('profession', FIELD_LABELS.profession, extracted.profession, student.identity.profession)
+  addScalar('reasonForStudying', FIELD_LABELS.reasonForStudying, extracted.reasonForStudying, student.profile.reasonForStudying)
+  addScalar('birthYear', FIELD_LABELS.birthYear, extracted.birthYear, student.identity.birthYear)
+  addScalar('countryOfResidence', FIELD_LABELS.countryOfResidence, extracted.countryOfResidence, student.identity.countryOfResidence)
+  addScalar('cityOfResidence', FIELD_LABELS.cityOfResidence, extracted.cityOfResidence, student.identity.cityOfResidence)
 
   for (const lang of extracted.nativeLanguages) {
-    rows.push({ id: newId(), fieldKey: 'nativeLanguages', label: 'Native Language', badge: 'ADDED', currentValue: null, value: lang })
+    rows.push({ id: newId(), fieldKey: 'nativeLanguages', label: FIELD_LABELS.nativeLanguages, badge: 'ADDED', currentValue: null, value: lang })
   }
   for (const lang of extracted.spokenLanguages) {
-    rows.push({ id: newId(), fieldKey: 'spokenLanguages', label: 'Spoken Language', badge: 'ADDED', currentValue: null, value: lang })
+    rows.push({ id: newId(), fieldKey: 'spokenLanguages', label: FIELD_LABELS.spokenLanguages, badge: 'ADDED', currentValue: null, value: lang })
   }
   for (const interest of extracted.interests) {
-    rows.push({ id: newId(), fieldKey: 'interests', label: 'Interest', badge: 'ADDED', currentValue: null, value: interest })
+    rows.push({ id: newId(), fieldKey: 'interests', label: FIELD_LABELS.interests, badge: 'ADDED', currentValue: null, value: interest })
   }
   for (const obj of extracted.shortTermObjectives) {
     rows.push({
       id: newId(),
       fieldKey: 'shortTermObjectives',
-      label: 'Short-term Objective',
+      label: FIELD_LABELS.shortTermObjectives,
       badge: 'ADDED',
       currentValue: null,
       value: obj.targetDate ? `${obj.text} (by ${obj.targetDate})` : obj.text,
@@ -96,7 +115,7 @@ export function buildDrawerRows(extracted: ExtractedStudentProfile, student: Stu
     rows.push({
       id: newId(),
       fieldKey: 'difficulties',
-      label: 'Difficulty',
+      label: FIELD_LABELS.difficulties,
       badge: 'ADDED',
       currentValue: null,
       value: diff.description,
@@ -104,7 +123,7 @@ export function buildDrawerRows(extracted: ExtractedStudentProfile, student: Stu
     })
   }
   for (const todo of extracted.teachingTodoTexts) {
-    rows.push({ id: newId(), fieldKey: 'teachingTodos', label: 'Idea for Next Class', badge: 'ADDED', currentValue: null, value: todo })
+    rows.push({ id: newId(), fieldKey: 'teachingTodos', label: FIELD_LABELS.teachingTodos, badge: 'ADDED', currentValue: null, value: todo })
   }
 
   return rows
@@ -178,9 +197,7 @@ export function mergeExtractedIntoStudent(
           description: row.value,
           competency: normalizeCompetency(row.extractedDifficulty?.competency),
           subcategory: row.extractedDifficulty?.subcategory ?? 'general',
-          severity: 'medium',
-          trend: 'stable',
-          status: 'Active',
+          ...DIFFICULTY_DEFAULTS,
         })
       }
     }
@@ -212,28 +229,28 @@ export function buildCreateDrawerRows(extracted: ExtractedStudentProfile): Drawe
     rows.push({ id: newId(), fieldKey, label, badge: 'NEW', currentValue: null, value: String(value) })
   }
 
-  addNew('name', 'Name', extracted.name)
-  addNew('cefrLevel', 'CEFR Level', extracted.cefrLevel)
-  addNew('profession', 'Profession', extracted.profession)
-  addNew('reasonForStudying', 'Reason for Studying', extracted.reasonForStudying)
-  addNew('birthYear', 'Birth Year', extracted.birthYear)
-  addNew('countryOfResidence', 'Country of Residence', extracted.countryOfResidence)
-  addNew('cityOfResidence', 'City of Residence', extracted.cityOfResidence)
+  addNew('name', FIELD_LABELS.name, extracted.name)
+  addNew('cefrLevel', FIELD_LABELS.cefrLevel, extracted.cefrLevel)
+  addNew('profession', FIELD_LABELS.profession, extracted.profession)
+  addNew('reasonForStudying', FIELD_LABELS.reasonForStudying, extracted.reasonForStudying)
+  addNew('birthYear', FIELD_LABELS.birthYear, extracted.birthYear)
+  addNew('countryOfResidence', FIELD_LABELS.countryOfResidence, extracted.countryOfResidence)
+  addNew('cityOfResidence', FIELD_LABELS.cityOfResidence, extracted.cityOfResidence)
 
   for (const lang of extracted.nativeLanguages) {
-    rows.push({ id: newId(), fieldKey: 'nativeLanguages', label: 'Native Language', badge: 'NEW', currentValue: null, value: lang })
+    rows.push({ id: newId(), fieldKey: 'nativeLanguages', label: FIELD_LABELS.nativeLanguages, badge: 'NEW', currentValue: null, value: lang })
   }
   for (const lang of extracted.spokenLanguages) {
-    rows.push({ id: newId(), fieldKey: 'spokenLanguages', label: 'Spoken Language', badge: 'NEW', currentValue: null, value: lang })
+    rows.push({ id: newId(), fieldKey: 'spokenLanguages', label: FIELD_LABELS.spokenLanguages, badge: 'NEW', currentValue: null, value: lang })
   }
   for (const interest of extracted.interests) {
-    rows.push({ id: newId(), fieldKey: 'interests', label: 'Interest', badge: 'NEW', currentValue: null, value: interest })
+    rows.push({ id: newId(), fieldKey: 'interests', label: FIELD_LABELS.interests, badge: 'NEW', currentValue: null, value: interest })
   }
   for (const obj of extracted.shortTermObjectives) {
     rows.push({
       id: newId(),
       fieldKey: 'shortTermObjectives',
-      label: 'Short-term Objective',
+      label: FIELD_LABELS.shortTermObjectives,
       badge: 'NEW',
       currentValue: null,
       value: obj.targetDate ? `${obj.text} (by ${obj.targetDate})` : obj.text,
@@ -244,7 +261,7 @@ export function buildCreateDrawerRows(extracted: ExtractedStudentProfile): Drawe
     rows.push({
       id: newId(),
       fieldKey: 'difficulties',
-      label: 'Difficulty',
+      label: FIELD_LABELS.difficulties,
       badge: 'NEW',
       currentValue: null,
       value: diff.description,
@@ -252,7 +269,7 @@ export function buildCreateDrawerRows(extracted: ExtractedStudentProfile): Drawe
     })
   }
   for (const todo of extracted.teachingTodoTexts) {
-    rows.push({ id: newId(), fieldKey: 'teachingTodos', label: 'Idea for Next Class', badge: 'NEW', currentValue: null, value: todo })
+    rows.push({ id: newId(), fieldKey: 'teachingTodos', label: FIELD_LABELS.teachingTodos, badge: 'NEW', currentValue: null, value: todo })
   }
 
   return rows
@@ -280,9 +297,7 @@ export function buildCreateRequestFromRows(rows: DrawerRow[]): StudentFormData {
       description: r.value,
       competency: normalizeCompetency(r.extractedDifficulty?.competency),
       subcategory: r.extractedDifficulty?.subcategory ?? 'general',
-      severity: 'medium',
-      trend: 'stable',
-      status: 'Active',
+      ...DIFFICULTY_DEFAULTS,
     })),
     birthYear,
     profession: get('profession'),

--- a/frontend/src/pages/StudentDetail.test.tsx
+++ b/frontend/src/pages/StudentDetail.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../api/followups', () => ({
 vi.mock('../api/students', () => ({
   getStudent: vi.fn(),
   updateStudent: vi.fn(),
+  patchStudentVoice: vi.fn().mockResolvedValue(undefined),
   appendTeachingTodo: vi.fn(),
   updateTeachingTodo: vi.fn(),
   deleteTeachingTodo: vi.fn(),

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -2,7 +2,7 @@ import { useCallback, useRef, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getStudent, updateStudent } from '../api/students'
+import { getStudent, updateStudent, patchStudentVoice } from '../api/students'
 import { logger } from '../lib/logger'
 import { newId } from '@/lib/newId'
 import { getFollowups } from '@/api/followups'
@@ -235,7 +235,7 @@ export default function StudentDetail() {
     if (!student) return
     setVoiceFlow('saving')
     try {
-      await updateStudent(id!, { ...buildStudentPayload(), ...patch })
+      await patchStudentVoice(id!, patch)
       queryClient.invalidateQueries({ queryKey: ['student', id] })
       setVoiceFlow('idle')
       setExtractedProfile(null)


### PR DESCRIPTION
## Summary

Closes #1236

- **AC3 (apply path):** `handleVoiceSave` in StudentDetail.tsx now calls `PATCH /api/students/{id}` via new `patchStudentVoice()` instead of `PUT /api/students/{id}`. Both voice flows confirmed PATCH-only in live verify.
- **AC2 (deduplication):** Extracted `FIELD_LABELS` and `DIFFICULTY_DEFAULTS` constants in `voiceUpdateMerge.ts`, eliminating label/default duplication between `buildDrawerRows` and `buildCreateDrawerRows`.
- **AC1 (field audit gap table):** See below.

## AC1: Field Coverage Gap Table

| Field | VoiceUpdateDrawer | Atelier | Notes |
|---|---|---|---|
| cefrLevel | yes | yes | |
| officialCefrLevel | yes | NO | Atelier flow does not emit this proposal |
| profession | yes | yes | |
| reasonForStudying | yes | NO | Not in `proposal-fields.json` studentFields |
| birthYear | yes | NO | Not emitted by AssistantController |
| countryOfResidence | yes | yes | |
| cityOfResidence | yes | NO | Not in `proposal-fields.json` studentFields |
| nativeLanguages | yes | NO | Not emitted by AssistantController |
| spokenLanguages | yes | NO | Not emitted by AssistantController |
| interests | yes | yes | |
| shortTermObjectives | yes | yes (as learningGoals, string[] not ShortTermObjective[]) | Different model |
| difficulties | yes | yes | |
| teachingTodoTexts | yes | yes | |
| teachingNotes | NO | yes | VoiceUpdateDrawer doesn't extract this |
| skillLevel overrides | NO | yes | VoiceUpdateDrawer doesn't extract these |

Gap fields are documented here for visibility. Parity is out of scope for this task per the issue "What MUST NOT happen" constraint.

## Backend Changes

- `PatchStudentRequest` extended with 10 new fields (officialCefrLevel, reasonForStudying, birthYear, cityOfResidence, nativeLanguages, spokenLanguages, interests, shortTermObjectives, difficulties, teachingTodos) using replace-semantics-when-non-null pattern
- `PatchStudent` controller updated to apply all new fields

## Frontend Changes

- `patchStudentVoice()` added to `students.ts` (imports `VoiceMergePatch` type)
- `StudentDetail.handleVoiceSave` switched from `updateStudent()` (PUT) to `patchStudentVoice()` (PATCH)
- `FIELD_LABELS` and `DIFFICULTY_DEFAULTS` constants extracted in `voiceUpdateMerge.ts`

## Live Verify Results

- VoiceUpdateDrawer: `PATCH /api/students/{id}` returned 200 (confirmed no PUT)
- Atelier apply: `PATCH /api/students/{id}/profile` returned 200
- Both flows confirmed working end-to-end on visual stack

## Test plan

- [ ] Open student → "Update via voice" → record note → VoiceUpdateDrawer shows extracted fields → apply → profile updates (CEFR, profession, city, etc.)
- [ ] Confirm network tab shows `PATCH /api/students/{id}` with 200 (no PUT)
- [ ] Open Atelier → type/record note → proposal cards appear → apply → student fields update via `PATCH /api/students/{id}/profile`
- [ ] Build passes: `dotnet build`, `dotnet test`, `npm build`, `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice-based student profile updates now support expanded fields, including official CEFR level, reason for studying, birth year, city of residence, native and spoken languages, interests, short-term learning objectives, and teaching notes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1243)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->