### PR TITLE
fix: remove PDF from Azure Vision OCR path

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/PdfTextExtractorTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/PdfTextExtractorTests.cs
@@ -56,30 +56,29 @@ public class PdfTextExtractorTests
     }
 
     [Fact]
-    public async Task ExtractTextAsync_TextBelowMinChars_ThrowsOcrFallbackException()
+    public async Task ExtractTextAsync_TextBelowMinChars_ThrowsOcrException()
     {
-        // Create a PDF with text shorter than threshold
         using var stream = CreateTypedPdfStream("Hi");
         var sut = CreateExtractor(minChars: 100);
 
         var act = () => sut.ExtractTextAsync(stream, PdfContentType);
 
-        await act.Should().ThrowAsync<OcrFallbackException>();
+        await act.Should().ThrowAsync<OcrException>();
     }
 
     [Fact]
-    public async Task ExtractTextAsync_EmptyStream_ThrowsOcrFallbackException()
+    public async Task ExtractTextAsync_EmptyStream_ThrowsOcrException()
     {
         using var stream = new MemoryStream();
         var sut = CreateExtractor();
 
         var act = () => sut.ExtractTextAsync(stream, PdfContentType);
 
-        await act.Should().ThrowAsync<OcrFallbackException>();
+        await act.Should().ThrowAsync<OcrException>();
     }
 
     [Fact]
-    public async Task ExtractTextAsync_GarbageBytes_ThrowsOcrFallbackException()
+    public async Task ExtractTextAsync_GarbageBytes_ThrowsOcrException()
     {
         var garbage = new byte[] { 0x00, 0x01, 0x02, 0xFF, 0xFE, 0xAB };
         using var stream = new MemoryStream(garbage);
@@ -87,7 +86,7 @@ public class PdfTextExtractorTests
 
         var act = () => sut.ExtractTextAsync(stream, PdfContentType);
 
-        await act.Should().ThrowAsync<OcrFallbackException>();
+        await act.Should().ThrowAsync<OcrException>();
     }
 
     [Fact]

--- a/backend/LangTeach.Api/Services/AzureVisionTextExtractor.cs
+++ b/backend/LangTeach.Api/Services/AzureVisionTextExtractor.cs
@@ -33,8 +33,7 @@ public class AzureVisionTextExtractor : ITextExtractor
         var mime = contentType?.Split(';', 2)[0].Trim() ?? string.Empty;
         return mime.Equals("image/jpeg", StringComparison.OrdinalIgnoreCase)
             || mime.Equals("image/png", StringComparison.OrdinalIgnoreCase)
-            || mime.Equals("image/webp", StringComparison.OrdinalIgnoreCase)
-            || mime.Equals("application/pdf", StringComparison.OrdinalIgnoreCase);
+            || mime.Equals("image/webp", StringComparison.OrdinalIgnoreCase);
     }
 
     public async Task<string> ExtractTextAsync(Stream stream, string contentType, CancellationToken ct = default)

--- a/backend/LangTeach.Api/Services/PdfTextExtractor.cs
+++ b/backend/LangTeach.Api/Services/PdfTextExtractor.cs
@@ -37,8 +37,8 @@ public class PdfTextExtractor : ITextExtractor
                 _logger.LogInformation("PdfTextExtractor: extracted {Chars} chars via text layer.", text.Length);
                 return Task.FromResult(text);
             }
-            _logger.LogInformation("PdfTextExtractor: text layer too short ({Chars} chars), falling back to Vision.", text.Length);
-            throw new OcrFallbackException(string.Empty);
+            _logger.LogInformation("PdfTextExtractor: text layer too short ({Chars} chars).", text.Length);
+            throw new OcrException("No se pudo extraer texto del PDF. Asegúrate de que el archivo no sea una imagen escaneada.");
         }
         catch (OcrFallbackException)
         {
@@ -50,8 +50,8 @@ public class PdfTextExtractor : ITextExtractor
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "PdfTextExtractor: could not read PDF text layer, falling back to Vision.");
-            throw new OcrFallbackException(string.Empty);
+            _logger.LogWarning(ex, "PdfTextExtractor: could not read PDF text layer.");
+            throw new OcrException("El archivo PDF no es válido o no contiene texto extraíble.");
         }
     }
 }

--- a/backend/LangTeach.Api/Services/PdfTextExtractor.cs
+++ b/backend/LangTeach.Api/Services/PdfTextExtractor.cs
@@ -40,7 +40,7 @@ public class PdfTextExtractor : ITextExtractor
             _logger.LogInformation("PdfTextExtractor: text layer too short ({Chars} chars).", text.Length);
             throw new OcrException("No se pudo extraer texto del PDF. Asegúrate de que el archivo no sea una imagen escaneada.");
         }
-        catch (OcrFallbackException)
+        catch (OcrException)
         {
             throw;
         }


### PR DESCRIPTION
## Summary

- `AzureVisionTextExtractor.CanHandle` was returning `true` for `application/pdf`, but the Azure AI Vision Image Analysis API does not support PDF binary uploads -- only image formats (JPEG, PNG, WEBP)
- Scanned PDFs (no text layer) caused PdfPig to fall back to Vision, which then threw a `RequestFailedException`, resulting in a 500 error instead of a user-facing message
- PDFs are now handled like DOCX: text-layer extraction only via PdfPig, with a clear Spanish error message if extraction fails

## Root cause

Reported on "redacción Rawad.pdf" -- a scanned student submission with no text layer.

## Test plan

- [ ] Upload a digital PDF (created from Word/Google Docs) -- should extract text successfully
- [ ] Upload a scanned/image-based PDF -- should return 422 with message "No se pudo extraer texto del PDF. Asegúrate de que el archivo no sea una imagen escaneada."
- [ ] Upload a JPEG/PNG -- Azure Vision OCR path unchanged, still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF text extraction error handling with more specific error messages in failure cases
  * Removed PDF support from the Azure Vision extractor (now supports images only: JPEG, PNG, WebP)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->