### PR TITLE
fix(#1263): B1 grammar scope -- separate receptive scope from active drill targets

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -1451,7 +1451,6 @@ public class PromptServiceTests
         var req = _sut.BuildGrammarPrompt(BaseCtx()); // B1
 
         req.UserPrompt.Should().Contain("GRAMMAR FOCUS CEILING");
-        req.UserPrompt.Should().Contain("B1.1");
         req.UserPrompt.Should().Contain("pluscuamperfecto");
         req.UserPrompt.Should().Contain("subjuntivo");
     }

--- a/backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs
@@ -189,6 +189,55 @@ public class PedagogyConfigServiceTests
         result.OutOfScope.Should().BeEmpty(because: "C1 grammarOutOfScope is an empty array");
     }
 
+    // --- GetActiveGrammarScope ---
+
+    [Fact]
+    public void GetActiveGrammarScope_B1_ReturnsGrammarFocusTargets_NotFullScope()
+    {
+        // B1 defines grammarFocusTargets (active drill only, not full receptive scope).
+        // Active scope must be a subset of the full receptive scope.
+        var active = _sut.GetActiveGrammarScope("B1");
+        var full = _sut.GetGrammarScope("B1");
+
+        active.InScope.Should().NotBeEmpty();
+        active.InScope.Length.Should().BeLessThan(full.InScope.Length,
+            because: "B1 active drill scope is a subset of the full receptive scope");
+    }
+
+    [Fact]
+    public void GetActiveGrammarScope_B1_DoesNotIncludeSubjuntivo()
+    {
+        // Active drill targets for B1 exclude subjuntivo (in receptive scope but not active drill scope).
+        var active = _sut.GetActiveGrammarScope("B1");
+
+        active.InScope.Should().NotContain(
+            s => s.Contains("subjuntivo", StringComparison.OrdinalIgnoreCase),
+            because: "subjuntivo is in B1 receptive scope but must not appear in the active drill targets used for lesson generation");
+    }
+
+    [Fact]
+    public void GetActiveGrammarScope_A1_FallsBackToFullInScope()
+    {
+        // A1 does not define grammarFocusTargets -- active scope equals full receptive scope.
+        var active = _sut.GetActiveGrammarScope("A1");
+        var full = _sut.GetGrammarScope("A1");
+
+        active.InScope.Should().BeEquivalentTo(full.InScope,
+            because: "levels without grammarFocusTargets fall back to full grammarInScope");
+    }
+
+    [Fact]
+    public void GetGrammarScope_B1_IncludesSubjuntivoInReceptiveScope()
+    {
+        // Full receptive scope for B1 must include cuando + subjuntivo so the correction
+        // pipeline does not suppress valid B1 structures (issue #1263).
+        var scope = _sut.GetGrammarScope("B1");
+
+        scope.InScope.Should().Contain(
+            s => s.Contains("subjuntivo", StringComparison.OrdinalIgnoreCase),
+            because: "cuando + subjuntivo is in B1 receptive scope per PCIC 29.1 and must not be suppressed by the correction filter");
+    }
+
     // --- GetVocabularyGuidance ---
 
     [Theory]

--- a/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionLevelFilterTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionLevelFilterTests.cs
@@ -387,8 +387,11 @@ public class RedaccionCorrectionLevelFilterTests : IDisposable
         var tags = new[] { new LevelFilterTagInput("G", "cuando llegues", "Construccion temporal con subjuntivo.") };
         var req = builder.Build("B1", tags);
 
-        req.UserPrompt.ToLowerInvariant().Should().Contain("subjuntivo",
-            because: "B1 full receptive scope includes cuando + subjuntivo; the correction filter must see it as in-scope");
+        var lines = req.UserPrompt.Split('\n');
+        var inScopeLine = lines.FirstOrDefault(l => l.StartsWith("Grammar in scope for B1:", StringComparison.OrdinalIgnoreCase));
+        inScopeLine.Should().NotBeNull("in-scope line must be present for B1");
+        inScopeLine!.ToLowerInvariant().Should().Contain("subjuntivo",
+            because: "B1 full receptive scope includes cuando + subjuntivo; the correction filter must see it as in-scope, not only in the out-of-scope list");
     }
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionLevelFilterTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionLevelFilterTests.cs
@@ -374,6 +374,43 @@ public class RedaccionCorrectionLevelFilterTests : IDisposable
             $"calibration cue for {cefr} must be injected into the user prompt");
     }
 
