### PR TITLE
fix(generation): grammar scope ceiling for B1 + warm-up icebreaker enforcement (#1227)

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -1445,6 +1445,25 @@ public class PromptServiceTests
         req.UserPrompt.Should().Contain("In scope:");
     }
 
+    [Fact]
+    public void GrammarPrompt_B1_ContainsGrammarFocusCeiling()
+    {
+        var req = _sut.BuildGrammarPrompt(BaseCtx()); // B1
+
+        req.UserPrompt.Should().Contain("GRAMMAR FOCUS CEILING");
+        req.UserPrompt.Should().Contain("B1.1");
+    }
+
+    [Fact]
+    public void WarmUpPrompt_ContainsNoCorrectionAnswerConstraint()
+    {
+        var ctx = BaseCtx() with { SectionType = "WarmUp" };
+        var req = _sut.BuildConversationPrompt(ctx);
+
+        req.UserPrompt.Should().Contain("Never generate grammar elicitation");
+        req.UserPrompt.Should().Contain("HARD CONSTRAINT");
+    }
+
     // --- Vocabulary prompt: vocabulary constraints injection ---
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -1460,8 +1460,8 @@ public class PromptServiceTests
         var ctx = BaseCtx() with { SectionType = "WarmUp" };
         var req = _sut.BuildConversationPrompt(ctx);
 
-        req.UserPrompt.Should().Contain("Never generate grammar elicitation");
-        req.UserPrompt.Should().Contain("HARD CONSTRAINT");
+        req.UserPrompt.Should().Contain("Warm-up is icebreaker activation only");
+        req.UserPrompt.Should().Contain("Never frame it as grammar elicitation");
     }
 
     // --- Vocabulary prompt: vocabulary constraints injection ---

--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -1452,6 +1452,8 @@ public class PromptServiceTests
 
         req.UserPrompt.Should().Contain("GRAMMAR FOCUS CEILING");
         req.UserPrompt.Should().Contain("B1.1");
+        req.UserPrompt.Should().Contain("pluscuamperfecto");
+        req.UserPrompt.Should().Contain("subjuntivo");
     }
 
     [Fact]
@@ -1462,6 +1464,7 @@ public class PromptServiceTests
 
         req.UserPrompt.Should().Contain("Warm-up is icebreaker activation only");
         req.UserPrompt.Should().Contain("Never frame it as grammar elicitation");
+        req.UserPrompt.Should().Contain("right or wrong answers");
     }
 
     // --- Vocabulary prompt: vocabulary constraints injection ---

--- a/backend/LangTeach.Api/AI/PedagogyConfig.cs
+++ b/backend/LangTeach.Api/AI/PedagogyConfig.cs
@@ -21,7 +21,8 @@ public record CefrLevelRules(
     string ErrorCorrection,
     string ScaffoldingDefault,
     GuidedWritingConfig? GuidedWriting = null,
-    NoticingTaskConfig? NoticingTask = null
+    NoticingTaskConfig? NoticingTask = null,
+    string? GrammarFocusCeiling = null
 );
 
 public record GuidedWritingConfig(

--- a/backend/LangTeach.Api/AI/PedagogyConfigDtos.cs
+++ b/backend/LangTeach.Api/AI/PedagogyConfigDtos.cs
@@ -4,7 +4,7 @@ namespace LangTeach.Api.AI;
 /// Output DTO for GetGrammarScope — contains in-scope and out-of-scope grammar lists for a CEFR level.
 /// Not a JSON deserialization model; constructed by PedagogyConfigService from CefrLevelRules data.
 /// </summary>
-public record GrammarScope(string[] InScope, string[] OutOfScope);
+public record GrammarScope(string[] InScope, string[] OutOfScope, string? CeilingNote = null);
 
 /// <summary>
 /// Output DTO for GetVocabularyGuidance.

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -234,6 +234,8 @@ public class PromptService : IPromptService
             sb.AppendLine($"In scope: {string.Join(", ", scope.InScope)}");
         if (scope.OutOfScope.Length > 0)
             sb.AppendLine($"Exclude from teaching targets: {string.Join(", ", scope.OutOfScope)}");
+        if (!string.IsNullOrWhiteSpace(scope.CeilingNote))
+            sb.AppendLine($"GRAMMAR FOCUS CEILING: {scope.CeilingNote}");
         return sb.ToString().TrimEnd();
     }
 

