### PR TITLE
fix(#1296): raise Claude HttpClient timeout from 300s to 600s

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionTimeoutsTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionTimeoutsTests.cs
@@ -1,0 +1,20 @@
+using FluentAssertions;
+using LangTeach.Api.AI;
+
+namespace LangTeach.Api.Tests.AI;
+
+public class RedaccionCorrectionTimeoutsTests
+{
+    [Fact]
+    public void HttpClientSeconds_Is600()
+    {
+        RedaccionCorrectionTimeouts.HttpClientSeconds.Should().Be(600);
+    }
+
+    [Fact]
+    public void StaleCorrigiendoSeconds_ExceedsHttpClientSeconds()
+    {
+        RedaccionCorrectionTimeouts.StaleCorrigiendoSeconds
+            .Should().BeGreaterThan(RedaccionCorrectionTimeouts.HttpClientSeconds);
+    }
+}

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionTimeouts.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionTimeouts.cs
@@ -9,7 +9,7 @@ namespace LangTeach.Api.AI;
 public static class RedaccionCorrectionTimeouts
 {
     /// <summary>Max seconds to wait for the Claude API to respond.</summary>
-    public const int HttpClientSeconds = 300;
+    public const int HttpClientSeconds = 600;
 
     /// <summary>
     /// Seconds before a correction stuck in Corrigiendo is considered stale.


### PR DESCRIPTION
Closes #1296

## Summary
- Raises `RedaccionCorrectionTimeouts.HttpClientSeconds` from 300 to 600. `StaleCorrigiendoSeconds` updates automatically to 660 (derived as `HttpClientSeconds + 60`), keeping the stale-recovery invariant intact.
- Adds two unit tests: one pinning the new constant value, one asserting `StaleCorrigiendoSeconds > HttpClientSeconds`.

## Root cause
After #1293 raised `MaxTokens` to 32768, dense A1 corrections now take longer than the previous 300s HttpClient deadline, causing `TaskCanceledException` and `CorreccionFallida`. 600s sits safely inside Claude's documented ~10 minute server-side limit.

## Test plan
- [x] `RedaccionCorrectionTimeoutsTests.HttpClientSeconds_Is600` passes
- [x] `RedaccionCorrectionTimeoutsTests.StaleCorrigiendoSeconds_ExceedsHttpClientSeconds` passes
- [x] Full test suite passes (105 frontend + all backend)
- [x] No hardcoded 300 timeout remaining in backend
- [x] Build verify PASS
- [x] QA verify PASS
- [x] Code review PASS
- [ ] Live browser verify (Marton K A1 correction, 4-7 min) -- requires dev stack rebuild; flagged for manual post-merge verification per issue Verify section

🤖 Generated with [Claude Code](https://claude.com/claude-code)