### PR TITLE
fix(#1299): show Corrigiendo spinner on detail page regardless of arrival path

### DIFF
--- a/e2e/tests/redaccion-corrigiendo-refresh.spec.ts
+++ b/e2e/tests/redaccion-corrigiendo-refresh.spec.ts
@@ -1,9 +1,18 @@
 import { test, expect } from '@playwright/test'
 import { createMockAuthContext } from '../helpers/auth-helper'
+import { setupMockTeacher } from '../helpers/mock-teacher-helper'
 import { createStudentViaApi } from '../helpers/students'
 import { NAV_TIMEOUT, UI_TIMEOUT } from '../helpers/timeouts'
 
 const API_BASE = process.env.VITE_API_BASE_URL ?? 'http://localhost:5000'
+
+test.beforeAll(async ({ browser }) => {
+  const ctx = await createMockAuthContext(browser)
+  const page = await ctx.newPage()
+  await setupMockTeacher(page)
+  await page.close()
+  await ctx.close()
+})
 
 /**
  * Regression test for #1299: detail page shows blank when arriving at a
@@ -15,11 +24,6 @@ test('detail page shows Corrigiendo spinner after F5 refresh (server-driven stat
   // Setup
   const setupCtx = await createMockAuthContext(browser)
   const setupPage = await setupCtx.newPage()
-  await setupPage.request
-    .post(`${API_BASE}/api/teachers/setup`, {
-      headers: { Authorization: 'Bearer test-token' },
-    })
-    .catch(() => {})
 
   const student = await createStudentViaApi(setupPage, {
     name: `Corrigiendo Refresh ${Date.now()}`,

--- a/e2e/tests/redaccion-corrigiendo-refresh.spec.ts
+++ b/e2e/tests/redaccion-corrigiendo-refresh.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test'
+import { createMockAuthContext } from '../helpers/auth-helper'
+import { createStudentViaApi } from '../helpers/students'
+import { NAV_TIMEOUT, UI_TIMEOUT } from '../helpers/timeouts'
+
+const API_BASE = process.env.VITE_API_BASE_URL ?? 'http://localhost:5000'
+
+/**
+ * Regression test for #1299: detail page shows blank when arriving at a
+ * Corrigiendo correction outside the local mutation flow (refresh, back/forward,
+ * direct link). The Corrigiendo spinner must render based on server status,
+ * not only on the local viewState set by onMutate.
+ */
+test('detail page shows Corrigiendo spinner after F5 refresh (server-driven state)', async ({ browser }) => {
+  // Setup
+  const setupCtx = await createMockAuthContext(browser)
+  const setupPage = await setupCtx.newPage()
+  await setupPage.request
+    .post(`${API_BASE}/api/teachers/setup`, {
+      headers: { Authorization: 'Bearer test-token' },
+    })
+    .catch(() => {})
+
+  const student = await createStudentViaApi(setupPage, {
+    name: `Corrigiendo Refresh ${Date.now()}`,
+    cefrLevel: 'A1',
+  })
+
+  const correctionRes = await setupPage.request.post(
+    `${API_BASE}/api/students/${student.id}/corrections`,
+    {
+      headers: { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' },
+      data: {
+        assignmentTitle: 'Redacción de prueba',
+        studentText: 'Ayer yo voy al mercado y compro muchas cosas.',
+      },
+    },
+  )
+  expect(correctionRes.ok()).toBeTruthy()
+  const correction = await correctionRes.json() as { id: string }
+
+  await setupPage.close()
+  await setupCtx.close()
+
+  // Test: navigate to the correction detail page with the API mocked to Corrigiendo
+  const ctx = await createMockAuthContext(browser)
+  const page = await ctx.newPage()
+
+  const correctionUrl = `**/api/students/${student.id}/corrections/${correction.id}`
+
+  const corrigendoResponse = {
+    id: correction.id,
+    studentId: student.id,
+    schemaVersion: 1,
+    status: 'Corrigiendo',
+    assignmentTitle: 'Redacción de prueba',
+    assignmentPrompt: null,
+    studentText: 'Ayer yo voy al mercado y compro muchas cosas.',
+    markedUpOutput: null,
+    tags: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    correctedAt: null,
+  }
+
+  await page.route(correctionUrl, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(corrigendoResponse) })
+  )
+
+  await page.goto(`/students/${student.id}/redacciones/${correction.id}`)
+
+  // Spinner visible on first load
+  await expect(page.getByRole('button', { name: /Corrigiendo/ })).toBeVisible({ timeout: NAV_TIMEOUT })
+  await expect(page.getByRole('button', { name: /Corrigiendo/ })).toBeDisabled()
+
+  // Reload (F5 — the bug scenario)
+  await page.reload()
+
+  // Spinner must still be visible after reload (this failed before the fix)
+  await expect(page.getByRole('button', { name: /Corrigiendo/ })).toBeVisible({ timeout: NAV_TIMEOUT })
+  await expect(page.getByRole('button', { name: /Corrigiendo/ })).toBeDisabled()
+
+  // Student text must be visible (ReadingColumn rendered)
+  await expect(page.getByText('Ayer yo voy al mercado')).toBeVisible({ timeout: UI_TIMEOUT })
+
+  await ctx.close()
+})

--- a/frontend/src/pages/RedaccionDetail.test.tsx
+++ b/frontend/src/pages/RedaccionDetail.test.tsx
@@ -119,6 +119,30 @@ describe('RedaccionDetail', () => {
     expect(await screen.findByText(/Descarga aún no disponible/i)).toBeInTheDocument()
   })
 
