### PR TITLE
infra: provision Azure Computer Vision and wire credentials end-to-end (#1280)

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -16,6 +16,12 @@ VITE_AUTH0_CLIENT_ID=your-spa-client-id
 # --- Claude API ---
 CLAUDE_API_KEY=
 
+# --- Azure Computer Vision (for OCR image/PDF upload testing) ---
+# Leave empty to skip image OCR tests (StubTextExtractor is used in E2ETesting env).
+# Get values from Azure Portal -> Computer Vision resource -> Keys and Endpoint.
+AZURE_AI_VISION_ENDPOINT=
+AZURE_AI_VISION_KEY=
+
 # --- E2E test account (must exist in Auth0) ---
 E2E_TEST_EMAIL=test-teacher@example.com
 E2E_TEST_PASSWORD=your-test-password

--- a/.env.qa.example
+++ b/.env.qa.example
@@ -21,6 +21,13 @@ VITE_AUTH0_CLIENT_ID=your-spa-client-id
 # --- Claude API ---
 CLAUDE_API_KEY=
 
+# --- Azure Computer Vision (for OCR image/PDF upload testing) ---
+# Required to test image and scanned-PDF upload in the Redacciones OCR flow.
+# Without these, the OCR endpoint fails at DI resolution time (graceful degradation
+# is added in #1279). Get values from Azure Portal -> Computer Vision -> Keys and Endpoint.
+AZURE_AI_VISION_ENDPOINT=
+AZURE_AI_VISION_KEY=
+
 # --- Teacher QA dedicated Auth0 account ---
 # Created once in Auth0 dashboard — separate from e2e test user so QA data persists.
 # Email format suggestion: teacher-qa@langteach.test (or any real email you control)

--- a/backend/LangTeach.Api/Program.cs
+++ b/backend/LangTeach.Api/Program.cs
@@ -63,6 +63,8 @@ if (!builder.Environment.IsDevelopment() && !builder.Environment.IsEnvironment("
         "AzureBlobStorage:ConnectionString",
         "Telegram:BotToken",
         "Telegram:WebhookSecret",
+        "AzureAIVision:Endpoint",
+        "AzureAIVision:Key",
     };
     if (transcriptionProvider == "AzureSpeech")
     {

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -66,6 +66,8 @@ services:
       Claude__ApiKey: "${CLAUDE_API_KEY}"
       AllowedOrigins__E2e: "http://frontend:5174"
       AzureBlobStorage__ConnectionString: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
+      AzureAIVision__Endpoint: "${AZURE_AI_VISION_ENDPOINT}"
+      AzureAIVision__Key: "${AZURE_AI_VISION_KEY}"
       E2E_TEST_EMAIL: "${E2E_TEST_EMAIL}"
     healthcheck:
       test: curl -sf http://localhost:5000/health || exit 1

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -65,6 +65,8 @@ services:
       # Host-side Playwright connects through localhost:5175
       AllowedOrigins__E2e: "http://localhost:5175"
       AzureBlobStorage__ConnectionString: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
+      AzureAIVision__Endpoint: "${AZURE_AI_VISION_ENDPOINT}"
+      AzureAIVision__Key: "${AZURE_AI_VISION_KEY}"
     ports:
       - "5176:5000"
     healthcheck:

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -48,6 +48,8 @@ var keyVaultName  = 'kv-lt-${env}-${take(uniqueString(resourceGroup().id), 6)}'
 var acrName = 'crlangteach${env}'
 // Azure OpenAI resource name
 var openaiName = 'oai-langteach-${env}'
+// Azure Computer Vision resource name
+var computerVisionName = 'vision-langteach-${env}'
 
 // ── Modules ───────────────────────────────────────────────────────────────────
 
@@ -121,6 +123,17 @@ module openai 'modules/openai.bicep' = {
   name: 'openai'
   params: {
     name: openaiName
+    location: location
+    keyVaultName: keyVaultName
+    appPrincipalId: containerApp.outputs.principalId
+  }
+  dependsOn: [kv]
+}
+
+module computerVision 'modules/computer-vision.bicep' = {
+  name: 'computervision'
+  params: {
+    name: computerVisionName
     location: location
     keyVaultName: keyVaultName
     appPrincipalId: containerApp.outputs.principalId

--- a/infra/modules/computer-vision.bicep
+++ b/infra/modules/computer-vision.bicep
@@ -1,0 +1,47 @@
+param name string
+param location string
+param keyVaultName string
+param appPrincipalId string
+
+// Built-in role: Key Vault Secrets User — same ID in every Azure tenant
+var kvSecretsUserRoleId = '4633458b-17de-408a-b874-0445c86b69e6'
+
+// Computer Vision free tier is F0 (not S0 like OpenAI). S1 is the standard paid tier.
+resource computerVision 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
+  name: name
+  location: location
+  kind: 'ComputerVision'
+  sku: { name: 'S1' }
+  properties: {
+    customSubDomainName: name
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+resource kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(kv.id, appPrincipalId, kvSecretsUserRoleId)
+  scope: kv
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', kvSecretsUserRoleId)
+    principalId: appPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource endpointSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: kv
+  name: 'AzureAIVision--Endpoint'
+  properties: { value: computerVision.properties.endpoint }
+}
+
+resource apiKeySecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+  parent: kv
+  name: 'AzureAIVision--Key'
+  properties: { value: computerVision.listKeys().key1 }
+}
+
+output endpoint string = computerVision.properties.endpoint

--- a/infra/required-secrets.json
+++ b/infra/required-secrets.json
@@ -1,5 +1,5 @@
 {
-  "_readme": "Secret names use double-dash (--) as the hierarchy separator, mirroring ASP.NET Core Key Vault config mapping (colon -> double-dash). These must match the keys in StartupConfigValidator (backend/LangTeach.Api/Infrastructure/StartupConfigValidator.cs) and the secrets defined in infra/modules/keyvault.bicep. NOTE: AzureSpeech--* and AzureOpenAIWhisper--* are mutually exclusive at runtime — only the set matching Transcription:Provider is validated at startup. Both sets appear here so operators know which secrets to provision for each provider.",
+  "_readme": "Secret names use double-dash (--) as the hierarchy separator, mirroring ASP.NET Core Key Vault config mapping (colon -> double-dash). These must match the keys in StartupConfigValidator (backend/LangTeach.Api/Infrastructure/StartupConfigValidator.cs) and the secrets defined in infra/modules/keyvault.bicep. NOTE: AzureSpeech--* and AzureOpenAIWhisper--* are mutually exclusive at runtime — only the set matching Transcription:Provider is validated at startup. Both sets appear here so operators know which secrets to provision for each provider. AzureAIVision--* is always required in Production (unconditional in the validator); optional in Development and E2ETesting via environment gating.",
   "requiredSecrets": [
     "ConnectionStrings--Default",
     "Auth0--Domain",
@@ -12,6 +12,8 @@
     "AzureOpenAIWhisper--Endpoint",
     "AzureOpenAIWhisper--DeploymentName",
     "Telegram--BotToken",
-    "Telegram--WebhookSecret"
+    "Telegram--WebhookSecret",
+    "AzureAIVision--Endpoint",
+    "AzureAIVision--Key"
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `infra/modules/computer-vision.bicep`: provisions a `Microsoft.CognitiveServices/accounts` resource (kind `ComputerVision`, SKU `S1`), writes `AzureAIVision--Endpoint` and `AzureAIVision--Key` to Key Vault, grants Container App managed identity read access
- Wires the module into `infra/main.bicep` (same `dependsOn: [kv]` pattern as the openai module)
- Adds `AzureAIVision--Endpoint` and `AzureAIVision--Key` to `infra/required-secrets.json` (enforced by `StartupConfigValidator` in Production; `Development` and `E2ETesting` environments are excluded from the validator via existing gating)
- Adds both keys to the production startup validator in `Program.cs`
- Passes `AzureAIVision__Endpoint` and `AzureAIVision__Key` through `docker-compose.qa.yml` and `docker-compose.e2e.yml` api service env blocks
- Adds `AZURE_AI_VISION_ENDPOINT` / `AZURE_AI_VISION_KEY` placeholder entries to `.env.e2e.example` and `.env.qa.example` with setup instructions

## Known limitation (pre-existing, addressed by #1279)

In `docker-compose.qa.yml` (Development environment), `AzureVisionTextExtractor` is registered. If Vision credentials are absent in `.env.qa`, the OCR endpoint fails at DI resolution time when called. This is pre-existing behaviour -- `appsettings.json` already had empty Vision config. The QA stack as a whole continues to work; only the OCR endpoint is affected. Graceful degradation so the extractor is skipped when unconfigured is scoped to #1279.

## Test plan

- [ ] Build: `bicep build`, `dotnet build`, `dotnet test`, `npm build`, `npm test` -- all PASS
- [ ] Post-Bicep deploy (production): Computer Vision resource exists in resource group; `AzureAIVision--Endpoint` and `AzureAIVision--Key` secrets present in Key Vault with non-empty values
- [ ] Local QA stack with Vision credentials populated: `docker compose -f docker-compose.qa.yml --env-file .env.qa exec api env | grep AzureAIVision` shows both vars set
- [ ] Full image/PDF upload verification: depends on #1279 also landing (removes e2e stub, adds real extractor tests)

Closes #1280

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Azure Computer Vision service configuration to enable optical character recognition (OCR) testing in E2E and QA environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->