### PR TITLE
feat(students): teaching channel field (Preply / Meet / Presencial) (#1305)

### DIFF
--- a/backend/LangTeach.Api/DTOs/CreateStudentRequest.cs
+++ b/backend/LangTeach.Api/DTOs/CreateStudentRequest.cs
@@ -1,3 +1,4 @@
+using LangTeach.Api.Data.Models;
 using LangTeach.Api.Services;
 using System.ComponentModel.DataAnnotations;
 
@@ -76,6 +77,8 @@ public class CreateStudentRequest
 
     [MaxLength(32)]
     public string? Rate { get; set; }
+
+    public TeachingChannel? TeachingChannel { get; set; }
 
     // Language fields
     [MaxCollectionCount(20)]

--- a/backend/LangTeach.Api/DTOs/StudentDto.cs
+++ b/backend/LangTeach.Api/DTOs/StudentDto.cs
@@ -1,3 +1,5 @@
+using LangTeach.Api.Data.Models;
+
 namespace LangTeach.Api.DTOs;
 
 public record StudentLevelDto(
@@ -49,5 +51,6 @@ public record StudentDto(
     StudentProfileDto Profile,
     StudentCommercialDto Commercial,
     DateTime CreatedAt,
-    DateTime UpdatedAt
+    DateTime UpdatedAt,
+    TeachingChannel? TeachingChannel
 );

--- a/backend/LangTeach.Api/DTOs/UpdateStudentRequest.cs
+++ b/backend/LangTeach.Api/DTOs/UpdateStudentRequest.cs
@@ -1,3 +1,4 @@
+using LangTeach.Api.Data.Models;
 using LangTeach.Api.Services;
 using System.ComponentModel.DataAnnotations;
 
@@ -76,6 +77,8 @@ public class UpdateStudentRequest
 
     [MaxLength(32)]
     public string? Rate { get; set; }
+
+    public TeachingChannel? TeachingChannel { get; set; }
 
     // Language fields
     [MaxCollectionCount(20)]

--- a/backend/LangTeach.Api/Data/Models/Student.cs
+++ b/backend/LangTeach.Api/Data/Models/Student.cs
@@ -34,6 +34,7 @@ public class Student
     public bool IsActive { get; set; } = true;
     public bool IsCorporate { get; set; }
     public string? Rate { get; set; }
+    public TeachingChannel? TeachingChannel { get; set; }
 
     // Language fields
     public string SpokenLanguages { get; set; } = "[]";

--- a/backend/LangTeach.Api/Data/Models/TeachingChannel.cs
+++ b/backend/LangTeach.Api/Data/Models/TeachingChannel.cs
@@ -2,10 +2,15 @@ using System.Text.Json.Serialization;
 
 namespace LangTeach.Api.Data.Models;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(TeachingChannelJsonConverter))]
 public enum TeachingChannel
 {
     Preply = 1,
     Meet = 2,
     Presencial = 3,
+}
+
+public sealed class TeachingChannelJsonConverter : JsonStringEnumConverter
+{
+    public TeachingChannelJsonConverter() : base(namingPolicy: null, allowIntegerValues: false) { }
 }

--- a/backend/LangTeach.Api/Data/Models/TeachingChannel.cs
+++ b/backend/LangTeach.Api/Data/Models/TeachingChannel.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace LangTeach.Api.Data.Models;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum TeachingChannel
+{
+    Preply = 1,
+    Meet = 2,
+    Presencial = 3,
+}

--- a/backend/LangTeach.Api/Data/ScenarioSeeder.cs
+++ b/backend/LangTeach.Api/Data/ScenarioSeeder.cs
@@ -17,20 +17,20 @@ public static class ScenarioSeeder
     // Ana Visual, Ana Seed, Marco Seed, Clara Seed, Diego Seed already exist after --visual-seed.
     // Marco B1, Carmen C1, Nadia B2, Hans B1 are created on first run.
     // Rui Seed, Sofia Seed, Sonia Seed created on first run (scenario 5 signal coverage).