--- a/backend/LangTeach.Api/Services/PedagogyConfigService.cs
+++ b/backend/LangTeach.Api/Services/PedagogyConfigService.cs
@@ -227,7 +227,7 @@ public class PedagogyConfigService : IPedagogyConfigService
         var normalLevel = NormalizeLevel(level);
         if (!_cefrRules.TryGetValue(normalLevel, out var rule))
             return new GrammarScope([], []);
-        return new GrammarScope(rule.GrammarInScope, rule.GrammarOutOfScope);
+        return new GrammarScope(rule.GrammarInScope, rule.GrammarOutOfScope, rule.GrammarFocusCeiling);
     }
 
     public GuidedWritingGuidance GetGuidedWritingGuidance(string level)

--- a/data/pedagogy/cefr-levels/b1.json
+++ b/data/pedagogy/cefr-levels/b1.json
@@ -2,28 +2,30 @@
   "level": "B1",
   "grammarInScope": [
     "Preterito imperfecto y su contraste con indefinido (habito vs evento, descripcion vs accion)",
-    "Preterito pluscuamperfecto",
     "Futuro simple (irregulares incluidos)",
     "Condicional simple",
-    "Subjuntivo presente (introduccion): ojala, quiero que, cuando + subjuntivo, para que, es necesario que",
     "Imperativo negativo",
     "Oraciones temporales (cuando, mientras, antes de que, despues de que)",
     "Oraciones causales y finales (porque, como, para que, a fin de que)",
-    "Estilo indirecto basico (dijo que + imperfecto)",
     "Conectores avanzados: sin embargo, no obstante, en primer lugar, por un lado/por otro, en conclusion",
     "Perifrasis: llevar + gerundio, dejar de + infinitivo, seguir + gerundio, volver a + infinitivo",
     "Oraciones relativas con indicativo (que, donde, quien)",
     "Expresar condiciones reales (si + presente, futuro)",
+    "Preterito pluscuamperfecto (B1.2 -- Grammar Focus target only after imperfecto/indefinido contrast is consolidated)",
+    "Subjuntivo presente introduccion: ojala, quiero que, cuando + subjuntivo, para que, es necesario que (B1.2 -- Grammar Focus target only after core B1.1 tenses are mastered)",
+    "Estilo indirecto basico con imperfecto indicativo: dijo que + imperfecto (B1.2 -- not imperfecto de subjuntivo, which is B2)",
     "Expresar hipotesis (si + imperfecto de subjuntivo, condicional) (B1.2)"
   ],
   "grammarOutOfScope": [
-    "Subjuntivo imperfecto en todos sus usos (solo la condicional irreal se introduce en B1.2)",
+    "Subjuntivo imperfecto en todos sus usos excepto la condicional irreal (B1.2)",
     "Subjuntivo perfecto y pluscuamperfecto",
     "Oraciones concesivas complejas (aunque + subjuntivo, se ve al final de B1.2/inicio de B2)",
     "Voz pasiva con ser (B2)",
     "Construcciones impersonales complejas",
-    "Perifrasis modales sofisticadas (venir a + infinitivo, dar por + participio)"
+    "Perifrasis modales sofisticadas (venir a + infinitivo, dar por + participio)",
+    "Subjuntivo imperfecto en estilo indirecto (dijo que enviara) -- B2, not B1"
   ],
+  "grammarFocusCeiling": "For students new to B1 (B1.1 stage), restrict Grammar Focus targets to: imperfecto/indefinido contrast, futuro simple, condicional simple, imperativo negativo, real conditions (si + presente), oraciones temporales/causales, conectores, and perifrasis. Pluscuamperfecto, subjuntivo (any mood), and indirect-speech tense shifts are B1.2 structures -- do not make them the Grammar Focus target unless teacher notes explicitly confirm prior mastery. Imperfecto de subjuntivo in indirect speech (e.g. dijo que enviara) is B2 and must never appear as a Grammar Focus target at B1.",
   "appropriateExerciseTypes": [
     "GR-01",
     "GR-02",

--- a/data/pedagogy/cefr-levels/b1.json
+++ b/data/pedagogy/cefr-levels/b1.json
@@ -25,7 +25,7 @@
     "Perifrasis modales sofisticadas (venir a + infinitivo, dar por + participio)",
     "Subjuntivo imperfecto en estilo indirecto (dijo que enviara) -- B2, not B1"
   ],
