### PR TITLE
fix(corrections): Claude HTTP/2 keepalive + Sonnet vision at temperature 0 for handwritten PDFs

### DIFF
--- a/backend/LangTeach.Api/AI/PromptService.cs
+++ b/backend/LangTeach.Api/AI/PromptService.cs
@@ -1804,15 +1804,18 @@ public class PromptService : IPromptService
     public ClaudeRequest BuildPdfOcrPrompt(byte[] pdfBytes)
     {
         const string system =
-            "Transcribe the PDF document exactly as written. " +
-            "Preserve every spelling mistake, grammar error, and accented character exactly as they appear. " +
-            "Output only the raw transcribed text with no commentary.";
+            "Transcribe the handwritten student text in this document. " +
+            "When text is crossed out and replaced, transcribe only the replacement. Crossed-out words are not part of the final submission. " +
+            "When text is inserted above, below, or beside a line as a correction, place it at the correct reading position. " +
+            "Preserve every spelling mistake, grammar error, and accented character exactly as written. Do not correct the student's language. " +
+            "Output only the transcribed text with no commentary.";
 
         return new ClaudeRequest(
             SystemPrompt: system,
             UserPrompt: "Transcribe this document.",
-            Model: ClaudeModel.Haiku,
+            Model: ClaudeModel.Sonnet,
             MaxTokens: 3072,
+            Temperature: 0,
             Attachments: [new ContentAttachment("application/pdf", pdfBytes, "document.pdf")]
         );
     }

--- a/backend/LangTeach.Api/Program.cs
+++ b/backend/LangTeach.Api/Program.cs
@@ -163,6 +163,15 @@ builder.Services.AddHttpClient("Claude", (sp, client) =>
     client.DefaultRequestHeaders.Add("x-api-key", opts.ApiKey);
     client.DefaultRequestHeaders.Add("anthropic-version", "2023-06-01");
     client.Timeout = TimeSpan.FromSeconds(RedaccionCorrectionTimeouts.HttpClientSeconds);
+})
+.ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+{
+    // Send HTTP/2 PING frames every 15 s so Docker/WSL2 NAT does not silently drop
+    // the idle TCP connection while Claude is generating a long response (stream=false).
+    KeepAlivePingDelay   = TimeSpan.FromSeconds(15),
+    KeepAlivePingTimeout = TimeSpan.FromSeconds(10),
+    KeepAlivePingPolicy  = HttpKeepAlivePingPolicy.Always,
+    PooledConnectionLifetime = TimeSpan.FromMinutes(5),
 });
 builder.Services.AddHttpClient("AzureSpeech", client =>
 {


### PR DESCRIPTION
## Summary

Two related hotfixes for the scanned-PDF correction flow:

1. **HTTP/2 keepalive on the Claude HttpClient** -- prevents long-lived connections from being silently dropped during large PDF uploads.
2. **Sonnet vision at temperature 0 for handwritten PDF OCR** -- Haiku at default temperature gave visibly different transcriptions each run and missed crossings-out and out-of-line insertions. Sonnet 4.6 handles those visual judgments meaningfully better; temperature 0 makes output deterministic. Prompt also tightened to instruct on replacements, insertions, and preserving the student's errors verbatim.

## Follow-ups (not in this PR)

- #1314 -- side-by-side scan + extracted text review pattern (closes the remaining OCR quality gap via human review)
- #1315 -- spike to evaluate Azure Document Intelligence as an alternative OCR backend if quality is still inadequate after #1314 ships

## Test plan

- [x] Pre-push build clean
- [x] Live test against scanned student PDF (Rawad redacción): single Sonnet call, model confirmed `claude-sonnet-4-6`, temperature 0, ~14s latency, extraction quality visibly improved over Haiku baseline
- [ ] Verify on a second scanned PDF before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced network connection stability during long document processing operations, reducing timeout-related interruptions

* **Improvements**
  * Improved handwritten document recognition with enhanced optical character recognition, delivering more accurate text extraction and better handling of crossed-out text and insertions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->