### PR TITLE
feat(observability): log full Claude request/response for every API call (#1317)

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/ClaudeApiClientUnitTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/ClaudeApiClientUnitTests.cs
@@ -164,7 +164,7 @@ public class ClaudeApiClientUnitTests
         var client     = new ClaudeApiClient(factory, capturingLogger);
 
         var chunks = new List<string>();
-        await foreach (var chunk in client.StreamAsync(new ClaudeRequest("sys", "hi", ClaudeModel.Haiku)))
+        await foreach (var chunk in client.StreamAsync(new ClaudeRequest("sys", "hi", ClaudeModel.Haiku, CallSite: "test")))
             chunks.Add(chunk);
 
         chunks.Should().Equal("complete");
@@ -223,7 +223,7 @@ public class ClaudeApiClientUnitTests
         var factory    = new FakeHttpClientFactory(httpClient);
         var client     = new ClaudeApiClient(factory, capturingLogger);
 
-        await client.CompleteAsync(new ClaudeRequest("sys", "hi", ClaudeModel.Haiku, MaxTokens: 100));
+        await client.CompleteAsync(new ClaudeRequest("sys", "hi", ClaudeModel.Haiku, MaxTokens: 100, CallSite: "test"));
 
         capturingLogger.Entries.Should().NotContain(e => e.Level == LogLevel.Warning);
     }

--- a/backend/LangTeach.Api/AI/ClaudeApiClient.cs
+++ b/backend/LangTeach.Api/AI/ClaudeApiClient.cs
@@ -183,7 +183,7 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
             // Emit log for cancellation or unexpected termination cases where message_delta was never received.
             if (!logEmitted)
             {
-                if (!sw.IsRunning) sw.Stop();
+                sw.Stop();
                 var stopReason = ct.IsCancellationRequested ? "cancelled" : "error";
                 EmitCallLog(request, usedModel, inputTokens, outputTokens, stopReason, sw.ElapsedMilliseconds, accumulated.ToString());
             }

--- a/backend/LangTeach.Api/AI/ClaudeApiClient.cs
+++ b/backend/LangTeach.Api/AI/ClaudeApiClient.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Net;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
@@ -57,6 +58,8 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
             "Claude complete: model={Model} input={Input} output={Output} maxTokens={MaxTokens} usage={UsagePct:F1}% stopReason={StopReason} latency={Latency}ms",
             usedModel, inputTokens, outputTokens, request.MaxTokens, usagePct, stopReason ?? "end_turn", sw.ElapsedMilliseconds);
 