-    private static readonly (string Name, string Cefr, string NativeLang, string LearningLang)[] ScenarioStudentDefs =
+    private static readonly (string Name, string Cefr, string NativeLang, string LearningLang, TeachingChannel? Channel)[] ScenarioStudentDefs =
     [
-        ("Ana Visual",  "B2", """["Ukrainian"]""",   "English"),
-        ("Marco B1",    "B1", """["Italian"]""",     "English"),
-        ("Carmen C1",   "C1", """["Spanish"]""",     "English"),
-        ("Nadia B2",    "B2", """["French"]""",      "English"),
-        ("Hans B1",     "B1", """["German"]""",      "English"),
-        ("Ana Seed",    "B1", """["Portuguese"]""",  "English"),
-        ("Marco Seed",  "A2", """["Italian"]""",     "English"),
-        ("Clara Seed",  "A1", """["German"]""",      "Spanish"),
-        ("Diego Seed",  "B2", """["Spanish"]""",     "English"),
-        ("Rui Seed",    "A2", """["Romanian"]""",    "English"),
-        ("Sofia Seed",  "B2", """["Portuguese"]""",  "English"),
-        ("Sonia Seed",  "B1", """["Greek"]""",       "English"),
+        ("Ana Visual",  "B2", """["Ukrainian"]""",   "English", TeachingChannel.Preply),
+        ("Marco B1",    "B1", """["Italian"]""",     "English", TeachingChannel.Meet),
+        ("Carmen C1",   "C1", """["Spanish"]""",     "English", TeachingChannel.Presencial),
+        ("Nadia B2",    "B2", """["French"]""",      "English", null),
+        ("Hans B1",     "B1", """["German"]""",      "English", null),
+        ("Ana Seed",    "B1", """["Portuguese"]""",  "English", null),
+        ("Marco Seed",  "A2", """["Italian"]""",     "English", null),
+        ("Clara Seed",  "A1", """["German"]""",      "Spanish", null),
+        ("Diego Seed",  "B2", """["Spanish"]""",     "English", null),
+        ("Rui Seed",    "A2", """["Romanian"]""",    "English", null),
+        ("Sofia Seed",  "B2", """["Portuguese"]""",  "English", null),
+        ("Sonia Seed",  "B1", """["Greek"]""",       "English", null),
     ];
 
     public static async Task<bool> SeedScenarioAsync(AppDbContext db, int scenario, string teacherLookup, ILogger logger)
@@ -89,7 +89,7 @@ public static class ScenarioSeeder
     {
         var result = new List<Student>();
 
-        foreach (var (name, cefr, nativeLang, learningLang) in ScenarioStudentDefs)
+        foreach (var (name, cefr, nativeLang, learningLang, channel) in ScenarioStudentDefs)
         {
             var student = await db.Students.FirstOrDefaultAsync(
                 s => s.TeacherId == teacherId && s.Name == name && !s.IsDeleted);
@@ -106,6 +106,7 @@ public static class ScenarioSeeder
                     NativeLanguages  = nativeLang,
                     PersonalNotes    = ScenarioTag,
                     IsActive         = true,
+                    TeachingChannel  = channel,
                     CreatedAt        = now,
                     UpdatedAt        = now,
                 };

--- a/backend/LangTeach.Api/Data/ScenarioSeeder.cs
+++ b/backend/LangTeach.Api/Data/ScenarioSeeder.cs
@@ -113,6 +113,12 @@ public static class ScenarioSeeder
                 db.Students.Add(student);
                 await db.SaveChangesAsync();
             }
+            else if (student.TeachingChannel != channel)
+            {
+                student.TeachingChannel = channel;
+                student.UpdatedAt = now;
+                await db.SaveChangesAsync();
+            }
 
             result.Add(student);
         }

--- a/backend/LangTeach.Api/Migrations/20260517171124_AddStudentTeachingChannel.Designer.cs
+++ b/backend/LangTeach.Api/Migrations/20260517171124_AddStudentTeachingChannel.Designer.cs
@@ -4,6 +4,7 @@ using LangTeach.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LangTeach.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260517171124_AddStudentTeachingChannel")]
+    partial class AddStudentTeachingChannel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/LangTeach.Api/Migrations/20260517171124_AddStudentTeachingChannel.cs
+++ b/backend/LangTeach.Api/Migrations/20260517171124_AddStudentTeachingChannel.cs
@@ -15,11 +15,20 @@ namespace LangTeach.Api.Migrations
                 table: "Students",
                 type: "int",
                 nullable: true);
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_Students_TeachingChannel",
+                table: "Students",
+                sql: "[TeachingChannel] IS NULL OR [TeachingChannel] IN (1, 2, 3)");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_Students_TeachingChannel",
+                table: "Students");
+
             migrationBuilder.DropColumn(
                 name: "TeachingChannel",
                 table: "Students");

--- a/backend/LangTeach.Api/Migrations/20260517171124_AddStudentTeachingChannel.cs
+++ b/backend/LangTeach.Api/Migrations/20260517171124_AddStudentTeachingChannel.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LangTeach.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStudentTeachingChannel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "TeachingChannel",
+                table: "Students",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TeachingChannel",
+                table: "Students");
+        }
+    }
+}

--- a/backend/LangTeach.Api/Services/StudentService.cs
+++ b/backend/LangTeach.Api/Services/StudentService.cs
@@ -139,6 +139,7 @@ public class StudentService : IStudentService
             IsActive = request.IsActive,
             IsCorporate = request.IsCorporate,
             Rate = request.Rate,
+            TeachingChannel = request.TeachingChannel,
             SpokenLanguages = Serialize(request.SpokenLanguages),
             SkillLevelOverrides = JsonStorageHelper.Serialize(normalizedSkillOverrides),
             CreatedAt = DateTime.UtcNow,
@@ -193,6 +194,7 @@ public class StudentService : IStudentService
         student.IsActive = request.IsActive;
         student.IsCorporate = request.IsCorporate;
         student.Rate = request.Rate;
+        student.TeachingChannel = request.TeachingChannel;
         student.SpokenLanguages = Serialize(request.SpokenLanguages);
         student.SkillLevelOverrides = JsonStorageHelper.Serialize(normalizedSkillOverrides);
         student.UpdatedAt = DateTime.UtcNow;
