### PR TITLE
revert(corrections): drop assistant prefill (Sonnet 4.6 rejects it with HTTP 400)

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/ClaudeApiClientUnitTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/ClaudeApiClientUnitTests.cs
@@ -228,50 +228,6 @@ public class ClaudeApiClientUnitTests
         capturingLogger.Entries.Should().NotContain(e => e.Level == LogLevel.Warning);
     }
 
-    [Fact]
-    public async Task CompleteAsync_WithAssistantPrefill_PrependsPrefillToContent()
-    {
-        var json = """
-            {
-              "model": "claude-haiku-4-5-20251001",
-              "content": [{ "type": "text", "text": "\"key\":\"value\"}" }],
-              "usage": { "input_tokens": 10, "output_tokens": 5 }
-            }
-            """;
-
-        var client = BuildClient(new HttpResponseMessage(HttpStatusCode.OK)
-        {
-            Content = new StringContent(json, Encoding.UTF8, "application/json"),
-        });
-
-        var result = await client.CompleteAsync(
-            new ClaudeRequest("sys", "hi", ClaudeModel.Haiku, AssistantPrefill: "{"));
-
-        result.Content.Should().Be("{\"key\":\"value\"}");
-    }
-
-    [Fact]
-    public async Task StreamAsync_WithAssistantPrefill_YieldsPrefillAsFirstChunk()
-    {
-        var sseBody = string.Join("\n",
-            "data: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"\\\"key\\\":\\\"value\\\"}\"}}",
-            "data: {\"type\":\"message_stop\"}",
-            "");
-
-        var client = BuildClient(new HttpResponseMessage(HttpStatusCode.OK)
-        {
-            Content = new StringContent(sseBody, Encoding.UTF8, "text/event-stream"),
-        });
-
-        var chunks = new List<string>();
-        await foreach (var chunk in client.StreamAsync(
-            new ClaudeRequest("sys", "hi", ClaudeModel.Haiku, AssistantPrefill: "{")))
-            chunks.Add(chunk);
-
-        chunks[0].Should().Be("{");
-        string.Concat(chunks).Should().Be("{\"key\":\"value\"}");
-    }
-
     // Minimal IHttpClientFactory implementation that returns a pre-built client.
     private sealed class FakeHttpClientFactory(HttpClient client) : IHttpClientFactory
     {

--- a/backend/LangTeach.Api/AI/ClaudeApiClient.cs
+++ b/backend/LangTeach.Api/AI/ClaudeApiClient.cs
@@ -58,9 +58,6 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
             "Claude complete: model={Model} input={Input} output={Output} maxTokens={MaxTokens} usage={UsagePct:F1}% stopReason={StopReason} latency={Latency}ms",
             usedModel, inputTokens, outputTokens, request.MaxTokens, usagePct, stopReason ?? "end_turn", sw.ElapsedMilliseconds);
 
-        if (request.AssistantPrefill is not null)
-            text = request.AssistantPrefill + text;
-
         EmitCallLog(request, usedModel, inputTokens, outputTokens, stopReason ?? "end_turn", sw.ElapsedMilliseconds, text);
 
         if (usagePct >= 80.0)
@@ -101,14 +98,6 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
         var streamStopReason = "end_turn";
         var accumulated     = new StringBuilder();
         var logEmitted      = false;
-
-        // Yield prefill as first chunk so downstream sees a complete JSON stream from the start.
-        // (prefill is not counted in output_tokens by the API)
-        if (request.AssistantPrefill is not null)
-        {
-            accumulated.Append(request.AssistantPrefill);
-            yield return request.AssistantPrefill;
-        }
 
         try
         {
@@ -225,23 +214,6 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
             latencyMs, request.SystemPrompt, request.UserPrompt, rawResponse);
     }
 