+        EmitCallLog(request, usedModel, inputTokens, outputTokens, stopReason ?? "end_turn", sw.ElapsedMilliseconds, text);
+
         if (usagePct >= 80.0)
             logger.LogWarning(
                 "Claude near max_tokens ceiling: output={Output} maxTokens={MaxTokens} usage={UsagePct:F1}% stopReason={StopReason}",
@@ -89,81 +92,131 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
         using var stream = await response.Content.ReadAsStreamAsync(ct);
         using var reader = new StreamReader(stream);
 
-        var usedModel    = modelId;
-        var inputTokens  = 0;
-        var outputTokens = 0;
+        var usedModel       = modelId;
+        var inputTokens     = 0;
+        var outputTokens    = 0;
+        var streamStopReason = "end_turn";
+        var accumulated     = new StringBuilder();
+        var logEmitted      = false;
 
-        while (!reader.EndOfStream && !ct.IsCancellationRequested)
+        try
         {
-            var line = await reader.ReadLineAsync(ct);
-            if (line is null) break;
-            if (!line.StartsWith("data: ")) continue;
-
-            var data = line["data: ".Length..];
-            if (data == "[DONE]") break;
-
-            string? chunk = null;
-            try
+            while (!reader.EndOfStream && !ct.IsCancellationRequested)
             {
-                using var eventDoc = JsonDocument.Parse(data);
-                var eventRoot = eventDoc.RootElement;
+                var line = await reader.ReadLineAsync(ct);
+                if (line is null) break;
+                if (!line.StartsWith("data: ")) continue;
 
-                if (!eventRoot.TryGetProperty("type", out var typeProp)) continue;
-                var type = typeProp.GetString();
+                var data = line["data: ".Length..];
+                if (data == "[DONE]") break;
 
-                if (type == "message_start")
+                string? chunk = null;
+                try
                 {
-                    if (eventRoot.TryGetProperty("message", out var msg))
+                    using var eventDoc = JsonDocument.Parse(data);
+                    var eventRoot = eventDoc.RootElement;
+
+                    if (!eventRoot.TryGetProperty("type", out var typeProp)) continue;
+                    var type = typeProp.GetString();
+
+                    if (type == "message_start")
                     {
-                        if (msg.TryGetProperty("model", out var m))
-                            usedModel = m.GetString() ?? modelId;
-                        if (msg.TryGetProperty("usage", out var startUsage) &&
-                            startUsage.TryGetProperty("input_tokens", out var it))
-                            inputTokens = it.GetInt32();
+                        if (eventRoot.TryGetProperty("message", out var msg))
+                        {
+                            if (msg.TryGetProperty("model", out var m))
+                                usedModel = m.GetString() ?? modelId;
+                            if (msg.TryGetProperty("usage", out var startUsage) &&
+                                startUsage.TryGetProperty("input_tokens", out var it))
+                                inputTokens = it.GetInt32();
+                        }
+                        continue;
                     }
+
+                    if (type == "message_delta")
+                    {
+                        if (eventRoot.TryGetProperty("usage", out var deltaUsage) &&
+                            deltaUsage.TryGetProperty("output_tokens", out var ot))
+                            outputTokens = ot.GetInt32();
+
+                        if (eventRoot.TryGetProperty("delta", out var deltaObj) &&
+                            deltaObj.TryGetProperty("stop_reason", out var sr))
+                            streamStopReason = sr.GetString() ?? "end_turn";
+
+                        if (streamStopReason == "max_tokens")
+                            logger.LogWarning(
+                                "Claude stream truncated: max_tokens ({MaxTokens}) reached. model={Model} input={Input} output={Output}",
+                                request.MaxTokens, usedModel, inputTokens, outputTokens);
+
+                        sw.Stop();
+                        logger.LogInformation(
+                            "Claude stream: model={Model} input={Input} output={Output} latency={Latency}ms stopReason={StopReason}",
+                            usedModel, inputTokens, outputTokens, sw.ElapsedMilliseconds, streamStopReason);
+
+                        EmitCallLog(request, usedModel, inputTokens, outputTokens, streamStopReason, sw.ElapsedMilliseconds, accumulated.ToString());
+                        logEmitted = true;
+                        continue;
+                    }
+
+                    if (type == "message_stop") break;
+                    if (type != "content_block_delta") continue;
+
+                    if (eventRoot.TryGetProperty("delta", out var textDelta) &&
+                        textDelta.TryGetProperty("text", out var textProp))
+                    {
+                        chunk = textProp.GetString();
+                    }
+                }
+                catch (JsonException)
+                {
                     continue;
                 }
 
-                if (type == "message_delta")
+                if (chunk is not null)
                 {
-                    if (eventRoot.TryGetProperty("usage", out var deltaUsage) &&
-                        deltaUsage.TryGetProperty("output_tokens", out var ot))
-                        outputTokens = ot.GetInt32();
-
-                    var stopReason = string.Empty;
-                    if (eventRoot.TryGetProperty("delta", out var deltaObj) &&
-                        deltaObj.TryGetProperty("stop_reason", out var sr))
-                        stopReason = sr.GetString() ?? string.Empty;
-
-                    if (stopReason == "max_tokens")
-                        logger.LogWarning(
-                            "Claude stream truncated: max_tokens ({MaxTokens}) reached. model={Model} input={Input} output={Output}",
-                            request.MaxTokens, usedModel, inputTokens, outputTokens);
-
-                    sw.Stop();
-                    logger.LogInformation(
-                        "Claude stream: model={Model} input={Input} output={Output} latency={Latency}ms stopReason={StopReason}",
-                        usedModel, inputTokens, outputTokens, sw.ElapsedMilliseconds, stopReason);
-                    continue;
-                }
-
-                if (type == "message_stop") break;
-                if (type != "content_block_delta") continue;
-
-                if (eventRoot.TryGetProperty("delta", out var textDelta) &&
-                    textDelta.TryGetProperty("text", out var textProp))
-                {
-                    chunk = textProp.GetString();
+                    accumulated.Append(chunk);
+                    yield return chunk;
                 }
             }
-            catch (JsonException)
-            {
-                continue;
-            }
-
-            if (chunk is not null) yield return chunk;
         }
+        finally
+        {
+            // Emit log for cancellation or unexpected termination cases where message_delta was never received.
+            if (!logEmitted)
+            {
+                if (!sw.IsRunning) sw.Stop();
+                var stopReason = ct.IsCancellationRequested ? "cancelled" : "error";
+                EmitCallLog(request, usedModel, inputTokens, outputTokens, stopReason, sw.ElapsedMilliseconds, accumulated.ToString());
+            }
+        }
+    }
 
