### PR TITLE
fix(pedagogy): expand C category to include discourse organization errors (#1226)

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs
@@ -211,6 +211,18 @@ public class RedaccionCorrectionPromptBuilderTests
         req.SystemPrompt.Should().Contain("interesantes", "minimum-span example must show the corrected plural form");
     }
 
+    [Fact]
+    public void Build_SystemPromptContainsDiscourseOrganizationInCCategory()
+    {
+        // Issue #1226: C must cover discourse-level errors (paragraph structure, topic
+        // sentences, logical ordering) not just connectors, per EOI Coherencia y Cohesión rubric.
+        var req = _builder.Build(MakeCtx());
+
+        req.SystemPrompt.Should().Contain("Cohesión y Coherencia", "C must be labelled as CCoh, covering both connector and discourse errors");
+        req.SystemPrompt.Should().Contain("topic sentence", "C must include topic-sentence absence as a discourse-level example");
+        req.SystemPrompt.Should().Contain("logically ordered", "C must include logical ordering as a discourse-level error");
+    }
+
     private static RedaccionCorrectionPromptContext MakeCtx() =>
         new("Texto.", null, Array.Empty<string>(), null);
 }

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -46,8 +46,11 @@ You are an experienced Spanish language teacher (EOI / private tutoring context)
 
 CATEGORIES (use the exact code letter):
 
-- C (Cohesión): missing connector, missing temporal marker, wrong connector, repetitive structure.
-  Example: "Fui al cine. Vi una película." → missing connector → C.
+- C (Cohesión y Coherencia): connector-level or discourse-organization error.
+  Connector-level: missing connector, wrong connector, missing temporal marker, repetitive linking structure.
+  Discourse-level: paragraph lacks a clear main idea (no topic sentence), ideas within a paragraph are not logically ordered, unclear pronoun or noun-phrase reference that disrupts cohesion.
+  Example (connector): "Fui al cine. Vi una película." → missing connector → C.
+  Example (discourse): A paragraph opens with a supporting detail before the main claim, leaving the reader uncertain what point is being made → C.
 - G (Gramática): verb conjugation, prepositions (selection, not spelling), gender/number agreement, word order, articles.
   Example: "*el problema es muy grande*" → if "el" is wrong gender for the noun, G.
 - L (Léxico): wrong vocabulary, literal translations from L1, unnatural usage, register mismatch (a structure or expression grammatically correct but inappropriate for the formality level of the task).

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -48,9 +48,9 @@ CATEGORIES (use the exact code letter):
 
 - C (Cohesión y Coherencia): connector-level or discourse-organization error.
   Connector-level: missing connector, wrong connector, missing temporal marker, repetitive linking structure.
-  Discourse-level: paragraph lacks a clear main idea (no topic sentence), ideas within a paragraph are not logically ordered, unclear pronoun or noun-phrase reference that disrupts cohesion.
+  Discourse-level (most significant at B2+): paragraph lacks a clear main idea (no topic sentence), ideas within a paragraph are not logically ordered.
   Example (connector): "Fui al cine. Vi una película." → missing connector → C.
-  Example (discourse): A paragraph opens with a supporting detail before the main claim, leaving the reader uncertain what point is being made → C.
+  Example (discourse): "Hay muchos plásticos en el océano. El reciclaje es costoso. Por eso debemos reciclar más." → the paragraph lists facts before stating the main claim, leaving the reader uncertain what point is being made → C.
 - G (Gramática): verb conjugation, prepositions (selection, not spelling), gender/number agreement, word order, articles.
   Example: "*el problema es muy grande*" → if "el" is wrong gender for the noun, G.
 - L (Léxico): wrong vocabulary, literal translations from L1, unnatural usage, register mismatch (a structure or expression grammatically correct but inappropriate for the formality level of the task).
@@ -72,7 +72,7 @@ CRITICAL RULES:
 - A wrong preposition is G, NEVER L.
 - A literal translation from the student's L1 is L, NEVER G.
 - A missing or wrong connector is C, NEVER G.
-- An ambiguous pronoun or noun-phrase reference where the word is grammatically correct but the referent is unclear is C, NEVER G or L.
+- An ambiguous pronoun or noun-phrase reference where the word is grammatically correct but the referent is unclear is C, NEVER G.
 
 OUTPUT CONTRACT:
 

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -72,6 +72,7 @@ CRITICAL RULES:
 - A wrong preposition is G, NEVER L.
 - A literal translation from the student's L1 is L, NEVER G.
 - A missing or wrong connector is C, NEVER G.
