### PR TITLE
feat(#1307): inline teaching channel picker on student detail and list

### DIFF
--- a/frontend/src/api/students.ts
+++ b/frontend/src/api/students.ts
@@ -158,6 +158,10 @@ export async function patchStudentVoice(id: string, patch: VoiceMergePatch): Pro
   await apiClient.patch(`/api/students/${id}`, patch)
 }
 
+export async function patchStudentChannel(id: string, teachingChannel: string | null): Promise<void> {
+  await apiClient.patch(`/api/students/${id}`, { teachingChannel })
+}
+
 export async function deleteStudent(id: string): Promise<void> {
   await apiClient.delete(`/api/students/${id}`)
 }

--- a/frontend/src/components/student/StudentDetailHeader.tsx
+++ b/frontend/src/components/student/StudentDetailHeader.tsx
@@ -1,7 +1,7 @@
 import { Link, useNavigate } from 'react-router-dom'
 import { ArrowLeft, NotebookPen, Pencil, CalendarClock, Mic } from 'lucide-react'
 import type { Student } from '@/api/students'
-import { TEACHING_CHANNEL_META } from '@/lib/teachingChannelMeta'
+import { TeachingChannelPicker } from '@/components/student/TeachingChannelPicker'
 import type { SessionLog } from '@/api/sessionLogs'
 import { formatDateShort } from '@/utils/formatDate'
 import { getInitials } from '@/utils/nameUtils'
