### PR TITLE
fix(redacciones): Atelier panel blur + upload label discoverability (#1273)

### DIFF
--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -304,7 +304,7 @@ export default function AtelierAssistantPanel({
     <Sheet open={open} onOpenChange={handleSheetOpenChange}>
       <SheetContent
         data-testid="assistant-panel"
-        className="right-0 left-auto w-[380px] max-w-full flex flex-col p-0 backdrop-blur-[12px] bg-white/80 shadow-[0_8px_40px_0_rgb(26_27_34_/_0.12)] data-open:slide-in-from-right data-closed:slide-out-to-right"
+        className="right-0 left-auto w-[380px] max-w-full flex flex-col p-0 bg-white shadow-[0_8px_40px_0_rgb(26_27_34_/_0.12)] data-open:slide-in-from-right data-closed:slide-out-to-right"
         overlayClassName="bg-transparent supports-backdrop-filter:backdrop-blur-none"
       >
         {/* Header */}

--- a/frontend/src/components/student/RedaccionesTab.tsx
+++ b/frontend/src/components/student/RedaccionesTab.tsx
@@ -549,6 +549,11 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved, onCorregirError
                     </>
                   )}
                 </div>
+                {!studentTextLocked && (
+                  <p className="text-[10px] text-gray-400" data-testid="correction-drawer-upload-hint">
+                    Acepta imagen (JPG, PNG), PDF y Word (.docx)
+                  </p>
+                )}
                 <Textarea
                   id="redaccion-text"
                   value={ocrState === 'loading' ? '' : text}

--- a/frontend/src/components/student/RedaccionesTab.tsx
+++ b/frontend/src/components/student/RedaccionesTab.tsx
@@ -551,7 +551,7 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved, onCorregirError
                 </div>
                 {!studentTextLocked && (
                   <p className="text-[10px] text-gray-400" data-testid="correction-drawer-upload-hint">
-                    Acepta imagen (JPG, PNG), PDF y Word (.docx)
+                    Acepta imagen (JPG, PNG, WEBP), PDF y Word (.docx)
                   </p>
                 )}
                 <Textarea

--- a/frontend/src/components/student/RedaccionesTab.tsx
+++ b/frontend/src/components/student/RedaccionesTab.tsx
@@ -550,7 +550,7 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved, onCorregirError
                   )}
                 </div>
                 {!studentTextLocked && (
-                  <p className="text-[10px] text-gray-400" data-testid="correction-drawer-upload-hint">
+                  <p className="text-[10px] text-zinc-400" data-testid="correction-drawer-upload-hint">
                     Acepta imagen (JPG, PNG, WEBP), PDF y Word (.docx)
                   </p>
                 )}


### PR DESCRIPTION
## Summary

- Removes `backdrop-blur-[12px]` from `AtelierAssistantPanel` `SheetContent` so student profile content behind the panel is fully readable when the Atelier is open (including during mic recording). Panel is now solid white (`bg-white`) -- the overlay already had blur removed in #1234.
- Adds helper text "Acepta imagen (JPG, PNG, WEBP), PDF y Word (.docx)" below the upload button in the Nueva redaccion drawer, making file type support discoverable. Button label already reads "Subir archivo" (not "Subir imagen").

Closes #1273.

## Test plan

- [ ] Open student profile > tap Atelier FAB > tap mic button > confirm no blur on background content (skill bars, tab labels, sessions are sharp)
- [ ] Close and re-open via session picker > confirm same no-blur appearance
- [ ] Open student profile > Redacciones tab > Nueva redaccion > confirm upload button reads "Subir archivo" and helper text lists accepted types
- [ ] Click upload button > confirm file picker accepts images, PDF, docx
- [ ] Check drawer at mobile width > confirm helper text wraps gracefully

## Reviewers

| Reviewer | Finding | Action |
|---|---|---|
| qa-verify | PASS WITH GAPS (no label/hint text assertions in existing tests) | Accepted -- these are cosmetic strings with no behavior |
| architecture-reviewer | PASS WITH NOTES -- WEBP missing from hint text | Fixed (included WEBP in hint) |
| review-ui | PASS -- noted `text-gray-400` vs drawer zinc palette | Fixed (`text-zinc-400`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)