+    private void EmitCallLog(
+        ClaudeRequest request,
+        string model,
+        int inputTokens,
+        int outputTokens,
+        string stopReason,
+        long latencyMs,
+        string rawResponse)
+    {
+        var correlationId = request.CorrelationId ?? Guid.NewGuid();
+        var promptHash    = ComputePromptHash(request.SystemPrompt, request.UserPrompt);
+
+        logger.LogInformation(
+            "ClaudeCall callSite={CallSite} correlationId={CorrelationId} model={Model} promptHash={PromptHash} " +
+            "inputTokens={InputTokens} outputTokens={OutputTokens} maxTokens={MaxTokens} stopReason={StopReason} " +
+            "latencyMs={LatencyMs} systemPrompt={SystemPrompt} userPrompt={UserPrompt} rawResponse={RawResponse}",
+            request.CallSite, correlationId, model, promptHash,
+            inputTokens, outputTokens, request.MaxTokens, stopReason,
+            latencyMs, request.SystemPrompt, request.UserPrompt, rawResponse);
+    }
+
+    // PromptHash is SHA256(SystemPrompt+UserPrompt) for dedup and lookup in KQL.
+    private static string ComputePromptHash(string systemPrompt, string userPrompt)
+    {
+        var input = systemPrompt + userPrompt;
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
     }
 
     private static object BuildRequestBody(ClaudeRequest request, string modelId, bool stream)

