### PR TITLE
infra: wire transcription and Telegram secrets into QA / e2e api containers (#1281)

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -22,6 +22,25 @@ CLAUDE_API_KEY=
 AZURE_AI_VISION_ENDPOINT=
 AZURE_AI_VISION_KEY=
 
+# --- Azure Speech (transcription provider: AzureSpeech) ---
+# Only needed when Transcription:Provider=AzureSpeech (not the default).
+# Note: e2e stack uses E2ETesting env -> StubTranscriptionService always used regardless.
+AZURE_SPEECH_API_KEY=
+AZURE_SPEECH_REGION=
+
+# --- Azure OpenAI Whisper (transcription provider: AzureOpenAIWhisper, default) ---
+# Note: e2e stack uses E2ETesting env -> StubTranscriptionService always used regardless.
+# Wired so credentials are available if environment is ever changed for targeted testing.
+AZURE_OPENAI_WHISPER_API_KEY=
+AZURE_OPENAI_WHISPER_ENDPOINT=
+AZURE_OPENAI_WHISPER_DEPLOYMENT_NAME=
+
+# --- Telegram bot ---
+# Required to test Telegram webhook flows. Without these, webhook signature auth fails.
+# Get values from @BotFather (token) and your webhook secret configuration.
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_WEBHOOK_SECRET=
+
 # --- E2E test account (must exist in Auth0) ---
 E2E_TEST_EMAIL=test-teacher@example.com
 E2E_TEST_PASSWORD=your-test-password

--- a/.env.qa.example
+++ b/.env.qa.example
@@ -28,6 +28,28 @@ CLAUDE_API_KEY=
 AZURE_AI_VISION_ENDPOINT=
 AZURE_AI_VISION_KEY=
 
+# --- Azure Speech (transcription provider: AzureSpeech) ---
+# Only needed when Transcription:Provider=AzureSpeech (not the default).
+# Get values from Azure Portal -> Speech resource -> Keys and Endpoint.
+AZURE_SPEECH_API_KEY=
+AZURE_SPEECH_REGION=
+
+# --- Azure OpenAI Whisper (transcription provider: AzureOpenAIWhisper, default) ---
+# Required for real voice-note transcription in QA (Development env uses real provider).
+# Without these, the API falls back to StubTranscriptionService and transcription tests
+# exercise the stub fixture instead of real Whisper output.
+# Get values from Azure Portal -> Azure OpenAI resource (Whisper deployment).
+AZURE_OPENAI_WHISPER_API_KEY=
+AZURE_OPENAI_WHISPER_ENDPOINT=
+AZURE_OPENAI_WHISPER_DEPLOYMENT_NAME=
+
+# --- Telegram bot ---
+# Required to test Telegram webhook flows in QA.
+# Without these, bot endpoints cannot authenticate webhook signatures.
+# Get values from @BotFather (token) and your webhook secret configuration.
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_WEBHOOK_SECRET=
+
 # --- Teacher QA dedicated Auth0 account ---
 # Created once in Auth0 dashboard — separate from e2e test user so QA data persists.
 # Email format suggestion: teacher-qa@langteach.test (or any real email you control)

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -68,6 +68,13 @@ services:
       AzureBlobStorage__ConnectionString: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
       AzureAIVision__Endpoint: "${AZURE_AI_VISION_ENDPOINT}"
       AzureAIVision__Key: "${AZURE_AI_VISION_KEY}"
+      AzureSpeech__ApiKey: "${AZURE_SPEECH_API_KEY}"
+      AzureSpeech__Region: "${AZURE_SPEECH_REGION}"
+      AzureOpenAIWhisper__ApiKey: "${AZURE_OPENAI_WHISPER_API_KEY}"
+      AzureOpenAIWhisper__Endpoint: "${AZURE_OPENAI_WHISPER_ENDPOINT}"
+      AzureOpenAIWhisper__DeploymentName: "${AZURE_OPENAI_WHISPER_DEPLOYMENT_NAME}"
+      Telegram__BotToken: "${TELEGRAM_BOT_TOKEN}"
+      Telegram__WebhookSecret: "${TELEGRAM_WEBHOOK_SECRET}"
       E2E_TEST_EMAIL: "${E2E_TEST_EMAIL}"
     healthcheck:
       test: curl -sf http://localhost:5000/health || exit 1

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -67,6 +67,13 @@ services:
       AzureBlobStorage__ConnectionString: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;"
       AzureAIVision__Endpoint: "${AZURE_AI_VISION_ENDPOINT}"
       AzureAIVision__Key: "${AZURE_AI_VISION_KEY}"
+      AzureSpeech__ApiKey: "${AZURE_SPEECH_API_KEY}"
+      AzureSpeech__Region: "${AZURE_SPEECH_REGION}"
+      AzureOpenAIWhisper__ApiKey: "${AZURE_OPENAI_WHISPER_API_KEY}"
+      AzureOpenAIWhisper__Endpoint: "${AZURE_OPENAI_WHISPER_ENDPOINT}"
+      AzureOpenAIWhisper__DeploymentName: "${AZURE_OPENAI_WHISPER_DEPLOYMENT_NAME}"
+      Telegram__BotToken: "${TELEGRAM_BOT_TOKEN}"
+      Telegram__WebhookSecret: "${TELEGRAM_WEBHOOK_SECRET}"
     ports:
       - "5176:5000"
     healthcheck:


### PR DESCRIPTION
## Summary

- Adds 7 env var pass-throughs to both `docker-compose.qa.yml` and `docker-compose.e2e.yml` api service environment blocks: `AzureSpeech__ApiKey`, `AzureSpeech__Region`, `AzureOpenAIWhisper__ApiKey`, `AzureOpenAIWhisper__Endpoint`, `AzureOpenAIWhisper__DeploymentName`, `Telegram__BotToken`, `Telegram__WebhookSecret`
- Updates `.env.qa.example` and `.env.e2e.example` with the three new variable groups and documentation comments
- No code changes: `Program.cs` stub gating (line 222) is already correct (E2ETesting/Testing env only); QA (Development env) now routes to real provider when credentials are populated

## Motivation

Secrets were declared in `appsettings.json`, validated by `StartupConfigValidator` in production, and present in `.env` files, but never passed through to the API container. The API fell back to `StubTranscriptionService` in QA and Telegram webhook auth failed silently. Same silent-stub pattern that hid the Vision OCR bug (#1280) for multiple sprint closes.

## Verification

- Both stacks rebuilt; `docker compose exec api env | grep -E "AzureSpeech|AzureOpenAIWhisper|Telegram"` confirmed all 7 vars present in both containers
- QA API health endpoint returns `{"status":"healthy"}` with empty Whisper creds (graceful fallback confirmed)
- e2e API (E2ETesting env) continues to use `StubTranscriptionService` regardless of creds (by design)

## Notes

- `AZURE_OPENAI_WHISPER_*` vars are not yet populated in `.env.qa` / `.env.e2e` (empty placeholders). Populate from the dev Azure OpenAI resource to enable real Whisper transcription in QA.
- Telegram path requires a public tunnel for webhook URL; that is a separate operational concern (out of scope per issue).

Closes #1281

🤖 Generated with [Claude Code](https://claude.com/claude-code)