### PR TITLE
feat(corrections): OCR fallback to Claude Haiku for scanned/handwritten PDFs

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/CurriculumGenerationServiceTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/CurriculumGenerationServiceTests.cs
@@ -37,6 +37,7 @@ internal sealed class FakePromptService : IPromptService
     public ClaudeRequest BuildStudentProfileExtractionPrompt(string text) => Dummy();
     public ClaudeRequest BuildReplanSuggestionPrompt(ReplanSuggestionContext ctx) => Dummy();
     public ClaudeRequest BuildCurriculumValidationPrompt(CurriculumValidationContext ctx) => Dummy();
+    public ClaudeRequest BuildPdfOcrPrompt(byte[] pdfBytes) => Dummy();
 
     public CurriculumContext? LastCurriculumContext { get; private set; }
 

--- a/backend/LangTeach.Api.Tests/Services/PdfClaudeExtractorTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/PdfClaudeExtractorTests.cs
@@ -1,0 +1,151 @@
+using FluentAssertions;
+using LangTeach.Api.AI;
+using LangTeach.Api.Data.Models;
+using LangTeach.Api.DTOs;
+using LangTeach.Api.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace LangTeach.Api.Tests.Services;
+
+file sealed class FakeClaudeClient : IClaudeClient
+{
+    private readonly Func<ClaudeRequest, ClaudeResponse>? _completeFunc;
+    public ClaudeRequest? LastRequest { get; private set; }
+
+    public FakeClaudeClient(Func<ClaudeRequest, ClaudeResponse>? completeFunc = null)
+    {
+        _completeFunc = completeFunc;
+    }
+
+    public Task<ClaudeResponse> CompleteAsync(ClaudeRequest request, CancellationToken ct = default)
+    {
+        LastRequest = request;
+        if (_completeFunc is null) throw new InvalidOperationException("No response configured.");
+        return Task.FromResult(_completeFunc(request));
+    }
+
+    public IAsyncEnumerable<string> StreamAsync(ClaudeRequest request, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+}
+
+file sealed class ThrowingClaudeClient(Exception toThrow) : IClaudeClient
+{
+    public Task<ClaudeResponse> CompleteAsync(ClaudeRequest request, CancellationToken ct = default) =>
+        Task.FromException<ClaudeResponse>(toThrow);
+
+    public IAsyncEnumerable<string> StreamAsync(ClaudeRequest request, CancellationToken ct = default) =>
+        throw new NotImplementedException();
+}
+
+file sealed class PassthroughPromptService : IPromptService
+{
+    public ClaudeRequest BuildPdfOcrPrompt(byte[] pdfBytes) =>
+        new("system", "user", ClaudeModel.Haiku, 8192,
+            [new ContentAttachment("application/pdf", pdfBytes, "document.pdf")]);
+
+    public ClaudeRequest BuildLessonPlanPrompt(GenerationContext ctx) => throw new NotImplementedException();
+    public ClaudeRequest BuildVocabularyPrompt(GenerationContext ctx) => throw new NotImplementedException();
+    public ClaudeRequest BuildGrammarPrompt(GenerationContext ctx) => throw new NotImplementedException();
+    public ClaudeRequest BuildExercisesPrompt(GenerationContext ctx) => throw new NotImplementedException();
+    public ClaudeRequest BuildConversationPrompt(GenerationContext ctx) => throw new NotImplementedException();
+    public ClaudeRequest BuildReadingPrompt(GenerationContext ctx) => throw new NotImplementedException();
+    public ClaudeRequest BuildHomeworkPrompt(GenerationContext ctx) => throw new NotImplementedException();
+    public ClaudeRequest BuildFreeTextPrompt(GenerationContext ctx) => throw new NotImplementedException();
+    public ClaudeRequest BuildGuidedWritingPrompt(GenerationContext ctx) => throw new NotImplementedException();
+    public ClaudeRequest BuildErrorCorrectionPrompt(GenerationContext ctx) => throw new NotImplementedException();
+    public ClaudeRequest BuildNoticingTaskPrompt(GenerationContext ctx) => throw new NotImplementedException();
+    public ClaudeRequest BuildCurriculumPrompt(CurriculumContext ctx) => throw new NotImplementedException();
+    public ClaudeRequest BuildReflectionExtractionPrompt(ReflectionExtractionContext ctx) => throw new NotImplementedException();
+    public ClaudeRequest BuildWhatWasCoveredFallbackPrompt(WhatWasCoveredFallbackContext ctx) => throw new NotImplementedException();
+    public ClaudeRequest BuildStudentProfileExtractionPrompt(string text) => throw new NotImplementedException();
+    public ClaudeRequest BuildReplanSuggestionPrompt(ReplanSuggestionContext ctx) => throw new NotImplementedException();
+    public ClaudeRequest BuildCurriculumValidationPrompt(CurriculumValidationContext ctx) => throw new NotImplementedException();
+}
+
+public class PdfClaudeExtractorTests
+{
+    private const string PdfContentType = "application/pdf";
+
+    private static PdfClaudeExtractor Create(IClaudeClient claude, long maxFileBytes = 10_485_760)
+    {
+        var options = Options.Create(new OcrOptions { PdfClaudeMaxFileBytes = maxFileBytes });
+        return new PdfClaudeExtractor(claude, new PassthroughPromptService(), options, NullLogger<PdfClaudeExtractor>.Instance);
+    }
+
+    [Fact]
+    public void CanHandle_PdfContentType_ReturnsTrue()
+    {
+        var sut = Create(new FakeClaudeClient());
+        sut.CanHandle(PdfContentType).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("image/jpeg")]
+    [InlineData("image/png")]
+    [InlineData("application/vnd.openxmlformats-officedocument.wordprocessingml.document")]
+    public void CanHandle_NonPdfContentType_ReturnsFalse(string contentType)
+    {
+        var sut = Create(new FakeClaudeClient());
+        sut.CanHandle(contentType).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_FileExceedsMaxBytes_ThrowsOcrException()
+    {
+        var sut = Create(new FakeClaudeClient(), maxFileBytes: 10);
+
+        var act = () => sut.ExtractTextAsync(new MemoryStream(new byte[100]), PdfContentType);
+
+        await act.Should().ThrowAsync<OcrException>();
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_SuccessfulClaudeResponse_ReturnsExtractedText()
+    {
+        var fake = new FakeClaudeClient(_ => new ClaudeResponse("Texto extraído del examen.", "claude-haiku", 500, 20));
+        var sut = Create(fake);
+
+        var result = await sut.ExtractTextAsync(new MemoryStream(new byte[100]), PdfContentType);
+
+        result.Should().Be("Texto extraído del examen.");
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_ClaudeApiException_ThrowsOcrException()
+    {
+        var throwing = new ThrowingClaudeClient(new ClaudeApiException(System.Net.HttpStatusCode.InternalServerError, "error"));
+        var sut = Create(throwing);
+
+        var act = () => sut.ExtractTextAsync(new MemoryStream(new byte[100]), PdfContentType);
+
+        await act.Should().ThrowAsync<OcrException>()
+            .WithMessage("*procesar*");
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_ClaudeRateLimitException_ThrowsOcrException()
+    {
+        var throwing = new ThrowingClaudeClient(new ClaudeRateLimitException(TimeSpan.FromSeconds(30)));
+        var sut = Create(throwing);
+
+        var act = () => sut.ExtractTextAsync(new MemoryStream(new byte[100]), PdfContentType);
+
+        await act.Should().ThrowAsync<OcrException>()
+            .WithMessage("*disponible*");
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_AttachmentHasPdfMediaType()
+    {
+        var fake = new FakeClaudeClient(_ => new ClaudeResponse("text", "claude-haiku", 100, 10));
+        var sut = Create(fake);
+
+        await sut.ExtractTextAsync(new MemoryStream(new byte[50]), PdfContentType);
+
+        fake.LastRequest.Should().NotBeNull();
+        fake.LastRequest!.Attachments.Should().HaveCount(1);
+        fake.LastRequest.Attachments![0].MediaType.Should().Be("application/pdf");
+    }
+}

--- a/backend/LangTeach.Api.Tests/Services/PdfTextExtractorTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/PdfTextExtractorTests.cs
@@ -56,14 +56,14 @@ public class PdfTextExtractorTests
     }
 
     [Fact]
-    public async Task ExtractTextAsync_TextBelowMinChars_ThrowsOcrException()
+    public async Task ExtractTextAsync_TextBelowMinChars_ThrowsOcrFallbackException()
     {
         using var stream = CreateTypedPdfStream("Hi");
         var sut = CreateExtractor(minChars: 100);
 
         var act = () => sut.ExtractTextAsync(stream, PdfContentType);
 
-        await act.Should().ThrowAsync<OcrException>();
+        await act.Should().ThrowAsync<OcrFallbackException>();
     }
 
     [Fact]

--- a/backend/LangTeach.Api/AI/IPromptService.cs
+++ b/backend/LangTeach.Api/AI/IPromptService.cs
@@ -30,6 +30,7 @@ public interface IPromptService
     ClaudeRequest BuildStudentProfileExtractionPrompt(string text);
     ClaudeRequest BuildReplanSuggestionPrompt(ReplanSuggestionContext ctx);
     ClaudeRequest BuildCurriculumValidationPrompt(CurriculumValidationContext ctx);
+    ClaudeRequest BuildPdfOcrPrompt(byte[] pdfBytes);
 }
 
 public record CurriculumContext(

--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1800,4 +1800,20 @@ public class PromptService : IPromptService
 
         return new ClaudeRequest(SystemPrompt: system, UserPrompt: user, Model: ClaudeModel.Sonnet, MaxTokens: 1000);
     }
+
+    public ClaudeRequest BuildPdfOcrPrompt(byte[] pdfBytes)
+    {
+        const string system =
+            "Transcribe the PDF document exactly as written. " +
+            "Preserve every spelling mistake, grammar error, and accented character exactly as they appear. " +
+            "Output only the raw transcribed text with no commentary.";
+
+        return new ClaudeRequest(
+            SystemPrompt: system,
+            UserPrompt: "Transcribe this document.",
+            Model: ClaudeModel.Haiku,
+            MaxTokens: 3072,
+            Attachments: [new ContentAttachment("application/pdf", pdfBytes, "document.pdf")]
+        );
+    }
 }

--- a/backend/LangTeach.Api/Program.cs
+++ b/backend/LangTeach.Api/Program.cs
@@ -243,8 +243,9 @@ if (builder.Environment.IsEnvironment("Testing"))
     builder.Services.AddScoped<ITextExtractor, StubTextExtractor>();
 else
 {
-    builder.Services.AddScoped<ITextExtractor, PdfTextExtractor>();        // fast-path: typed PDFs skip Vision
-    builder.Services.AddScoped<ITextExtractor, AzureVisionTextExtractor>(); // Vision fallback for scanned/encrypted PDFs and images; degrades gracefully when unconfigured
+    builder.Services.AddScoped<ITextExtractor, PdfTextExtractor>();        // fast-path: typed PDFs via text layer
+    builder.Services.AddScoped<ITextExtractor, PdfClaudeExtractor>();     // fallback: scanned/handwritten PDFs via Claude
+    builder.Services.AddScoped<ITextExtractor, AzureVisionTextExtractor>(); // images (jpeg/png/webp)
     builder.Services.AddScoped<ITextExtractor, OpenXmlDocxTextExtractor>(); // .docx
 }
 builder.Services.Configure<OcrOptions>(builder.Configuration.GetSection(OcrOptions.SectionName));

--- a/backend/LangTeach.Api/Services/OcrOptions.cs
+++ b/backend/LangTeach.Api/Services/OcrOptions.cs
@@ -14,4 +14,7 @@ public class OcrOptions
         "application/pdf",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ];
+
+    // Separate from MaxBytes (upload limit) -- Claude API has its own document size constraints.
+    public long PdfClaudeMaxFileBytes { get; set; } = 10_485_760;
 }

--- a/backend/LangTeach.Api/Services/PdfClaudeExtractor.cs
+++ b/backend/LangTeach.Api/Services/PdfClaudeExtractor.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using LangTeach.Api.AI;
 using Microsoft.Extensions.Options;
 
@@ -24,12 +25,25 @@ public class PdfClaudeExtractor : ITextExtractor
     public async Task<string> ExtractTextAsync(Stream stream, string contentType, CancellationToken ct = default)
     {
         using var ms = new MemoryStream();
-        await stream.CopyToAsync(ms, ct);
+        var buffer = ArrayPool<byte>.Shared.Rent(81_920);
+        try
+        {
+            long total = 0;
+            int read;
+            while ((read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), ct)) > 0)
+            {
+                total += read;
+                if (total > _options.PdfClaudeMaxFileBytes)
+                    throw new OcrException("El PDF supera el tamaño máximo permitido para el procesamiento por IA.");
+                ms.Write(buffer, 0, read);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
         var bytes = ms.ToArray();
-
-        if (bytes.Length > _options.PdfClaudeMaxFileBytes)
-            throw new OcrException("El PDF supera el tamaño máximo permitido para el procesamiento por IA.");
-
         var request = _prompts.BuildPdfOcrPrompt(bytes);
 
         try
@@ -45,6 +59,11 @@ public class PdfClaudeExtractor : ITextExtractor
         catch (ClaudeApiException ex)
         {
             _logger.LogWarning(ex, "PdfClaudeExtractor: Claude API error.");
+            throw new OcrException("No se pudo procesar el PDF escaneado. Inténtalo de nuevo.");
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "PdfClaudeExtractor: unexpected Claude failure.");
             throw new OcrException("No se pudo procesar el PDF escaneado. Inténtalo de nuevo.");
         }
     }

