### PR TITLE
feat(redacciones): add .docx Word file upload to OCR flow (#1257)

### DIFF
--- a/backend/LangTeach.Api.Tests/Controllers/OcrControllerTests.cs
+++ b/backend/LangTeach.Api.Tests/Controllers/OcrControllerTests.cs
@@ -52,6 +52,23 @@ public class OcrControllerTests
         res.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var body = await res.Content.ReadAsStringAsync();
         body.Should().Contain("Formato no compatible");
+        body.Should().Contain("DOCX");
+    }
+
+    [Fact]
+    public async Task Extract_ValidDocx_ReturnsOkWithTextAndBlobUrl()
+    {
+        var client = _factory.CreateAuthenticatedClient("auth0|ocr-docx", "ocr-docx@example.com");
+        var form = CreateFileContent(
+            "homework.docx",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+
+        var res = await client.PostAsync("/api/corrections/ocr", form);
+
+        res.StatusCode.Should().Be(HttpStatusCode.OK);
+        var json = JsonDocument.Parse(await res.Content.ReadAsStringAsync()).RootElement;
+        json.GetProperty("text").GetString().Should().NotBeNullOrEmpty();
+        json.GetProperty("blobUrl").GetString().Should().NotBeNullOrEmpty();
     }
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/Services/OpenXmlDocxTextExtractorTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/OpenXmlDocxTextExtractorTests.cs
@@ -1,0 +1,127 @@
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using FluentAssertions;
+using LangTeach.Api.Services;
+using Microsoft.Extensions.Options;
+
+namespace LangTeach.Api.Tests.Services;
+
+public class OpenXmlDocxTextExtractorTests
+{
+    private const string DocxContentType =
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+    private static readonly OcrOptions DefaultOptions = new();
+
+    private static OpenXmlDocxTextExtractor CreateExtractor(OcrOptions? options = null) =>
+        new(Options.Create(options ?? DefaultOptions));
+
+    private static MemoryStream CreateDocxStream(params string[] paragraphs)
+    {
+        var ms = new MemoryStream();
+        using (var doc = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document, autoSave: true))
+        {
+            var main = doc.AddMainDocumentPart();
+            main.Document = new Document(new Body(
+                paragraphs
+                    .Select(text => (OpenXmlElement)new Paragraph(new Run(new Text(text))))
+                    .Append(new SectionProperties())
+                    .ToArray()
+            ));
+        }
+        ms.Position = 0;
+        return ms;
+    }
+
+    [Fact]
+    public void CanHandle_DocxContentType_ReturnsTrue()
+    {
+        var sut = CreateExtractor();
+        sut.CanHandle(DocxContentType).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("image/jpeg")]
+    [InlineData("image/png")]
+    [InlineData("application/pdf")]
+    [InlineData("image/gif")]
+    public void CanHandle_NonDocxContentType_ReturnsFalse(string contentType)
+    {
+        var sut = CreateExtractor();
+        sut.CanHandle(contentType).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_ValidDocx_ReturnsText()
+    {
+        var sut = CreateExtractor();
+        using var ms = CreateDocxStream("El alumno escribió su redacción con esfuerzo.");
+
+        var text = await sut.ExtractTextAsync(ms, DocxContentType);
+
+        text.Should().Contain("redacción");
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_PreservesAccentedCharacters()
+    {
+        var sut = CreateExtractor();
+        using var ms = CreateDocxStream("Tiene problemas con á, é, í, ó, ú y ñ.");
+
+        var text = await sut.ExtractTextAsync(ms, DocxContentType);
+
+        text.Should().Contain("á");
+        text.Should().Contain("é");
+        text.Should().Contain("ñ");
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_MultipleParagraphs_JoinsWithNewlines()
+    {
+        var sut = CreateExtractor();
+        using var ms = CreateDocxStream("Primera línea.", "Segunda línea.");
+
+        var text = await sut.ExtractTextAsync(ms, DocxContentType);
+
+        text.Should().Contain("Primera");
+        text.Should().Contain("Segunda");
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_EmptyDocx_ThrowsOcrException()
+    {
+        var sut = CreateExtractor();
+        using var ms = CreateDocxStream();
+
+        var act = () => sut.ExtractTextAsync(ms, DocxContentType);
+
+        await act.Should().ThrowAsync<OcrException>()
+            .WithMessage("*extraer texto*");
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_TextBelowMinChars_ThrowsOcrException()
+    {
+        var options = new OcrOptions { MinExtractedChars = 100 };
+        var sut = CreateExtractor(options);
+        using var ms = CreateDocxStream("Corto.");
+
+        var act = () => sut.ExtractTextAsync(ms, DocxContentType);
+
+        await act.Should().ThrowAsync<OcrException>()
+            .WithMessage("*extraer texto*");
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_CorruptStream_ThrowsOcrExceptionWithDamagedMessage()
+    {
+        var sut = CreateExtractor();
+        using var ms = new MemoryStream("this is not a valid docx file"u8.ToArray());
+
+        var act = () => sut.ExtractTextAsync(ms, DocxContentType);
+
+        await act.Should().ThrowAsync<OcrException>()
+            .WithMessage("*no es válido*");
+    }
+}

--- a/backend/LangTeach.Api.Tests/Services/OpenXmlDocxTextExtractorTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/OpenXmlDocxTextExtractorTests.cs
@@ -3,7 +3,6 @@ using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
 using FluentAssertions;
 using LangTeach.Api.Services;
-using Microsoft.Extensions.Options;
 
 namespace LangTeach.Api.Tests.Services;
 
@@ -12,10 +11,7 @@ public class OpenXmlDocxTextExtractorTests
     private const string DocxContentType =
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
-    private static readonly OcrOptions DefaultOptions = new();
-
-    private static OpenXmlDocxTextExtractor CreateExtractor(OcrOptions? options = null) =>
-        new(Options.Create(options ?? DefaultOptions));
+    private static OpenXmlDocxTextExtractor CreateExtractor() => new();
 
     private static MemoryStream CreateDocxStream(params string[] paragraphs)
     {
@@ -48,8 +44,7 @@ public class OpenXmlDocxTextExtractorTests
     [InlineData("image/gif")]
     public void CanHandle_NonDocxContentType_ReturnsFalse(string contentType)
     {
-        var sut = CreateExtractor();
-        sut.CanHandle(contentType).Should().BeFalse();
+        CreateExtractor().CanHandle(contentType).Should().BeFalse();
     }
 
     [Fact]
@@ -89,23 +84,10 @@ public class OpenXmlDocxTextExtractorTests
     }
 
     [Fact]
-    public async Task ExtractTextAsync_EmptyDocx_ThrowsOcrException()
+    public async Task ExtractTextAsync_DocxWithNoParagraphs_ThrowsOcrException()
     {
         var sut = CreateExtractor();
         using var ms = CreateDocxStream();
-
-        var act = () => sut.ExtractTextAsync(ms, DocxContentType);
-
-        await act.Should().ThrowAsync<OcrException>()
-            .WithMessage("*extraer texto*");
-    }
-
-    [Fact]
-    public async Task ExtractTextAsync_TextBelowMinChars_ThrowsOcrException()
-    {
-        var options = new OcrOptions { MinExtractedChars = 100 };
-        var sut = CreateExtractor(options);
-        using var ms = CreateDocxStream("Corto.");
 
         var act = () => sut.ExtractTextAsync(ms, DocxContentType);
 

--- a/backend/LangTeach.Api/Controllers/OcrController.cs
+++ b/backend/LangTeach.Api/Controllers/OcrController.cs
@@ -14,20 +14,20 @@ namespace LangTeach.Api.Controllers;
 [Authorize]
 public class OcrController : ControllerBase
 {
-    private readonly IOcrService _ocr;
+    private readonly IEnumerable<ITextExtractor> _extractors;
     private readonly ICorrectionsBlobStorage _blob;
     private readonly IProfileService _profileService;
     private readonly OcrOptions _options;
     private readonly ILogger<OcrController> _logger;
 
     public OcrController(
-        IOcrService ocr,
+        IEnumerable<ITextExtractor> extractors,
         ICorrectionsBlobStorage blob,
         IProfileService profileService,
         IOptions<OcrOptions> options,
         ILogger<OcrController> logger)
     {
-        _ocr = ocr;
+        _extractors = extractors;
         _blob = blob;
         _profileService = profileService;
         _options = options.Value;
@@ -47,10 +47,17 @@ public class OcrController : ControllerBase
             return BadRequest(new { code = "OCR_NO_FILE", message = "No se recibió ningún archivo." });
 
         if (!_options.AcceptedContentTypes.Contains(file.ContentType, StringComparer.OrdinalIgnoreCase))
-            return BadRequest(new { code = "OCR_FORMAT_UNSUPPORTED", message = "Formato no compatible. Usa JPG, PNG, WEBP o PDF." });
+            return BadRequest(new { code = "OCR_FORMAT_UNSUPPORTED", message = "Formato no compatible. Usa JPG, PNG, WEBP, PDF o DOCX." });
 
         if (file.Length > _options.MaxBytes)
             return BadRequest(new { code = "OCR_FILE_TOO_LARGE", message = $"El archivo supera el tamaño máximo de {_options.MaxBytes / 1_048_576} MB." });
+
+        var extractor = _extractors.FirstOrDefault(e => e.CanHandle(file.ContentType));
+        if (extractor is null)
+        {
+            _logger.LogError("No ITextExtractor registered for content type {ContentType}", file.ContentType);
+            return BadRequest(new { code = "OCR_FORMAT_UNSUPPORTED", message = "Formato no compatible. Usa JPG, PNG, WEBP, PDF o DOCX." });
+        }
 
         var teacherId = await _profileService.UpsertTeacherAsync(Auth0Id, Email);
 
@@ -60,7 +67,7 @@ public class OcrController : ControllerBase
 
         var blobPath = $"{teacherId}/{Guid.NewGuid()}/source.{ext}";
 
-        // Copy to MemoryStream to guarantee seekability for both upload and OCR.
+        // Copy to MemoryStream to guarantee seekability for both upload and extraction.
         // IFormFile.OpenReadStream() may return a non-seekable stream in some hosting environments.
         using var memStream = new MemoryStream();
         await file.CopyToAsync(memStream, cancellationToken);
@@ -82,21 +89,21 @@ public class OcrController : ControllerBase
         string text;
         try
         {
-            text = await _ocr.ExtractTextAsync(memStream, file.ContentType, cancellationToken);
+            text = await extractor.ExtractTextAsync(memStream, file.ContentType, cancellationToken);
         }
         catch (OcrException ex)
         {
-            _logger.LogWarning("OCR returned no text. BlobPath={BlobPath} Message={Message}", blobPath, ex.Message);
-            return UnprocessableEntity(new { code = "OCR_NO_TEXT", message = "No se pudo extraer texto del archivo. Comprueba que la imagen sea legible." });
+            _logger.LogWarning("Extractor returned no text. BlobPath={BlobPath} Message={Message}", blobPath, ex.Message);
+            return UnprocessableEntity(new { code = "OCR_NO_TEXT", message = ex.Message });
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "OCR service error. BlobPath={BlobPath}", blobPath);
-            return StatusCode(500, new { code = "OCR_SERVICE_ERROR", message = "El servicio de OCR no está disponible. Inténtalo de nuevo." });
+            _logger.LogError(ex, "Text extractor error. BlobPath={BlobPath}", blobPath);
+            return StatusCode(500, new { code = "OCR_SERVICE_ERROR", message = "El servicio de extracción no está disponible. Inténtalo de nuevo." });
         }
 
         _logger.LogInformation(
-            "OCR extraction complete. TeacherId={TeacherId} BlobPath={BlobPath} ExtractedChars={Chars}",
+            "Text extraction complete. TeacherId={TeacherId} BlobPath={BlobPath} ExtractedChars={Chars}",
             teacherId, blobPath, text.Length);
 
         return Ok(new OcrResultDto(text, blobUrl, Incomplete: text.Length < _options.MinExtractedChars));

--- a/backend/LangTeach.Api/Program.cs
+++ b/backend/LangTeach.Api/Program.cs
@@ -234,9 +234,12 @@ builder.Services.AddSingleton<IVoiceNoteBlobStorage>(sp => sp.GetRequiredService
 builder.Services.AddSingleton<CorrectionsBlobStorage>();
 builder.Services.AddSingleton<ICorrectionsBlobStorage>(sp => sp.GetRequiredService<CorrectionsBlobStorage>());
 if (builder.Environment.IsEnvironment("E2ETesting") || builder.Environment.IsEnvironment("Testing"))
-    builder.Services.AddScoped<IOcrService, StubOcrService>();
+    builder.Services.AddScoped<ITextExtractor, StubTextExtractor>();
 else
-    builder.Services.AddScoped<IOcrService, AzureAIVisionOcrService>();
+{
+    builder.Services.AddScoped<ITextExtractor, AzureVisionTextExtractor>();
+    builder.Services.AddScoped<ITextExtractor, OpenXmlDocxTextExtractor>();
+}
 builder.Services.Configure<OcrOptions>(builder.Configuration.GetSection(OcrOptions.SectionName));
 builder.Services.AddScoped<IVoiceNoteService, VoiceNoteService>();
 builder.Services.AddScoped<ILessonService, LessonService>();

--- a/backend/LangTeach.Api/Services/AzureVisionTextExtractor.cs
+++ b/backend/LangTeach.Api/Services/AzureVisionTextExtractor.cs
@@ -19,8 +19,14 @@ public class AzureVisionTextExtractor : ITextExtractor
         _logger = logger;
     }
 
-    public bool CanHandle(string contentType) =>
-        contentType is "image/jpeg" or "image/png" or "image/webp" or "application/pdf";
+    public bool CanHandle(string contentType)
+    {
+        var mime = contentType?.Split(';', 2)[0].Trim() ?? string.Empty;
+        return mime.Equals("image/jpeg", StringComparison.OrdinalIgnoreCase)
+            || mime.Equals("image/png", StringComparison.OrdinalIgnoreCase)
+            || mime.Equals("image/webp", StringComparison.OrdinalIgnoreCase)
+            || mime.Equals("application/pdf", StringComparison.OrdinalIgnoreCase);
+    }
 
     public async Task<string> ExtractTextAsync(Stream stream, string contentType, CancellationToken ct = default)
     {

--- a/backend/LangTeach.Api/Services/AzureVisionTextExtractor.cs
+++ b/backend/LangTeach.Api/Services/AzureVisionTextExtractor.cs
@@ -31,7 +31,7 @@ public class AzureVisionTextExtractor : ITextExtractor
         if (readResult is null || readResult.Blocks.Count == 0)
         {
             _logger.LogWarning("Azure AI Vision returned no text blocks.");
-            throw new OcrException("No text could be extracted from the image.");
+            throw new OcrException("No se pudo extraer texto del archivo. Comprueba que la imagen sea legible.");
         }
 
         var lines = readResult.Blocks

--- a/backend/LangTeach.Api/Services/AzureVisionTextExtractor.cs
+++ b/backend/LangTeach.Api/Services/AzureVisionTextExtractor.cs
@@ -3,12 +3,12 @@ using Azure.AI.Vision.ImageAnalysis;
 
 namespace LangTeach.Api.Services;
 
-public class AzureAIVisionOcrService : IOcrService
+public class AzureVisionTextExtractor : ITextExtractor
 {
     private readonly ImageAnalysisClient _client;
-    private readonly ILogger<AzureAIVisionOcrService> _logger;
+    private readonly ILogger<AzureVisionTextExtractor> _logger;
 
-    public AzureAIVisionOcrService(IConfiguration configuration, ILogger<AzureAIVisionOcrService> logger)
+    public AzureVisionTextExtractor(IConfiguration configuration, ILogger<AzureVisionTextExtractor> logger)
     {
         var endpoint = configuration["AzureAIVision:Endpoint"]
             ?? throw new InvalidOperationException("AzureAIVision:Endpoint is not configured.");
@@ -19,9 +19,12 @@ public class AzureAIVisionOcrService : IOcrService
         _logger = logger;
     }
 
-    public async Task<string> ExtractTextAsync(Stream imageStream, string contentType, CancellationToken ct = default)
+    public bool CanHandle(string contentType) =>
+        contentType is "image/jpeg" or "image/png" or "image/webp" or "application/pdf";
+
+    public async Task<string> ExtractTextAsync(Stream stream, string contentType, CancellationToken ct = default)
     {
-        var imageData = BinaryData.FromStream(imageStream);
+        var imageData = BinaryData.FromStream(stream);
         var result = await _client.AnalyzeAsync(imageData, VisualFeatures.Read, cancellationToken: ct);
 
         var readResult = result.Value.Read;

--- a/backend/LangTeach.Api/Services/IOcrService.cs
+++ b/backend/LangTeach.Api/Services/IOcrService.cs
@@ -1,6 +1,0 @@
-namespace LangTeach.Api.Services;
-
-public interface IOcrService
-{
-    Task<string> ExtractTextAsync(Stream imageStream, string contentType, CancellationToken ct = default);
-}

--- a/backend/LangTeach.Api/Services/ITextExtractor.cs
+++ b/backend/LangTeach.Api/Services/ITextExtractor.cs
@@ -1,0 +1,7 @@
+namespace LangTeach.Api.Services;
+
+public interface ITextExtractor
+{
+    bool CanHandle(string contentType);
+    Task<string> ExtractTextAsync(Stream stream, string contentType, CancellationToken ct = default);
+}

--- a/backend/LangTeach.Api/Services/OcrOptions.cs
+++ b/backend/LangTeach.Api/Services/OcrOptions.cs
@@ -12,5 +12,6 @@ public class OcrOptions
         "image/png",
         "image/webp",
         "application/pdf",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ];
 }

--- a/backend/LangTeach.Api/Services/OpenXmlDocxTextExtractor.cs
+++ b/backend/LangTeach.Api/Services/OpenXmlDocxTextExtractor.cs
@@ -5,13 +5,6 @@ namespace LangTeach.Api.Services;
 
 public class OpenXmlDocxTextExtractor : ITextExtractor
 {
-    private readonly OcrOptions _options;
-
-    public OpenXmlDocxTextExtractor(Microsoft.Extensions.Options.IOptions<OcrOptions> options)
-    {
-        _options = options.Value;
-    }
-
     public bool CanHandle(string contentType) =>
         contentType == "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
@@ -39,7 +32,7 @@ public class OpenXmlDocxTextExtractor : ITextExtractor
             throw new OcrException("El archivo Word no es válido o está dañado.");
         }
 
-        if (string.IsNullOrWhiteSpace(text) || text.Length < _options.MinExtractedChars)
+        if (string.IsNullOrWhiteSpace(text))
             throw new OcrException("No se pudo extraer texto del archivo Word.");
 
         return Task.FromResult(text);

--- a/backend/LangTeach.Api/Services/OpenXmlDocxTextExtractor.cs
+++ b/backend/LangTeach.Api/Services/OpenXmlDocxTextExtractor.cs
@@ -1,0 +1,47 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace LangTeach.Api.Services;
+
+public class OpenXmlDocxTextExtractor : ITextExtractor
+{
+    private readonly OcrOptions _options;
+
+    public OpenXmlDocxTextExtractor(Microsoft.Extensions.Options.IOptions<OcrOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public bool CanHandle(string contentType) =>
+        contentType == "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+    public Task<string> ExtractTextAsync(Stream stream, string contentType, CancellationToken ct = default)
+    {
+        string text;
+        try
+        {
+            using var doc = WordprocessingDocument.Open(stream, isEditable: false);
+            var body = doc.MainDocumentPart?.Document?.Body
+                ?? throw new OcrException("No se pudo extraer texto del archivo Word.");
+
+            var paragraphs = body.Descendants<Paragraph>()
+                .Select(p => p.InnerText)
+                .Where(t => !string.IsNullOrWhiteSpace(t));
+
+            text = string.Join("\n", paragraphs);
+        }
+        catch (OcrException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is OpenXmlPackageException || ex is System.IO.FileFormatException)
+        {
+            throw new OcrException("El archivo Word no es válido o está dañado.");
+        }
+
+        if (string.IsNullOrWhiteSpace(text) || text.Length < _options.MinExtractedChars)
+            throw new OcrException("No se pudo extraer texto del archivo Word.");
+
+        return Task.FromResult(text);
+    }
+}

--- a/backend/LangTeach.Api/Services/OpenXmlDocxTextExtractor.cs
+++ b/backend/LangTeach.Api/Services/OpenXmlDocxTextExtractor.cs
@@ -6,7 +6,10 @@ namespace LangTeach.Api.Services;
 public class OpenXmlDocxTextExtractor : ITextExtractor
 {
     public bool CanHandle(string contentType) =>
-        contentType == "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+        string.Equals(
+            contentType?.Split(';', 2)[0].Trim(),
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            StringComparison.OrdinalIgnoreCase);
 
     public Task<string> ExtractTextAsync(Stream stream, string contentType, CancellationToken ct = default)
     {

--- a/backend/LangTeach.Api/Services/StubTextExtractor.cs
+++ b/backend/LangTeach.Api/Services/StubTextExtractor.cs
@@ -1,8 +1,10 @@
 namespace LangTeach.Api.Services;
 
-public class StubOcrService : IOcrService
+public class StubTextExtractor : ITextExtractor
 {
-    public Task<string> ExtractTextAsync(Stream imageStream, string contentType, CancellationToken ct = default)
+    public bool CanHandle(string contentType) => true;
+
+    public Task<string> ExtractTextAsync(Stream stream, string contentType, CancellationToken ct = default)
     {
         return Task.FromResult(
             "Este es un texto de prueba extraído por el servicio OCR de pruebas. " +

--- a/backend/LangTeach.Api/appsettings.json
+++ b/backend/LangTeach.Api/appsettings.json
@@ -31,7 +31,7 @@
   "Ocr": {
     "MaxBytes": 10485760,
     "MinExtractedChars": 10,
-    "AcceptedContentTypes": [ "image/jpeg", "image/png", "image/webp", "application/pdf" ]
+    "AcceptedContentTypes": [ "image/jpeg", "image/png", "image/webp", "application/pdf", "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ]
   },
   "GenerationLimits": {
     "FreeTierMonthlyLimit": 50,

--- a/frontend/src/components/student/RedaccionesTab.tsx
+++ b/frontend/src/components/student/RedaccionesTab.tsx
@@ -292,7 +292,7 @@ interface CorrectionDrawerProps {
   onCorregirError: (msg: string) => void
 }
 
-const OCR_ACCEPTED = '.jpg,.jpeg,.png,.webp,.pdf'
+const OCR_ACCEPTED = '.jpg,.jpeg,.png,.webp,.pdf,.docx'
 const HEIC_EXTENSIONS = ['.heic', '.heif']
 
 function CorrectionDrawer({ studentId, editId, onClose, onSaved, onCorregirError }: CorrectionDrawerProps) {


### PR DESCRIPTION
Closes #1257

## Summary

- Renames `IOcrService` -> `ITextExtractor` (adds `CanHandle(string contentType)`) -- no remaining references to the old name
- Renames `AzureAIVisionOcrService` -> `AzureVisionTextExtractor`, `StubOcrService` -> `StubTextExtractor`
- Adds `OpenXmlDocxTextExtractor` using `DocumentFormat.OpenXml` (already a transitive dep) -- handles `.docx` MIME type, extracts paragraph text, throws Spanish `OcrException` for empty/corrupt files
- `OcrController` now resolves `IEnumerable<ITextExtractor>` and dispatches via `CanHandle` -- no if/else format routing; adding a new format = new class + one DI line
- Frontend `OCR_ACCEPTED` extended to include `.docx`
- `appsettings.json` and `OcrOptions` default include the docx MIME type

## Architecture decisions

- `MinExtractedChars` threshold enforced uniformly by the controller (via `Incomplete` flag) for all extractors -- not inside extractors, to keep behavior consistent between image and docx paths
- All `OcrException` messages are in Spanish to match the pattern of other error responses

## Test plan

- [x] 10 unit tests for `OpenXmlDocxTextExtractor` (CanHandle, accents, multi-paragraph, empty/corrupt)
- [x] Integration test `Extract_ValidDocx_ReturnsOkWithTextAndBlobUrl` via `StubTextExtractor`
- [x] `Extract_UnsupportedContentType_ReturnsBadRequest` updated to assert "DOCX" in error message
- [x] All existing OCR controller tests pass (6 total)
- [x] Full build verify: bicep, dotnet build, dotnet test, npm lint, npm build, npm test -- all PASS
- [ ] Live verify (requires .docx upload in browser against e2e stack)

## Reviewers

| Reviewer | Finding | Action |
|---|---|---|
| qa-verify | PASS WITH GAPS (no e2e test with realistic 50+ word .docx) | Accepted -- e2e covered by live verify step |
| architecture-reviewer | English OcrException message; MinExtractedChars inconsistency | Fixed in follow-up commit |
| review-ui | Trivial-frontend exemption applied (1-line accept attribute change) | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for extracting text from DOCX (Word) documents. Users can now upload .docx files in the correction tool alongside existing supported formats (JPEG, PNG, WebP, PDF).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->