### PR TITLE
polish(pedagogy): correction-categories.json C description + antiPatternRules guard (#1266)

### DIFF
--- a/data/pedagogy/correction-categories.json
+++ b/data/pedagogy/correction-categories.json
@@ -3,7 +3,7 @@
     {
       "code": "C",
       "name": "Cohesión y Coherencia",
-      "description": "connector-level or discourse-organization error.",
+      "description": "cohesion or discourse-organization error (includes connector misuse, paragraph structure, logical sequencing).",
       "subTypes": [
         "Connector-level: missing connector, wrong connector, missing temporal marker, repetitive linking structure.",
         "Discourse-level (most significant at B2 and above): paragraph lacks a clear main idea (no topic sentence), ideas within a paragraph are not logically ordered."
@@ -109,6 +109,7 @@
     }
   ],
   "antiPatternRules": [
+    "_note: Do not add ser/estar entries here -- it is covered fully in criticalRules above. Adding it would cause duplicate emission in the system prompt.",
     "A wrong preposition is G, NEVER L.",
     "A literal translation from the student's L1 is L, NEVER G.",
     "A missing or wrong connector is C, NEVER G.",

--- a/data/pedagogy/correction-categories.json
+++ b/data/pedagogy/correction-categories.json
@@ -108,8 +108,10 @@
       ]
     }
   ],
+  "_authoringNotes": {
+    "antiPatternRules": "Do not add ser/estar entries here -- it is covered fully in criticalRules above. Adding it would cause duplicate emission in the system prompt."
+  },
   "antiPatternRules": [
-    "_note: Do not add ser/estar entries here -- it is covered fully in criticalRules above. Adding it would cause duplicate emission in the system prompt.",
     "A wrong preposition is G, NEVER L.",
     "A literal translation from the student's L1 is L, NEVER G.",
     "A missing or wrong connector is C, NEVER G.",


### PR DESCRIPTION
Closes #1266

## Summary

- Updated C category description from "connector-level or discourse-organization error" to "cohesion or discourse-organization error (includes connector misuse, paragraph structure, logical sequencing)". The old text led with "connector-level" which biased the model to treat C as connector errors only, not the full CCoh competency. The new text leads with the broad concept and the parenthetical matches the existing subTypes.
- Added `_authoringNotes` top-level key with a guard warning future editors not to add ser/estar to `antiPatternRules` (already covered in `criticalRules`, would cause duplicate emission). The key is a no-op at runtime: System.Text.Json ignores unknown properties on deserialization. Note was originally placed inside the `antiPatternRules` array but moved after review because the builder emits all array entries verbatim to the model.

## Reviewers

| Reviewer | Finding | Action |
|---|---|---|
| QA Verify | All acceptance criteria met | PASS |
| Architecture | `_authoringNotes` convention matches existing `_note` in b1.json | PASS |
| Isaac (pedagogy) | Raised that `_note` inside array would leak to prompt | Fixed (moved to `_authoringNotes` top-level key) |
| Prompt health | New C description aligns exactly with subTypes and antiPatternRules; no contradictions | CLEAN |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the definition of cohesion and coherence writing feedback to explicitly specify which issues are covered, including connector usage, paragraph structure, and logical sequencing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->