+- An ambiguous pronoun or noun-phrase reference where the word is grammatically correct but the referent is unclear is C, NEVER G or L.
 
 OUTPUT CONTRACT:
 

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -48,7 +48,7 @@ CATEGORIES (use the exact code letter):
 
 - C (Cohesión y Coherencia): connector-level or discourse-organization error.
   Connector-level: missing connector, wrong connector, missing temporal marker, repetitive linking structure.
-  Discourse-level (most significant at B2+): paragraph lacks a clear main idea (no topic sentence), ideas within a paragraph are not logically ordered.
+  Discourse-level (most significant at B2 and above): paragraph lacks a clear main idea (no topic sentence), ideas within a paragraph are not logically ordered.
   Example (connector): "Fui al cine. Vi una película." → missing connector → C.
   Example (discourse): "Hay muchos plásticos en el océano. El reciclaje es costoso. Por eso debemos reciclar más." → the paragraph lists facts before stating the main claim, leaving the reader uncertain what point is being made → C.
 - G (Gramática): verb conjugation, prepositions (selection, not spelling), gender/number agreement, word order, articles.

--- a/backend/LangTeach.Api/AI/RedaccionLevelFilterPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionLevelFilterPromptBuilder.cs
@@ -52,7 +52,7 @@ GUIDANCE:
 - Use the grammar in-scope and out-of-scope lists to anchor your decision.
 - When a structure is on the out-of-scope list, use "soften" if the student attempted it correctly or nearly correctly, "remove" if the attempt is clearly wrong and above level.
 - When the out-of-scope list is empty (e.g. C1/C2), keep everything or promote to muybien; softening and removal are rarely appropriate at this level.
-- G (Gramática), L (Léxico), C (Cohesión) tags may be softened, removed, or promoted to muybien based on level scope.
+- G (Gramática), L (Léxico), C (Cohesión y Coherencia) tags may be softened, removed, or promoted to muybien based on level scope.
 - Use "muybien" only when the student demonstrates genuinely strong usage: a structure at or near their level ceiling, used correctly, AND fitting the register of the assignment.
 - Use "soften" when a student attempts an above-scope structure that shows intentional effort, even if imperfect.
 

--- a/frontend/src/lib/correction-colors.ts
+++ b/frontend/src/lib/correction-colors.ts
@@ -10,7 +10,7 @@ export interface CategoryStyle {
 
 const STYLES: Record<Exclude<CorrectionTagCategory, 'MuyBien'>, CategoryStyle> = {
   C: {
-    label: 'Cohesión',
+    label: 'Cohesión y Coherencia',
     underline: 'decoration-indigo-500',
     chipBg: 'bg-indigo-100',
     chipText: 'text-indigo-700',


### PR DESCRIPTION
## Summary

- Expands the C error category in `RedaccionCorrectionPromptBuilder` from connector-only ("Cohesión") to both connector-level and discourse-level ("Cohesión y Coherencia"), aligning with EOI CCoh rubric used at B2/C1
- Adds discourse-level subcategories: missing topic sentence, illogically ordered paragraph ideas
- Adds ambiguous-pronoun-reference disambiguation rule to CRITICAL RULES (grammatically correct word but unclear referent = C, not G)
- Updates the C label consistently in `RedaccionLevelFilterPromptBuilder` and `correction-colors.ts` (UI chip)

## Why

At B2/C1, a structurally incoherent paragraph with correct connectors would receive no C tag under the old narrow definition. EOI prueba de expresión escrita rubrics explicitly score "cohesión y coherencia" as a criterion covering both connector use and paragraph-level discourse organization.

## Verify

Submitted a B2 redacción (Ana Visual, e2e stack) with correct connectors but a second paragraph that had no topic sentence and disordered ideas. Pass 1 generated C tags on the second paragraph with explanations referencing "oración temática (topic sentence)" and lack of cohesive links. PASS.

## Test plan

- [x] `RedaccionCorrectionPromptBuilderTests` (17 tests, all pass) -- new test `Build_SystemPromptContainsDiscourseOrganizationInCCategory` asserts on "Cohesión y Coherencia", "topic sentence", and "logically ordered"
- [x] Full backend suite: 1401 passed, 0 failed (incl. `CefrSublevelsGuardTest`)
- [x] Frontend tests: 1759 passed, 0 failed
- [x] Live e2e verify: C tag generated on structurally incoherent B2 paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)