### PR TITLE
fix(corrections): use contextBefore to disambiguate rescue tag placement (#1239)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionServiceTests.cs
@@ -300,6 +300,65 @@ public class RedaccionCorrectionServiceTests : IDisposable
         _claude.CompleteCallCount.Should().Be(0, "no AI call should be made for idempotent Corrigiendo");
     }
 
+    [Fact]
+    public async Task CorregirAsync_ContextBefore_PicksCorrectOccurrenceOverNearer()
+    {
+        // "es" appears at [10,12) (correct ser use) and [22,24) (actual error).
+        // Model offset drifts to 5, nearer to [10,12) than [22,24).
+        // contextBefore="y " uniquely identifies the second "es" via combined search.
+        var text = "La ciudad es bonita y es en la costa.";
+        var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
+
+        _claude.EnqueueResponse(BuildAiJsonWithContext(
+            "G", startIndex: 5, endIndex: 7, spannedText: "es", contextBefore: "y ",
+            explanation: "Ubicación requiere estar.", correctedForm: "está"));
+
+        await _sut.CorregirAsync(_teacherId, _studentId, id);
+        var row = await WaitForDbStatusAsync(id, CorrectionStatus.Corregida);
+
+        row.Tags.Should().HaveCount(1);
+        row.Tags.First().StartIndex.Should().Be(22, "contextBefore 'y ' uniquely identifies the second 'es'");
+    }
+
+    [Fact]
+    public async Task CorregirAsync_NoContextBefore_MultipleOccurrences_UsesProximity()
+    {
+        // Without contextBefore the rescue heuristic falls back to nearest-by-distance.
+        // Model reports offset 8, nearest to "es" at [10,12) over "es" at [22,24).
+        var text = "La ciudad es bonita y es en la costa.";
+        var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
+
+        _claude.EnqueueResponse(BuildAiJson(new[]
+        {
+            ("G", 8, 10, "es", "Usar estar.", "está"),
+        }));
+
+        await _sut.CorregirAsync(_teacherId, _studentId, id);
+        var row = await WaitForDbStatusAsync(id, CorrectionStatus.Corregida);
+
+        row.Tags.Should().HaveCount(1);
+        row.Tags.First().StartIndex.Should().Be(10, "proximity picks the occurrence nearest to reported offset 8");
+    }
+
+    [Fact]
+    public async Task CorregirAsync_ContextBeforeAmbiguous_FallsBackToProximity()
+    {
+        // "y es" appears twice so the combined key does not disambiguate.
+        // Falls back to proximity: model reports offset 12, nearer to "es" at [14,16).
+        var text = "y es bonita y es en la costa.";
+        var id = SeedCorrection(text: text, status: CorrectionStatus.Entregada);
+
+        _claude.EnqueueResponse(BuildAiJsonWithContext(
+            "G", startIndex: 12, endIndex: 14, spannedText: "es", contextBefore: "y ",
+            explanation: "Usar estar.", correctedForm: "está"));
+
+        await _sut.CorregirAsync(_teacherId, _studentId, id);
+        var row = await WaitForDbStatusAsync(id, CorrectionStatus.Corregida);
+
+        row.Tags.Should().HaveCount(1);
+        row.Tags.First().StartIndex.Should().Be(14, "contextBefore ambiguous so proximity picks nearest to offset 12");
+    }
+
     // ----- helpers -----
 
     private async Task<Correction> WaitForDbStatusAsync(Guid correctionId, string expectedStatus,
@@ -381,5 +440,26 @@ public class RedaccionCorrectionServiceTests : IDisposable
                 explanation = (string?)(string.IsNullOrEmpty(t.explanation) ? null : t.explanation),
                 correctedForm = (string?)(string.IsNullOrEmpty(t.correctedForm) ? null : t.correctedForm),
             }).ToArray(),