--- a/backend/LangTeach.Api/AI/ClaudeApiClient.cs
+++ b/backend/LangTeach.Api/AI/ClaudeApiClient.cs
@@ -199,6 +199,9 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
         long latencyMs,
         string rawResponse)
     {
+        if (request.CallSite == "unknown")
+            logger.LogWarning("ClaudeCall missing CallSite tag: model={Model} promptHash={PromptHash}", model, ComputePromptHash(request.SystemPrompt, request.UserPrompt));
+
         var correlationId = request.CorrelationId ?? Guid.NewGuid();
         var promptHash    = ComputePromptHash(request.SystemPrompt, request.UserPrompt);
 

--- a/backend/LangTeach.Api/AI/IClaudeClient.cs
+++ b/backend/LangTeach.Api/AI/IClaudeClient.cs
@@ -8,13 +8,18 @@ public interface IClaudeClient
 
 public record ContentAttachment(string MediaType, byte[] Data, string FileName);
 
+// ClaudeRequest carries both the wire payload and call context (CallSite, CorrelationId).
+// Full prompts and raw responses are logged unconditionally: PII boundary is already crossed
+// when text is sent to Claude; Azure Log Analytics is inside the same trust boundary.
 public record ClaudeRequest(
     string SystemPrompt,
     string UserPrompt,
     ClaudeModel Model,
     int MaxTokens = 2048,
     IReadOnlyList<ContentAttachment>? Attachments = null,
-    double? Temperature = null
+    double? Temperature = null,
+    string CallSite = "unknown",
+    Guid? CorrelationId = null
 );
 
 public record ClaudeResponse(

--- a/backend/LangTeach.Api/Controllers/GenerateController.cs
+++ b/backend/LangTeach.Api/Controllers/GenerateController.cs
@@ -212,6 +212,7 @@ public class GenerateController : ControllerBase
 
         var claudeRequest = buildPrompt(_promptService, ctx);
         claudeRequest = AttachMaterials(claudeRequest, materials);
+        claudeRequest = claudeRequest with { CallSite = "lesson.generation" };
 
         Response.ContentType = "text/event-stream";
         Response.Headers["Cache-Control"] = "no-cache";
@@ -383,6 +384,7 @@ public class GenerateController : ControllerBase
 
         var claudeRequest = buildPrompt(ctx);
         claudeRequest = AttachMaterials(claudeRequest, materials);
+        claudeRequest = claudeRequest with { CallSite = "lesson.generation" };
 
         ClaudeResponse response;
         try

--- a/backend/LangTeach.Api/Controllers/GenerateController.cs
+++ b/backend/LangTeach.Api/Controllers/GenerateController.cs
@@ -212,7 +212,7 @@ public class GenerateController : ControllerBase
 
         var claudeRequest = buildPrompt(_promptService, ctx);
         claudeRequest = AttachMaterials(claudeRequest, materials);
-        claudeRequest = claudeRequest with { CallSite = "lesson.generation" };
+        claudeRequest = claudeRequest with { CallSite = "lesson.generation.stream" };
 
         Response.ContentType = "text/event-stream";
         Response.Headers["Cache-Control"] = "no-cache";
@@ -384,7 +384,7 @@ public class GenerateController : ControllerBase
 
         var claudeRequest = buildPrompt(ctx);
         claudeRequest = AttachMaterials(claudeRequest, materials);
-        claudeRequest = claudeRequest with { CallSite = "lesson.generation" };
+        claudeRequest = claudeRequest with { CallSite = "lesson.generation.complete" };
 
         ClaudeResponse response;
         try

--- a/backend/LangTeach.Api/Services/CurriculumGenerationService.cs
+++ b/backend/LangTeach.Api/Services/CurriculumGenerationService.cs
@@ -85,7 +85,7 @@ public class CurriculumGenerationService : ICurriculumGenerationService
                 var personalizationCtx = ctx with { TemplateUnits = templateUnits };
                 try
                 {
-                    var request = _prompts.BuildCurriculumPrompt(personalizationCtx);
+                    var request = _prompts.BuildCurriculumPrompt(personalizationCtx) with { CallSite = "curriculum.personalization" };
                     var response = await _claude.CompleteAsync(request, ct);
                     ApplyPersonalization(skeletons, response.Content);
                 }
@@ -104,7 +104,7 @@ public class CurriculumGenerationService : ICurriculumGenerationService
         }
 
         // Free AI generation path
-        var aiRequest = _prompts.BuildCurriculumPrompt(ctx);
+        var aiRequest = _prompts.BuildCurriculumPrompt(ctx) with { CallSite = "curriculum.generation" };
         var aiResponse = await _claude.CompleteAsync(aiRequest, ct);
 
         var strippedAiContent = ContentJsonHelper.StripFences(aiResponse.Content);
@@ -157,7 +157,7 @@ public class CurriculumGenerationService : ICurriculumGenerationService
             var personalizationCtx = ctx with { TemplateUnits = templateUnits };
             try
             {
-                var personalizationRequest = _prompts.BuildCurriculumPrompt(personalizationCtx);
+                var personalizationRequest = _prompts.BuildCurriculumPrompt(personalizationCtx) with { CallSite = "curriculum.personalization" };
                 var personalizationResponse = await _claude.CompleteAsync(personalizationRequest, ct);
                 ApplyPersonalization(freeEntries, personalizationResponse.Content);
             }

--- a/backend/LangTeach.Api/Services/CurriculumValidationService.cs
+++ b/backend/LangTeach.Api/Services/CurriculumValidationService.cs
@@ -40,7 +40,7 @@ public class CurriculumValidationService : ICurriculumValidationService
             allowedGrammar,
             entriesWithGrammar.Select(e => (e.OrderIndex, e.GrammarFocus!)).ToList());
 