@@ -75,12 +75,13 @@ function HeaderObjective({ student }: { student: Student }) {
 interface StudentDetailHeaderProps {
   onVoiceUpdateClick?: () => void
   voiceFlowActive?: boolean
+  onChannelChange?: (v: string | null) => void
   student: Student
   nextSession: SessionLog | null
   sessionFrequency: string | null
 }
 
-export function StudentDetailHeader({ student, nextSession, sessionFrequency, onVoiceUpdateClick, voiceFlowActive }: StudentDetailHeaderProps) {
+export function StudentDetailHeader({ student, nextSession, sessionFrequency, onVoiceUpdateClick, voiceFlowActive, onChannelChange }: StudentDetailHeaderProps) {
   const navigate = useNavigate()
   const identitySubtitle = buildIdentitySubtitle(student)
 
@@ -157,20 +158,11 @@ export function StudentDetailHeader({ student, nextSession, sessionFrequency, on
                   Inactive
                 </span>
               )}
-              {student.teachingChannel && (() => {
-                const meta = TEACHING_CHANNEL_META[student.teachingChannel]
-                if (!meta) return null
-                const Icon = meta.icon
-                return (
-                  <span
-                    className="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[0.6875rem] font-bold uppercase tracking-[0.05em] bg-zinc-100 text-zinc-600"
-                    data-testid="teaching-channel-badge"
-                  >
-                    <Icon className="h-3 w-3" />
-                    {meta.label}
-                  </span>
-                )
-              })()}
+              <TeachingChannelPicker
+                value={student.teachingChannel}
+                studentId={student.id}
+                onSaved={onChannelChange}
+              />
               {nextSession && (
                 <span
                   className="inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium bg-[#E8E7F1] text-[#464455]"

--- a/frontend/src/components/student/TeachingChannelPicker.test.tsx
+++ b/frontend/src/components/student/TeachingChannelPicker.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TeachingChannelPicker } from './TeachingChannelPicker'
+import * as studentsApi from '@/api/students'
+
+vi.mock('@/api/students', () => ({
+  patchStudentChannel: vi.fn(),
+}))
+
+function wrapper(ui: React.ReactElement) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(studentsApi.patchStudentChannel).mockResolvedValue(undefined)
+})
+
+describe('TeachingChannelPicker', () => {
+  it('renders the channel badge when value is set', () => {
+    wrapper(<TeachingChannelPicker value="Preply" studentId="s1" />)
+    expect(screen.getByTestId('teaching-channel-badge')).toBeInTheDocument()
+    expect(screen.getByText('Preply')).toBeInTheDocument()
+  })
+
+  it('renders the ghost pill when value is null', () => {
+    wrapper(<TeachingChannelPicker value={null} studentId="s1" />)
+    expect(screen.getByTestId('teaching-channel-ghost')).toBeInTheDocument()
+  })
+
+  it('calls patchStudentChannel and onSaved when a new option is selected', async () => {
+    const user = userEvent.setup()
+    const onSaved = vi.fn()
+    wrapper(<TeachingChannelPicker value="Preply" studentId="s1" onSaved={onSaved} />)
+
+    await user.click(screen.getByTestId('teaching-channel-badge'))
+    await user.click(screen.getByTestId('channel-option-meet'))
+
+    await waitFor(() => {
+      expect(studentsApi.patchStudentChannel).toHaveBeenCalledWith('s1', 'Meet')
+      expect(onSaved).toHaveBeenCalledWith('Meet')
+    })
+  })
+
+  it('is a no-op when selecting the current value', async () => {
+    const user = userEvent.setup()
+    const onSaved = vi.fn()
+    wrapper(<TeachingChannelPicker value="Meet" studentId="s1" onSaved={onSaved} />)
+
+    await user.click(screen.getByTestId('teaching-channel-badge'))
+    await user.click(screen.getByTestId('channel-option-meet'))
+
+    expect(studentsApi.patchStudentChannel).not.toHaveBeenCalled()
+    expect(onSaved).not.toHaveBeenCalled()
+  })
+
+  it('reverts optimistic value and shows error on PATCH failure', async () => {
+    vi.mocked(studentsApi.patchStudentChannel).mockRejectedValue(new Error('Network error'))
+    const user = userEvent.setup()
+    wrapper(<TeachingChannelPicker value="Preply" studentId="s1" />)
+
+    await user.click(screen.getByTestId('teaching-channel-badge'))
+    await user.click(screen.getByTestId('channel-option-meet'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('channel-error')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('teaching-channel-badge')).toHaveTextContent('Preply')
+  })
+
+  it('clears the channel when None is selected', async () => {
+    const user = userEvent.setup()
+    const onSaved = vi.fn()
+    wrapper(<TeachingChannelPicker value="Preply" studentId="s1" onSaved={onSaved} />)
+
+    await user.click(screen.getByTestId('teaching-channel-badge'))
+    await user.click(screen.getByTestId('channel-option-none'))
+
+    await waitFor(() => {
+      expect(studentsApi.patchStudentChannel).toHaveBeenCalledWith('s1', null)
+      expect(onSaved).toHaveBeenCalledWith(null)
+    })
+  })
+})

--- a/frontend/src/components/student/TeachingChannelPicker.tsx
+++ b/frontend/src/components/student/TeachingChannelPicker.tsx
@@ -1,0 +1,140 @@
+import { useState, useRef, useEffect } from 'react'
+import { ChevronDown, Plus } from 'lucide-react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { TEACHING_CHANNEL_META, TEACHING_CHANNEL_OPTIONS } from '@/lib/teachingChannelMeta'
+import { patchStudentChannel } from '@/api/students'
+
+interface TeachingChannelPickerProps {
+  value: string | null
+  studentId: string
+  onSaved?: (v: string | null) => void
+}
+
+export function TeachingChannelPicker({ value, studentId, onSaved }: TeachingChannelPickerProps) {
+  const [optimisticValue, setOptimisticValue] = useState<string | null | undefined>(undefined)
+  const [isPending, setIsPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => () => { if (errorTimerRef.current) clearTimeout(errorTimerRef.current) }, [])
+
+  const current = optimisticValue !== undefined ? optimisticValue : value
+
+  async function handleSelect(next: string | null) {
+    if (next === current) return
+    const prev = current
+    setOptimisticValue(next)
+    setIsPending(true)
+    setError(null)
+    try {
+      await patchStudentChannel(studentId, next)
+      setOptimisticValue(undefined)
+      onSaved?.(next)
+    } catch {
+      setOptimisticValue(prev)
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current)
+      setError("Couldn't save channel")
+      errorTimerRef.current = setTimeout(() => setError(null), 3000)
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  const trigger = current ? (
+    <button
+      type="button"
+      disabled={isPending}
+      onClick={(e) => e.stopPropagation()}
+      className={[
+        'group inline-flex items-center gap-1 rounded-md px-2 py-0.5',
+        'text-[0.6875rem] font-bold uppercase tracking-[0.05em]',
+        'bg-zinc-100 text-zinc-600',
+        'hover:bg-zinc-200 transition-colors cursor-pointer select-none',
+        isPending ? 'opacity-50 cursor-not-allowed' : '',
+      ].join(' ')}
+      data-testid="teaching-channel-badge"
+    >
+      {(() => {
+        const meta = TEACHING_CHANNEL_META[current]
+        if (!meta) return null
+        const Icon = meta.icon
+        return (
+          <>
+            <Icon className="h-3 w-3" />
+            {meta.label}
+          </>
+        )
+      })()}
+      <ChevronDown className="h-3 w-3 opacity-0 group-hover:opacity-60 transition-opacity -ml-0.5" />
+    </button>
+  ) : (
+    <button
+      type="button"
+      disabled={isPending}
+      onClick={(e) => e.stopPropagation()}
+      className={[
+        'inline-flex items-center gap-1 rounded-md px-2 py-0.5',
+        'text-[0.6875rem] font-medium text-zinc-400',
+        'border border-dashed border-zinc-300',
+        'hover:border-zinc-400 hover:text-zinc-500 transition-colors cursor-pointer select-none',
+        isPending ? 'opacity-50 cursor-not-allowed' : '',
+      ].join(' ')}
+      data-testid="teaching-channel-ghost"
+    >
+      <Plus className="h-3 w-3" />
+      channel
+    </button>
+  )
+
+  return (
+    <div className="inline-flex flex-col items-start gap-0.5">
+      <Popover>
+        <PopoverTrigger render={trigger} />
+        <PopoverContent
+          className="w-44 p-1 bg-white/80 backdrop-blur-[12px] shadow-lg"
+          side="bottom"
+          align="start"
+          sideOffset={4}
+        >
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); handleSelect(null) }}
+            className={[
+              'w-full flex items-center gap-2 rounded px-2 py-1.5 text-xs text-zinc-500',
+              'hover:bg-zinc-100 transition-colors text-left',
+              current === null ? 'font-semibold text-zinc-700 bg-zinc-50' : '',
+            ].join(' ')}
+            data-testid="channel-option-none"
+          >
+            None
+          </button>
+          {TEACHING_CHANNEL_OPTIONS.map((opt) => {
+            const meta = TEACHING_CHANNEL_META[opt]
+            const Icon = meta.icon
+            return (
+              <button
+                key={opt}
+                type="button"
+                onClick={(e) => { e.stopPropagation(); handleSelect(opt) }}
+                className={[
+                  'w-full flex items-center gap-2 rounded px-2 py-1.5 text-xs',
+                  'hover:bg-zinc-100 transition-colors text-left',
+                  current === opt ? 'font-semibold text-zinc-700 bg-zinc-50' : 'text-zinc-600',
+                ].join(' ')}
+                data-testid={`channel-option-${opt.toLowerCase()}`}
+              >
+                <Icon className="h-3.5 w-3.5 shrink-0" />
+                {meta.label}
+              </button>
+            )
+          })}
+        </PopoverContent>
+      </Popover>
+      {error && (
+        <span className="text-[0.625rem] text-red-500 leading-tight" data-testid="channel-error">
+          {error}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/student/TeachingChannelPicker.tsx
+++ b/frontend/src/components/student/TeachingChannelPicker.tsx
@@ -21,7 +21,7 @@ export function TeachingChannelPicker({ value, studentId, onSaved }: TeachingCha
   const current = optimisticValue !== undefined ? optimisticValue : value
 
   async function handleSelect(next: string | null) {
-    if (next === current) return
+    if (isPending || next === current) return
     const prev = current
     setOptimisticValue(next)
     setIsPending(true)
@@ -98,10 +98,11 @@ export function TeachingChannelPicker({ value, studentId, onSaved }: TeachingCha
         >
           <button
             type="button"
+            disabled={isPending}
             onClick={(e) => { e.stopPropagation(); handleSelect(null) }}
             className={[
               'w-full flex items-center gap-2 rounded px-2 py-1.5 text-xs text-zinc-500',
-              'hover:bg-zinc-100 transition-colors text-left',
+              'hover:bg-zinc-100 transition-colors text-left disabled:opacity-50',
               current === null ? 'font-semibold text-zinc-700 bg-zinc-50' : '',
             ].join(' ')}
             data-testid="channel-option-none"
@@ -115,10 +116,11 @@ export function TeachingChannelPicker({ value, studentId, onSaved }: TeachingCha
               <button
                 key={opt}
                 type="button"
+                disabled={isPending}
                 onClick={(e) => { e.stopPropagation(); handleSelect(opt) }}
                 className={[
                   'w-full flex items-center gap-2 rounded px-2 py-1.5 text-xs',
-                  'hover:bg-zinc-100 transition-colors text-left',
+                  'hover:bg-zinc-100 transition-colors text-left disabled:opacity-50',
                   current === opt ? 'font-semibold text-zinc-700 bg-zinc-50' : 'text-zinc-600',
                 ].join(' ')}
                 data-testid={`channel-option-${opt.toLowerCase()}`}

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -289,6 +289,7 @@ export default function StudentDetail() {
         sessionFrequency={sessionFrequency}
         onVoiceUpdateClick={() => setVoiceFlow('recording')}
         voiceFlowActive={voiceFlow !== 'idle'}
+        onChannelChange={() => queryClient.invalidateQueries({ queryKey: ['student', id] })}
       />
 
       {voiceFlow === 'recording' && (

--- a/frontend/src/pages/Students.test.tsx
+++ b/frontend/src/pages/Students.test.tsx
@@ -201,11 +201,11 @@ describe('Students page', () => {
     expect(cell).toHaveTextContent('Meet')
   })
 
-  it('renders empty CHANNEL cell when teachingChannel is null', async () => {
+  it('renders ghost pill in CHANNEL cell when teachingChannel is null', async () => {
     vi.mocked(studentsApi.getStudents).mockResolvedValue(makeListResponse([makeStudent()]))
     wrapper(<Students />)
     const cell = await screen.findByTestId('channel-cell')
-    expect(cell).toBeEmptyDOMElement()
+    expect(cell.querySelector('[data-testid="teaching-channel-ghost"]')).toBeInTheDocument()
   })
 
   it('renders empty state when no students', async () => {

--- a/frontend/src/pages/Students.tsx
+++ b/frontend/src/pages/Students.tsx
@@ -19,7 +19,7 @@ import { extractStudentProfile } from '@/api/studentExtraction'
 import { useVoiceExtractionFlow } from '@/hooks/useVoiceExtractionFlow'
 import { buildCreateRequestFromRows, type DrawerRow } from '@/lib/voiceUpdateMerge'
 import { logger } from '@/lib/logger'
-import { TEACHING_CHANNEL_META } from '@/lib/teachingChannelMeta'
+import { TeachingChannelPicker } from '@/components/student/TeachingChannelPicker'
 
 // ── Avatar helpers ──────────────────────────────────────────────────────────
 
@@ -632,13 +632,12 @@ export default function Students() {
                     </span>
 
                     {/* Teaching channel */}
-                    <span className="flex items-center gap-1 text-sm text-zinc-500 truncate" data-testid="channel-cell">
-                      {(() => {
-                        const meta = student.teachingChannel ? TEACHING_CHANNEL_META[student.teachingChannel] : null
-                        if (!meta) return null
-                        const Icon = meta.icon
-                        return <><Icon className="h-3.5 w-3.5 shrink-0" />{meta.label}</>
-                      })()}
+                    <span className="flex items-center" data-testid="channel-cell">
+                      <TeachingChannelPicker
+                        value={student.teachingChannel}
+                        studentId={student.id}
+                        onSaved={() => queryClient.invalidateQueries({ queryKey: ['students'] })}
+                      />
                     </span>
 
                     {/* Last session */}


### PR DESCRIPTION
## Summary

- New `TeachingChannelPicker` component: popover with four options (None, Preply, Meet, Presencial); optimistic update with revert + inline error on PATCH failure
- Student detail header: static channel badge replaced by the picker; ghost "+ channel" pill shown when channel is null
- Student list: channel cell uses the same picker inline; `e.stopPropagation()` on trigger prevents row Link navigation
- `patchStudentChannel` added to `students.ts` (thin wrapper around existing PATCH endpoint from #1305)

## Fixes applied during review

- Critical: added `e.stopPropagation()` to picker trigger buttons so clicking in the Students list row does not navigate to the student detail page
- `optimisticValue` reset to `undefined` after successful PATCH so external query refetches (voice flow, etc.) are reflected on the next render
- Error `setTimeout` cleanup via `useRef` + `useEffect` to avoid setState-on-unmounted-component

## Test plan

- [ ] `TeachingChannelPicker.test.tsx` (6 new unit tests): happy-path select, no-op on same value, error revert, None clears channel, ghost pill for null value
- [ ] `Students.test.tsx` updated: null-channel cell now asserts ghost pill instead of empty element
- [ ] All 1775 frontend tests pass

## Reviewer findings table

| Reviewer | Finding | Action |
|----------|---------|--------|
| review-plan | Add test file to plan | Fixed (TeachingChannelPicker.test.tsx added) |
| qa-verify | PASS WITH GAPS: loading state, portal, dismiss-without-select not unit tested | Accepted (visual/Radix concerns, not unit-testable) |
| code-review | CRITICAL: picker inside Link causes navigation | Fixed (stopPropagation on triggers) |
| code-review | optimisticValue masks external refetches after first edit | Fixed (reset to undefined on success) |
| code-review | setTimeout leak on unmount | Fixed (ref + useEffect cleanup) |
| review-ui | PASS: badges render correctly on both surfaces; ghost pill looks correct; glassmorphism compliant | No action |
| review-ui | GAP: channel badge pattern not in design system | Deferred (Vera discussion) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Teaching channel is now editable directly from student detail and list views via an interactive picker.
  * Channel selection includes a "None" option with real-time updates and automatic error recovery.

* **Tests**
  * Added comprehensive test suite for the teaching channel picker component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->