-    private static object BuildUserMessageWithAttachments(ClaudeRequest request)
-    {
-        var contentParts = new List<object>();
-        foreach (var att in request.Attachments!)
-        {
-            var isPdf = string.Equals(att.MediaType, "application/pdf", StringComparison.OrdinalIgnoreCase);
-            var blockType = isPdf ? "document" : "image";
-            contentParts.Add(new
-            {
-                type = blockType,
-                source = new { type = "base64", media_type = att.MediaType, data = Convert.ToBase64String(att.Data) }
-            });
-        }
-        contentParts.Add(new { type = "text", text = request.UserPrompt });
-        return new { role = "user", content = (object)contentParts };
-    }
-
     // PromptHash is SHA256(SystemPrompt+UserPrompt) for dedup and lookup in KQL.
     private static string ComputePromptHash(string systemPrompt, string userPrompt)
     {
@@ -252,17 +224,27 @@ public class ClaudeApiClient(IHttpClientFactory httpClientFactory, ILogger<Claud
 
     private static object BuildRequestBody(ClaudeRequest request, string modelId, bool stream)
     {
-        var userMessage = request.Attachments is { Count: > 0 }
-            ? BuildUserMessageWithAttachments(request)
-            : new { role = "user", content = (object)request.UserPrompt };
-
-        // When AssistantPrefill is set, append an assistant turn so the model continues from
-        // that text instead of generating a preamble. See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/prefill-claudes-response
-        if (request.AssistantPrefill is not null && string.IsNullOrEmpty(request.AssistantPrefill))
-            throw new ArgumentException("AssistantPrefill must be non-empty when set.", nameof(request));
-        object messages = request.AssistantPrefill is not null
-            ? new object[] { userMessage, new { role = "assistant", content = (object)request.AssistantPrefill } }
-            : new object[] { userMessage };
+        object messages;
+        if (request.Attachments is { Count: > 0 })
+        {
+            var contentParts = new List<object>();
+            foreach (var att in request.Attachments)
+            {
+                var isPdf = string.Equals(att.MediaType, "application/pdf", StringComparison.OrdinalIgnoreCase);
+                var blockType = isPdf ? "document" : "image";
+                contentParts.Add(new
+                {
+                    type = blockType,
+                    source = new { type = "base64", media_type = att.MediaType, data = Convert.ToBase64String(att.Data) }
+                });
+            }
+            contentParts.Add(new { type = "text", text = request.UserPrompt });
+            messages = new[] { new { role = "user", content = (object)contentParts } };
+        }
+        else
+        {
+            messages = new[] { new { role = "user", content = (object)request.UserPrompt } };
+        }
 
         var body = new Dictionary<string, object?>
         {

--- a/backend/LangTeach.Api/AI/IClaudeClient.cs
+++ b/backend/LangTeach.Api/AI/IClaudeClient.cs
@@ -19,8 +19,7 @@ public record ClaudeRequest(
     IReadOnlyList<ContentAttachment>? Attachments = null,
     double? Temperature = null,
     string CallSite = "unknown",
-    Guid? CorrelationId = null,
-    string? AssistantPrefill = null
+    Guid? CorrelationId = null
 );
 
 public record ClaudeResponse(

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -39,10 +39,7 @@ public class RedaccionCorrectionPromptBuilder
         // MaxTokens 32768: A1 students produce 30+ errors/150 words (~50-100 tokens/tag);
         // Hardening II prompt additions (#1222/#1226/#1227) increased output verbosity further.
         // 16384 was no longer sufficient for real A1 content (#1293).
-        // AssistantPrefill "{": forces JSON-first output on error-dense inputs where Sonnet 4.6
-        // otherwise emits chain-of-thought prose before any JSON, burning the token budget (#1316).
-        return new ClaudeRequest(system, user, ClaudeModel.Sonnet, MaxTokens: 32768, Temperature: 0,
-            AssistantPrefill: "{");
+        return new ClaudeRequest(system, user, ClaudeModel.Sonnet, MaxTokens: 32768, Temperature: 0);
     }
 
     private static string BuildSystemPrompt(CorrectionCategoriesFile config)
@@ -98,7 +95,7 @@ public class RedaccionCorrectionPromptBuilder
     private const string OutputContract = """
 OUTPUT CONTRACT:
 
-Emit raw JSON only. No markdown fences. No prose after the closing brace. The JSON must match exactly:
+Emit raw JSON only. Start directly with {. No prose before or after. No markdown fences. The JSON must match exactly:
 
 {
   "schemaVersion": 1,


### PR DESCRIPTION
## Summary

Reverts PR #1320 (`feat(corrections): prefill assistant turn with { ...`).

Sonnet 4.6 rejects assistant message prefill with:

> `Claude API error 400: "This model does not support assistant message prefill. The conversation must end with a user message."`

Every correction call after deploy at 09:16 UTC failed in ~200ms with `CorreccionFallida`. Production is broken now; this restores the known baseline.

## Why prefill is not viable on this model

Sonnet 4.6 is in the extended-thinking family. Anthropic's API explicitly forbids assistant prefill on these models. This is content-independent: any call with a prefill 400s before Claude reads the prompt.

PR #1320's `qa-verify` row marked the PR PASS with the note *"all 7 criteria met; live production verify deferred to post-deployment"*. The live verify against the real Anthropic API would have caught this 400 in 200ms. Process gap is tracked in #1321 (qa-verify must hard-fail PRs with deferred live verifies).

## Live verify

Ran `RedaccionCorrectionVerbatimTests.Verbatim_OnB1_FixtureSucceeds` against the real Anthropic API after the revert (`AI_INTEGRATION_TESTS=1`, real `Claude:ApiKey`):

- No HTTP 400. The call to Anthropic was accepted and Claude began generating.
- Test harness timed out at its own 120s polling deadline; production has no such deadline (the correction runs on a background scope and the frontend polls indefinitely).
- A 120s timeout in the test only means "Sonnet 4.6 without prefill is slow on moderate-difficulty B1 inputs" — same as the known behaviour before PR #1320. Not a regression.

## What this fix does NOT solve

The original #1316 root cause (Sonnet 4.6 emits chain-of-thought prose, sometimes burning the entire 32k output budget on error-dense inputs like Gergana B1) is back. That class of correction will continue to fail until the structural fix lands.

Structural fix tracked in **#1319** (migrate the correction pipeline to Anthropic tool calling). Tool calls cannot contain prose preamble and are supported on Sonnet 4.6 including thinking variants. That is the next thing to ship.

## Files

- `RedaccionCorrectionPromptBuilder.cs`: `AssistantPrefill: "{"` removed; OUTPUT CONTRACT line "Start directly with `{`" restored.
- `IClaudeClient.cs`: `AssistantPrefill` field removed from `ClaudeRequest`.
- `ClaudeApiClient.cs`: assistant-turn append path and prefill-prepend logic removed from both `CompleteAsync` and `StreamAsync`.
- `ClaudeApiClientUnitTests.cs`: prefill-related unit tests removed.

## Test plan

- [x] `dotnet build` clean
- [x] All 1493 unit tests pass
- [x] Live verify against real Anthropic API: no HTTP 400, correction call accepted (test timed out on 120s test-harness deadline, not on the Claude call)
- [ ] After deploy: trigger a normal-difficulty correction in production; confirm it reaches `Corregida` and tags land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)