### PR TITLE
fix(corrections): prefill assistant turn with { to prevent chain-of-thought prose on error-dense redacciones (#1316)

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/ClaudeApiClientUnitTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/ClaudeApiClientUnitTests.cs
@@ -228,6 +228,50 @@ public class ClaudeApiClientUnitTests
         capturingLogger.Entries.Should().NotContain(e => e.Level == LogLevel.Warning);
     }
 
+    [Fact]
+    public async Task CompleteAsync_WithAssistantPrefill_PrependsPrefillToContent()
+    {
+        var json = """
+            {
+              "model": "claude-haiku-4-5-20251001",
+              "content": [{ "type": "text", "text": "\"key\":\"value\"}" }],
+              "usage": { "input_tokens": 10, "output_tokens": 5 }
+            }
+            """;
+
+        var client = BuildClient(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        });
+
+        var result = await client.CompleteAsync(
+            new ClaudeRequest("sys", "hi", ClaudeModel.Haiku, AssistantPrefill: "{"));
+
+        result.Content.Should().Be("{\"key\":\"value\"}");
+    }
+
+    [Fact]
+    public async Task StreamAsync_WithAssistantPrefill_YieldsPrefillAsFirstChunk()
+    {
+        var sseBody = string.Join("\n",
+            "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"\\\"key\\\":\\\"value\\\"}\"}}",
+            "data: {\"type\":\"message_stop\"}",
+            "");
+
+        var client = BuildClient(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(sseBody, Encoding.UTF8, "text/event-stream"),
+        });
+
+        var chunks = new List<string>();
+        await foreach (var chunk in client.StreamAsync(
+            new ClaudeRequest("sys", "hi", ClaudeModel.Haiku, AssistantPrefill: "{")))
+            chunks.Add(chunk);
+
+        chunks[0].Should().Be("{");
+        string.Concat(chunks).Should().Be("{\"key\":\"value\"}");
+    }
+
     // Minimal IHttpClientFactory implementation that returns a pre-built client.
     private sealed class FakeHttpClientFactory(HttpClient client) : IHttpClientFactory
     {

--- a/backend/LangTeach.Api/AI/ClaudeApiClient.cs
+++ b/backend/LangTeach.Api/AI/ClaudeApiClient.cs
@@ -58,6 +58,9 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
             "Claude complete: model={Model} input={Input} output={Output} maxTokens={MaxTokens} usage={UsagePct:F1}% stopReason={StopReason} latency={Latency}ms",
             usedModel, inputTokens, outputTokens, request.MaxTokens, usagePct, stopReason ?? "end_turn", sw.ElapsedMilliseconds);
 
+        if (request.AssistantPrefill is not null)
+            text = request.AssistantPrefill + text;
+
         EmitCallLog(request, usedModel, inputTokens, outputTokens, stopReason ?? "end_turn", sw.ElapsedMilliseconds, text);
 
         if (usagePct >= 80.0)
@@ -69,9 +72,6 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
             throw new ClaudeApiException(
                 System.Net.HttpStatusCode.OK,
                 $"Response truncated: max_tokens ({request.MaxTokens}) reached before completion.");
-
-        if (request.AssistantPrefill is not null)
-            text = request.AssistantPrefill + text;
 
         return new ClaudeResponse(text, usedModel, inputTokens, outputTokens);
     }
@@ -258,6 +258,8 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
 
         // When AssistantPrefill is set, append an assistant turn so the model continues from
         // that text instead of generating a preamble. See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/prefill-claudes-response
+        if (request.AssistantPrefill is not null && string.IsNullOrEmpty(request.AssistantPrefill))
+            throw new ArgumentException("AssistantPrefill must be non-empty when set.", nameof(request));
         object messages = request.AssistantPrefill is not null
             ? new object[] { userMessage, new { role = "assistant", content = (object)request.AssistantPrefill } }
             : new object[] { userMessage };

