### PR TITLE
tech-debt(#1233): prompt-health sweep -- pre-existing redundancies and negative bloat

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -839,7 +839,7 @@ public class PromptServiceTests
     {
         var req = _sut.BuildExercisesPrompt(BaseCtx());
 
-        req.SystemPrompt.Should().Contain("text-only and self-contained");
+        req.SystemPrompt.Should().Contain("self-contained");
         req.SystemPrompt.Should().Contain("completable using only the text provided");
     }
 
@@ -850,7 +850,7 @@ public class PromptServiceTests
 
         var req = _sut.BuildExercisesPrompt(ctx);
 
-        req.SystemPrompt.Should().Contain("text-only and self-contained");
+        req.SystemPrompt.Should().Contain("self-contained");
     }
 
     [Fact]
@@ -860,7 +860,7 @@ public class PromptServiceTests
 
         var req = _sut.BuildExercisesPrompt(ctx);
 
-        req.SystemPrompt.Should().NotContain("text-only and self-contained");
+        req.SystemPrompt.Should().NotContain("self-contained:");
     }
 
     // --- Mandatory Production and Practice ordering ---

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -606,7 +606,7 @@ public class PromptService : IPromptService
         else
         {
             sb.AppendLine();
-            sb.AppendLine("All content must be text-only and self-contained. Every exercise, example, and activity must be completable using only the text provided.");
+            sb.AppendLine("All content must be self-contained: every exercise, example, and activity must be completable using only the text provided.");
         }
 
         sb.AppendLine();
@@ -830,6 +830,10 @@ public class PromptService : IPromptService
             .Take(5)
             .ToArray();
         var guidance = _profiles.GetGuidance(sectionKey, level);
+        var effectiveGuidance = forbiddenReasons.Length > 0
+            ? (string.IsNullOrEmpty(guidance) ? "" : guidance + " ")
+              + "Avoid: " + string.Join("; ", forbiddenReasons) + "."
+            : guidance;
 
         var sb = new StringBuilder();
 
@@ -841,18 +845,12 @@ public class PromptService : IPromptService
             sb.AppendLine($"Duration: {duration.Min}-{duration.Max} minutes.");
         if (!string.IsNullOrEmpty(interactionPattern))
             sb.AppendLine($"Interaction pattern: {interactionPattern}.");
-        if (forbiddenReasons.Length > 0)
-        {
-            sb.AppendLine("Do not generate activities that:");
-            foreach (var reason in forbiddenReasons)
-                sb.AppendLine($"- {reason}");
-        }
 
         sb.AppendLine($"{mainInstruction} Return JSON:");
         sb.AppendLine("{\"scenarios\":[{\"setup\":\"\",\"roleA\":\"Teacher\",\"roleB\":\"Student\",\"roleAPhrases\":[\"\"],\"roleBPhrases\":[\"\"]}]}");
 
-        if (!string.IsNullOrEmpty(guidance))
-            sb.AppendLine(guidance);
+        if (!string.IsNullOrEmpty(effectiveGuidance))
+            sb.AppendLine(effectiveGuidance);
 
         // Normalize sectionKey ("warmup") to canonical camelCase ("warmUp") for template lookups
         var canonicalKey = SectionKeys.CanonicalOrder
@@ -1547,7 +1545,7 @@ public class PromptService : IPromptService
 
             IMPORTANT CONTEXT: There is no open session in scope.
             Exception — present-day anchor: if the teacher's statement opens with a present-day anchor ("hoy", "en la clase de hoy", "esta mañana", "este mediodía", "today", "this morning", or an explicit time for today such as "de las 10:00"), treat this as a live post-class reflection for TODAY's session. Set sessionDate=today and populate sessionTitle and whatWasCovered as normal. See the newSessionTitle field rule for the null-when-today constraint. Past-tense verbs ("hemos trabajado", "hicimos") in a reflection that opens with a present-day anchor do NOT indicate retrospective registration.
-            Otherwise: if the teacher describes a class that already happened without a present-day anchor (cues: "le di clase", "ayer trabajamos", "la semana pasada hicimos"), treat it as retrospective session registration: populate newSessionTitle and newSessionDate; leave sessionTitle and whatWasCovered null.
+            Otherwise: if the teacher describes a class that already happened without a present-day anchor (cues: "le di clase", "ayer trabajamos", "la semana pasada hicimos"), treat it as retrospective session registration: populate newSessionTitle and newSessionDate.
             """;
 
         var system = $"""
@@ -1557,6 +1555,8 @@ public class PromptService : IPromptService
             IMPORTANT: All text values in your response MUST be written in the same language as the teacher's input text. If the teacher writes in Spanish, every string value — including sessionTitle, topicTags, teachingTodos, teacherFollowups, and all summaries — must be in Spanish. Never translate or switch to English.
 
             Today is {today.DayOfWeek}, {today:yyyy-MM-dd}.{weekdayFactsSection}