+        });
+
+    private static string BuildAiJsonWithContext(
+        string category, int startIndex, int endIndex, string spannedText, string contextBefore,
+        string explanation, string correctedForm) =>
+        JsonSerializer.Serialize(new
+        {
+            schemaVersion = 1,
+            tags = new[]
+            {
+                new
+                {
+                    category,
+                    startIndex,
+                    endIndex,
+                    spannedText,
+                    contextBefore,
+                    explanation,
+                    correctedForm,
+                },
+            },
         });
 }

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -100,8 +100,8 @@ OFFSETS (read carefully — accented characters cause silent errors if you count
   3. Locate spannedText inside the student text using a forward string search (like indexOf / find), starting from position 0.
   4. Set startIndex to the result of that search. Set endIndex = startIndex + length(spannedText).
 - spannedText MUST equal the student text at [startIndex, endIndex).
-- contextBefore MUST be the exact characters immediately preceding spannedText in the student text (up to 20 chars). This is used to locate spannedText unambiguously when it appears more than once. Always include it.
-- If spannedText still appears more than once even with contextBefore context, choose a longer or more specific span for spannedText that is unique. Tags that cannot be located will be dropped.
+- contextBefore MUST always be emitted: it is the exact characters immediately preceding spannedText in the student text (up to 20 chars, or an empty string if spannedText starts at position 0). It is used server-side to locate the correct occurrence when spannedText appears more than once.
+- If spannedText is still ambiguous after contextBefore (i.e. the same contextBefore + spannedText sequence appears more than once), choose a longer or more specific span for spannedText that is unique. Tags that cannot be located will be dropped.
 - spannedText MUST be the minimum substring that is itself erroneous: the specific word or
   morpheme to replace, not its surrounding context. For a verb error, span the verb only.
   For a missing accent, span the word only. Never span a surrounding phrase (unless a wider

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -82,6 +82,7 @@ Emit raw JSON only. Start directly with {. No prose before or after. No markdown
       "startIndex": <int>,
       "endIndex": <int>,
       "spannedText": "<exact substring of the student text at [startIndex..endIndex]>",
+      "contextBefore": "<the substring of the student text immediately before spannedText, up to 20 characters; use empty string if spannedText starts at position 0>",
       "explanation": "<short, in Spanish>",
       "correctedForm": "<the corrected form>"
     }
@@ -99,7 +100,8 @@ OFFSETS (read carefully — accented characters cause silent errors if you count
   3. Locate spannedText inside the student text using a forward string search (like indexOf / find), starting from position 0.
   4. Set startIndex to the result of that search. Set endIndex = startIndex + length(spannedText).
 - spannedText MUST equal the student text at [startIndex, endIndex).
-- If spannedText would appear more than once in the student text, choose a longer or more specific span that is unique. Tags whose spannedText cannot be located unambiguously will be dropped.
+- contextBefore MUST be the exact characters immediately preceding spannedText in the student text (up to 20 chars). This is used to locate spannedText unambiguously when it appears more than once. Always include it.
+- If spannedText still appears more than once even with contextBefore context, choose a longer or more specific span for spannedText that is unique. Tags that cannot be located will be dropped.
 - spannedText MUST be the minimum substring that is itself erroneous: the specific word or
   morpheme to replace, not its surrounding context. For a verb error, span the verb only.
   For a missing accent, span the word only. Never span a surrounding phrase (unless a wider

--- a/backend/LangTeach.Api/Schemas/redaccion-correction.schema.json
+++ b/backend/LangTeach.Api/Schemas/redaccion-correction.schema.json
@@ -26,7 +26,7 @@
         "startIndex": { "type": "integer", "minimum": 0 },
         "endIndex": { "type": "integer", "minimum": 1 },
         "spannedText": { "type": "string", "minLength": 1 },
-        "contextBefore": { "type": ["string", "null"] },
+        "contextBefore": { "type": ["string", "null"], "maxLength": 40 },
         "explanation": { "type": ["string", "null"] },
         "correctedForm": { "type": ["string", "null"] }
       },

--- a/backend/LangTeach.Api/Schemas/redaccion-correction.schema.json
+++ b/backend/LangTeach.Api/Schemas/redaccion-correction.schema.json
@@ -26,6 +26,7 @@
         "startIndex": { "type": "integer", "minimum": 0 },
         "endIndex": { "type": "integer", "minimum": 1 },
         "spannedText": { "type": "string", "minLength": 1 },
+        "contextBefore": { "type": ["string", "null"] },
         "explanation": { "type": ["string", "null"] },
         "correctedForm": { "type": ["string", "null"] }
       },

--- a/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
+++ b/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
@@ -357,40 +357,67 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
                         "Drop tag: spannedText is null or empty. CorrectionId={CorrectionId}", correctionId);
                     continue;
                 }