+    [Fact]
+    public void LevelFilterPrompt_B1_CuandoSubjuntivoIsInScope()
+    {
+        // Issue #1263: B1 correction filter prompt must include cuando + subjuntivo in the in-scope list
+        // so the filter LLM knows to validate (not suppress) correct B1 subjunctive usage.
+        var sps = new SectionProfileService(NullLogger<SectionProfileService>.Instance);
+        var pedagogy = new PedagogyConfigService(NullLogger<PedagogyConfigService>.Instance, sps);
+        var builder = new RedaccionLevelFilterPromptBuilder(pedagogy,
+            NullLogger<RedaccionLevelFilterPromptBuilder>.Instance);
+
+        var tags = new[] { new LevelFilterTagInput("G", "cuando llegues", "Construccion temporal con subjuntivo.") };
+        var req = builder.Build("B1", tags);
+
+        req.UserPrompt.ToLowerInvariant().Should().Contain("subjuntivo",
+            because: "B1 full receptive scope includes cuando + subjuntivo; the correction filter must see it as in-scope");
+    }
+
+    [Fact]
+    public void LevelFilterPrompt_A1_SubjuntivoNotInGrammarInScope()
+    {
+        // A1 does not have subjuntivo in grammarInScope -- it appears only in grammarOutOfScope.
+        // The filter prompt must not list subjuntivo as an in-scope structure for A1.
+        var sps = new SectionProfileService(NullLogger<SectionProfileService>.Instance);
+        var pedagogy = new PedagogyConfigService(NullLogger<PedagogyConfigService>.Instance, sps);
+        var builder = new RedaccionLevelFilterPromptBuilder(pedagogy,
+            NullLogger<RedaccionLevelFilterPromptBuilder>.Instance);
+
+        var tags = new[] { new LevelFilterTagInput("G", "ojala vengas", "Subjuntivo presente.") };
+        var req = builder.Build("A1", tags);
+
+        var lines = req.UserPrompt.Split('\n');
+        var inScopeLine = lines.FirstOrDefault(l => l.StartsWith("Grammar in scope for A1:", StringComparison.OrdinalIgnoreCase));
+        inScopeLine.Should().NotBeNull("in-scope line must be present for A1");
+        inScopeLine!.ToLowerInvariant().Should().NotContain("subjuntivo",
+            because: "subjuntivo is not in A1 grammarInScope and must not appear in the in-scope part of the prompt");
+    }
+
     // ─── Helpers ────────────────────────────────────────────────────────────────
 
     private void SeedStudent(string cefrLevel = "A2")

