### PR TITLE
test(infra): CorrectionTestHarness extraction + corrections sprint spec (#1232)

### DIFF
--- a/.claude/skills/teacher-qa/playwright/tests/corrections-sprint.spec.ts
+++ b/.claude/skills/teacher-qa/playwright/tests/corrections-sprint.spec.ts
@@ -1,0 +1,224 @@
+/**
+ * Corrections Sprint Spec — real Claude API integration test
+ *
+ * Exercises the Redacciones correction pipeline end-to-end against the QA stack:
+ *   1. Creates A2 and B1 test students (idempotent via upsertStudent)
+ *   2. Navigates to the A2 student Redacciones tab
+ *   3. Creates corrections for both students via the API (same seed text at two CEFR levels)
+ *   4. Triggers Corregir for both via the API
+ *   5. Polls for Corregida status (up to 3 minutes per correction)
+ *   6. Asserts: (a) Corregida status reached, (b) at least one G tag present,
+ *      (c) A2/B1 moat — tag count or category distribution must differ
+ *
+ * Run: npx playwright test tests/corrections-sprint.spec.ts --config playwright.config.ts
+ */
+import { test, expect, Page } from '@playwright/test'
+import { createQAAuthContext } from '../helpers/auth'
+import { upsertStudent } from '../helpers/navigation'
+
+// Seed text: a realistic ~180-word redacción with deliberate errors across C/G/L/O categories.
+// Submitted unchanged at A2 and B1 to verify CEFR-calibrated markup differs.
+const SEED_TEXT = [
+  'El fin de semana pasado, yo hago muchas cosas con mis amigos. Primero, fuimos al mercado para',
+  'comprar verduras y frutas frescas para preparar una cena especial para toda la familia. Mi madre',
+  'siempre dice que ablamos demasiado durante la cena, pero creo que es importante comunicarse bien.',
+  '',
+  'Después de cenar, vimos una película muy interesante sobre la historia de España. También hablé',
+  'con mis amistades viejas por teléfono — llevamos muchos años sin vernos. La conversación fue muy',
+  'emotiva y fue bonita recordar los viejos tiempos juntos.',
+  '',
+  'Y luego fuimos al parque. Y luego volvimos a casa para descansar un poco antes de la noche.',
+  'El domingo, depende en mi familia para organizar las actividades del día. Hago muchas fotos con',
+  'mi cámara nueva durante el paseo por el barrio histórico. Fue un fin de semana muy completo.',
+].join('\n')
+
+const ASSIGNMENT_TITLE = '[QA] Corrections Sprint — A2/B1 moat'
+const ASSIGNMENT_PROMPT = 'Describe tu fin de semana.'
+
+const CORREGIDA_POLL_INTERVAL_MS = 3000
+const CORREGIDA_TIMEOUT_MS = 180_000
+
+// API calls go through the page context so Auth0 token in localStorage is accessible.
+// The frontend on port 5175 reverse-proxies /api to the backend on port 5176.
+async function apiCall<T>(
+  page: Page,
+  method: 'GET' | 'POST',
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  return page.evaluate(
+    async ({ method, path, body }) => {
+      const auth0KeyPrefix = '@@auth0spajs@@'
+      const cacheKey = Object.keys(localStorage).find(
+        k => k.startsWith(auth0KeyPrefix) && !k.endsWith('::@@user@@'),
+      )
+      if (!cacheKey) throw new Error('Auth0 token cache key not found in localStorage')
+      const raw = localStorage.getItem(cacheKey)
+      if (!raw) throw new Error('Auth0 token cache empty')
+      const parsed = JSON.parse(raw)
+      const token = parsed?.body?.access_token
+      if (!token) throw new Error('No access_token in Auth0 cache')
+
+      const res = await fetch(path, {
+        method,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      })
+      if (!res.ok) {
+        const text = await res.text()
+        throw new Error(`${method} ${path} failed: ${res.status} ${text}`)
+      }
+      if (res.status === 204) return null as unknown as T
+      return res.json() as Promise<T>
+    },
+    { method, path, body },
+  )
+}
+
+interface CorrectionDetail {
+  id: string
+  status: string
+  tags: Array<{ category: string; spannedText?: string; explanation?: string }>
+}
+
+async function createCorrection(page: Page, studentId: string): Promise<string> {
+  const detail = await apiCall<CorrectionDetail>(
+    page,
+    'POST',
+    `/api/students/${studentId}/corrections`,
+    { assignmentTitle: ASSIGNMENT_TITLE, assignmentPrompt: ASSIGNMENT_PROMPT, studentText: SEED_TEXT },
+  )
+  return detail.id
+}
+
+async function triggerCorregir(page: Page, studentId: string, correctionId: string): Promise<void> {
+  await page.evaluate(
+    async ({ studentId, correctionId }) => {
+      const auth0KeyPrefix = '@@auth0spajs@@'
+      const cacheKey = Object.keys(localStorage).find(
+        k => k.startsWith(auth0KeyPrefix) && !k.endsWith('::@@user@@'),
+      )
+      if (!cacheKey) throw new Error('Auth0 token cache key not found')
+      const raw = localStorage.getItem(cacheKey)
+      if (!raw) throw new Error('Auth0 token cache empty')
+      const token = JSON.parse(raw)?.body?.access_token
+      if (!token) throw new Error('No access_token in Auth0 cache')
+
+      const res = await fetch(`/api/students/${studentId}/corrections/${correctionId}/corregir`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      // 200 = corregir accepted; 409 = already running (both are OK)
+      if (!res.ok && res.status !== 409) {
+        const text = await res.text()
+        throw new Error(`POST /corregir failed: ${res.status} ${text}`)
+      }
+    },
+    { studentId, correctionId },
+  )
+}
+
+async function pollForCorregida(
+  page: Page,
+  studentId: string,
+  correctionId: string,
+): Promise<CorrectionDetail> {
+  const deadline = Date.now() + CORREGIDA_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    const detail = await apiCall<CorrectionDetail>(
+      page,
+      'GET',
+      `/api/students/${studentId}/corrections/${correctionId}`,
+    )
+    if (detail.status === 'Corregida') return detail
+    if (detail.status === 'CorreccionFallida') {
+      throw new Error(`Correction ${correctionId} reached CorreccionFallida — check Claude API key / backend logs`)
+    }
+    await new Promise(r => setTimeout(r, CORREGIDA_POLL_INTERVAL_MS))
+  }
+  throw new Error(
+    `Correction ${correctionId} did not reach Corregida within ${CORREGIDA_TIMEOUT_MS / 1000}s`,
+  )
+}
+
+function tagDistributionKey(tags: CorrectionDetail['tags']): string {
+  return tags
+    .map(t => t.category)
+    .sort()
+    .join(',')
+}
+
+test('Corrections Sprint — A2/B1 moat and tag coverage', async ({ browser }) => {
+  const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5175'
+  const context = await createQAAuthContext(browser)
+  const page = await context.newPage()
+
+  // 1. Ensure A2 and B1 students exist (idempotent)
+  const a2StudentId = await upsertStudent(page, {
+    name: '[QA] Corrections A2',
+    language: 'Spanish',
+    cefrLevel: 'A2',
+    nativeLanguage: 'French',
+  })
+  const b1StudentId = await upsertStudent(page, {
+    name: '[QA] Corrections B1',
+    language: 'Spanish',
+    cefrLevel: 'B1',
+    nativeLanguage: 'German',
+  })
+
+  // 2. Navigate to A2 student's Redacciones tab (UI coverage)
+  await page.goto(`${baseURL}/students/${a2StudentId}?tab=redacciones`)
+  await page.waitForLoadState('networkidle', { timeout: 15000 })
+  await expect(page.getByTestId('redacciones-tab')).toBeVisible({ timeout: 10000 })
+
+  // 3. Create corrections for both students via the API (same seed text)
+  const a2CorrectionId = await createCorrection(page, a2StudentId)
+  const b1CorrectionId = await createCorrection(page, b1StudentId)
+
+  console.log(`[corrections-sprint] Created A2 correction ${a2CorrectionId}`)
+  console.log(`[corrections-sprint] Created B1 correction ${b1CorrectionId}`)
+
+  // 4. Trigger Corregir for both (fires async background job on the backend)
+  await triggerCorregir(page, a2StudentId, a2CorrectionId)
+  await triggerCorregir(page, b1StudentId, b1CorrectionId)
+
+  // Navigate to A2 correction detail to show in-progress state (UI coverage)
+  await page.goto(`${baseURL}/students/${a2StudentId}/redacciones/${a2CorrectionId}`)
+  await expect(page.locator('h1')).toBeVisible({ timeout: 10000 })
+
+  // 5. Poll both corrections for Corregida status (real Claude API — up to 3 min each)
+  // Run concurrently so total wait is bounded by the slower of the two, not both summed.
+  const [a2Detail, b1Detail] = await Promise.all([
+    pollForCorregida(page, a2StudentId, a2CorrectionId),
+    pollForCorregida(page, b1StudentId, b1CorrectionId),
+  ])
+
+  // Navigate to A2 correction detail to capture final state (UI coverage)
+  await page.goto(`${baseURL}/students/${a2StudentId}/redacciones/${a2CorrectionId}`)
+  await expect(page.getByTestId('marked-up-text')).toBeVisible({ timeout: 10000 })
+
+  // 6. Assert (a): Corregida status reached for both levels
+  expect(a2Detail.status).toBe('Corregida')
+  expect(b1Detail.status).toBe('Corregida')
+
+  const a2Tags = a2Detail.tags ?? []
+  const b1Tags = b1Detail.tags ?? []
+
+  console.log(`[corrections-sprint] A2 tags (${a2Tags.length}): ${tagDistributionKey(a2Tags)}`)
+  console.log(`[corrections-sprint] B1 tags (${b1Tags.length}): ${tagDistributionKey(b1Tags)}`)
+
+  // 6. Assert (b): at least one G (Grammar) tag present across both corrections
+  const allTags = [...a2Tags, ...b1Tags]
+  expect(allTags.some(t => t.category === 'G')).toBe(true)
+
+  // 6. Assert (c): CEFR moat — A2 and B1 must differ in tag count or category distribution
+  const countDiffers = a2Tags.length !== b1Tags.length
+  const distributionDiffers = tagDistributionKey(a2Tags) !== tagDistributionKey(b1Tags)
+  expect(countDiffers || distributionDiffers).toBe(true)
+
+  await context.close()
+})

--- a/.claude/skills/teacher-qa/playwright/tests/corrections-sprint.spec.ts
+++ b/.claude/skills/teacher-qa/playwright/tests/corrections-sprint.spec.ts
@@ -6,7 +6,7 @@
  *   2. Navigates to the A2 student Redacciones tab
  *   3. Creates corrections for both students via the API (same seed text at two CEFR levels)
  *   4. Triggers Corregir for both via the API
- *   5. Polls for Corregida status (up to 3 minutes per correction)
+ *   5. Polls for Corregida status (up to 3 minutes per correction, run concurrently)
  *   6. Asserts: (a) Corregida status reached, (b) at least one G tag present,
  *      (c) A2/B1 moat — tag count or category distribution must differ
  *
@@ -38,6 +38,12 @@ const ASSIGNMENT_PROMPT = 'Describe tu fin de semana.'
 const CORREGIDA_POLL_INTERVAL_MS = 3000
 const CORREGIDA_TIMEOUT_MS = 180_000
 
+interface CorrectionDetail {
+  id: string
+  status: string
+  tags: Array<{ category: string; spannedText?: string; explanation?: string }>
+}
+
 // API calls go through the page context so Auth0 token in localStorage is accessible.
 // The frontend on port 5175 reverse-proxies /api to the backend on port 5176.
 async function apiCall<T>(
@@ -45,9 +51,10 @@ async function apiCall<T>(
   method: 'GET' | 'POST',
   path: string,
   body?: unknown,
+  extraOkStatuses: number[] = [],
 ): Promise<T> {
   return page.evaluate(
-    async ({ method, path, body }) => {
+    async ({ method, path, body, extraOkStatuses }) => {
       const auth0KeyPrefix = '@@auth0spajs@@'
       const cacheKey = Object.keys(localStorage).find(
         k => k.startsWith(auth0KeyPrefix) && !k.endsWith('::@@user@@'),
@@ -67,21 +74,16 @@ async function apiCall<T>(
         },
         body: body !== undefined ? JSON.stringify(body) : undefined,
       })
-      if (!res.ok) {
+      if (!res.ok && !extraOkStatuses.includes(res.status)) {
         const text = await res.text()
         throw new Error(`${method} ${path} failed: ${res.status} ${text}`)
       }
-      if (res.status === 204) return null as unknown as T
+      if (res.status === 204 || (res.status === 409 && extraOkStatuses.includes(409)))
+        return null as unknown as T
       return res.json() as Promise<T>
     },
-    { method, path, body },
+    { method, path, body, extraOkStatuses },
   )
-}
-
-interface CorrectionDetail {
-  id: string
-  status: string
-  tags: Array<{ category: string; spannedText?: string; explanation?: string }>
 }
 
 async function createCorrection(page: Page, studentId: string): Promise<string> {
@@ -95,29 +97,13 @@ async function createCorrection(page: Page, studentId: string): Promise<string> 
 }
 
 async function triggerCorregir(page: Page, studentId: string, correctionId: string): Promise<void> {
-  await page.evaluate(
-    async ({ studentId, correctionId }) => {
-      const auth0KeyPrefix = '@@auth0spajs@@'
-      const cacheKey = Object.keys(localStorage).find(
-        k => k.startsWith(auth0KeyPrefix) && !k.endsWith('::@@user@@'),
-      )
-      if (!cacheKey) throw new Error('Auth0 token cache key not found')
-      const raw = localStorage.getItem(cacheKey)
-      if (!raw) throw new Error('Auth0 token cache empty')
-      const token = JSON.parse(raw)?.body?.access_token
-      if (!token) throw new Error('No access_token in Auth0 cache')
-
-      const res = await fetch(`/api/students/${studentId}/corrections/${correctionId}/corregir`, {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${token}` },
-      })
-      // 200 = corregir accepted; 409 = already running (both are OK)
-      if (!res.ok && res.status !== 409) {
-        const text = await res.text()
-        throw new Error(`POST /corregir failed: ${res.status} ${text}`)
-      }
-    },
-    { studentId, correctionId },
+  // 200 = corregir accepted; 409 = already running (both are OK)
+  await apiCall<null>(
+    page,
+    'POST',
+    `/api/students/${studentId}/corrections/${correctionId}/corregir`,
+    undefined,
+    [409],
   )
 }
 
@@ -172,8 +158,7 @@ test('Corrections Sprint — A2/B1 moat and tag coverage', async ({ browser }) =
 
   // 2. Navigate to A2 student's Redacciones tab (UI coverage)
   await page.goto(`${baseURL}/students/${a2StudentId}?tab=redacciones`)
-  await page.waitForLoadState('networkidle', { timeout: 15000 })
-  await expect(page.getByTestId('redacciones-tab')).toBeVisible({ timeout: 10000 })
+  await expect(page.getByTestId('redacciones-tab')).toBeVisible({ timeout: 15000 })
 
   // 3. Create corrections for both students via the API (same seed text)
   const a2CorrectionId = await createCorrection(page, a2StudentId)
@@ -190,14 +175,14 @@ test('Corrections Sprint — A2/B1 moat and tag coverage', async ({ browser }) =
   await page.goto(`${baseURL}/students/${a2StudentId}/redacciones/${a2CorrectionId}`)
   await expect(page.locator('h1')).toBeVisible({ timeout: 10000 })
 
-  // 5. Poll both corrections for Corregida status (real Claude API — up to 3 min each)
+  // 5. Poll both corrections for Corregida status (real Claude API — up to 3 min each).
   // Run concurrently so total wait is bounded by the slower of the two, not both summed.
   const [a2Detail, b1Detail] = await Promise.all([
     pollForCorregida(page, a2StudentId, a2CorrectionId),
     pollForCorregida(page, b1StudentId, b1CorrectionId),
   ])
 
-  // Navigate to A2 correction detail to capture final state (UI coverage)
+  // Navigate to the A2 correction detail to show the final marked-up result (UI coverage)
   await page.goto(`${baseURL}/students/${a2StudentId}/redacciones/${a2CorrectionId}`)
   await expect(page.getByTestId('marked-up-text')).toBeVisible({ timeout: 10000 })
 

--- a/.claude/skills/teacher-qa/playwright/tests/corrections-sprint.spec.ts
+++ b/.claude/skills/teacher-qa/playwright/tests/corrections-sprint.spec.ts
@@ -13,6 +13,8 @@
  * Run: npx playwright test tests/corrections-sprint.spec.ts --config playwright.config.ts
  */
 import { test, expect, Page } from '@playwright/test'
+import path from 'path'
+import fs from 'fs'
 import { createQAAuthContext } from '../helpers/auth'
 import { upsertStudent } from '../helpers/navigation'
 
@@ -195,6 +197,35 @@ test('Corrections Sprint — A2/B1 moat and tag coverage', async ({ browser }) =
 
   console.log(`[corrections-sprint] A2 tags (${a2Tags.length}): ${tagDistributionKey(a2Tags)}`)
   console.log(`[corrections-sprint] B1 tags (${b1Tags.length}): ${tagDistributionKey(b1Tags)}`)
+
+  // Save run artifacts for post-run review (matches teacher-qa spec convention)
+  const outputDir = path.resolve(
+    __dirname,
+    '../../output',
+    `corrections-sprint-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}`,
+  )
+  fs.mkdirSync(outputDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(outputDir, 'run-metadata.json'),
+    JSON.stringify({
+      persona: 'Corrections Sprint',
+      a2StudentId,
+      b1StudentId,
+      a2CorrectionId,
+      b1CorrectionId,
+      a2TagCount: a2Tags.length,
+      b1TagCount: b1Tags.length,
+      a2Distribution: tagDistributionKey(a2Tags),
+      b1Distribution: tagDistributionKey(b1Tags),
+      branch: process.env.QA_BRANCH ?? 'unknown',
+      timestamp: new Date().toISOString(),
+    }, null, 2),
+  )
+  fs.writeFileSync(
+    path.join(outputDir, 'correction-tags.json'),
+    JSON.stringify({ a2: a2Detail, b1: b1Detail }, null, 2),
+  )
+  console.log(`[corrections-sprint] Artifacts saved to ${outputDir}`)
 
   // 6. Assert (b): at least one G (Grammar) tag present across both corrections
   const allTags = [...a2Tags, ...b1Tags]

--- a/backend/LangTeach.Api.Tests/Helpers/CorrectionTestHarness.cs
+++ b/backend/LangTeach.Api.Tests/Helpers/CorrectionTestHarness.cs
@@ -4,7 +4,6 @@ using LangTeach.Api.Data;
 using LangTeach.Api.Data.Models;
 using LangTeach.Api.DTOs;
 using LangTeach.Api.Services;
-using LangTeach.Api.Tests.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -120,7 +119,7 @@ public static class CorrectionTestHarness
         {
             using var check = new AppDbContext(dbOptions);
             var row = check.Corrections.Include(c => c.Tags).FirstOrDefault(c => c.Id == correctionId);
-            if (row?.Status == "Corregida")
+            if (row?.Status == CorrectionStatus.Corregida)
             {
                 detail = CorrectionDtoMapper.ToDetail(row, row.Tags);
                 break;

--- a/backend/LangTeach.Api.Tests/Helpers/CorrectionTestHarness.cs
+++ b/backend/LangTeach.Api.Tests/Helpers/CorrectionTestHarness.cs
@@ -106,7 +106,8 @@ public static class CorrectionTestHarness
         scopeServices.AddSingleton<IClaudeClient>(claude);
         scopeServices.AddSingleton<ICorrectionPromptService>(correctionPromptService);
         scopeServices.AddLogging();
-        var scopeFactory = new FakeServiceScopeFactory(scopeServices.BuildServiceProvider());
+        var scopeSp = scopeServices.BuildServiceProvider();
+        var scopeFactory = new FakeServiceScopeFactory(scopeSp);
 
         var service = new RedaccionCorrectionService(db, scopeFactory,
             NullLogger<RedaccionCorrectionService>.Instance);
@@ -129,7 +130,7 @@ public static class CorrectionTestHarness
         if (detail is null)
             throw new TimeoutException($"Correction {correctionId} never reached Corregida in 120s.");
 
-        return new CorrectionRun(detail, db, sp);
+        return new CorrectionRun(detail, db, sp, scopeSp);
     }
 }
 
@@ -139,11 +140,13 @@ public static class CorrectionTestHarness
 public sealed record CorrectionRun(
     CorrectionDetailDto Result,
     AppDbContext Db,
-    ServiceProvider ServiceProvider) : IAsyncDisposable
+    ServiceProvider ServiceProvider,
+    ServiceProvider ScopeServiceProvider) : IAsyncDisposable
 {
     public async ValueTask DisposeAsync()
     {
         await Db.DisposeAsync();
+        await ScopeServiceProvider.DisposeAsync();
         await ServiceProvider.DisposeAsync();
     }
 }

--- a/backend/LangTeach.Api.Tests/Helpers/CorrectionTestHarness.cs
+++ b/backend/LangTeach.Api.Tests/Helpers/CorrectionTestHarness.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using LangTeach.Api.AI;
+using LangTeach.Api.Data;
+using LangTeach.Api.Data.Models;
+using LangTeach.Api.DTOs;
+using LangTeach.Api.Services;
+using LangTeach.Api.Tests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace LangTeach.Api.Tests.Helpers;
+
+/// <summary>
+/// Shared harness for AI integration tests that invoke the correction pipeline against the real
+/// Claude API. Extracted from RedaccionCorrectionDualLevelTests and RedaccionCorrectionVerbatimTests
+/// which had identical RunCorregirAsync implementations.
+/// </summary>
+public static class CorrectionTestHarness
+{
+    /// <summary>
+    /// Seeds an in-memory database with a teacher, student, and correction, runs CorregirAsync,
+    /// and polls until the correction reaches Corregida status (up to 120s).
+    /// </summary>
+    /// <param name="seedText">The student text to correct.</param>
+    /// <param name="cefr">CEFR level of the student (e.g. "A2", "B1").</param>
+    /// <param name="l1">Native language of the student (e.g. "French").</param>
+    /// <param name="prefix">Optional prefix for seed identifiers (used in Auth0UserId/Email).</param>
+    public static async Task<CorrectionRun> RunCorregirAsync(
+        string seedText, string cefr, string l1, string prefix = "harness")
+    {
+        var config = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json", optional: true)
+            .AddUserSecrets<Program>(optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var services = new ServiceCollection();
+        services.Configure<ClaudeClientOptions>(config.GetSection(ClaudeClientOptions.SectionName));
+        services.AddHttpClient("Claude", (sp, client) =>
+        {
+            var opts = sp.GetRequiredService<IOptions<ClaudeClientOptions>>().Value;
+            client.BaseAddress = new Uri(opts.BaseUrl);
+            client.DefaultRequestHeaders.Add("x-api-key", opts.ApiKey);
+            client.DefaultRequestHeaders.Add("anthropic-version", "2023-06-01");
+        });
+        var sp = services.BuildServiceProvider();
+
+        var dbOptions = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var db = new AppDbContext(dbOptions);
+
+        var teacherId = Guid.NewGuid();
+        var studentId = Guid.NewGuid();
+        var correctionId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+
+        db.Teachers.Add(new Teacher
+        {
+            Id = teacherId,
+            Auth0UserId = $"auth0|{prefix}-{cefr}-{l1}",
+            Email = $"{prefix}-{cefr}-{l1}@test.com",
+            DisplayName = $"{prefix} Test",
+            IsApproved = true,
+            CreatedAt = now, UpdatedAt = now,
+        });
+        db.Students.Add(new Student
+        {
+            Id = studentId,
+            TeacherId = teacherId,
+            Name = $"{prefix}-{cefr}",
+            LearningLanguage = "Spanish",
+            CefrLevel = cefr,
+            NativeLanguages = JsonSerializer.Serialize(new[] { l1 }),
+            Difficulties = "[]",
+            CreatedAt = now, UpdatedAt = now,
+        });
+        db.Corrections.Add(new Correction
+        {
+            Id = correctionId,
+            TeacherId = teacherId,
+            StudentId = studentId,
+            SchemaVersion = 1,
+            Status = CorrectionStatus.Entregada,
+            AssignmentTitle = "AI Integration Test",
+            AssignmentPrompt = "Cuenta tu fin de semana.",
+            StudentText = seedText,
+            CreatedAt = now, UpdatedAt = now,
+        });
+        await db.SaveChangesAsync();
+
+        var sps = new SectionProfileService(NullLogger<SectionProfileService>.Instance);
+        var pedagogy = new PedagogyConfigService(NullLogger<PedagogyConfigService>.Instance, sps);
+        var promptBuilder = new RedaccionCorrectionPromptBuilder(pedagogy,
+            NullLogger<RedaccionCorrectionPromptBuilder>.Instance);
+        var filterPromptBuilder = new RedaccionLevelFilterPromptBuilder(pedagogy,
+            NullLogger<RedaccionLevelFilterPromptBuilder>.Instance);
+        var correctionPromptService = new CorrectionPromptService(promptBuilder, filterPromptBuilder);
+        var claude = new ClaudeApiClient(sp.GetRequiredService<IHttpClientFactory>(),
+            NullLogger<ClaudeApiClient>.Instance);
+
+        var scopeServices = new ServiceCollection();
+        scopeServices.AddSingleton<AppDbContext>(_ => new AppDbContext(dbOptions));
+        scopeServices.AddSingleton<IClaudeClient>(claude);
+        scopeServices.AddSingleton<ICorrectionPromptService>(correctionPromptService);
+        scopeServices.AddLogging();
+        var scopeFactory = new FakeServiceScopeFactory(scopeServices.BuildServiceProvider());
+
+        var service = new RedaccionCorrectionService(db, scopeFactory,
+            NullLogger<RedaccionCorrectionService>.Instance);
+
+        await service.CorregirAsync(teacherId, studentId, correctionId);
+
+        var deadline = DateTime.UtcNow.AddSeconds(120);
+        CorrectionDetailDto? detail = null;
+        while (DateTime.UtcNow < deadline)
+        {
+            using var check = new AppDbContext(dbOptions);
+            var row = check.Corrections.Include(c => c.Tags).FirstOrDefault(c => c.Id == correctionId);
+            if (row?.Status == "Corregida")
+            {
+                detail = CorrectionDtoMapper.ToDetail(row, row.Tags);
+                break;
+            }
+            await Task.Delay(500);
+        }
+        if (detail is null)
+            throw new TimeoutException($"Correction {correctionId} never reached Corregida in 120s.");
+
+        return new CorrectionRun(detail, db, sp);
+    }
+}
+
+/// <summary>
+/// Disposable result of a CorrectionTestHarness.RunCorregirAsync call.
+/// </summary>
+public sealed record CorrectionRun(
+    CorrectionDetailDto Result,
+    AppDbContext Db,
+    ServiceProvider ServiceProvider) : IAsyncDisposable
+{
+    public async ValueTask DisposeAsync()
+    {
+        await Db.DisposeAsync();
+        await ServiceProvider.DisposeAsync();
+    }
+}

--- a/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionDualLevelTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionDualLevelTests.cs
@@ -1,16 +1,6 @@
-using System.Text.Json;
 using FluentAssertions;
-using LangTeach.Api.AI;
-using LangTeach.Api.Data;
-using LangTeach.Api.Data.Models;
 using LangTeach.Api.DTOs;
-using LangTeach.Api.Services;
 using LangTeach.Api.Tests.Helpers;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 
 namespace LangTeach.Api.Tests.Services;
 
@@ -41,8 +31,8 @@ public class RedaccionCorrectionDualLevelTests
     {
         var seed = SeedText;
 
-        await using var a2Run = await RunCorregirAsync(seed, "A2", "French");
-        await using var b2Run = await RunCorregirAsync(seed, "B2", "German");
+        await using var a2Run = await CorrectionTestHarness.RunCorregirAsync(seed, "A2", "French", "dual");
+        await using var b2Run = await CorrectionTestHarness.RunCorregirAsync(seed, "B2", "German", "dual");
 
         var a2Tags = a2Run.Result.Tags;
         var b2Tags = b2Run.Result.Tags;
@@ -96,137 +86,23 @@ public class RedaccionCorrectionDualLevelTests
         var accentCount = first100.Count(c => "áéíóúàèìòùäëïöüâêîôûñÁÉÍÓÚÀÈÌÒÙÄËÏÖÜÂÊÎÔÛÑ".Contains(c));
         accentCount.Should().BeGreaterThanOrEqualTo(4, "test text must have 4+ accented chars in first 100 chars");
 
-        await using var run = await RunCorregirAsync(accentedB1Text, "B1", "English");
+        await using var run = await CorrectionTestHarness.RunCorregirAsync(accentedB1Text, "B1", "English", "dual");
 
         run.Result.Tags.Should().HaveCountGreaterThanOrEqualTo(5,
             "a B1 text with multiple clear errors and accented chars must not have tags silently truncated. "
             + $"Tags found: {string.Join(", ", run.Result.Tags.Select(t => $"[{t.Category}] \"{t.SpannedText}\""))}");
     }
 
-    private static IEnumerable<string> CategoryDistribution(IEnumerable<LangTeach.Api.DTOs.CorrectionTagDto> tags) =>
+    private static IEnumerable<string> CategoryDistribution(IEnumerable<CorrectionTagDto> tags) =>
         tags.GroupBy(t => t.Category).Select(g => $"{g.Key}:{g.Count()}").OrderBy(s => s);
 
     private static string SideBySide(
-        IEnumerable<LangTeach.Api.DTOs.CorrectionTagDto> a2Tags,
-        IEnumerable<LangTeach.Api.DTOs.CorrectionTagDto> b2Tags)
+        IEnumerable<CorrectionTagDto> a2Tags,
+        IEnumerable<CorrectionTagDto> b2Tags)
     {
         var a2Lines = a2Tags.Select(t => $"  [{t.Category}] \"{t.SpannedText}\" — {t.Explanation}").ToList();
         var b2Lines = b2Tags.Select(t => $"  [{t.Category}] \"{t.SpannedText}\" — {t.Explanation}").ToList();
         return $"\n--- A2 tags ({a2Lines.Count}) ---\n{string.Join("\n", a2Lines)}"
              + $"\n--- B2 tags ({b2Lines.Count}) ---\n{string.Join("\n", b2Lines)}";
-    }
-
-    private static async Task<DualLevelRun> RunCorregirAsync(string seedText, string cefr, string l1)
-    {
-        var config = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.json", optional: true)
-            .AddUserSecrets<Program>(optional: true)
-            .AddEnvironmentVariables()
-            .Build();
-
-        var services = new ServiceCollection();
-        services.Configure<ClaudeClientOptions>(config.GetSection(ClaudeClientOptions.SectionName));
-        services.AddHttpClient("Claude", (sp, client) =>
-        {
-            var opts = sp.GetRequiredService<IOptions<ClaudeClientOptions>>().Value;
-            client.BaseAddress = new Uri(opts.BaseUrl);
-            client.DefaultRequestHeaders.Add("x-api-key", opts.ApiKey);
-            client.DefaultRequestHeaders.Add("anthropic-version", "2023-06-01");
-        });
-        var sp = services.BuildServiceProvider();
-
-        var dbOptions = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        var db = new AppDbContext(dbOptions);
-
-        var teacherId = Guid.NewGuid();
-        var studentId = Guid.NewGuid();
-        var correctionId = Guid.NewGuid();
-        var now = DateTime.UtcNow;
-
-        db.Teachers.Add(new Teacher
-        {
-            Id = teacherId,
-            Auth0UserId = $"auth0|dual-{cefr}-{l1}",
-            Email = $"dual-{cefr}-{l1}@test.com",
-            DisplayName = "Dual Level",
-            IsApproved = true,
-            CreatedAt = now, UpdatedAt = now,
-        });
-        db.Students.Add(new Student
-        {
-            Id = studentId,
-            TeacherId = teacherId,
-            Name = $"Dual-{cefr}",
-            LearningLanguage = "Spanish",
-            CefrLevel = cefr,
-            NativeLanguages = JsonSerializer.Serialize(new[] { l1 }),
-            Difficulties = "[]",
-            CreatedAt = now, UpdatedAt = now,
-        });
-        db.Corrections.Add(new Correction
-        {
-            Id = correctionId,
-            TeacherId = teacherId,
-            StudentId = studentId,
-            SchemaVersion = 1,
-            Status = CorrectionStatus.Entregada,
-            AssignmentTitle = "Dual-level moat",
-            AssignmentPrompt = "Cuenta tu fin de semana.",
-            StudentText = seedText,
-            CreatedAt = now, UpdatedAt = now,
-        });
-        await db.SaveChangesAsync();
-
-        var sps = new SectionProfileService(NullLogger<SectionProfileService>.Instance);
-        var pedagogy = new PedagogyConfigService(NullLogger<PedagogyConfigService>.Instance, sps);
-        var promptBuilder = new RedaccionCorrectionPromptBuilder(pedagogy,
-            NullLogger<RedaccionCorrectionPromptBuilder>.Instance);
-        var filterPromptBuilder = new RedaccionLevelFilterPromptBuilder(pedagogy,
-            NullLogger<RedaccionLevelFilterPromptBuilder>.Instance);
-        var correctionPromptService = new CorrectionPromptService(promptBuilder, filterPromptBuilder);
-        var claude = new ClaudeApiClient(sp.GetRequiredService<IHttpClientFactory>(),
-            NullLogger<ClaudeApiClient>.Instance);
-
-        var scopeServices = new ServiceCollection();
-        scopeServices.AddSingleton<AppDbContext>(_ => new AppDbContext(dbOptions));
-        scopeServices.AddSingleton<IClaudeClient>(claude);
-        scopeServices.AddSingleton<ICorrectionPromptService>(correctionPromptService);
-        scopeServices.AddLogging();
-        var scopeFactory = new FakeServiceScopeFactory(scopeServices.BuildServiceProvider());
-
-        var service = new RedaccionCorrectionService(db, scopeFactory,
-            NullLogger<RedaccionCorrectionService>.Instance);
-
-        await service.CorregirAsync(teacherId, studentId, correctionId);
-
-        var deadline = DateTime.UtcNow.AddSeconds(120);
-        CorrectionDetailDto? detail = null;
-        while (DateTime.UtcNow < deadline)
-        {
-            using var check = new AppDbContext(dbOptions);
-            var row = check.Corrections.Include(c => c.Tags).FirstOrDefault(c => c.Id == correctionId);
-            if (row?.Status == "Corregida")
-            {
-                detail = CorrectionDtoMapper.ToDetail(row, row.Tags);
-                break;
-            }
-            await Task.Delay(500);
-        }
-        if (detail is null) throw new TimeoutException($"Correction {correctionId} never reached Corregida in 120s.");
-        return new DualLevelRun(detail, db, sp);
-    }
-
-    private sealed record DualLevelRun(
-        LangTeach.Api.DTOs.CorrectionDetailDto Result,
-        AppDbContext Db,
-        ServiceProvider ServiceProvider) : IAsyncDisposable
-    {
-        public async ValueTask DisposeAsync()
-        {
-            await Db.DisposeAsync();
-            await ServiceProvider.DisposeAsync();
-        }
     }
 }

--- a/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionVerbatimTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionVerbatimTests.cs
@@ -1,16 +1,6 @@
-using System.Text.Json;
 using FluentAssertions;
-using LangTeach.Api.AI;
-using LangTeach.Api.Data;
 using LangTeach.Api.Data.Models;
-using LangTeach.Api.DTOs;
-using LangTeach.Api.Services;
 using LangTeach.Api.Tests.Helpers;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 
 namespace LangTeach.Api.Tests.Services;
 
@@ -28,7 +18,7 @@ public class RedaccionCorrectionVerbatimTests
     public async Task Verbatim_OnB1_FixtureSucceeds()
     {
         var seedText = LoadSeedText();
-        await using var run = await RunCorregirAsync(seedText, "B1", "German");
+        await using var run = await CorrectionTestHarness.RunCorregirAsync(seedText, "B1", "German", "verbatim");
 
         // Issue #1166 scope: the verbatim originalText echo (and therefore the strict
         // ordinal guard in RedaccionCorrectionService) must succeed on a representative
@@ -50,7 +40,7 @@ public class RedaccionCorrectionVerbatimTests
         // redacción." Same logic as the B1 case - the assertion is that the strict ordinal
         // guard passes on a longer text. Tag count is not asserted (see comment above).
         var seedText = LoadSeedText("RedaccionMoatSeedB2.es.txt");
-        await using var run = await RunCorregirAsync(seedText, "B2", "German");
+        await using var run = await CorrectionTestHarness.RunCorregirAsync(seedText, "B2", "German", "verbatim");
 
         run.Result.Status.Should().Be(CorrectionStatus.Corregida);
     }
@@ -66,7 +56,7 @@ public class RedaccionCorrectionVerbatimTests
         // the service would have thrown), and the model's tag-offset accuracy on accented
         // text is a separate, pre-existing issue logged in plan/observed-issues.md.
         var text = "Hoy ablar con mi amigo. Mi casa esta cerca del parque. Yo voy en mi casa todos los días.";
-        await using var run = await RunCorregirAsync(text, "B1", "German");
+        await using var run = await CorrectionTestHarness.RunCorregirAsync(text, "B1", "German", "verbatim");
 
         run.Result.Status.Should().Be(CorrectionStatus.Corregida);
         // MarkedUpOutput is the raw JSON written by the service; its originalText must equal
@@ -76,121 +66,5 @@ public class RedaccionCorrectionVerbatimTests
         markedUp.Should().Contain("\"ablar\"", "the misspelling must be preserved verbatim, not silently fixed to 'hablar'");
         markedUp.Should().Contain("Mi casa esta cerca", "the missing-tilde 'esta' (vs 'está') must be preserved verbatim");
         markedUp.Should().Contain("voy en mi casa", "the wrong-preposition 'en mi casa' must be preserved verbatim");
-    }
-
-    private static async Task<CorrectionRun> RunCorregirAsync(string seedText, string cefr, string l1)
-    {
-        var config = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.json", optional: true)
-            .AddUserSecrets<Program>(optional: true)
-            .AddEnvironmentVariables()
-            .Build();
-
-        var services = new ServiceCollection();
-        services.Configure<ClaudeClientOptions>(config.GetSection(ClaudeClientOptions.SectionName));
-        services.AddHttpClient("Claude", (sp, client) =>
-        {
-            var opts = sp.GetRequiredService<IOptions<ClaudeClientOptions>>().Value;
-            client.BaseAddress = new Uri(opts.BaseUrl);
-            client.DefaultRequestHeaders.Add("x-api-key", opts.ApiKey);
-            client.DefaultRequestHeaders.Add("anthropic-version", "2023-06-01");
-        });
-        var sp = services.BuildServiceProvider();
-
-        var dbOptions = new DbContextOptionsBuilder<AppDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        var db = new AppDbContext(dbOptions);
-
-        var teacherId = Guid.NewGuid();
-        var studentId = Guid.NewGuid();
-        var correctionId = Guid.NewGuid();
-        var now = DateTime.UtcNow;
-
-        db.Teachers.Add(new Teacher
-        {
-            Id = teacherId,
-            Auth0UserId = $"auth0|verbatim-{cefr}-{l1}",
-            Email = $"verbatim-{cefr}-{l1}@test.com",
-            DisplayName = "Verbatim Test",
-            IsApproved = true,
-            CreatedAt = now, UpdatedAt = now,
-        });
-        db.Students.Add(new Student
-        {
-            Id = studentId,
-            TeacherId = teacherId,
-            Name = $"Verbatim-{cefr}",
-            LearningLanguage = "Spanish",
-            CefrLevel = cefr,
-            NativeLanguages = JsonSerializer.Serialize(new[] { l1 }),
-            Difficulties = "[]",
-            CreatedAt = now, UpdatedAt = now,
-        });
-        db.Corrections.Add(new Correction
-        {
-            Id = correctionId,
-            TeacherId = teacherId,
-            StudentId = studentId,
-            SchemaVersion = 1,
-            Status = CorrectionStatus.Entregada,
-            AssignmentTitle = "Verbatim smoke",
-            AssignmentPrompt = "Cuenta tu fin de semana.",
-            StudentText = seedText,
-            CreatedAt = now, UpdatedAt = now,
-        });
-        await db.SaveChangesAsync();
-
-        var sps = new SectionProfileService(NullLogger<SectionProfileService>.Instance);
-        var pedagogy = new PedagogyConfigService(NullLogger<PedagogyConfigService>.Instance, sps);
-        var promptBuilder = new RedaccionCorrectionPromptBuilder(pedagogy,
-            NullLogger<RedaccionCorrectionPromptBuilder>.Instance);
-        var filterPromptBuilder = new RedaccionLevelFilterPromptBuilder(pedagogy,
-            NullLogger<RedaccionLevelFilterPromptBuilder>.Instance);
-        var correctionPromptService = new CorrectionPromptService(promptBuilder, filterPromptBuilder);
-        var claude = new ClaudeApiClient(sp.GetRequiredService<IHttpClientFactory>(),
-            NullLogger<ClaudeApiClient>.Instance);
-
-        // Build a scope factory so the background Task.Run can resolve fresh dependencies.
-        var scopeServices = new ServiceCollection();
-        scopeServices.AddSingleton<AppDbContext>(_ => new AppDbContext(dbOptions));
-        scopeServices.AddSingleton<IClaudeClient>(claude);
-        scopeServices.AddSingleton<ICorrectionPromptService>(correctionPromptService);
-        scopeServices.AddLogging();
-        var scopeFactory = new FakeServiceScopeFactory(scopeServices.BuildServiceProvider());
-
-        var service = new RedaccionCorrectionService(db, scopeFactory,
-            NullLogger<RedaccionCorrectionService>.Instance);
-
-        await service.CorregirAsync(teacherId, studentId, correctionId);
-
-        // Background task calls the real Claude API; poll until completed (up to 120s).
-        var deadline = DateTime.UtcNow.AddSeconds(120);
-        CorrectionDetailDto? detail = null;
-        while (DateTime.UtcNow < deadline)
-        {
-            using var check = new AppDbContext(dbOptions);
-            var row = check.Corrections.Include(c => c.Tags).FirstOrDefault(c => c.Id == correctionId);
-            if (row?.Status == "Corregida")
-            {
-                detail = CorrectionDtoMapper.ToDetail(row, row.Tags);
-                break;
-            }
-            await Task.Delay(500);
-        }
-        if (detail is null) throw new TimeoutException($"Correction {correctionId} never reached Corregida in 120s.");
-        return new CorrectionRun(detail, db, sp);
-    }
-
-    private sealed record CorrectionRun(
-        LangTeach.Api.DTOs.CorrectionDetailDto Result,
-        AppDbContext Db,
-        ServiceProvider ServiceProvider) : IAsyncDisposable
-    {
-        public async ValueTask DisposeAsync()
-        {
-            await Db.DisposeAsync();
-            await ServiceProvider.DisposeAsync();
-        }
     }
 }

--- a/frontend/src/pages/StudentForm.test.tsx
+++ b/frontend/src/pages/StudentForm.test.tsx
@@ -570,7 +570,7 @@ describe('StudentForm', () => {
 
   it('includes identity fields in form submission', async () => {
     const { default: userEvent } = await import('@testing-library/user-event')
-    const user = userEvent.setup()
+    const user = userEvent.setup({ delay: null })
     mockCreateStudent.mockResolvedValue({ id: 'new-id' })
     renderNew()
 
@@ -599,7 +599,7 @@ describe('StudentForm', () => {
           cityOfResidence: 'Madrid',
         }),
       )
-    })
+    }, { timeout: 8000 })
   })
 
   it('renders Reason for Studying textarea', () => {


### PR DESCRIPTION
## Summary

- **CorrectionTestHarness**: Extracts the near-identical `RunCorregirAsync` method from `RedaccionCorrectionDualLevelTests` and `RedaccionCorrectionVerbatimTests` into a shared `Helpers/CorrectionTestHarness.cs` static class with a unified `CorrectionRun` disposable record (Problem 3 from #1232).
- **corrections-sprint.spec.ts**: Adds a dedicated Playwright spec to the teacher-qa suite that navigates to the Redacciones tab, creates A2 and B1 corrections with the same seed text, triggers Corregir, polls for Corregida status, and asserts the G-tag + A2/B1 CEFR moat (Problem 1 from #1232).
- **Vitest flake fix**: Raises `vi.waitFor` timeout to 8s and adds `delay: null` to `userEvent.setup` in `StudentForm.test.tsx > "includes identity fields in form submission"` to reduce flakiness under parallel load (Problem 4 from #1232).

Note: Problem 2 (StubClaudeClient/SequentialClaudeClient overlap) is not addressed -- the condition "when a third AI integration test adds the same setup" is not triggered by this change (the new spec is Playwright, not a C# AI integration test).

## Test plan

- [ ] `dotnet build` passes (verified locally)
- [ ] `npm test` passes: 105 suites, 1759 tests (verified locally)
- [ ] `corrections-sprint.spec.ts` runs against the QA stack with a live Claude API key:
  - Navigate to A2 student Redacciones tab
  - Both A2 and B1 corrections reach Corregida status
  - At least one G tag present across both
  - Tag count or distribution differs between A2 and B1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end testing for the corrections workflow across multiple proficiency levels.
  * Refactored test infrastructure for improved maintainability and reusability across correction validation tests.
  * Enhanced test reliability and performance for form submission validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1255)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->