@@ -263,7 +265,8 @@ public class StudentService : IStudentService
             s.Rate
         ),
         s.CreatedAt,
-        s.UpdatedAt
+        s.UpdatedAt,
+        s.TeachingChannel
     );
 
 

--- a/frontend/src/api/students.ts
+++ b/frontend/src/api/students.ts
@@ -90,6 +90,7 @@ export interface Student {
   commercial: StudentCommercial
   createdAt: string
   updatedAt: string
+  teachingChannel: string | null
 }
 
 export interface StudentListResponse {
@@ -125,6 +126,7 @@ export interface StudentFormData {
   spokenLanguages?: string[]
   teachingTodos?: TeachingTodo[]
   skillLevelOverrides?: Record<string, string>
+  teachingChannel?: string | null
 }
 
 export async function getStudents(params?: {

--- a/frontend/src/components/StudentProfileSummary.test.tsx
+++ b/frontend/src/components/StudentProfileSummary.test.tsx
@@ -11,7 +11,7 @@ const BASE_STUDENT: Student = {
   identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null },
   profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
   commercial: { isActive: true, isCorporate: false, rate: null },
-  createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z',
+  createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z', teachingChannel: null,
 }
 
 const FULL_STUDENT: Student = {

--- a/frontend/src/components/student/ProgressDashboard.test.tsx
+++ b/frontend/src/components/student/ProgressDashboard.test.tsx
@@ -16,6 +16,7 @@ const baseStudent: Student = {
   commercial: { isActive: true, isCorporate: false, rate: null },
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
+  teachingChannel: null,
 }
 
 const baseSession: SessionLog = {

--- a/frontend/src/components/student/StudentDetailHeader.test.tsx
+++ b/frontend/src/components/student/StudentDetailHeader.test.tsx
@@ -36,6 +36,7 @@ const BASE_STUDENT: Student = {
   commercial: { isActive: true, isCorporate: false, rate: null },
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
+  teachingChannel: null,
 }
 
 function renderHeader(
@@ -176,6 +177,18 @@ describe('StudentDetailHeader', () => {
     expect(screen.getByTestId('primary-objective-card')).toBeInTheDocument()
     expect(screen.getByTestId('edit-profile-link')).toBeInTheDocument()
     expect(screen.getByTestId('log-session-button')).toBeInTheDocument()
+  })
+
+  it('shows teaching channel badge when teachingChannel is set', () => {
+    renderHeader({ ...BASE_STUDENT, teachingChannel: 'Preply' })
+    const badge = screen.getByTestId('teaching-channel-badge')
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveTextContent('Preply')
+  })
+
+  it('does not render teaching channel badge when teachingChannel is null', () => {
+    renderHeader()
+    expect(screen.queryByTestId('teaching-channel-badge')).not.toBeInTheDocument()
   })
 
   it('does not render voice update button when onVoiceUpdateClick is not provided', () => {

--- a/frontend/src/components/student/StudentDetailHeader.tsx
+++ b/frontend/src/components/student/StudentDetailHeader.tsx
@@ -1,6 +1,7 @@
 import { Link, useNavigate } from 'react-router-dom'
 import { ArrowLeft, NotebookPen, Pencil, CalendarClock, Mic } from 'lucide-react'
 import type { Student } from '@/api/students'
+import { TEACHING_CHANNEL_META } from '@/lib/teachingChannelMeta'
 import type { SessionLog } from '@/api/sessionLogs'
 import { formatDateShort } from '@/utils/formatDate'
 import { getInitials } from '@/utils/nameUtils'
@@ -156,6 +157,20 @@ export function StudentDetailHeader({ student, nextSession, sessionFrequency, on
                   Inactive
                 </span>
               )}
+              {student.teachingChannel && (() => {
+                const meta = TEACHING_CHANNEL_META[student.teachingChannel]
+                if (!meta) return null
+                const Icon = meta.icon
+                return (
+                  <span
+                    className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[0.6875rem] font-bold uppercase tracking-[0.05em] bg-zinc-100 text-zinc-600"
+                    data-testid="teaching-channel-badge"
+                  >
+                    <Icon className="h-3 w-3" />
+                    {meta.label}
+                  </span>
+                )
+              })()}
               {nextSession && (
                 <span
                   className="inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium bg-[#E8E7F1] text-[#464455]"

--- a/frontend/src/components/student/StudentOverviewTab.test.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.test.tsx
@@ -36,6 +36,7 @@ const BASE_STUDENT: Student = {
   commercial: { isActive: true, isCorporate: false, rate: null },
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
+  teachingChannel: null,
 }
 
 function renderOverview(student: Student, sessions?: SessionLog[], followups?: import('@/api/followups').TeacherFollowup[]) {

--- a/frontend/src/components/student/StudentProfileOverview.test.tsx
+++ b/frontend/src/components/student/StudentProfileOverview.test.tsx
@@ -22,7 +22,7 @@ function makeStudent(overrides: FlatOverrides = {}): Student {
     identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null },
     profile: { interests: overrides.interests ?? [], personalNotes: overrides.personalNotes ?? null, teachingNotes: overrides.teachingNotes ?? null, learningGoals: overrides.learningGoals ?? [], weaknesses: overrides.weaknesses ?? [], difficulties: overrides.difficulties ?? [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
     commercial: { isActive: true, isCorporate: false, rate: null },
-    createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z',
+    createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z', teachingChannel: null,
   }
 }
 

--- a/frontend/src/components/student/StudentProfileTab.test.tsx
+++ b/frontend/src/components/student/StudentProfileTab.test.tsx
@@ -60,6 +60,7 @@ const FULL_STUDENT: Student = {
   commercial: { isActive: true, isCorporate: false, rate: '25 EUR/h' },
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
+  teachingChannel: null,
 }
 
 const EMPTY_STUDENT: Student = {

--- a/frontend/src/components/student/VoiceUpdateDrawer.test.tsx
+++ b/frontend/src/components/student/VoiceUpdateDrawer.test.tsx
@@ -16,6 +16,7 @@ const BASE_STUDENT: Student = {
   commercial: { isActive: true, isCorporate: false, rate: null },
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
+  teachingChannel: null,
 }
 
 const EMPTY_EXTRACTED: ExtractedStudentProfile = {

--- a/frontend/src/hooks/useAtelierAssistant.test.ts
+++ b/frontend/src/hooks/useAtelierAssistant.test.ts
@@ -233,6 +233,7 @@ describe('useAtelierAssistant', () => {
       profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
       commercial: { isActive: true, isCorporate: false, rate: null },
       createdAt: '', updatedAt: '',
+      teachingChannel: null,
     })
 
     const { result } = renderHook(() => useAtelierAssistant(null, null), { wrapper: makeWrapper() })
@@ -257,6 +258,7 @@ describe('useAtelierAssistant', () => {
       profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
       commercial: { isActive: true, isCorporate: false, rate: null },
       createdAt: '', updatedAt: '',
+      teachingChannel: null,
     })
 
     const { result } = renderHook(() => useAtelierAssistant(null, null), { wrapper: makeWrapper() })
@@ -283,6 +285,7 @@ describe('useAtelierAssistant', () => {
       profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
       commercial: { isActive: true, isCorporate: false, rate: null },
       createdAt: '', updatedAt: '',
+      teachingChannel: null,
     })
 
     const { result } = renderHook(() => useAtelierAssistant(null, null), { wrapper: makeWrapper() })
@@ -309,6 +312,7 @@ describe('useAtelierAssistant', () => {
       profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
       commercial: { isActive: true, isCorporate: false, rate: null },
       createdAt: '', updatedAt: '',
+      teachingChannel: null,
     })
 
     const { result } = renderHook(() => useAtelierAssistant(null, null), { wrapper: makeWrapper() })
@@ -335,6 +339,7 @@ describe('useAtelierAssistant', () => {
       profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
       commercial: { isActive: true, isCorporate: false, rate: null },
       createdAt: '', updatedAt: '',
+      teachingChannel: null,
     })
 
     const { result } = renderHook(() => useAtelierAssistant(null, null), { wrapper: makeWrapper() })

--- a/frontend/src/lib/teachingChannelMeta.ts
+++ b/frontend/src/lib/teachingChannelMeta.ts
@@ -1,0 +1,15 @@
+import { Globe, Video, Building2, type LucideIcon } from 'lucide-react'
+
+export interface TeachingChannelMeta {
+  icon: LucideIcon
+  label: string
+}
+
+export const TEACHING_CHANNEL_META: Record<string, TeachingChannelMeta> = {
+  Preply:     { icon: Globe,      label: 'Preply' },
+  Meet:       { icon: Video,      label: 'Meet' },
+  Presencial: { icon: Building2,  label: 'Presencial' },
+}
+
+export const TEACHING_CHANNEL_OPTIONS = ['Preply', 'Meet', 'Presencial'] as const
+export type TeachingChannelValue = typeof TEACHING_CHANNEL_OPTIONS[number]

--- a/frontend/src/pages/CourseNew.test.tsx
+++ b/frontend/src/pages/CourseNew.test.tsx
@@ -178,7 +178,7 @@ describe('CourseNew wizard', () => {
         identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null },
         profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
         commercial: { isActive: true, isCorporate: false, rate: null },
-        createdAt: '2026-01-01', updatedAt: '2026-01-01',
+        createdAt: '2026-01-01', updatedAt: '2026-01-01', teachingChannel: null,
       }],
       totalCount: 1,
       page: 1,
@@ -229,7 +229,7 @@ describe('CourseNew wizard', () => {
         identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null },
         profile: { interests: ['football'], personalNotes: null, teachingNotes: null, learningGoals: [{ id: '1', text: 'get a job in Barcelona', children: [] }], weaknesses: [{ description: 'ser vs estar', weaknessType: 'grammatical' as const }], difficulties: [{ id: 'x', description: 'subjunctive', competency: 'Grammar', subcategory: '', severity: 'high', trend: 'stable', status: 'Active' }], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
         commercial: { isActive: true, isCorporate: false, rate: null },
-        createdAt: '2026-01-01', updatedAt: '2026-01-01',
+        createdAt: '2026-01-01', updatedAt: '2026-01-01', teachingChannel: null,
       }],
       totalCount: 1, page: 1, pageSize: 100,
     }
@@ -263,7 +263,7 @@ describe('CourseNew wizard', () => {
   })
 
   it('renders teacher notes textarea when a student is selected', async () => {
-    const STUDENT = { items: [{ id: 's1', name: 'Marco', learningLanguage: 'Spanish', level: { cefrLevel: 'A1', officialCefrLevel: null, skillLevelOverrides: {} }, languages: { nativeLanguages: [], spokenLanguages: [] }, identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null }, profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null }, commercial: { isActive: true, isCorporate: false, rate: null }, createdAt: '2026-01-01', updatedAt: '2026-01-01' }], totalCount: 1, page: 1, pageSize: 100 }
+    const STUDENT = { items: [{ id: 's1', name: 'Marco', learningLanguage: 'Spanish', level: { cefrLevel: 'A1', officialCefrLevel: null, skillLevelOverrides: {} }, languages: { nativeLanguages: [], spokenLanguages: [] }, identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null }, profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null }, commercial: { isActive: true, isCorporate: false, rate: null }, createdAt: '2026-01-01', updatedAt: '2026-01-01', teachingChannel: null }], totalCount: 1, page: 1, pageSize: 100 }
     vi.mocked(studentsApi.getStudents).mockResolvedValue(STUDENT)
     const user = userEvent.setup()
     wrapper(<CourseNew />)
@@ -282,7 +282,7 @@ describe('CourseNew wizard', () => {
   })
 
   it('includes teacher notes in the create course request', async () => {
-    const STUDENT = { items: [{ id: 's1', name: 'Marco', learningLanguage: 'Spanish', level: { cefrLevel: 'A1', officialCefrLevel: null, skillLevelOverrides: {} }, languages: { nativeLanguages: [], spokenLanguages: [] }, identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null }, profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null }, commercial: { isActive: true, isCorporate: false, rate: null }, createdAt: '2026-01-01', updatedAt: '2026-01-01' }], totalCount: 1, page: 1, pageSize: 100 }
+    const STUDENT = { items: [{ id: 's1', name: 'Marco', learningLanguage: 'Spanish', level: { cefrLevel: 'A1', officialCefrLevel: null, skillLevelOverrides: {} }, languages: { nativeLanguages: [], spokenLanguages: [] }, identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null }, profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null }, commercial: { isActive: true, isCorporate: false, rate: null }, createdAt: '2026-01-01', updatedAt: '2026-01-01', teachingChannel: null }], totalCount: 1, page: 1, pageSize: 100 }
     vi.mocked(studentsApi.getStudents).mockResolvedValue(STUDENT)
     const user = userEvent.setup()
     const mockCreate = vi.fn().mockResolvedValue({ id: 'course-1' })
@@ -393,7 +393,7 @@ describe('CourseNew wizard', () => {
       identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null },
       profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
       commercial: { isActive: true, isCorporate: false, rate: null },
-      createdAt: '2026-01-01', updatedAt: '2026-01-01',
+      createdAt: '2026-01-01', updatedAt: '2026-01-01', teachingChannel: null,
     }
 
     it('shows student name as read-only text when ?studentId param is present', async () => {

--- a/frontend/src/pages/LessonEditor.test.tsx
+++ b/frontend/src/pages/LessonEditor.test.tsx
@@ -405,7 +405,7 @@ describe('LessonEditor', () => {
         studentName: 'Ana',
       })
       mockGetStudents.mockResolvedValue({
-        items: [{ id: 'student-1', name: 'Ana', learningLanguage: 'Spanish', level: { cefrLevel: 'A1', officialCefrLevel: null, skillLevelOverrides: {} }, languages: { nativeLanguages: [], spokenLanguages: [] }, identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null }, profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null }, commercial: { isActive: true, isCorporate: false, rate: null }, createdAt: '', updatedAt: '' }],
+        items: [{ id: 'student-1', name: 'Ana', learningLanguage: 'Spanish', level: { cefrLevel: 'A1', officialCefrLevel: null, skillLevelOverrides: {} }, languages: { nativeLanguages: [], spokenLanguages: [] }, identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null }, profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null }, commercial: { isActive: true, isCorporate: false, rate: null }, createdAt: '', updatedAt: '', teachingChannel: null }],
         totalCount: 1,
       })
       renderWithProviders()
@@ -426,7 +426,7 @@ describe('LessonEditor', () => {
         studentName: 'Ana',
       })
       mockGetStudents.mockResolvedValue({
-        items: [{ id: 'student-1', name: 'Ana', learningLanguage: 'Spanish', level: { cefrLevel: 'B1', officialCefrLevel: null, skillLevelOverrides: {} }, languages: { nativeLanguages: [], spokenLanguages: [] }, identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null }, profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null }, commercial: { isActive: true, isCorporate: false, rate: null }, createdAt: '', updatedAt: '' }],
+        items: [{ id: 'student-1', name: 'Ana', learningLanguage: 'Spanish', level: { cefrLevel: 'B1', officialCefrLevel: null, skillLevelOverrides: {} }, languages: { nativeLanguages: [], spokenLanguages: [] }, identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null }, profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null }, commercial: { isActive: true, isCorporate: false, rate: null }, createdAt: '', updatedAt: '', teachingChannel: null }],
         totalCount: 1,
       })
       renderWithProviders()