--- a/backend/LangTeach.Api/Services/PdfClaudeExtractor.cs
+++ b/backend/LangTeach.Api/Services/PdfClaudeExtractor.cs
@@ -1,0 +1,51 @@
+using LangTeach.Api.AI;
+using Microsoft.Extensions.Options;
+
+namespace LangTeach.Api.Services;
+
+public class PdfClaudeExtractor : ITextExtractor
+{
+    private readonly IClaudeClient _claude;
+    private readonly IPromptService _prompts;
+    private readonly OcrOptions _options;
+    private readonly ILogger<PdfClaudeExtractor> _logger;
+
+    public PdfClaudeExtractor(IClaudeClient claude, IPromptService prompts, IOptions<OcrOptions> options, ILogger<PdfClaudeExtractor> logger)
+    {
+        _claude = claude;
+        _prompts = prompts;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public bool CanHandle(string contentType) =>
+        string.Equals(contentType?.Split(';', 2)[0].Trim(), "application/pdf", StringComparison.OrdinalIgnoreCase);
+
+    public async Task<string> ExtractTextAsync(Stream stream, string contentType, CancellationToken ct = default)
+    {
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms, ct);
+        var bytes = ms.ToArray();
+
+        if (bytes.Length > _options.PdfClaudeMaxFileBytes)
+            throw new OcrException("El PDF supera el tamaño máximo permitido para el procesamiento por IA.");
+
+        var request = _prompts.BuildPdfOcrPrompt(bytes);
+
+        try
+        {
+            var response = await _claude.CompleteAsync(request, ct);
+            _logger.LogInformation("PdfClaudeExtractor: extracted {Chars} chars via Claude.", response.Content.Length);
+            return response.Content;
+        }
+        catch (ClaudeRateLimitException)
+        {
+            throw new OcrException("El servicio no está disponible ahora mismo. Inténtalo en un momento.");
+        }
+        catch (ClaudeApiException ex)
+        {
+            _logger.LogWarning(ex, "PdfClaudeExtractor: Claude API error.");
+            throw new OcrException("No se pudo procesar el PDF escaneado. Inténtalo de nuevo.");
+        }
+    }
+}