-                // Collect all occurrences of spannedText in the original text.
-                var occurrences = new List<int>();
-                var searchFrom = 0;
-                while (true)
+
+                // Try contextBefore + spannedText for unambiguous rescue (avoids proximity
+                // heuristic failures when a common word like "es" appears many times).
+                int? contextFoundAt = null;
+                if (!string.IsNullOrEmpty(tag.ContextBefore))
                 {
-                    var hit = originalText.IndexOf(tag.SpannedText, searchFrom, StringComparison.Ordinal);
-                    if (hit < 0) break;
-                    occurrences.Add(hit);
-                    searchFrom = hit + 1;
+                    var combined = tag.ContextBefore + tag.SpannedText;
+                    var combinedHits = new List<int>();
+                    var cf = 0;
+                    while (true)
+                    {
+                        var hit = originalText.IndexOf(combined, cf, StringComparison.Ordinal);
+                        if (hit < 0) break;
+                        combinedHits.Add(hit + tag.ContextBefore.Length);
+                        cf = hit + 1;
+                    }
+                    if (combinedHits.Count == 1)
+                        contextFoundAt = combinedHits[0];
                 }
-                if (occurrences.Count == 0)
+
+                if (contextFoundAt.HasValue)
                 {
+                    tag = tag with { StartIndex = contextFoundAt.Value, EndIndex = contextFoundAt.Value + tag.SpannedText.Length };
+                }
+                else
+                {
+                    // Fall back to proximity-based rescue.
+                    var occurrences = new List<int>();
+                    var searchFrom = 0;
+                    while (true)
+                    {
+                        var hit = originalText.IndexOf(tag.SpannedText, searchFrom, StringComparison.Ordinal);
+                        if (hit < 0) break;
+                        occurrences.Add(hit);
+                        searchFrom = hit + 1;
+                    }
+                    if (occurrences.Count == 0)
+                    {
+                        logger.LogWarning(
+                            "Drop tag: spannedText '{Spanned}' not found in originalText (model hallucinated span). CorrectionId={CorrectionId}",
+                            tag.SpannedText, correctionId);
+                        continue;
+                    }
+                    // When there are multiple occurrences, use the model's startIndex as a proximity hint:
+                    // the model knows approximately where the error is even if the exact offset drifted due
+                    // to accented characters. Pick the occurrence closest to the reported startIndex.
+                    // On a tie (two occurrences equidistant), MinBy returns the earlier one (stable).
+                    var foundAt = occurrences.Count == 1
+                        ? occurrences[0]
+                        : occurrences.MinBy(p => Math.Abs(p - tag.StartIndex));
+                    if (occurrences.Count > 1)
+                    {
+                        logger.LogWarning(
+                            "Rescue tag: '{Spanned}' found {N} times; chose position {Chosen} nearest model-reported {Reported}. CorrectionId={CorrectionId}",
+                            tag.SpannedText, occurrences.Count, foundAt, tag.StartIndex, correctionId);
+                    }
                     logger.LogWarning(
-                        "Drop tag: spannedText '{Spanned}' not found in originalText (model hallucinated span). CorrectionId={CorrectionId}",
-                        tag.SpannedText, correctionId);
-                    continue;
+                        "Rescue tag: Unicode offset drift; spannedText '{Spanned}' relocated from model-reported [{Start},{End}) to [{Fixed},{FixedEnd}). CorrectionId={CorrectionId}",
+                        tag.SpannedText, tag.StartIndex, tag.EndIndex, foundAt, foundAt + tag.SpannedText.Length, correctionId);
+                    tag = tag with { StartIndex = foundAt, EndIndex = foundAt + tag.SpannedText.Length };
                 }
