### PR TITLE
polish(#1261): fix textarea height collapse and mislabelled upload button

### DIFF
--- a/frontend/src/components/student/RedaccionesTab.tsx
+++ b/frontend/src/components/student/RedaccionesTab.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
-import { ChevronRight, ImageUp, Loader2, X } from 'lucide-react'
+import { ChevronRight, FileUp, Loader2, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
@@ -538,13 +538,13 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved, onCorregirError
                         onClick={() => fileInputRef.current?.click()}
                         disabled={ocrState === 'loading'}
                         className="flex items-center gap-1 text-[10px] font-semibold tracking-wide text-indigo-600 hover:text-indigo-800 disabled:opacity-50 disabled:cursor-not-allowed"
-                        title="Subir foto o archivo para extraer texto"
+                        title="Subir archivo: foto, PDF o documento Word"
                         data-testid="correction-drawer-upload-btn"
                       >
                         {ocrState === 'loading'
                           ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                          : <ImageUp className="h-3.5 w-3.5" />}
-                        Subir imagen
+                          : <FileUp className="h-3.5 w-3.5" />}
+                        Subir archivo
                       </button>
                     </>
                   )}
@@ -555,7 +555,7 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved, onCorregirError
                   onChange={(e) => setText(e.target.value.slice(0, TEXT_MAX))}
                   placeholder={ocrState === 'loading' ? 'Extrayendo texto...' : 'Pega el texto del alumno aquí'}
                   rows={10}
-                  className="resize-y max-h-[50vh]"
+                  className="resize-y max-h-[50vh] min-h-[12rem]"
                   disabled={studentTextLocked || ocrState === 'loading'}
                   data-testid="correction-drawer-text"
                 />
@@ -572,7 +572,7 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved, onCorregirError
                 <p className="text-xs text-zinc-500">
                   {studentTextLocked
                     ? 'El texto no se puede modificar una vez generada la corrección.'
-                    : 'Si ya tienes el texto del alumno, pégalo aquí o sube una foto. Lo puedes añadir más tarde.'}
+                    : 'Si ya tienes el texto del alumno, pégalo aquí o sube una foto, PDF o documento Word. Lo puedes añadir más tarde.'}
                 </p>
                 {textLockedError && (
                   <p className="text-xs text-red-600" data-testid="correction-drawer-text-error">


### PR DESCRIPTION
Fixes #1261

## Summary

- Add `min-h-[12rem]` to the "Texto del alumno" textarea as a local class override (base `Textarea` component unchanged) so the field shows ~8 lines when empty instead of collapsing to 2 lines due to `field-sizing-content`
- Rename upload button from "Subir imagen" to "Subir archivo" and replace `ImageUp` icon with `FileUp` so teachers with PDF or Word files are not misled
- Update button tooltip and hint text paragraph to reference "foto, PDF o documento Word"

## Test plan

- [x] Build verify: all checks pass (bicep, dotnet build/test, npm lint/build/test)
- [x] Live verify: Playwright against worktree Vite dev server + e2e API (VITE_E2E_TEST_MODE)
  - Textarea height: 192px (>= 160px / 8 lines) PASS
  - Button label "Subir archivo" PASS
  - Button tooltip references PDF and Word PASS
  - Hint text references PDF and Word PASS
  - Mobile 375px textarea height 192px PASS
- [x] qa-verify: PASS WITH GAPS (no automated test for PDF upload flow; pre-existing pipeline is already covered by existing tests)
- [x] architecture-reviewer: PASS WITH NOTES (minor: existing upload affordances use `Upload` icon; `FileUp` kept as more semantically specific for file upload)
- [x] review-ui: PASS (diff verified mechanically correct; consistent with design system)

## Out of scope

- Changes to the base `Textarea` component (per issue spec)
- PDF/DOCX text extraction pipeline
- Textarea height in other forms (session notes etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Document upload interface now clearly supports photos, PDFs, and Word documents
  * Updated instructional guidance indicating users can add text alongside document submissions
  * Refined text input styling with improved height constraints for better usability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1262)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->