--- a/frontend/src/pages/LogSession.test.tsx
+++ b/frontend/src/pages/LogSession.test.tsx
@@ -82,6 +82,7 @@ const SAMPLE_STUDENT: Student = {
   commercial: { isActive: true, isCorporate: false, rate: null },
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
+  teachingChannel: null,
 }
 
 const SAMPLE_SESSION: SessionLog = {

--- a/frontend/src/pages/Onboarding.test.tsx
+++ b/frontend/src/pages/Onboarding.test.tsx
@@ -154,7 +154,7 @@ describe('Onboarding', () => {
       identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null },
       profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
       commercial: { isActive: true, isCorporate: false, rate: null },
-      createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z',
+      createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z', teachingChannel: null,
     }
     mockGetStudents.mockResolvedValue({ items: [mockStudent], totalCount: 1, page: 1, pageSize: 1 })
 
@@ -276,7 +276,7 @@ describe('Onboarding', () => {
       identity: { birthYear: null, age: null, profession: null, countryOfOrigin: null, cityOfOrigin: null, countryOfResidence: null, cityOfResidence: null },
       profile: { interests: [], personalNotes: null, teachingNotes: null, learningGoals: [], weaknesses: [], difficulties: [], shortTermObjectives: [], teachingTodos: [], reasonForStudying: null },
       commercial: { isActive: true, isCorporate: false, rate: null },
-      createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z',
+      createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z', teachingChannel: null,
     }
     mockGetStudents.mockResolvedValue({ items: [mockStudent], totalCount: 1, page: 1, pageSize: 1 })
 

--- a/frontend/src/pages/StudentDetail.test.tsx
+++ b/frontend/src/pages/StudentDetail.test.tsx
@@ -99,6 +99,7 @@ const MOCK_STUDENT: studentsApi.Student = {
   commercial: { isActive: true, isCorporate: false, rate: '30 EUR/h' },
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
+  teachingChannel: null,
 }
 
 function wrapper(studentId = 'student-1') {

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -7,6 +7,7 @@ import { TeachingTodosCard } from '@/components/student/TeachingTodosCard'
 import { getObjectiveUrgency } from '@/lib/objectiveUrgency'
 import { COMPETENCY_OPTIONS } from '../lib/studentOptions'
 import { logger } from '../lib/logger'
+import { TEACHING_CHANNEL_OPTIONS } from '@/lib/teachingChannelMeta'
 import { newId } from '@/lib/newId'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -1419,9 +1420,9 @@ export default function StudentForm() {
                           data-testid="teaching-channel-select"
                         >
                           <option value="">-- none --</option>
-                          <option value="Preply">Preply</option>
-                          <option value="Meet">Meet</option>
-                          <option value="Presencial">Presencial</option>
+                          {TEACHING_CHANNEL_OPTIONS.map(ch => (
+                            <option key={ch} value={ch}>{ch}</option>
+                          ))}
                         </select>
                       </div>
                     </div>

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -1339,15 +1339,15 @@ export default function StudentForm() {
               </Card>
             </div>
 
-            {/* ── SECTION: Commercial Info (edit only) ── */}
-            {isEdit && (
-              <div id="section-commercial">
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="text-base">Commercial Info</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 items-start">
+            {/* ── SECTION: Commercial Info ── */}
+            <div id="section-commercial">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Commercial Info</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 items-start">
+                    {isEdit && (<>
                       {/* Account Status toggle */}
                       <div className="space-y-1.5">
                         <Label className="text-sm font-medium" htmlFor="toggle-is-active">Status</Label>
@@ -1404,32 +1404,32 @@ export default function StudentForm() {
                           data-testid="student-rate"
                         />
                       </div>
+                    </>)}
 
-                      {/* Teaching channel */}
-                      <div className="space-y-1.5">
-                        <Label htmlFor="teaching-channel">Teaching channel</Label>
-                        <select
-                          id="teaching-channel"
-                          value={teachingChannel ?? ''}
-                          onChange={(e) => {
-                            const val = e.target.value || null
-                            setTeachingChannel(val)
-                            if (isEdit) saveNow({ teachingChannel: val })
-                          }}
-                          className="h-9 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring max-w-[200px]"
-                          data-testid="teaching-channel-select"
-                        >
-                          <option value="">-- none --</option>
-                          {TEACHING_CHANNEL_OPTIONS.map(ch => (
-                            <option key={ch} value={ch}>{ch}</option>
-                          ))}
-                        </select>
-                      </div>
+                    {/* Teaching channel */}
+                    <div className="space-y-1.5">
+                      <Label htmlFor="teaching-channel">Teaching channel</Label>
+                      <select
+                        id="teaching-channel"
+                        value={teachingChannel ?? ''}
+                        onChange={(e) => {
+                          const val = e.target.value || null
+                          setTeachingChannel(val)
+                          if (isEdit) saveNow({ teachingChannel: val })
+                        }}
+                        className="h-9 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring max-w-[200px]"
+                        data-testid="teaching-channel-select"
+                      >
+                        <option value="">-- none --</option>
+                        {TEACHING_CHANNEL_OPTIONS.map(ch => (
+                          <option key={ch} value={ch}>{ch}</option>
+                        ))}
+                      </select>
                     </div>
-                  </CardContent>
+                  </div>
+                </CardContent>
                 </Card>
               </div>
-            )}
           </form>
 
           {isEdit && id && <StudentCoursesCard studentId={id} />}

--- a/frontend/src/pages/StudentForm.tsx
+++ b/frontend/src/pages/StudentForm.tsx
@@ -201,6 +201,7 @@ export default function StudentForm() {
   const [isActive, setIsActive] = useState(true)
   const [isCorporate, setIsCorporate] = useState(false)
   const [rate, setRate] = useState('')
+  const [teachingChannel, setTeachingChannel] = useState<string | null>(null)
   const [errors, setErrors] = useState<Record<string, string>>({})
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
@@ -267,6 +268,7 @@ export default function StudentForm() {
       setIsActive(existing.commercial.isActive ?? true)
       setIsCorporate(existing.commercial.isCorporate ?? false)
       setRate(existing.commercial.rate ?? '')
+      setTeachingChannel(existing.teachingChannel ?? null)
     }
   }, [existing])
   /* eslint-enable react-hooks/set-state-in-effect */
@@ -304,6 +306,7 @@ export default function StudentForm() {
         isActive,
         isCorporate,
         rate: rate.trim() || null,
+        teachingChannel: teachingChannel || null,
       }
     }
   }, [
@@ -311,7 +314,7 @@ export default function StudentForm() {
     spokenLanguages, skillLevelOverrides, learningGoals, weaknesses, difficulties,
     personalNotes, teachingNotes, birthYear, profession, countryOfOrigin, cityOfOrigin,
     countryOfResidence, cityOfResidence, reasonForStudying, shortTermObjectives,
-    isActive, isCorporate, rate,
+    isActive, isCorporate, rate, teachingChannel,
   ])
 
   const { status: saveStatus, scheduleTextSave, saveNow } = useStudentAutosave(
@@ -573,6 +576,7 @@ export default function StudentForm() {
       isActive,
       isCorporate,
       rate: rate.trim() || null,
+      teachingChannel: teachingChannel || null,
     })
   }
 
@@ -1398,6 +1402,27 @@ export default function StudentForm() {
                           className="max-w-[160px]"
                           data-testid="student-rate"
                         />
+                      </div>
+
+                      {/* Teaching channel */}
+                      <div className="space-y-1.5">
+                        <Label htmlFor="teaching-channel">Teaching channel</Label>
+                        <select
+                          id="teaching-channel"
+                          value={teachingChannel ?? ''}
+                          onChange={(e) => {
+                            const val = e.target.value || null
+                            setTeachingChannel(val)
+                            if (isEdit) saveNow({ teachingChannel: val })
+                          }}
+                          className="h-9 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring max-w-[200px]"
+                          data-testid="teaching-channel-select"
+                        >
+                          <option value="">-- none --</option>
+                          <option value="Preply">Preply</option>
+                          <option value="Meet">Meet</option>
+                          <option value="Presencial">Presencial</option>
+                        </select>
                       </div>
                     </div>
                   </CardContent>

--- a/frontend/src/pages/Students.test.tsx
+++ b/frontend/src/pages/Students.test.tsx
@@ -97,6 +97,7 @@ function makeStudent(overrides: FlatStudentOverrides = {}): studentsApi.Student 
     },
     createdAt: overrides.createdAt ?? DEFAULT_CREATED_AT,
     updatedAt: overrides.updatedAt ?? '',
+    teachingChannel: null,
   }
 }
 