+
+            Weekday resolution rules: "hoy"/"today" = today, "ayer"/"yesterday" = yesterday. For past weekday references (e.g. "el lunes pasado", "el pasado martes"): {weekdayBackwardRule} For future weekday references (e.g. "el lunes", "next Monday"): count forward to the first occurrence of that weekday strictly after today (if today is Saturday, the next Monday is exactly 2 days away, NOT 3). "la semana que viene" = same day next week. These rules apply to both sessionDate and newSessionDate.
             {difficultiesSection}
             Respond ONLY with a valid JSON object using these exact keys:
             - whatWasCovered: object or null. When present, the object has two keys: "value" (string) and "mode" (one of "append", "replace", or "skip").
@@ -1580,7 +1580,7 @@ public class PromptService : IPromptService
                 Set mode to "replace" if teacher corrects prior plans (signal words: "me equivoqué", "en realidad", "no, mejor", corrections).
                 Set mode to "skip" if this field should not be updated.
                 Return null if no next-session ideas are mentioned.
-            - sessionDate: string or null — ISO 8601 date (YYYY-MM-DD) of the session being described. When a clock time is mentioned, capture it in `sessionStartTime` and keep `sessionDate` as YYYY-MM-DD only. Resolve date references using today's date and day of week: "hoy"/"today" = today, "ayer"/"yesterday" = yesterday, {weekdayBackwardRule} Null if no date is mentioned. The opening clause is the primary temporal anchor: it wins over any date mentioned later in the body (past-date references inside the body, e.g. "la pizarra del 30 de abril", are content references, not session date anchors).
+            - sessionDate: string or null — ISO 8601 date (YYYY-MM-DD) of the session being described. When a clock time is mentioned, capture it in `sessionStartTime` and keep `sessionDate` as YYYY-MM-DD only. Apply the weekday resolution rules above. Null if no date is mentioned. The opening clause is the primary temporal anchor: it wins over any date mentioned later in the body (past-date references inside the body, e.g. "la pizarra del 30 de abril", are content references, not session date anchors).
             - sessionStartTime: string or null — 24-hour time (HH:MM) when the session started (e.g. "09:00", "18:30"). Extract from any clock time mentioned, including present-day anchors ("la clase de hoy de las 13:00" → "13:00"). Null if not mentioned.
             - sessionTitle: string or null — a concise title (under 60 chars) for this session derived from what was covered, written in the same language as the teacher's input. Examples (Spanish input): "Subjuntivo en cláusulas temporales", "Pasado compuesto — revisión". Null if no content is mentioned. Null when there is no active session (use newSessionTitle instead).
             - suggestedDifficulties: array of objects (can be empty []) — structured breakdown of the same difficulties mentioned in areasToImprove
@@ -1597,7 +1597,7 @@ public class PromptService : IPromptService
             - difficultiesWorkedOn: array of strings — copy verbatim from the student's known difficulties list any difficulty that was explicitly worked on in this session. Empty array if none or if no known difficulties were provided.
             - newSessionTitle: string or null — concise title (under 60 chars) for a NEW session record the teacher is creating, either scheduled for the future or retroactively registered for a past date. Set to null when the transcript is a post-class reflection for today's session (i.e. the opening contains a present-day anchor such as "hoy", "en la clase de hoy", or a specific time). Set for explicit scheduling statements ("next Monday I want to do a session on the subjunctive", "la semana que viene hagamos una sesión sobre el subjuntivo") and for retrospective registration when the teacher explicitly says they forgot to register a past session ("que se me olvidó registrarla", "apunta una sesión del lunes pasado sobre X"). Past-date mentions inside the body of a reflection (e.g. "la pizarra del 30 de abril") are content references, not triggers for a new session record. Distinct from nextLessonIdeas (planning ideas without a scheduled appointment). Both newSessionTitle and nextLessonIdeas may be set simultaneously if the teacher is scheduling AND has broader ideas.
                 When the teacher uses a todo-creation trigger phrase ({todoTriggersList}), produce a todo object and leave newSessionTitle null — the idea belongs to the todo, not a new session.