--- a/backend/LangTeach.Api/AI/ClaudeApiClient.cs
+++ b/backend/LangTeach.Api/AI/ClaudeApiClient.cs
@@ -70,6 +70,9 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
                 System.Net.HttpStatusCode.OK,
                 $"Response truncated: max_tokens ({request.MaxTokens}) reached before completion.");
 
+        if (request.AssistantPrefill is not null)
+            text = request.AssistantPrefill + text;
+
         return new ClaudeResponse(text, usedModel, inputTokens, outputTokens);
     }
 
@@ -98,6 +101,14 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
         var streamStopReason = "end_turn";
         var accumulated     = new StringBuilder();
         var logEmitted      = false;
+
+        // Yield prefill as first chunk so downstream sees a complete JSON stream from the start.
+        // (prefill is not counted in output_tokens by the API)
+        if (request.AssistantPrefill is not null)
+        {
+            accumulated.Append(request.AssistantPrefill);
+            yield return request.AssistantPrefill;
+        }
 
         try
         {
@@ -214,6 +225,23 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
             latencyMs, request.SystemPrompt, request.UserPrompt, rawResponse);
     }
 
+    private static object BuildUserMessageWithAttachments(ClaudeRequest request)
+    {
+        var contentParts = new List<object>();
+        foreach (var att in request.Attachments!)
+        {
+            var isPdf = string.Equals(att.MediaType, "application/pdf", StringComparison.OrdinalIgnoreCase);
+            var blockType = isPdf ? "document" : "image";
+            contentParts.Add(new
+            {
+                type = blockType,
+                source = new { type = "base64", media_type = att.MediaType, data = Convert.ToBase64String(att.Data) }
+            });
+        }
+        contentParts.Add(new { type = "text", text = request.UserPrompt });
+        return new { role = "user", content = (object)contentParts };
+    }
+
     // PromptHash is SHA256(SystemPrompt+UserPrompt) for dedup and lookup in KQL.
     private static string ComputePromptHash(string systemPrompt, string userPrompt)
     {
@@ -224,27 +252,15 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
 
     private static object BuildRequestBody(ClaudeRequest request, string modelId, bool stream)
     {
-        object messages;
-        if (request.Attachments is { Count: > 0 })
-        {
-            var contentParts = new List<object>();
-            foreach (var att in request.Attachments)
-            {
-                var isPdf = string.Equals(att.MediaType, "application/pdf", StringComparison.OrdinalIgnoreCase);
-                var blockType = isPdf ? "document" : "image";
-                contentParts.Add(new
-                {
-                    type = blockType,
-                    source = new { type = "base64", media_type = att.MediaType, data = Convert.ToBase64String(att.Data) }
-                });
-            }
-            contentParts.Add(new { type = "text", text = request.UserPrompt });
-            messages = new[] { new { role = "user", content = (object)contentParts } };
-        }
-        else
-        {
-            messages = new[] { new { role = "user", content = (object)request.UserPrompt } };
-        }
+        var userMessage = request.Attachments is { Count: > 0 }
+            ? BuildUserMessageWithAttachments(request)
+            : new { role = "user", content = (object)request.UserPrompt };
+
+        // When AssistantPrefill is set, append an assistant turn so the model continues from
+        // that text instead of generating a preamble. See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/prefill-claudes-response
+        object messages = request.AssistantPrefill is not null
+            ? new object[] { userMessage, new { role = "assistant", content = (object)request.AssistantPrefill } }
+            : new object[] { userMessage };
 
         var body = new Dictionary<string, object?>
         {

--- a/backend/LangTeach.Api/AI/IClaudeClient.cs
+++ b/backend/LangTeach.Api/AI/IClaudeClient.cs
@@ -19,7 +19,8 @@ public record ClaudeRequest(
     IReadOnlyList<ContentAttachment>? Attachments = null,
     double? Temperature = null,
     string CallSite = "unknown",
-    Guid? CorrelationId = null
+    Guid? CorrelationId = null,
+    string? AssistantPrefill = null
 );
 
 public record ClaudeResponse(

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -98,7 +98,7 @@ public class RedaccionCorrectionPromptBuilder
     private const string OutputContract = """
 OUTPUT CONTRACT:
 
-Emit raw JSON only. Start directly with {. No prose before or after. No markdown fences. The JSON must match exactly:
+Emit raw JSON only. No markdown fences. No prose after the closing brace. The JSON must match exactly:
 
 {
   "schemaVersion": 1,

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -39,7 +39,10 @@ public class RedaccionCorrectionPromptBuilder
         // MaxTokens 32768: A1 students produce 30+ errors/150 words (~50-100 tokens/tag);
         // Hardening II prompt additions (#1222/#1226/#1227) increased output verbosity further.
         // 16384 was no longer sufficient for real A1 content (#1293).
-        return new ClaudeRequest(system, user, ClaudeModel.Sonnet, MaxTokens: 32768, Temperature: 0);
+        // AssistantPrefill "{": forces JSON-first output on error-dense inputs where Sonnet 4.6
+        // otherwise emits chain-of-thought prose before any JSON, burning the token budget (#1316).
+        return new ClaudeRequest(system, user, ClaudeModel.Sonnet, MaxTokens: 32768, Temperature: 0,
+            AssistantPrefill: "{");
     }
 
     private static string BuildSystemPrompt(CorrectionCategoriesFile config)


### PR DESCRIPTION
## Summary

- Adds `string? AssistantPrefill` to `ClaudeRequest`; when set, `ClaudeApiClient` appends an `assistant`-role message before the wire call so the model physically cannot emit a prose preamble
- Sets `AssistantPrefill: "{"` on `correction.pass1` only (`RedaccionCorrectionPromptBuilder`)
- Both `CompleteAsync` and `StreamAsync` prepend the prefill to returned content so downstream JSON parsing sees a complete object
- Removes now-redundant "Start directly with {" clause from the correction OUTPUT CONTRACT (structurally enforced by prefill)
- Adds `IsNullOrEmpty` guard so an empty-string prefill fails at the call site, not at the Anthropic API boundary

## Root cause

Sonnet 4.6 emits chain-of-thought reasoning prose before any JSON on error-dense redacciones (e.g. Gergana B1, 1154 chars, CorrectionId `417ea48d`). With `temperature=0` it locks into the same trajectory on every retry. The 32k budget is consumed by prose; JSON never finishes (`stopReason=max_tokens`, latency 339s).

## Verify

Live production verify pending manual trigger after deployment:
1. Trigger correction `417ea48d-5b25-4a4e-8125-b025622780cf` (manual production reset already applied)
2. Confirm `stopReason=end_turn`, tags land in DB, latency well under 60s
3. Azure logs: `rawResponse` starts with `{"schemaVersion":` not prose

## Review summary

| Reviewer | Finding | Action |
|---|---|---|
| qa-verify | PASS -- all 7 criteria met; live production verify deferred to post-deployment | Documented |
| architecture-reviewer | PASS WITH NOTES -- `EmitCallLog` in `CompleteAsync` fired before prefill prepend, making logged rawResponse incomplete | Fixed (moved prepend before EmitCallLog) |
| sophy | APPROVE -- minor: add IsNullOrEmpty guard for empty-string prefill | Fixed |
| prompt-health-reviewer | CLEAN -- "Start directly with {" is now dead-weight (structurally enforced by prefill); minor | Fixed (trimmed redundant clause) |

Closes #1316

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented assistant prefill support in API responses for both streaming and non-streaming completion modes
  * Added request correlation ID tracking for improved request traceability
  * Enhanced JSON output formatting to ensure consistent, well-formed results

* **Tests**
  * Added unit tests validating assistant prefill behavior across streaming and non-streaming scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->