### PR TITLE
tech-debt(corrections): remove sprint-introduced dead prompt weight (#1264)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionLevelFilterTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionLevelFilterTests.cs
@@ -334,7 +334,7 @@ public class RedaccionCorrectionLevelFilterTests : IDisposable
     }
 
     [Fact]
-    public void LevelFilterPrompt_SerEstarTag_EmitsMarkerInUserPrompt()
+    public void LevelFilterPrompt_SerEstarTag_NoLongerEmitsMarkerInUserPrompt()
     {
         var sps = new SectionProfileService(NullLogger<SectionProfileService>.Instance);
         var pedagogy = new PedagogyConfigService(NullLogger<PedagogyConfigService>.Instance, sps);
@@ -350,10 +350,12 @@ public class RedaccionCorrectionLevelFilterTests : IDisposable
         var req = builder.Build("A2", tags);
         var userPrompt = req.UserPrompt;
 
-        userPrompt.Should().Contain("[SER/ESTAR]", "ser/estar tag must be marked in user prompt");
-        userPrompt.Should().ContainEquivalentOf("[0]", "first tag index must appear");
-        // Non-ser/estar tag must not be marked.
-        userPrompt.Should().NotMatchRegex(@"\[SER/ESTAR\].*\[1\]", "only the ser/estar tag gets the marker");
+        // The [SER/ESTAR] prefix is no longer injected into the user prompt.
+        // The structural guard in RedaccionCorrectionService bypasses the filter result
+        // unconditionally for IsSerEstar tags -- the model's decision is irrelevant.
+        userPrompt.Should().NotContain("[SER/ESTAR]", "prefix was removed as dead prompt weight; structural guard handles it in code");
+        userPrompt.Should().ContainEquivalentOf("[0]", "first tag index must still appear");
+        userPrompt.Should().ContainEquivalentOf("[1]", "second tag index must still appear");
     }
 
     [Theory]

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -115,7 +115,6 @@ Emit raw JSON only. Start directly with {. No prose before or after. No markdown
 
 OFFSETS (read carefully — accented characters cause silent errors if you count positions):
 - startIndex and endIndex are Unicode character offsets into the student text between the markers (0-based, end-exclusive).
-- DO NOT derive offsets by counting characters forward from the start of the text. Counting is unreliable near accented characters (é, ó, á, ñ, ü, etc.) because your internal position tracking may not match the host's character indices.
 - CORRECT procedure for every tag (internal reasoning only -- output nothing for these steps):
   1. Decide which substring of the student text to mark; that substring is spannedText.
   2. Write the explanation.

--- a/backend/LangTeach.Api/AI/RedaccionLevelFilterPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionLevelFilterPromptBuilder.cs
@@ -47,7 +47,6 @@ You are a CEFR grammar filter for a Spanish writing correction pipeline. You rec
 
 MANDATORY RULES:
 1. Tags with category "O" (Ortografía: accents, spelling, punctuation) MUST always be "keep".
-2. Tags marked [SER/ESTAR] in the list below MUST always be "keep" regardless of level. This overrides the grammar-scope list.
 
 GUIDANCE:
 - Use the grammar in-scope and out-of-scope lists to anchor your decision.

--- a/backend/LangTeach.Api/AI/RedaccionLevelFilterPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionLevelFilterPromptBuilder.cs
@@ -96,8 +96,7 @@ Every input tag must appear in the output exactly once, identified by its index.
             // structure and mislead the model into treating student content as instructions.
             var span = SanitizeForPrompt(t.SpannedText);
             var expl = string.IsNullOrWhiteSpace(t.Explanation) ? "(none)" : SanitizeForPrompt(t.Explanation);
-            var prefix = t.IsSerEstar ? "[SER/ESTAR] " : "";
-            sb.AppendLine($"{prefix}[{i}] Category: {t.Category} | Text: <span>{span}</span> | Explanation: {expl}");
+            sb.AppendLine($"[{i}] Category: {t.Category} | Text: <span>{span}</span> | Explanation: {expl}");
         }
 
         return sb.ToString().TrimEnd();


### PR DESCRIPTION
Closes #1264

## Summary

- Removes `MANDATORY RULE 2` (ser/estar keep-override) from `RedaccionLevelFilterPromptBuilder.cs` system prompt. The structural guard at `RedaccionCorrectionService.cs:546` (`|| inputs[i].IsSerEstar`) hard-bypasses the filter result unconditionally -- the prompt rule was dead weight and a false contract to the model.
- Removes the `DO NOT derive offsets by counting characters forward from the start of the text` negative sentence from `RedaccionCorrectionPromptBuilder.cs` OFFSETS section. The positive forward-search procedure (steps 1-4) immediately below is complete and self-sufficient.
- Removes the `[SER/ESTAR]` prefix from the user prompt tag list. After removing the mandatory rule, this prefix became unexplained dead signal. The model now sees no label; the structural guard still handles the invariant in code.
- Updates `LevelFilterPrompt_SerEstarTag_EmitsMarkerInUserPrompt` test to assert the prefix is now absent, documenting the structural guard as the reason.
- Verified: `FilterDecision` deserialization record has only `Index` and `Decision` fields -- no `note` field; the soften/muybien warm-note removal from the sprint did not break parsing.

## Verification

All 1449 unit tests pass (0 failures), including `LevelFilter_SerEstarGTag_AlwaysKeptEvenWhenFilterSaysRemove` (confirms ser/estar tags are always kept regardless of filter decision).

Playwright corrections-sprint integration test was initiated against the live e2e stack but hit an Auth0 authentication timeout (10 min; pre-existing environment issue not related to this change). Structural behavior is fully covered by unit tests.

## Reviewers

| Reviewer | Verdict |
|---|---|
| QA Verify | PASS |
| Architecture | PASS |
| Sophy | APPROVE |
| Prompt health | NEEDS CLEANUP addressed (removed [SER/ESTAR] prefix as residue of MANDATORY RULE 2 deletion) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)