### PR TITLE
fix(atelier): standardize SessionLogId naming and add date concat comments (#1230)

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/AssistantControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/AssistantControllerTests.cs
@@ -106,7 +106,7 @@ public class AssistantControllerTests
         {
             Text = "Nueva alumna: María García, ingeniera, aprende inglés.",
             StudentId = null,
-            SessionId = null,
+            SessionLogId = null,
         };
         var response = await client.PostAsJsonAsync("/api/assistant/propose", request);
 
@@ -452,7 +452,7 @@ public class AssistantControllerTests
         {
             Text = "Le di clase ayer, trabajamos el subjuntivo. [schedule-new-session]",
             StudentId = studentId,
-            SessionId = null, // student-detail context: no open session
+            SessionLogId = null, // student-detail context: no open session
         };
         var response = await client.PostAsJsonAsync("/api/assistant/propose", request);
 
@@ -474,7 +474,7 @@ public class AssistantControllerTests
         {
             Text = "Normal text without schedule trigger.",
             StudentId = studentId,
-            SessionId = null,
+            SessionLogId = null,
         };
         var response = await client.PostAsJsonAsync("/api/assistant/propose", request);
 

--- a/backend/LangTeach.Api/Controllers/AssistantController.cs
+++ b/backend/LangTeach.Api/Controllers/AssistantController.cs
@@ -64,7 +64,7 @@ public class AssistantController : ControllerBase
             .ToList() as IReadOnlyList<string>;
 
         var studentTask = _studentExtractionService.ExtractAsync(request.Text, ct);
-        var reflectionTask = _reflectionExtractionService.ExtractAsync(request.Text, knownDifficulties, hasOpenSession: request.SessionId.HasValue, ct);
+        var reflectionTask = _reflectionExtractionService.ExtractAsync(request.Text, knownDifficulties, hasOpenSession: request.SessionLogId.HasValue, ct);
 
         await Task.WhenAll(studentTask, reflectionTask);
 
@@ -72,8 +72,8 @@ public class AssistantController : ControllerBase
         var reflectionExtraction = await reflectionTask;
 
         SessionLogDto? session = null;
-        if (student != null && request.SessionId.HasValue)
-            session = await _sessionLogService.GetByIdAsync(teacherId, student.Id, request.SessionId.Value, ct);
+        if (student != null && request.SessionLogId.HasValue)
+            session = await _sessionLogService.GetByIdAsync(teacherId, student.Id, request.SessionLogId.Value, ct);
 
         var proposals = new List<ProposalDto>();
 
@@ -193,6 +193,7 @@ public class AssistantController : ControllerBase
         if (reflectionExtraction.ProposedNewSession is { } proposed)
         {
             var dateOnly = proposed.Date ?? DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd");
+            // dateOnly is yyyy-MM-dd; t is HH:mm -- both guaranteed by the extraction schema.
             var sessionDate = reflectionExtraction.SessionStartTime is { } t
                 ? $"{dateOnly}T{t}"
                 : dateOnly;
@@ -209,7 +210,7 @@ public class AssistantController : ControllerBase
         }
 
         Guid? suggestedSessionLogId = null;
-        if (student != null && !request.SessionId.HasValue)
+        if (student != null && !request.SessionLogId.HasValue)
         {
             var sessions = await _sessionLogService.ListAsync(teacherId, student.Id, ct);
             suggestedSessionLogId = sessions
@@ -224,6 +225,7 @@ public class AssistantController : ControllerBase
         string? extractedSessionDate = null;
         if (reflectionExtraction.SessionDate is { } sd)
         {
+            // sd is yyyy-MM-dd; st is HH:mm -- both guaranteed by the extraction schema.
             extractedSessionDate = reflectionExtraction.SessionStartTime is { } st
                 ? $"{sd}T{st}"
                 : sd;

--- a/backend/LangTeach.Api/DTOs/AssistantDtos.cs
+++ b/backend/LangTeach.Api/DTOs/AssistantDtos.cs
@@ -10,7 +10,7 @@ public class AssistantProposeRequest
     public string Text { get; set; } = "";
 
     public Guid? StudentId { get; set; }
-    public Guid? SessionId { get; set; }
+    public Guid? SessionLogId { get; set; }
     public Guid? VoiceNoteId { get; set; }
 }
 

--- a/frontend/src/api/assistant.ts
+++ b/frontend/src/api/assistant.ts
@@ -46,7 +46,7 @@ export async function proposeAssistant(
   const res = await apiClient.post<ProposeResponse>('/api/assistant/propose', {
     text,
     studentId: studentId ?? null,
-    sessionId: sessionId ?? null,
+    sessionLogId: sessionId ?? null,
     voiceNoteId: voiceNoteId ?? null,
   })
   return res.data


### PR DESCRIPTION
Closes #1230

## Summary

- **AC1 (naming asymmetry):** Renamed `AssistantProposeRequest.SessionId` to `SessionLogId` so request and response use the same field name. Updated all 4 controller sites, 3 test sites, and the frontend JSON payload key.
- **AC2 (date concat):** Added format-contract comments to both `$"{sd}T{st}"` concat sites in `AssistantController` documenting that `sd` is `yyyy-MM-dd` and `st`/`t` is `HH:mm`, both guaranteed by the extraction schema.
- **AC3 (CEFR regex):** Already satisfied by `CefrConstants.ValidationPattern` used consistently across all DTOs -- no raw regex literals remain. Note: `[RegularExpression]` attributes require compile-time constants and cannot read from `IPedagogyConfigService` at runtime; `CefrConstants` is the correct single definition.
- **Items 3, 4 (DTO flattening, proposal taxonomy):** Both already resolved on the sprint branch (`ProposedNewSession` nested record, `_pedagogy.ProposalFields` extraction).

## Files changed

| File | Change |
|---|---|
| `AssistantDtos.cs` | Renamed `SessionId` -> `SessionLogId` on `AssistantProposeRequest` |
| `AssistantController.cs` | 4 ref updates + 2 date concat comments |
| `AssistantControllerTests.cs` | 3 property rename updates |
| `frontend/src/api/assistant.ts` | JSON key `sessionId` -> `sessionLogId` in propose body |

## Test plan

- [x] `dotnet build` -- PASS
- [x] `dotnet test` -- PASS
- [x] `npm lint` -- PASS
- [x] `npm build` -- PASS
- [x] `npm test` -- PASS (105 passed)
- [x] qa-verify agent -- PASS WITH GAPS (gap on AC3 is a false gap; compile-time constant required)
- [x] Code review -- PASS
- [x] Architecture review -- PASS (rename now consistent with all other DTO SessionLogId fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)