+  describe('server-driven Corrigiendo (fresh page load mid-correction)', () => {
+    it('renders spinner branch when data.status is Corrigiendo and viewState is idle', async () => {
+      mockGet.mockResolvedValue({ ...corregida(), status: 'Corrigiendo', tags: [] })
+      renderAt('/students/stu-1/redacciones/cor-1')
+      const btn = await screen.findByRole('button', { name: /Corrigiendo/ })
+      expect(btn).toBeDisabled()
+    })
+
+    it('shows slow hint after 60 seconds when arriving mid-correction', async () => {
+      vi.useFakeTimers()
+      try {
+        mockGet.mockResolvedValue({ ...corregida(), status: 'Corrigiendo', tags: [] })
+        renderAt('/students/stu-1/redacciones/cor-1')
+        // advance just enough to flush the initial query resolution without looping the refetch interval
+        await act(async () => { await vi.advanceTimersByTimeAsync(100) })
+        expect(screen.queryByTestId('hint-slow')).not.toBeInTheDocument()
+        act(() => vi.advanceTimersByTime(60_001))
+        expect(screen.getByTestId('hint-slow')).toBeInTheDocument()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
   describe('slow-correction UX hints', () => {
     beforeEach(() => vi.useFakeTimers())
     afterEach(() => vi.useRealTimers())

--- a/frontend/src/pages/RedaccionDetail.tsx
+++ b/frontend/src/pages/RedaccionDetail.tsx
@@ -36,6 +36,7 @@ export default function RedaccionDetail() {
     queryKey,
     queryFn: () => getCorrection(studentId!, correctionId!),
     enabled: !!studentId && !!correctionId,
+    refetchInterval: (q) => q.state.data?.status === 'Corrigiendo' ? 5000 : false,
   })
 
   const { data: student } = useQuery({
@@ -58,7 +59,8 @@ export default function RedaccionDetail() {
   })
 
   useEffect(() => {
-    if (viewState !== 'generating') return
+    const isInProgress = viewState === 'generating' || data?.status === 'Corrigiendo'
+    if (!isInProgress) return
     const slowTimer = setTimeout(() => setElapsedHint('slow'), 60_000)
     const verySlowTimer = setTimeout(() => setElapsedHint('very-slow'), 4 * 60_000)
     return () => {
@@ -66,7 +68,7 @@ export default function RedaccionDetail() {
       clearTimeout(verySlowTimer)
       setElapsedHint('none')
     }
-  }, [viewState])
+  }, [viewState, data?.status])
 
   const onDownload = async () => {
     if (!data) return
@@ -170,7 +172,7 @@ export default function RedaccionDetail() {
         </div>
       )}
 
-      {viewState === 'generating' && data.studentText && (
+      {(viewState === 'generating' || data.status === 'Corrigiendo') && data.studentText && (
         <div className="space-y-4">
           <ReadingColumn text={data.studentText} />
           <Button disabled>

--- a/frontend/src/pages/RedaccionDetail.tsx
+++ b/frontend/src/pages/RedaccionDetail.tsx
@@ -36,7 +36,7 @@ export default function RedaccionDetail() {
     queryKey,
     queryFn: () => getCorrection(studentId!, correctionId!),
     enabled: !!studentId && !!correctionId,
-    refetchInterval: (q) => q.state.data?.status === 'Corrigiendo' ? 5000 : false,
+    refetchInterval: (q) => q.state.data?.status === 'Corrigiendo' ? 3000 : false,
   })
 
   const { data: student } = useQuery({


### PR DESCRIPTION
Fixes #1299.

## Summary

- Gate the Corrigiendo spinner branch on `data.status === 'Corrigiendo'` in addition to `viewState === 'generating'`, so the spinner renders on refresh/back/direct-link arrivals
- Update hint-timer `useEffect` to fire on server status too (`[viewState, data?.status]` deps)
- Add `refetchInterval: 3s` while Corrigiendo so the page auto-transitions to Corregida without a manual refresh (matches RedaccionesTab.tsx cadence)

## Tests

- 2 new unit tests: spinner renders with server-driven Corrigiendo status; slow hint fires after 60s
- 1 new e2e regression test (`redaccion-corrigiendo-refresh.spec.ts`): page.route mocks correction as Corrigiendo, reloads, asserts spinner still visible -- confirmed FAIL on old code at 5174, PASS on fixed code

## Live verify

E2e Playwright test covers the exact refresh scenario from the issue. The Corrigiendo state requires an in-flight AI correction to test live; no seeded correction in that state exists in the visual stack. The test was run against both old and new code to confirm regression/fix.

## Reviewer findings

| Reviewer | Finding | Action |
|----------|---------|--------|
| qa-verify | All 8 acceptance criteria met | PASS |
| code-review | Static StatusPill pill on server-driven path (no animate-pulse dot) -- minor accessibility inconsistency | Deferred (pre-existing pattern, not in scope) |
| architecture | `setupMockTeacher` missing in e2e test; poll interval 5s vs 3s in RedaccionesTab | Fixed in second commit |
| ui-review | No live Corrigiendo screenshot (no in-flight correction in stack); code analysis confirms correct render; Corregida state renders cleanly | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added e2e regression test verifying the "Corrigiendo" spinner persists correctly after page refresh.
  * Added unit tests for server-driven correction processing state.

* **Bug Fixes**
  * Correction detail page now properly displays processing state based on server status, not just local state.
  * Enabled automatic polling while correction is in progress.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->