--- a/backend/LangTeach.Api/AI/PedagogyConfig.cs
+++ b/backend/LangTeach.Api/AI/PedagogyConfig.cs
@@ -58,7 +58,8 @@ public record CefrLevelRules(
     string ScaffoldingDefault,
     GuidedWritingConfig? GuidedWriting = null,
     NoticingTaskConfig? NoticingTask = null,
-    string? GrammarFocusCeiling = null
+    string? GrammarFocusCeiling = null,
+    string[]? GrammarFocusTargets = null
 );
 
 public record GuidedWritingConfig(

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -224,7 +224,7 @@ public class PromptService : IPromptService
 
     private string BuildGrammarScopeBlock(string level)
     {
-        var scope = _pedagogy.GetGrammarScope(level);
+        var scope = _pedagogy.GetActiveGrammarScope(level);
         if (scope.InScope.Length == 0 && scope.OutOfScope.Length == 0)
             return string.Empty;
 

--- a/backend/LangTeach.Api/Services/IPedagogyConfigService.cs
+++ b/backend/LangTeach.Api/Services/IPedagogyConfigService.cs
@@ -21,9 +21,17 @@ public interface IPedagogyConfigService
 
     /// <summary>
     /// Returns in-scope and out-of-scope grammar lists for the CEFR level.
+    /// Returns the full receptive scope -- used by the correction pipeline.
     /// Returns empty arrays if the level is not found.
     /// </summary>
     GrammarScope GetGrammarScope(string level);
+
+    /// <summary>
+    /// Returns the active drill grammar scope for lesson generation.
+    /// For levels that define grammarFocusTargets (currently B1), returns the focused active-drill targets.
+    /// For other levels, falls back to the full grammarInScope.
+    /// </summary>
+    GrammarScope GetActiveGrammarScope(string level);
 
     /// <summary>
     /// Returns guided writing parameters (word counts, complexity, structure expectations) for the CEFR level.

--- a/backend/LangTeach.Api/Services/PedagogyConfigService.cs
+++ b/backend/LangTeach.Api/Services/PedagogyConfigService.cs
@@ -239,6 +239,17 @@ public class PedagogyConfigService : IPedagogyConfigService
         return new GrammarScope(rule.GrammarInScope, rule.GrammarOutOfScope, rule.GrammarFocusCeiling);
     }
 
+    public GrammarScope GetActiveGrammarScope(string level)
+    {
+        var normalLevel = NormalizeLevel(level);
+        if (!_cefrRules.TryGetValue(normalLevel, out var rule))
+            return new GrammarScope([], []);
+        var inScope = rule.GrammarFocusTargets is { Length: > 0 }
+            ? rule.GrammarFocusTargets
+            : rule.GrammarInScope;
+        return new GrammarScope(inScope, rule.GrammarOutOfScope, rule.GrammarFocusCeiling);
+    }
+
     public GuidedWritingGuidance GetGuidedWritingGuidance(string level)
     {
         var normalLevel = NormalizeLevel(level);

--- a/data/pedagogy/cefr-levels/b1.json
+++ b/data/pedagogy/cefr-levels/b1.json
@@ -30,7 +30,7 @@
     "Expresar condiciones reales (si + presente, futuro)"
   ],
   "grammarOutOfScope": [
-    "Subjuntivo imperfecto en todos sus usos excepto la condicional irreal (B1.2)",
+    "Subjuntivo imperfecto en todos sus usos excepto la condicional irreal -- la condicional irreal (si + imperfecto de subjuntivo, condicional) esta incluida en grammarInScope",
     "Subjuntivo perfecto y pluscuamperfecto",
     "Oraciones concesivas complejas (aunque + subjuntivo, se ve al final de B1.2/inicio de B2)",
     "Voz pasiva con ser (B2)",
@@ -38,7 +38,7 @@
     "Perifrasis modales sofisticadas (venir a + infinitivo, dar por + participio)",
     "Subjuntivo imperfecto en estilo indirecto (dijo que enviara) -- B2, not B1"
   ],
-  "grammarFocusCeiling": "Grammar Focus targets for B1.1 students are restricted to: imperfecto/indefinido contrast, futuro simple, condicional simple, imperativo negativo, real conditions (si + presente), oraciones temporales/causales, conectores, and perifrasis verbales. Pluscuamperfecto, subjuntivo (any mood), and indirect-speech tense shifts are B1.2 structures; they become available as Grammar Focus targets only when teacher notes confirm prior mastery.",
+  "grammarFocusCeiling": "Pluscuamperfecto, subjuntivo (any mood), and indirect-speech tense shifts become available as Grammar Focus targets only when teacher notes confirm prior mastery of core B1 tenses.",
   "appropriateExerciseTypes": [
     "GR-01",
     "GR-02",

--- a/data/pedagogy/cefr-levels/b1.json
+++ b/data/pedagogy/cefr-levels/b1.json
@@ -1,5 +1,6 @@
 {
   "level": "B1",
+  "_note": "grammarInScope = full B1 receptive scope (correction validation). grammarFocusTargets = B1.1 active drill scope (lesson generation). Never encode sub-level qualifications in grammarInScope -- they confuse the correction LLM.",
   "grammarInScope": [
     "Preterito imperfecto y su contraste con indefinido (habito vs evento, descripcion vs accion)",
     "Futuro simple (irregulares incluidos)",
@@ -11,10 +12,22 @@
     "Perifrasis: llevar + gerundio, dejar de + infinitivo, seguir + gerundio, volver a + infinitivo",
     "Oraciones relativas con indicativo (que, donde, quien)",
     "Expresar condiciones reales (si + presente, futuro)",
-    "Preterito pluscuamperfecto (B1.2 -- Grammar Focus target only after imperfecto/indefinido contrast is consolidated)",
-    "Subjuntivo presente introduccion: ojala, quiero que, cuando + subjuntivo, para que, es necesario que (B1.2 -- Grammar Focus target only after core B1.1 tenses are mastered)",
-    "Estilo indirecto basico con imperfecto indicativo: dijo que + imperfecto (B1.2 -- not imperfecto de subjuntivo, which is B2)",
-    "Expresar hipotesis (si + imperfecto de subjuntivo, condicional) (B1.2)"
+    "Preterito pluscuamperfecto",
+    "Subjuntivo presente: ojala, quiero que, cuando + subjuntivo, para que, es necesario que",
+    "Estilo indirecto basico con imperfecto indicativo: dijo que + imperfecto",
+    "Expresar hipotesis (si + imperfecto de subjuntivo, condicional)"
+  ],
+  "grammarFocusTargets": [
+    "Preterito imperfecto y su contraste con indefinido",
+    "Futuro simple",
+    "Condicional simple",
+    "Imperativo negativo",
+    "Oraciones temporales (cuando, mientras, antes de que, despues de que)",
+    "Oraciones causales y finales (porque, como, para que, a fin de que)",
+    "Conectores avanzados: sin embargo, no obstante, en primer lugar, por un lado/por otro, en conclusion",
+    "Perifrasis verbales: llevar + gerundio, dejar de + infinitivo, seguir + gerundio, volver a + infinitivo",
+    "Oraciones relativas con indicativo (que, donde, quien)",
+    "Expresar condiciones reales (si + presente, futuro)"
   ],
   "grammarOutOfScope": [
     "Subjuntivo imperfecto en todos sus usos excepto la condicional irreal (B1.2)",

--- a/data/pedagogy/correction-calibration.json
+++ b/data/pedagogy/correction-calibration.json
@@ -2,7 +2,7 @@
   "cefrCalibration": {
     "A1": "Be maximally encouraging. Prefer soften over remove for above-scope structures. Use remove only when an above-scope attempt would confuse rather than support learning.",
     "A2": "Be encouraging. Prefer soften for genuine above-scope attempts that show effort. Use remove only for clearly wrong out-of-scope structures that could mislead.",
-    "B1": "Apply balanced calibration. Use soften for intentional above-scope attempts (even if imperfect), remove for clearly wrong out-of-scope errors. Use muybien when a structure at the level ceiling is used correctly.",
+    "B1": "Apply balanced calibration. Use soften for intentional above-scope attempts (even if imperfect), remove for clearly wrong out-of-scope errors. Use muybien when a structure at the level ceiling is used correctly. Note: soften applies to correction pipeline output; the B1.1 Grammar Focus ceiling (grammarFocusTargets in b1.json) applies only to lesson generation -- they are separate pipelines.",
     "B2": "Apply standard calibration. Use muybien generously for well-used advanced structures appropriate to the register. Use remove for clearly wrong out-of-scope errors.",
     "C1": "Rarely soften or remove. Use muybien generously when a student demonstrates strong command of complex structures. Keep most tags.",
     "C2": "Keep or promote to muybien for almost all tags. Removal is almost never appropriate at this level."


### PR DESCRIPTION
## Summary

- Splits `b1.json` `grammarInScope` (full B1 receptive scope for correction validation) from new `grammarFocusTargets` (B1.1 active drill scope for lesson generation)
- Removes confusing "(B1.2 -- ...)" parenthetical annotations from `grammarInScope` so the correction filter LLM sees `cuando + subjuntivo` as unambiguously in-scope
- Adds `GetActiveGrammarScope` to `PedagogyConfigService`; `BuildGrammarScopeBlock` (lesson generation) uses it; `RedaccionLevelFilterPromptBuilder` (correction) stays on `GetGrammarScope`
- Trims `grammarFocusCeiling` to remove item enumeration now redundant with `grammarFocusTargets`
- Clarifies `grammarOutOfScope` subjuntivo imperfecto entry with explicit carve-out for the condicional irreal

## Test plan

- [x] 6 new unit tests: `GetActiveGrammarScope_B1_*`, `GetGrammarScope_B1_IncludesSubjuntivoInReceptiveScope`, `LevelFilterPrompt_B1_CuandoSubjuntivoIsInScope`, `LevelFilterPrompt_A1_SubjuntivoNotInGrammarInScope`
- [x] Updated `GrammarPrompt_B1_ContainsGrammarFocusCeiling` (removed "B1.1" assertion after ceiling trimmed)
- [x] All 1449 non-skipped tests pass
- [ ] **Live verify unexecuted** (logged to plan/observed-issues.md): validate post-merge by submitting a 100+ word B1 redaccion with correct `cuando + subjuntivo` and confirming no soften/remove tag on that construction

## Review findings

| Reviewer | Finding | Action |
|---|---|---|
| qa-verify | All code-level ACs covered; live verify unexecuted | Deferred, logged to observed-issues.md |
| architecture-reviewer | PASS -- patterns match conventions exactly | - |
| Sophy | APPROVE -- add startup validation that grammarFocusTargets ⊆ grammarInScope | Deferred to backlog |
| Isaac (pedagogy) | SOUND -- clarify grammarOutOfScope carve-out for condicional irreal | Fixed in second commit |
| Prompt-health | NEEDS CLEANUP -- trim ceiling redundant enumeration; omit OutOfScope from generation when FocusTargets present | #1 Fixed; #2 Deferred to backlog |
| CodeRabbit | (pending) | - |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for grammar scope behavior, validating active vs. full scope distinctions and level-specific grammar filtering across B1 and A1 levels.

* **Configuration**
  * Refined B1 grammar configuration with explicit focus targets for drilling, clarifying the separation between full receptive grammar scope (for corrections) and active drill scope (for lessons). Updated calibration guidance to reflect these distinctions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->