-            - newSessionDate: string or null — ISO 8601 date (YYYY-MM-DD) for the proposed new session. For future dates: resolve forward from today — "el lunes" or "next Monday" = the next Monday strictly after today (count forward to the first occurrence of that weekday; if today is Saturday, the next Monday is exactly 2 days away, NOT 3). "la semana que viene" = same day next week. For retrospective sessions with explicit past markers ("pasado", "de la semana pasada", "que se me olvidó registrar"): resolve backward — {weekdayBackwardRule} Null only when no specific day or date can be inferred (e.g. "next class", "soon") — do NOT default to today when no date cue is present. Null if newSessionTitle is null. If a date is mentioned without a topic, set both fields to null.
+            - newSessionDate: string or null — ISO 8601 date (YYYY-MM-DD) for the proposed new session. Apply the weekday resolution rules above: for future dates resolve forward; for retrospective sessions with explicit past markers ("pasado", "de la semana pasada", "que se me olvidó registrar") resolve backward. "la semana que viene" = same day next week. Null only when no specific day or date can be inferred (e.g. "next class", "soon") — do NOT default to today when no date cue is present. Null if newSessionTitle is null. If a date is mentioned without a topic, set both fields to null.
 
             For suggestedDifficulties, each object must have:
             - description: full sentence describing the difficulty, extracted verbatim from the teacher's language

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -98,7 +98,7 @@ Emit raw JSON only. Start directly with {. No prose before or after. No markdown
 OFFSETS (read carefully — accented characters cause silent errors if you count positions):
 - startIndex and endIndex are Unicode character offsets into the student text between the markers (0-based, end-exclusive).
 - DO NOT derive offsets by counting characters forward from the start of the text. Counting is unreliable near accented characters (é, ó, á, ñ, ü, etc.) because your internal position tracking may not match the host's character indices.
-- CORRECT procedure for every tag:
+- CORRECT procedure for every tag (internal reasoning only -- output nothing for these steps):
   1. Decide which substring of the student text to mark; that substring is spannedText.
   2. Write the explanation.
   3. Locate spannedText inside the student text using a forward string search (like indexOf / find), starting from position 0.
@@ -113,7 +113,7 @@ OFFSETS (read carefully — accented characters cause silent errors if you count
   Example: in "Los libros son interesante", spannedText must be "interesante" (the wrong
   adjective) and correctedForm must be "interesantes", not "Los libros son interesante"
   or any larger span.
-- Tags MUST NOT overlap. Sort tags by startIndex.
+- Sort tags by startIndex.
 """;
 
     private string BuildUserPrompt(RedaccionCorrectionPromptContext ctx)

--- a/backend/LangTeach.Api/AI/RedaccionLevelFilterPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionLevelFilterPromptBuilder.cs
@@ -31,8 +31,8 @@ public class RedaccionLevelFilterPromptBuilder
             "PromptUser | blockType=redaccion-level-filter level={Level} tagCount={Count}\n{UserPrompt}",
             cefr, tags.Count, user);
 
-        // Scale MaxTokens with tag count: each decision + optional note is ~60-80 tokens;
-        // 2048 is safe for up to ~25 tags with notes; hard cap avoids truncation on dense texts.
+        // Scale MaxTokens with tag count: each decision is ~30-40 tokens;
+        // 2048 is safe for up to ~50 tags; hard cap avoids truncation on dense texts.
         var maxTokens = Math.Max(1024, Math.Min(2048, 512 + tags.Count * 64));
         return new ClaudeRequest(SystemPrompt, user, ClaudeModel.Haiku, MaxTokens: maxTokens, Temperature: 0);
     }
@@ -40,9 +40,9 @@ public class RedaccionLevelFilterPromptBuilder
     private const string SystemPrompt = """
 You are a CEFR grammar filter for a Spanish writing correction pipeline. You receive a numbered list of error tags detected in a student's text, the student's CEFR level, the grammar scope for that level, and the assignment context. For each tag, classify it as one of:
 - keep    -- the error is within the student's level scope; surface it.
-- soften  -- the error is above level but the attempt deserves a warm acknowledgement; do not penalise. (include a warm note in Spanish)
+- soften  -- the error is above level but the attempt deserves a warm acknowledgement; do not penalise.
 - remove  -- the error is above level and should not be surfaced.
-- muybien -- the structure is at or near the student's level ceiling, used correctly or nearly correctly, AND appropriate for the register of the assignment; highlight it as praiseworthy. (include a warm note in Spanish)
+- muybien -- the structure is at or near the student's level ceiling, used correctly or nearly correctly, AND appropriate for the register of the assignment; highlight it as praiseworthy.
 
 MANDATORY RULES:
 1. Tags with category "O" (Ortografía: accents, spelling, punctuation) MUST always be "keep".
@@ -59,7 +59,7 @@ GUIDANCE:
 OUTPUT CONTRACT:
 Emit raw JSON only. No prose. No markdown fences. The JSON must be an array:
 [
-  {"index": <int>, "decision": "keep" | "soften" | "remove" | "muybien", "note": "<warm praise in Spanish, only when decision=soften or decision=muybien>"}
+  {"index": <int>, "decision": "keep" | "soften" | "remove" | "muybien"}
 ]
 Every input tag must appear in the output exactly once, identified by its index.
 """;

--- a/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
+++ b/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
@@ -564,8 +564,6 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
                 case "soften":
                 case "muybien":
                     // Convert to MuyBien: highlights the attempt without penalising the student.
-                    // decision.Note (the warm Spanish praise) is not persisted to DB in this
-                    // version; CorrectionTag has no note column. Pending schema enhancement.
                     result.Add(tag with
                     {
                         Category = CorrectionTagCategory.MuyBien,

--- a/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
+++ b/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
@@ -614,6 +614,5 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
 
     private record FilterDecision(
         [property: JsonPropertyName("index")] int Index,
-        [property: JsonPropertyName("decision")] string Decision,
-        [property: JsonPropertyName("note")] string? Note);
+        [property: JsonPropertyName("decision")] string Decision);
 }

--- a/data/pedagogy/l1-influence.json
+++ b/data/pedagogy/l1-influence.json
@@ -205,7 +205,7 @@
         "Grammatical gender",
         "Similar verb system"
       ],
-      "additionalNotes": "Portuguese has the same ser/estar distinction as Spanish (positive transfer). Do not apply the romance family ser-estar contrastive note to Portuguese speakers.",
+      "additionalNotes": "Portuguese has the same ser/estar distinction as Spanish (positive transfer). When a Portuguese student makes a ser/estar error, flag and correct it as normal -- do not add an L1 contrastive explanation in the popover, since this is not an L1 interference point.",
       "contrastivePatterns": [
         {
           "pattern": "false-cognates",

--- a/data/pedagogy/l1-influence.json
+++ b/data/pedagogy/l1-influence.json
@@ -205,7 +205,7 @@
         "Grammatical gender",
         "Similar verb system"
       ],
-      "additionalNotes": "Portuguese has the same ser/estar distinction as Spanish (positive transfer). When a Portuguese student makes a ser/estar error, flag and correct it as normal -- do not add an L1 contrastive explanation in the popover, since this is not an L1 interference point.",
+      "additionalNotes": "Portuguese has the same ser/estar distinction as Spanish (positive transfer). When a Portuguese student makes a ser/estar error, flag it as a Spanish grammar error and provide a standard correction; do not add an L1 contrastive explanation, as this is not an L1 interference point for Portuguese speakers.",
       "contrastivePatterns": [
         {
           "pattern": "false-cognates",


### PR DESCRIPTION
## Summary

- Extracts weekday backward-resolution rule to a shared preamble in `BuildReflectionExtractionPrompt`; `sessionDate` and `newSessionDate` cross-reference it instead of duplicating (Items 1)
- Removes redundant "leave sessionTitle and whatWasCovered null" clause from the no-open-session IMPORTANT CONTEXT block -- covered by field-level null guards (Item 2)
- Surfaces `BuildSectionConversationPrompt` `forbiddenReasons` via guidance string instead of a standalone negative-list block (Item 3)
- Merges duplicate "text-only and self-contained" sentence in `BuildSystemPrompt` (Item 4)
- Removes "Tags MUST NOT overlap" from `RedaccionCorrectionPromptBuilder` system prompt -- enforced by `ValidateAndOrderTags` at the service layer (Item 5)
- Rewrites Portuguese `additionalNotes` in `l1-influence.json`: preserves ser/estar error detection while suppressing the L1 contrastive popover explanation (Item 6)
- Marks OFFSETS CORRECT procedure steps as "internal reasoning only -- output nothing" to eliminate post-JSON token generation (Item 7)
- Drops `note` field from `RedaccionLevelFilterPromptBuilder` output contract and removes the dead `Note` property from `FilterDecision` -- field was never persisted (Item 8)

## Reviewers

| Reviewer | Verdict |
|---|---|
| QA verify | PASS (after commit) |
| Prompt health | CLEAN |
| Architecture | PASS |
| Sophy | APPROVE |
| Isaac | SOUND (minor wording improvement applied) |

## Test plan

- [x] All 1422 dotnet tests pass (0 failures)
- [x] npm lint + build + tests pass (105 passed)
- [x] No live Verify section in issue -- prompt-only changes, no runtime behaviour to exercise in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed level filtering for writing exercises—difficulty adjustments now properly applied.

* **Improvements**
  * Refined AI prompts to ensure exercises are completable with provided materials only.
  * Enhanced conversation guidance generation in exercise prompts.
  * Improved writing error correction feedback formatting and accuracy.
  * Optimized writing correction feedback for cleaner output.
  * Better error handling for Portuguese learners on Spanish ser/estar mistakes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1256)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->