--- a/backend/LangTeach.Api/Services/PdfTextExtractor.cs
+++ b/backend/LangTeach.Api/Services/PdfTextExtractor.cs
@@ -37,8 +37,8 @@ public class PdfTextExtractor : ITextExtractor
                 _logger.LogInformation("PdfTextExtractor: extracted {Chars} chars via text layer.", text.Length);
                 return Task.FromResult(text);
             }
-            _logger.LogInformation("PdfTextExtractor: text layer too short ({Chars} chars).", text.Length);
-            throw new OcrException("No se pudo extraer texto del PDF. Asegúrate de que el archivo no sea una imagen escaneada.");
+            _logger.LogInformation("PdfTextExtractor: text layer too short ({Chars} chars), signalling fallback.", text.Length);
+            throw new OcrFallbackException("Texto insuficiente en la capa de texto del PDF.");
         }
         catch (OcrException)
         {

--- a/backend/LangTeach.Api/appsettings.json
+++ b/backend/LangTeach.Api/appsettings.json
@@ -31,7 +31,8 @@
   "Ocr": {
     "MaxBytes": 10485760,
     "MinExtractedChars": 10,
-    "AcceptedContentTypes": [ "image/jpeg", "image/png", "image/webp", "application/pdf", "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ]
+    "AcceptedContentTypes": [ "image/jpeg", "image/png", "image/webp", "application/pdf", "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ],
+    "PdfClaudeMaxFileBytes": 10485760
   },
   "GenerationLimits": {
     "FreeTierMonthlyLimit": 50,


### PR DESCRIPTION
Closes #1311

## Summary

- `PdfTextExtractor`: when the text layer is too short, now throws `OcrFallbackException` (signal "try next extractor") instead of `OcrException` (signal "stop")
- New `PdfClaudeExtractor`: sends the PDF as a native document attachment to Claude Haiku; system prompt instructs exact transcription with no error correction
- `IPromptService` / `PromptService`: new `BuildPdfOcrPrompt(byte[] pdfBytes)` method (follows architecture pattern for AI prompts)
- `OcrOptions`: new `PdfClaudeMaxFileBytes` guard (separate from the upload `MaxBytes` -- Claude API has its own limits)
- DI order: `PdfTextExtractor` first (fast, free), `PdfClaudeExtractor` second (fallback for scanned/handwritten)

## Verify

Tested against live e2e stack with worktree build:

- Scanned PDF (image-based, no text layer): Claude extracted "Hola me yamo Juan. Tengo 15 anyos. Mi clase de espaniol es muy interesante. Ayer fui al parke con mis amigoes." -- misspellings preserved, no silent correction
- Digital PDF (with text layer): log showed `PdfTextExtractor: extracted 72 chars via text layer.` -- Claude not involved
- 1493 unit tests pass, 0 failures

## Review summary

| Reviewer | Finding | Action |
|---|---|---|
| qa-verify | All 6 AC met; DOCX path has no new test (pre-existing coverage unchanged) | Dismissed (no regression) |
| code-review | Spanish error strings vs codes (pre-existing pattern across all extractors) | Deferred (existing debt) |
| code-review | Token usage not logged in PdfClaudeExtractor | Deferred (#1312) |
| architecture | PdfClaudeExtractor bypassed IPromptService (system prompt inline) | Fixed: moved to `BuildPdfOcrPrompt` in PromptService |
| prompt-health | Negative constraint "Do not correct..." redundant with positive "exactly as written" | Fixed: removed redundant line |
| prompt-health | MaxTokens 8192 too large for exam transcription | Fixed: reduced to 3072 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced PDF text extraction with improved AI-powered OCR processing as a fallback for better accuracy on complex or scanned documents
  * Added configurable maximum file size limits for PDF processing to prevent resource exhaustion (default: 10 MB)
  * Improved error handling with better fallback mechanisms for extraction failures

* **Tests**
  * Added comprehensive test coverage for the new PDF extraction functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->