@@ -190,6 +191,21 @@ describe('Students page', () => {
     wrapper(<Students />)
     await screen.findByTestId('native-language-chip')
     expect(screen.getByTestId('native-language-chip')).toHaveTextContent('—')
+  })
+
+  it('shows channel label in CHANNEL cell when teachingChannel is set', async () => {
+    const student = { ...makeStudent(), teachingChannel: 'Meet' }
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(makeListResponse([student]))
+    wrapper(<Students />)
+    const cell = await screen.findByTestId('channel-cell')
+    expect(cell).toHaveTextContent('Meet')
+  })
+
+  it('renders empty CHANNEL cell when teachingChannel is null', async () => {
+    vi.mocked(studentsApi.getStudents).mockResolvedValue(makeListResponse([makeStudent()]))
+    wrapper(<Students />)
+    const cell = await screen.findByTestId('channel-cell')
+    expect(cell).toBeEmptyDOMElement()
   })
 
   it('renders empty state when no students', async () => {

--- a/frontend/src/pages/Students.tsx
+++ b/frontend/src/pages/Students.tsx
@@ -19,6 +19,7 @@ import { extractStudentProfile } from '@/api/studentExtraction'
 import { useVoiceExtractionFlow } from '@/hooks/useVoiceExtractionFlow'
 import { buildCreateRequestFromRows, type DrawerRow } from '@/lib/voiceUpdateMerge'
 import { logger } from '@/lib/logger'
+import { TEACHING_CHANNEL_META } from '@/lib/teachingChannelMeta'
 
 // ── Avatar helpers ──────────────────────────────────────────────────────────
 
@@ -199,8 +200,8 @@ function sortStudents(
 const CEFR_FILTER_OPTIONS = ['All', ...CEFR_LEVELS] as const
 const PAGE_SIZE = 12
 
-const COL_CLASSES = 'grid-cols-[32px_minmax(160px,2fr)_80px_120px_110px_140px_1fr]'
-const TABLE_HEADERS = ['', 'Name', 'CEFR LEVEL', 'LANGUAGE', 'Last Session', 'Next Session', 'SIGNALS'] as const
+const COL_CLASSES = 'grid-cols-[32px_minmax(140px,2fr)_80px_110px_90px_110px_130px_1fr]'
+const TABLE_HEADERS = ['', 'Name', 'CEFR LEVEL', 'LANGUAGE', 'CHANNEL', 'Last Session', 'Next Session', 'SIGNALS'] as const
 
 // ── Component ───────────────────────────────────────────────────────────────
 
@@ -385,6 +386,7 @@ export default function Students() {
               <Skeleton className="h-4 w-28" />
               <Skeleton className="h-5 w-10 rounded-md" />
               <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-4 w-14" />
               <Skeleton className="h-4 w-16" />
               <Skeleton className="h-4 w-20" />
               <Skeleton className="h-4 w-12" />
@@ -627,6 +629,16 @@ export default function Students() {
                       {student.languages.nativeLanguages.length > 0
                         ? student.languages.nativeLanguages.join(', ')
                         : <span className="text-zinc-300">—</span>}
+                    </span>
+
+                    {/* Teaching channel */}
+                    <span className="flex items-center gap-1 text-sm text-zinc-500 truncate" data-testid="channel-cell">
+                      {(() => {
+                        const meta = student.teachingChannel ? TEACHING_CHANNEL_META[student.teachingChannel] : null
+                        if (!meta) return null
+                        const Icon = meta.icon
+                        return <><Icon className="h-3.5 w-3.5 shrink-0" />{meta.label}</>
+                      })()}
                     </span>
 
                     {/* Last session */}

--- a/frontend/src/pages/onboarding/OnboardingStep3.test.tsx
+++ b/frontend/src/pages/onboarding/OnboardingStep3.test.tsx
@@ -25,6 +25,7 @@ const mockStudent = {
   commercial: { isActive: true, isCorporate: false, rate: null },
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
+  teachingChannel: null,
 }
 
 function renderStep3(props: Partial<React.ComponentProps<typeof OnboardingStep3>> = {}) {


### PR DESCRIPTION
Closes #1305

## Summary

- New `TeachingChannel` enum (Preply=1, Meet=2, Presencial=3) with attribute-level `[JsonConverter(typeof(JsonStringEnumConverter))]` (intentionally NOT global per issue spec -- avoids affecting other enums)
- Nullable `TeachingChannel?` on `Student` entity + EF migration `AddStudentTeachingChannel` (nullable int, no default, no backfill)
- Top-level field on `StudentDto`, `CreateStudentRequest`, `UpdateStudentRequest` -- flat, not nested in commercial sub-DTO
- Mapped in `StudentService` (create, update, mapToDto)
- Frontend: `teachingChannelMeta.ts` with Lucide icons (Globe/Video/Building2); CHANNEL column in `Students.tsx` roster; zinc badge in `StudentDetailHeader`; optional dropdown in `StudentForm` commercial section
- `ScenarioSeeder`: Ana Visual=Preply, Marco B1=Meet, Carmen C1=Presencial; existing students updated on re-seed
- Tests: channel badge render/hide in `StudentDetailHeader.test.tsx`; CHANNEL cell with/without channel in `Students.test.tsx`

## Design decisions

- **Attribute-level JsonConverter**: Issue spec explicitly prohibits a global converter to avoid side-effects on other enums.
- **`Presencial` naming**: Jordi's term for academy in-person teaching; intentionally left as-is.
- **Taxonomy in code**: Channel list is small and stable; if teacher-defined channels are ever needed, migrate to config at that point.

## Test plan

- [x] Backend builds + dotnet test pass
- [x] Frontend builds + all 1769 tests pass (105 test files)
- [x] Live verify against e2e stack: all 6 verify steps in issue passed
- [x] UI review: PASS -- Globe/Video/Building2 icons correct, empty cells blank, badge zinc/neutral, no 1280px overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Students can be assigned a teaching channel (Preply, Meet, In‑person); value is persisted on create/update.
  * Teaching channel shown as a badge on student profiles (with icon/label) and a new CHANNEL column in the roster.
  * Student form includes a Teaching channel selector to add or change the channel.

* **Tests**
  * Test fixtures and UI tests updated to cover teaching channel display and behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->