-        var request = _prompts.BuildCurriculumValidationPrompt(ctx);
+        var request = _prompts.BuildCurriculumValidationPrompt(ctx) with { CallSite = "curriculum.validation" };
 
         try
         {

--- a/backend/LangTeach.Api/Services/PdfClaudeExtractor.cs
+++ b/backend/LangTeach.Api/Services/PdfClaudeExtractor.cs
@@ -44,7 +44,7 @@ public class PdfClaudeExtractor : ITextExtractor
         }
 
         var bytes = ms.ToArray();
-        var request = _prompts.BuildPdfOcrPrompt(bytes);
+        var request = _prompts.BuildPdfOcrPrompt(bytes) with { CallSite = "pdf.extraction" };
 
         try
         {

--- a/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
+++ b/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
@@ -188,7 +188,7 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
 
         var cefr = CefrLevelNormalizer.Normalize(student.CefrLevel);
         var ctx = BuildPromptContext(correction, student);
-        var request = correctionPromptService.BuildCorrectionPrompt(ctx);
+        var request = correctionPromptService.BuildCorrectionPrompt(ctx) with { CallSite = "correction.pass1", CorrelationId = correctionId };
         var sentText = ctx.StudentText.TrimEnd();
 
         var response = await claude.CompleteAsync(request, CancellationToken.None);
@@ -501,7 +501,7 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
         ClaudeResponse filterResponse;
         try
         {
-            var filterRequest = correctionPromptService.BuildLevelFilterPrompt(cefr, inputs, assignmentPrompt);
+            var filterRequest = correctionPromptService.BuildLevelFilterPrompt(cefr, inputs, assignmentPrompt) with { CallSite = "correction.filter", CorrelationId = correctionId };
             filterResponse = await claude.CompleteAsync(filterRequest, CancellationToken.None);
         }
         catch (Exception ex)
@@ -615,7 +615,7 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
         List<ScopeAffirmerSpan>? results;
         try
         {
-            var request = correctionPromptService.BuildScopeAffirmerPrompt(cefr, originalText, nextCefr);
+            var request = correctionPromptService.BuildScopeAffirmerPrompt(cefr, originalText, nextCefr) with { CallSite = "correction.scopeAffirmer", CorrelationId = correctionId };
             var response = await claude.CompleteAsync(request, CancellationToken.None);
             var raw = ContentJsonHelper.StripFences(response.Content);
             results = JsonSerializer.Deserialize<List<ScopeAffirmerSpan>>(raw ?? string.Empty, JsonOpts);

--- a/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
+++ b/backend/LangTeach.Api/Services/ReflectionExtractionService.cs
@@ -28,7 +28,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
 
     public async Task<ExtractedReflectionDto> ExtractAsync(string text, IReadOnlyList<string>? knownDifficulties = null, bool hasOpenSession = false, CancellationToken ct = default)
     {
-        var request = _prompts.BuildReflectionExtractionPrompt(new ReflectionExtractionContext(DateOnly.FromDateTime(DateTime.UtcNow), text, knownDifficulties, hasOpenSession));
+        var request = _prompts.BuildReflectionExtractionPrompt(new ReflectionExtractionContext(DateOnly.FromDateTime(DateTime.UtcNow), text, knownDifficulties, hasOpenSession)) with { CallSite = "reflection.extraction" };
 
         ClaudeResponse response;
         try
@@ -99,7 +99,7 @@ public class ReflectionExtractionService : IReflectionExtractionService
 
         try
         {
-            var resp = await _claude.CompleteAsync(_prompts.BuildWhatWasCoveredFallbackPrompt(ctx), ct);
+            var resp = await _claude.CompleteAsync(_prompts.BuildWhatWasCoveredFallbackPrompt(ctx) with { CallSite = "reflection.covered" }, ct);
             var sentence = resp.Content?.Trim().Trim('"').Trim();
             if (!string.IsNullOrWhiteSpace(sentence)) return sentence;
             _logger.LogInformation("Fallback whatWasCovered synthesis returned empty content; using deterministic join");

--- a/backend/LangTeach.Api/Services/ReplanSuggestionService.cs
+++ b/backend/LangTeach.Api/Services/ReplanSuggestionService.cs
@@ -91,7 +91,7 @@ public class ReplanSuggestionService : IReplanSuggestionService
             course.Name, course.Language, course.TargetCefrLevel, course.Student?.Name,
             taughtEntries, plannedEntries, difficulties, MaxSuggestions);
 
-        var request = _prompts.BuildReplanSuggestionPrompt(promptContext);
+        var request = _prompts.BuildReplanSuggestionPrompt(promptContext) with { CallSite = "replanning" };
 
         ClaudeResponse response;
         try

--- a/backend/LangTeach.Api/Services/StudentProfileExtractionService.cs
+++ b/backend/LangTeach.Api/Services/StudentProfileExtractionService.cs
@@ -33,7 +33,7 @@ public class StudentProfileExtractionService : IStudentProfileExtractionService
 
     public async Task<ExtractedStudentProfileDto> ExtractAsync(string text, CancellationToken ct = default)
     {
-        var request = _prompts.BuildStudentProfileExtractionPrompt(text);
+        var request = _prompts.BuildStudentProfileExtractionPrompt(text) with { CallSite = "student.extraction" };
 
         ClaudeResponse response;
         try


### PR DESCRIPTION
## Summary

- Extends `ClaudeRequest` record with `CallSite` (string) and `CorrelationId` (Guid?) fields; defaults preserve backward compatibility at all 13 call sites
- `ClaudeApiClient` emits one structured `Information`-level log per call with: CorrelationId, PromptHash (SHA256), SystemPrompt, UserPrompt, RawResponse, Model, InputTokens, OutputTokens, MaxTokens, StopReason, LatencyMs, CallSite
- Streaming path accumulates response text in a StringBuilder; log emits on `message_delta`, with try/finally fallback for cancellation/error cases where `message_delta` is never received
- All 13 call sites tagged with descriptive CallSite (`correction.pass1`, `correction.filter`, `correction.scopeAffirmer`, `lesson.generation.stream`, `lesson.generation.complete`, `curriculum.generation`, `curriculum.personalization`, `curriculum.validation`, `reflection.extraction`, `reflection.covered`, `pdf.extraction`, `student.extraction`, `replanning`); correction callers also thread `correctionId` as `CorrelationId`
- `LogWarning` emitted when CallSite is `"unknown"` to surface missed tags on future call sites

## Design decisions

- Full prompts and raw responses logged unconditionally. PII boundary already crossed when text is sent to Claude; Azure Log Analytics is inside the same trust boundary (per issue discussion with Sophy)
- No DB table, no migration: existing Azure Log Analytics with KQL retention covers the use case
- `CallSite` is a free string with `"unknown"` default; a const class would prevent typos but adds ceremony for little gain when KQL surfacing is near-instant

## KQL query pattern

```kql
customEvents
| where customDimensions.CorrelationId == "417ea48d-..."
```

## Verify

1. Trigger a normal correction in e2e. Confirm structured log entry contains full prompt + full response.
2. Force a `max_tokens` failure (lower the cap to 200 temporarily). Confirm the log entry still appears with the truncated raw response and `StopReason=max_tokens`.
3. Query Azure Log Analytics by `CorrelationId` and confirm a single matching record.

## Blocks

Unblocks #1316 (correction hits max_tokens ceiling -- needs this for diagnosis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented structured logging for AI API calls to track request origins, token usage, response latency, and completion details across all features including curriculum generation, lesson planning, document extraction, student profiling, and written work correction, enhancing system observability, diagnostic capabilities, and request traceability for improved troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->