-  "grammarFocusCeiling": "For students new to B1 (B1.1 stage), restrict Grammar Focus targets to: imperfecto/indefinido contrast, futuro simple, condicional simple, imperativo negativo, real conditions (si + presente), oraciones temporales/causales, conectores, and perifrasis. Pluscuamperfecto, subjuntivo (any mood), and indirect-speech tense shifts are B1.2 structures -- do not make them the Grammar Focus target unless teacher notes explicitly confirm prior mastery. Imperfecto de subjuntivo in indirect speech (e.g. dijo que enviara) is B2 and must never appear as a Grammar Focus target at B1.",
+  "grammarFocusCeiling": "Grammar Focus targets for B1.1 students are restricted to: imperfecto/indefinido contrast, futuro simple, condicional simple, imperativo negativo, real conditions (si + presente), oraciones temporales/causales, conectores, and perifrasis verbales. Pluscuamperfecto, subjuntivo (any mood), and indirect-speech tense shifts are B1.2 structures; they become available as Grammar Focus targets only when teacher notes confirm prior mastery.",
   "appropriateExerciseTypes": [
     "GR-01",
     "GR-02",

--- a/data/section-profiles/warmup.json
+++ b/data/section-profiles/warmup.json
@@ -5,7 +5,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "yes/no or either/or questions using only known vocabulary. Accept single-word answers. Purpose: reduce anxiety. Example: Te gusta mas el cafe o el te? Keep to 1-2 teacher turns.",
+      "guidance": "HARD CONSTRAINT: Never generate grammar elicitation, vocabulary tests, or any activity with correct/incorrect answers -- warm-up is icebreaker activation only. Use yes/no or either/or questions using only known vocabulary. Accept single-word answers. Purpose: reduce anxiety. Example: Te gusta mas el cafe o el te? Keep to 1-2 teacher turns.",
       "duration": {
         "min": 2,
         "max": 3
@@ -46,7 +46,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "Open personal questions using present tense. Expect a 2-3 sentence response. Example: Que haces los fines de semana? Include 2-3 suggested follow-up questions. Note: Use preterite only if the student has already learned it.",
+      "guidance": "HARD CONSTRAINT: Never generate grammar elicitation, vocabulary tests, or any activity with correct/incorrect answers -- warm-up is icebreaker activation only. Open personal questions using present tense. Expect a 2-3 sentence response. Example: Que haces los fines de semana? Include 2-3 suggested follow-up questions. Note: Use preterite only if the student has already learned it.",
       "duration": {
         "min": 2,
         "max": 4
@@ -89,7 +89,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "Opinion prompts with light justification. Que opinas de...? Por que? Tied to the lesson topic. 2-3 follow-up questions. No scaffolding phrases needed.",
+      "guidance": "HARD CONSTRAINT: Never generate grammar elicitation, vocabulary tests, or any activity with correct/incorrect answers -- warm-up is icebreaker activation only. Opinion prompts with light justification. Que opinas de...? Por que? Tied to the lesson topic. 2-3 follow-up questions. No scaffolding phrases needed.",
       "duration": {
         "min": 3,
         "max": 5
@@ -126,7 +126,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "News-related or cultural discussion starters. Expects 4-5 sentence connected discourse. agree/disagree or headline prediction format. 2-3 follow-up questions.",
+      "guidance": "HARD CONSTRAINT: Never generate grammar elicitation, vocabulary tests, or any activity with correct/incorrect answers -- warm-up is icebreaker activation only. News-related or cultural discussion starters. Expects 4-5 sentence connected discourse. agree/disagree or headline prediction format. 2-3 follow-up questions.",
       "duration": {
         "min": 3,
         "max": 5
@@ -163,7 +163,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "Provocative statement, abstract prompt, or ethical dilemma. Expects nuanced argumentation. Single trigger, no follow-ups needed; teacher improvises. circumlocution or semantic mapping as alternatives.",
+      "guidance": "HARD CONSTRAINT: Never generate grammar elicitation, vocabulary tests, or any activity with correct/incorrect answers -- warm-up is icebreaker activation only. Provocative statement, abstract prompt, or ethical dilemma. Expects nuanced argumentation. Single trigger, no follow-ups needed; teacher improvises. circumlocution or semantic mapping as alternatives.",
       "duration": {
         "min": 3,
         "max": 5
@@ -201,7 +201,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "Devil advocate positions or mediation warm-ups (summarize a concept for a non-expert). Expects register-aware extended discourse. Same trigger types as C1.",
+      "guidance": "HARD CONSTRAINT: Never generate grammar elicitation, vocabulary tests, or any activity with correct/incorrect answers -- warm-up is icebreaker activation only. Devil advocate positions or mediation warm-ups (summarize a concept for a non-expert). Expects register-aware extended discourse. Same trigger types as C1.",
       "duration": {
         "min": 3,
         "max": 5

--- a/data/section-profiles/warmup.json
+++ b/data/section-profiles/warmup.json
@@ -5,7 +5,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers.Use yes/no or either/or questions using only known vocabulary. Accept single-word answers. Purpose: reduce anxiety. Example: Te gusta mas el cafe o el te? Keep to 1-2 teacher turns.",
+      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers. Use yes/no or either/or questions using only known vocabulary. Accept single-word answers. Purpose: reduce anxiety. Example: Te gusta mas el cafe o el te? Keep to 1-2 teacher turns.",
       "duration": {
         "min": 2,
         "max": 3
@@ -46,7 +46,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers.Open personal questions using present tense. Expect a 2-3 sentence response. Example: Que haces los fines de semana? Include 2-3 suggested follow-up questions. Note: Use preterite only if the student has already learned it.",
+      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers. Open personal questions using present tense. Expect a 2-3 sentence response. Example: Que haces los fines de semana? Include 2-3 suggested follow-up questions. Note: Use preterite only if the student has already learned it.",
       "duration": {
         "min": 2,
         "max": 4
@@ -89,7 +89,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers.Opinion prompts with light justification. Que opinas de...? Por que? Tied to the lesson topic. 2-3 follow-up questions. No scaffolding phrases needed.",
+      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers. Opinion prompts with light justification. Que opinas de...? Por que? Tied to the lesson topic. 2-3 follow-up questions. No scaffolding phrases needed.",
       "duration": {
         "min": 3,
         "max": 5
@@ -126,7 +126,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers.News-related or cultural discussion starters. Expects 4-5 sentence connected discourse. agree/disagree or headline prediction format. 2-3 follow-up questions.",
+      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers. News-related or cultural discussion starters. Expects 4-5 sentence connected discourse. agree/disagree or headline prediction format. 2-3 follow-up questions.",
       "duration": {
         "min": 3,
         "max": 5
@@ -163,7 +163,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers.Provocative statement, abstract prompt, or ethical dilemma. Expects nuanced argumentation. Single trigger, no follow-ups needed; teacher improvises. circumlocution or semantic mapping as alternatives.",
+      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers. Provocative statement, abstract prompt, or ethical dilemma. Expects nuanced argumentation. Single trigger, no follow-ups needed; teacher improvises. circumlocution or semantic mapping as alternatives.",
       "duration": {
         "min": 3,
         "max": 5
@@ -201,7 +201,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers.Devil advocate positions or mediation warm-ups (summarize a concept for a non-expert). Expects register-aware extended discourse. Same trigger types as C1.",
+      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers. Devil advocate positions or mediation warm-ups (summarize a concept for a non-expert). Expects register-aware extended discourse. Same trigger types as C1.",
       "duration": {
         "min": 3,
         "max": 5

--- a/data/section-profiles/warmup.json
+++ b/data/section-profiles/warmup.json
@@ -5,7 +5,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "HARD CONSTRAINT: Never generate grammar elicitation, vocabulary tests, or any activity with correct/incorrect answers -- warm-up is icebreaker activation only. Use yes/no or either/or questions using only known vocabulary. Accept single-word answers. Purpose: reduce anxiety. Example: Te gusta mas el cafe o el te? Keep to 1-2 teacher turns.",
+      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers.Use yes/no or either/or questions using only known vocabulary. Accept single-word answers. Purpose: reduce anxiety. Example: Te gusta mas el cafe o el te? Keep to 1-2 teacher turns.",
       "duration": {
         "min": 2,
         "max": 3
@@ -46,7 +46,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "HARD CONSTRAINT: Never generate grammar elicitation, vocabulary tests, or any activity with correct/incorrect answers -- warm-up is icebreaker activation only. Open personal questions using present tense. Expect a 2-3 sentence response. Example: Que haces los fines de semana? Include 2-3 suggested follow-up questions. Note: Use preterite only if the student has already learned it.",
+      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers.Open personal questions using present tense. Expect a 2-3 sentence response. Example: Que haces los fines de semana? Include 2-3 suggested follow-up questions. Note: Use preterite only if the student has already learned it.",
       "duration": {
         "min": 2,
         "max": 4
@@ -89,7 +89,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "HARD CONSTRAINT: Never generate grammar elicitation, vocabulary tests, or any activity with correct/incorrect answers -- warm-up is icebreaker activation only. Opinion prompts with light justification. Que opinas de...? Por que? Tied to the lesson topic. 2-3 follow-up questions. No scaffolding phrases needed.",
+      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers.Opinion prompts with light justification. Que opinas de...? Por que? Tied to the lesson topic. 2-3 follow-up questions. No scaffolding phrases needed.",
       "duration": {
         "min": 3,
         "max": 5
@@ -126,7 +126,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "HARD CONSTRAINT: Never generate grammar elicitation, vocabulary tests, or any activity with correct/incorrect answers -- warm-up is icebreaker activation only. News-related or cultural discussion starters. Expects 4-5 sentence connected discourse. agree/disagree or headline prediction format. 2-3 follow-up questions.",
+      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers.News-related or cultural discussion starters. Expects 4-5 sentence connected discourse. agree/disagree or headline prediction format. 2-3 follow-up questions.",
       "duration": {
         "min": 3,
         "max": 5
@@ -163,7 +163,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "HARD CONSTRAINT: Never generate grammar elicitation, vocabulary tests, or any activity with correct/incorrect answers -- warm-up is icebreaker activation only. Provocative statement, abstract prompt, or ethical dilemma. Expects nuanced argumentation. Single trigger, no follow-ups needed; teacher improvises. circumlocution or semantic mapping as alternatives.",
+      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers.Provocative statement, abstract prompt, or ethical dilemma. Expects nuanced argumentation. Single trigger, no follow-ups needed; teacher improvises. circumlocution or semantic mapping as alternatives.",
       "duration": {
         "min": 3,
         "max": 5
@@ -201,7 +201,7 @@
       "contentTypes": [
         "conversation"
       ],
-      "guidance": "HARD CONSTRAINT: Never generate grammar elicitation, vocabulary tests, or any activity with correct/incorrect answers -- warm-up is icebreaker activation only. Devil advocate positions or mediation warm-ups (summarize a concept for a non-expert). Expects register-aware extended discourse. Same trigger types as C1.",
+      "guidance": "Warm-up is icebreaker activation only: open personal questions, anecdote elicitation, thematic association. Never frame it as grammar elicitation or as any activity where responses have right or wrong answers.Devil advocate positions or mediation warm-ups (summarize a concept for a non-expert). Expects register-aware extended discourse. Same trigger types as C1.",
       "duration": {
         "min": 3,
         "max": 5


### PR DESCRIPTION
## Summary

- Adds a `grammarFocusCeiling` field to `b1.json` that explicitly restricts Grammar Focus targets for early-B1 students to B1.1-safe structures (imperfecto/indefinido contrast, futuro, condicional, real conditions). Pluscuamperfecto, subjuntivo, and indirect-speech tense shifts are annotated as B1.2-only.
- Adds positive-framing warm-up constraint to all 6 CEFR level guidance fields in `warmup.json`: "Warm-up is icebreaker activation only -- never frame it as grammar elicitation or any activity with right/wrong answers."
- Extends `CefrLevelRules`/`GrammarScope` DTO pipeline to carry the ceiling note to `BuildGrammarScopeBlock` output.
- Two new unit tests verify the ceiling note and warm-up constraint land in generated prompts.

## Test plan

- [x] `GrammarPrompt_B1_ContainsGrammarFocusCeiling` -- ceiling note present in B1 grammar prompt
- [x] `WarmUpPrompt_ContainsNoCorrectionAnswerConstraint` -- icebreaker constraint present in warm-up prompt
- [x] Full build verify: PASS (dotnet test, npm test, bicep build)
- [x] Live e2e: generated Grammar Focus lesson for Agnieszka (B1, Spanish) on "Los habitos en el pasado" -- Presentation section targeted imperfecto/indefinido contrast only, no pluscuamperfecto or subjuntivo; Warm Up used open personal childhood-habit question, no right/wrong answers

## Reviewers

- qa-verify: PASS
- code-review: PASS
- architecture: PASS WITH NOTES (dual enforcement removed -- warmup constraint now in JSON only, matching other section types)
- prompt-health: NEEDS CLEANUP addressed (removed negative bloat, removed duplicate grammarOutOfScope sentence from ceiling)

Closes #1227

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grammar lessons now support focus ceiling definitions for each proficiency level, clarifying which topics are included and when advancement occurs.

* **Chores**
  * Updated B1 proficiency level grammar specifications with refined scope boundaries.
  * Enhanced conversation section guidance to prioritize interaction-focused practice over grammar correction.

* **Tests**
  * Added validation tests for grammar ceiling specifications and conversation prompt behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1249)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->