### PR TITLE
fix(pedagogy): close silent ceiling gap for antes/despues de que (#1272)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/PedagogyConfigServiceTests.cs
@@ -205,14 +205,36 @@ public class PedagogyConfigServiceTests
     }
 
     [Fact]
-    public void GetActiveGrammarScope_B1_DoesNotIncludeSubjuntivo()
+    public void GetActiveGrammarScope_B1_DoesNotIncludeSubjuntivoAsStandaloneTarget()
     {
-        // Active drill targets for B1 exclude subjuntivo (in receptive scope but not active drill scope).
+        // Active drill targets for B1 must not list subjuntivo as a drill goal.
+        // Qualifier notes on other entries may mention subjuntivo in a restriction context
+        // (e.g. "antes de que: solo indicativo; el subjuntivo es receptivo").
         var active = _sut.GetActiveGrammarScope("B1");
 
         active.InScope.Should().NotContain(
-            s => s.Contains("subjuntivo", StringComparison.OrdinalIgnoreCase),
-            because: "subjuntivo is in B1 receptive scope but must not appear in the active drill targets used for lesson generation");
+            s => s.StartsWith("Subjuntivo", StringComparison.OrdinalIgnoreCase)
+                 || (s.Contains("subjuntivo", StringComparison.OrdinalIgnoreCase)
+                     && !s.Contains("receptivo", StringComparison.OrdinalIgnoreCase)),
+            because: "subjuntivo must not appear in B1 active drill targets except inside a restriction qualifier that labels it receptive-only");
+    }
+
+    [Fact]
+    public void GetActiveGrammarScope_B1_TemporalConjunctionsHaveSubjuntivoRestrictionQualifier()
+    {
+        // The temporal conjunctions entry must carry a qualifier making clear that
+        // antes/despues de que drills stay in indicative or infinitive at B1.1.
+        var active = _sut.GetActiveGrammarScope("B1");
+
+        var temporalEntry = active.InScope.FirstOrDefault(
+            s => s.Contains("antes de que", StringComparison.OrdinalIgnoreCase));
+
+        temporalEntry.Should().NotBeNull(
+            because: "B1 active drill scope must include temporal conjunctions (antes de que / despues de que)");
+        temporalEntry!.Should().Contain("indicativo",
+            because: "the qualifier must restrict antes/despues de que drills to indicative or infinitive only");
+        temporalEntry.Should().Contain("receptivo",
+            because: "the qualifier must clarify that subjuntivo usage of these conjunctions is receptive-only at B1.1");
     }
 
     [Fact]

--- a/data/pedagogy/cefr-levels/b1.json
+++ b/data/pedagogy/cefr-levels/b1.json
@@ -22,7 +22,7 @@
     "Futuro simple",
     "Condicional simple",
     "Imperativo negativo",
-    "Oraciones temporales (cuando, mientras, antes de que, despues de que)",
+    "Oraciones temporales (cuando, mientras, antes de que, despues de que) (en ejercicios activos: solo indicativo o infinitivo; el subjuntivo en estas conjunciones es receptivo, no objetivo de drill en B1.1)",
     "Oraciones causales y finales (porque, como, para que, a fin de que)",
     "Conectores avanzados: sin embargo, no obstante, en primer lugar, por un lado/por otro, en conclusion",
     "Perifrasis verbales: llevar + gerundio, dejar de + infinitivo, seguir + gerundio, volver a + infinitivo",

--- a/data/pedagogy/correction-categories.json
+++ b/data/pedagogy/correction-categories.json
@@ -55,6 +55,7 @@
         {
           "text": "Si te invitaran",
           "note": "over-formal for a casual informal letter register when the task rubric penalises register mismatch",
+          "rationale": "tagged L not G because the register mismatch is the pedagogically salient correction at this level; grammar scope ceiling is enforced separately in the generation pipeline",
           "label": "L"
         }
       ]
@@ -108,9 +109,7 @@
       ]
     }
   ],
-  "_authoringNotes": {
-    "antiPatternRules": "Do not add ser/estar entries here -- it is covered fully in criticalRules above. Adding it would cause duplicate emission in the system prompt."
-  },
+  "antiPatternRules_GUARD": "Do not add ser/estar entries here -- it is covered fully in criticalRules above. Adding it would cause duplicate emission in the system prompt.",
   "antiPatternRules": [
     "A wrong preposition is G, NEVER L.",
     "A literal translation from the student's L1 is L, NEVER G.",


### PR DESCRIPTION
## Summary

- Add subjuntivo restriction qualifier to B1 `grammarFocusTargets` temporal conjunctions entry so the generation model limits drills to indicative or infinitive only (closes the silent ceiling gap where `antes de que + subjuntivo` could appear in B1.1 Grammar Focus drills)
- Rename `_authoringNotes` to `antiPatternRules_GUARD` for author visibility when editing `antiPatternRules`
- Add `rationale` field to L category `Si te invitaran` example explaining why it is L not G

Closes #1272

## Live Verify

Browser verify was skipped (no `.env.qa` configured for teacher-qa). Code-level verification complete: qualifier text confirmed to flow through `GetActiveGrammarScope` -> `BuildGrammarScopeBlock` -> prompt. All 120 pedagogy tests pass including two new assertions for the qualifier.

## Test plan

- [x] Existing test updated: `GetActiveGrammarScope_B1_DoesNotIncludeSubjuntivoAsStandaloneTarget` now allows "subjuntivo" in restriction qualifiers (checks "receptivo" co-occurrence)
- [x] New test: `GetActiveGrammarScope_B1_TemporalConjunctionsHaveSubjuntivoRestrictionQualifier` asserts qualifier reaches active scope with "indicativo" and "receptivo"
- [x] `grammarInScope` temporal conjunctions entry unchanged (receptive scope preserved per PCIC B1)
- [x] `antiPatternRules_GUARD` key not deserialized (no C# record field), no runtime impact
- [x] `rationale` field not in `CorrectionCategoryExample` record, ignored by deserializer
- [ ] In-browser: generate B1.1 Grammar Focus lesson with temporal topic, verify no antes/despues de que + subjuntivo drills (requires .env.qa setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for B1-level grammar scope, adding specific validation for subjunctive mood handling in drill targets and temporal conjunction restrictions.

* **Configuration**
  * Refined B1-level grammar drill rules for temporal conjunctions to clarify that subjunctive forms are receptive-only, not active drill targets.
  * Updated correction category documentation with clearer rationale explanations for grammar scope enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->