### PR TITLE
fix(prompts): warmup sharedGuidance coverage + correction-calibration note leak

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/PromptServiceTests.cs
@@ -609,6 +609,15 @@ public class PromptServiceTests
         req.UserPrompt.Should().NotContain("NEVER generate a vocabulary list");
     }
 
+    [Fact]
+    public void LessonPlanPrompt_WarmUp_ContainsSharedGuidance()
+    {
+        var req = _sut.BuildLessonPlanPrompt(BaseCtx());
+
+        req.UserPrompt.Should().Contain("no right or wrong answers",
+            "sharedGuidance from warmup.json must be surfaced in the lesson plan prompt");
+    }
+
     // --- Reading & Comprehension template ---
 
     [Fact]

--- a/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionLevelFilterTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionLevelFilterTests.cs
@@ -377,6 +377,21 @@ public class RedaccionCorrectionLevelFilterTests : IDisposable
     }
 
     [Fact]
+    public void LevelFilterPrompt_B1_DoesNotLeakPipelineDisambiguationNote()
+    {
+        var sps = new SectionProfileService(NullLogger<SectionProfileService>.Instance);
+        var pedagogy = new PedagogyConfigService(NullLogger<PedagogyConfigService>.Instance, sps);
+        var builder = new RedaccionLevelFilterPromptBuilder(pedagogy,
+            NullLogger<RedaccionLevelFilterPromptBuilder>.Instance);
+
+        var tags = new[] { new LevelFilterTagInput("G", "hable", "Conjugación incorrecta.") };
+        var req = builder.Build("B1", tags);
+
+        req.UserPrompt.Should().NotContain("separate pipelines",
+            "pipeline-disambiguation note is author-facing and must not reach the model");
+    }
+
+    [Fact]
     public void LevelFilterPrompt_B1_CuandoSubjuntivoIsInScope()
     {
         // Issue #1263: B1 correction filter prompt must include cuando + subjuntivo in the in-scope list

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1134,9 +1134,13 @@ public class PromptService : IPromptService
         var sbSections = new StringBuilder();
         foreach (var sectionName in SectionOrder)
         {
+            var sharedGuidance = _profiles.GetSharedGuidance(sectionName);
             var baseGuidance = _profiles.GetGuidance(sectionName, cefrLevel);
             if (string.IsNullOrEmpty(baseGuidance))
                 baseGuidance = GetSectionFallbackGuidance(sectionName);
+            var fullGuidance = !string.IsNullOrEmpty(sharedGuidance)
+                ? $"{sharedGuidance} {baseGuidance}"
+                : baseGuidance;
 
             var duration = _profiles.GetDuration(sectionName, cefrLevel);
             var scope = _pedagogy.GetResolvedScope(sectionName, cefrLevel, string.IsNullOrEmpty(templateName) ? null : templateName);
@@ -1145,7 +1149,7 @@ public class PromptService : IPromptService
                 ? $" ({duration.Min}-{duration.Max} min{scopeLabel})"
                 : (scope == "brief" ? " (scope: brief)" : "");
 
-            sbSections.AppendLine($"- {sectionName}{durationStr}: {baseGuidance}");
+            sbSections.AppendLine($"- {sectionName}{durationStr}: {fullGuidance}");
 
             if (templateEntry?.Sections.TryGetValue(sectionName, out var secOverride) == true
                 && !string.IsNullOrWhiteSpace(secOverride.OverrideGuidance))

--- a/data/pedagogy/correction-calibration.json
+++ b/data/pedagogy/correction-calibration.json
@@ -2,9 +2,12 @@
   "cefrCalibration": {
     "A1": "Be maximally encouraging. Prefer soften over remove for above-scope structures. Use remove only when an above-scope attempt would confuse rather than support learning.",
     "A2": "Be encouraging. Prefer soften for genuine above-scope attempts that show effort. Use remove only for clearly wrong out-of-scope structures that could mislead.",
-    "B1": "Apply balanced calibration. Use soften for intentional above-scope attempts (even if imperfect), remove for clearly wrong out-of-scope errors. Use muybien when a structure at the level ceiling is used correctly. Note: soften applies to correction pipeline output; the B1.1 Grammar Focus ceiling (grammarFocusTargets in b1.json) applies only to lesson generation -- they are separate pipelines.",
+    "B1": "Apply balanced calibration. Use soften for intentional above-scope attempts (even if imperfect), remove for clearly wrong out-of-scope errors. Use muybien when a structure at the level ceiling is used correctly.",
     "B2": "Apply standard calibration. Use muybien generously for well-used advanced structures appropriate to the register. Use remove for clearly wrong out-of-scope errors.",
     "C1": "Rarely soften or remove. Use muybien generously when a student demonstrates strong command of complex structures. Keep most tags.",
     "C2": "Keep or promote to muybien for almost all tags. Removal is almost never appropriate at this level."
+  },
+  "_authoringNotes": {
+    "B1": "soften applies to correction pipeline output; the B1.1 Grammar Focus ceiling (grammarFocusTargets in b1.json) applies only to lesson generation -- they are separate pipelines."
   }
 }


### PR DESCRIPTION
## Summary

Closes #1271

- **Fix 1**: `LessonPlanUserPrompt` now calls `GetSharedGuidance()` per section and prepends it to per-level guidance, closing the coverage gap where `warmup.json` sharedGuidance only reached the conversation generator.
- **Fix 2**: Moved the B1 pipeline-disambiguation note from the calibration cue string (emitted to the model) into a root-level `_authoringNotes` field in `correction-calibration.json` (ignored by C# deserializer).
- **Tests**: Added assertions for sharedGuidance presence in lesson plan prompt and pipeline note absence from level-filter prompt.

## Test plan

- [x] `dotnet test` 478 passed (476 existing + 2 new)
- [x] `npm test` 105 passed
- [x] Build verify passes (bicep, dotnet, npm lint/build/test)
- [x] `grep "GetSharedGuidance"` shows calls in both BuildSectionConversationPrompt and LessonPlanUserPrompt
- [x] `grep "separate pipelines"` only hits `_authoringNotes`, not the calibration cue
- [ ] Live: generate B1 lesson with Warm Up (icebreaker behavior unchanged)
- [ ] Live: submit B1 redaccion correction (soften/keep/correct unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)