-                // When there are multiple occurrences, use the model's startIndex as a proximity hint:
-                // the model knows approximately where the error is even if the exact offset drifted due
-                // to accented characters. Pick the occurrence closest to the reported startIndex.
-                // On a tie (two occurrences equidistant), MinBy returns the earlier one (stable).
-                var foundAt = occurrences.Count == 1
-                    ? occurrences[0]
-                    : occurrences.MinBy(p => Math.Abs(p - tag.StartIndex));
-                if (occurrences.Count > 1)
-                {
-                    logger.LogWarning(
-                        "Rescue tag: '{Spanned}' found {N} times; chose position {Chosen} nearest model-reported {Reported}. CorrectionId={CorrectionId}",
-                        tag.SpannedText, occurrences.Count, foundAt, tag.StartIndex, correctionId);
-                }
-                logger.LogWarning(
-                    "Rescue tag: Unicode offset drift; spannedText '{Spanned}' relocated from model-reported [{Start},{End}) to [{Fixed},{FixedEnd}). CorrectionId={CorrectionId}",
-                    tag.SpannedText, tag.StartIndex, tag.EndIndex, foundAt, foundAt + tag.SpannedText.Length, correctionId);
-                tag = tag with { StartIndex = foundAt, EndIndex = foundAt + tag.SpannedText.Length };
             }
 
             string? explanation = tag.Explanation;
@@ -572,7 +599,8 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
         [property: JsonPropertyName("endIndex")] int EndIndex,
         [property: JsonPropertyName("spannedText")] string SpannedText,
         [property: JsonPropertyName("explanation")] string? Explanation,
-        [property: JsonPropertyName("correctedForm")] string? CorrectedForm);
+        [property: JsonPropertyName("correctedForm")] string? CorrectedForm,
+        [property: JsonPropertyName("contextBefore")] string? ContextBefore = null);
 
     private record FilterDecision(
         [property: JsonPropertyName("index")] int Index,


### PR DESCRIPTION
## Summary

- Adds `contextBefore` (nullable string, max ~20 chars) to `RedaccionCorrectionTagDto` -- the exact characters immediately preceding `spannedText` in the student text
- `ValidateAndOrderTags` now searches for `contextBefore + spannedText` first when `contextBefore` is non-empty; if exactly one match, uses it silently (no WRN logged). Falls back to existing proximity heuristic if contextBefore is absent or ambiguous
- System prompt updated to always require `contextBefore` in the output contract
- JSON schema updated with the new field (`maxLength: 40`)
- Three new unit tests: (1) contextBefore picks correct occurrence over nearer wrong one, (2) no-contextBefore falls back to proximity, (3) ambiguous contextBefore falls back to proximity

## Root cause fixed

Gergana's El Clot correction (CorrectionId `95290b6c-a9d8-41ff-b1af-f6f251ba9164`): tag 1 ("es" -> "está", ubicación) was placed on "Barcelona **es** una ciudad" (correct ser, position 93) instead of "y **es** en la costa" (actual error, position 153). The wrong occurrence won the proximity race by 6 chars. With `contextBefore="y "`, the combined key "y es" is unique even though "es" appears 25 times.

## Live verify result

Live correction on e2e stack with the exact El Clot text: tag 1 now lands at **[153]** (correct), not [93]. 14+ WRN logs from the original correction are eliminated for disambiguated tags.

## Test plan

- [ ] Build passes (dotnet test, npm test all green)
- [ ] Three new unit tests cover: correct-occurrence-wins, proximity-fallback, ambiguous-contextBefore-fallback
- [ ] Live correction with El Clot text: tag 1 at [153] confirmed
- [ ] No DB migration needed (contextBefore not persisted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Improved text correction accuracy when student submissions contain repeated phrases; the system now uses surrounding context to disambiguate which occurrence requires correction.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1245)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->