### PR TITLE
polish(corrections): thumbs feedback label, Atelier session picker contrast, DS spec updates

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -640,3 +640,64 @@ Used alongside error annotation spans (§11.16) to mark stretches of text that t
 - **When NOT to use:** for error categories (use §11.16 instead), for general bold emphasis in body copy, or for teacher-authored comments.
 
 Reference implementation: `MarkedUpText.tsx` `renderPiece`.
+
+### 11.18 Correction Feedback Thumbs
+
+Used in the correction detail view (`RedaccionDetail.tsx`) to collect teacher rating on AI correction quality.
+
+```tsx
+<div className="space-y-2">
+  <p className="text-xs text-zinc-500">¿Fue útil esta corrección?</p>
+  {/* thumbs buttons or thumbs-down text input */}
+</div>
+```
+
+**Label:** Always show `¿Fue útil esta corrección?` as a `text-xs text-zinc-500` paragraph above the controls. Place it outside the conditional blocks so it appears in all non-success states (idle and thumbs-down-open).
+
+**Idle state (thumbs pair):**
+- Both icons: `text-zinc-400`, 16x16.
+- Thumbs-up hover: `hover:text-emerald-600`.
+- Thumbs-down hover: `hover:text-red-500`.
+- Pending spinner: `Loader2 animate-spin text-zinc-400`.
+
+**Thumbs-down open state:** replaces icons with an inline text input + Send + Cancel row.
+
+**Success state:** replace entire block with `<p className="text-sm text-zinc-500" role="status">Gracias por tu feedback.</p>`.
+
+Reference implementation: `RedaccionDetail.tsx` `CorrectionFeedback`.
+
+### 11.19 Atelier Inline Session Picker
+
+Used inside the Atelier proposals view when no session is selected and session proposals exist. Rendered as an inline banner above the proposal cards.
+
+```tsx
+<div className="flex flex-col gap-1.5 px-3 py-2.5 rounded-xl bg-violet-50">
+  <p className="text-xs font-inter text-gray-700 leading-snug mb-1">
+    Choose a session to apply these notes to:
+  </p>
+  {/* New session button */}
+  <button className="flex items-center gap-2 px-2.5 py-2 rounded-lg text-xs font-inter font-semibold transition-colors text-left text-indigo-600 hover:bg-indigo-50">
+    <Plus className="h-3.5 w-3.5 shrink-0" />
+    New session
+  </button>
+  {/* Selected state */}
+  <button className="... text-indigo-700 bg-indigo-100">
+    <Check className="h-3.5 w-3.5 shrink-0" />
+    New session
+  </button>
+  {/* Existing session row */}
+  <button className="flex items-center gap-2 px-2.5 py-2 rounded-lg text-xs font-inter text-zinc-600 hover:bg-violet-100 transition-colors text-left">
+    <CalendarDays className="h-3.5 w-3.5 shrink-0 text-zinc-400" />
+    <span className="truncate">{dateLabel} — {title}</span>
+  </button>
+</div>
+```
+
+- **Container:** `bg-violet-50 rounded-xl` — tonal match to the Atelier violet theme.
+- **Instruction text:** `text-xs font-inter text-gray-700` — minimum for WCAG AA at 12px on `bg-violet-50`.
+- **New session / unselected:** `text-indigo-600 hover:bg-indigo-50`.
+- **Selected state:** `text-indigo-700 bg-indigo-100` + Check icon replaces Plus.
+- **Existing session rows:** ghost style `text-zinc-600 hover:bg-violet-100` to stay within the violet container theme.
+- No selected/active state defined for existing session rows — clicking immediately applies and dismisses the picker.
+
+Reference implementation: `AtelierAssistantPanel.tsx` `session-picker-banner` test id.

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -353,7 +353,7 @@ export default function AtelierAssistantPanel({
               <button
                 onClick={() => setPendingClose(false)}
                 data-testid="discard-confirm-cancel"
-                className="text-sm font-inter font-medium text-indigo-600 hover:text-indigo-700 transition-colors px-2 py-1 rounded-lg hover:bg-indigo-50"
+                className="text-sm font-inter font-medium text-zinc-500 hover:text-zinc-700 px-2 py-1 rounded-lg hover:bg-zinc-100"
               >
                 Keep editing
               </button>
@@ -445,7 +445,7 @@ export default function AtelierAssistantPanel({
                         className="flex flex-col gap-1.5 px-3 py-2.5 rounded-xl bg-violet-50"
                         data-testid="session-picker-banner"
                       >
-                        <p className="text-xs font-inter text-violet-700 leading-snug mb-1">
+                        <p className="text-xs font-inter text-gray-700 leading-snug mb-1">
                           Choose a session to apply these notes to:
                         </p>
                         <button

--- a/frontend/src/pages/RedaccionDetail.tsx
+++ b/frontend/src/pages/RedaccionDetail.tsx
@@ -235,6 +235,7 @@ function CorrectionFeedback({ studentId, correctionId }: CorrectionFeedbackProps
 
   return (
     <div className="space-y-2">
+      <p className="text-xs text-zinc-500">¿Fue útil esta corrección?</p>
       {inputState !== 'down-open' && (
         <div className="flex items-center gap-3">
           <button

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -27,6 +27,7 @@ Out-of-scope observations logged by agents during implementation. Each row is so
 | #1065 | 2026-05-04 | low | CreateTeachingTodoDto.DueDate is string? while sibling CreateTeacherFollowupRequest.DueDate is DateOnly?; inconsistent binding strategy for same entity field (arch review) |
 | #1165 | 2026-05-09 | low | AssistantProposeRequest uses `SessionId` but AssistantProposeResponse uses `SessionLogId` for the same entity; naming asymmetry in the API contract (Sophy) |
 | #smoke-hardening | 2026-05-04 | low | "Apply" button in Atelier Assistant proposal flow not smoke-testable without real audio; #1065 fix end-to-end unconfirmed |
+| #1231 | 2026-05-12 | low | Arch reviewer noted AtelierAssistantPanel mic-retry-btn (line 377) uses indigo while Keep editing uses zinc; these are different UI states (mic error vs discard confirm) so no inconsistency -- dismissed. |
 | #1153 | 2026-05-08 | low | `frontend/src/pages/StudentForm.test.tsx > "includes identity fields in form submission"` is flaky under parallel vitest load (1 fail in full run, 72/72 pass when isolated). Pre-existing, unrelated to redacciones. |
 | #1155 | 2026-05-08 | low | CorrectionDetailDto has no studentTextUpdatedAt field; stale-markup banner (issue #1155 edge case) deferred until DTO grows that field (plan revision) |
 | #1155 | 2026-05-08 | low | DemoSeeder Ana Visual correction duplicates marked-up JSON literal and tagSpecs array; could be serialized once from tagSpecs (Sophy) |


### PR DESCRIPTION
Closes #1231

## Summary

- Add `¿Fue útil esta corrección?` label above thumbs icons in `CorrectionFeedback` (`RedaccionDetail.tsx`) — placed outside both conditional blocks so it shows in idle and thumbs-down-open states, disappears only on success.
- Fix Atelier session picker instruction text contrast: `text-violet-700` -> `text-gray-700` on `bg-violet-50` (estimated contrast ~7.7:1, well above WCAG AA 4.5:1 for 12px text).
- Fix `Keep editing` button tonal color in `AtelierAssistantPanel` discard-confirm: indigo -> zinc per DS §11.11 spec.
- Add DS §11.18 Correction Feedback Thumbs and §11.19 Atelier Inline Session Picker spec entries to `docs/design-system.md`.

## Test plan

- [x] Build passes (dotnet + npm + all 105 tests)
- [x] Live Verify: correction detail shows label above thumbs; session picker instruction text legible; Keep editing is zinc tonal
- [x] UI review agent: all 3 changes PASS
- [x] qa-verify: PASS WITH GAPS (CSS class changes have no unit test coverage — visual polish, confirmed via live review)
- [x] architecture-reviewer: PASS WITH NOTES — noted indigo button at line 377 as inconsistent, but that is the `mic-retry-btn` (unrelated state), not a second Keep editing. Dismissed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)