### PR TITLE
chore(nav): hide Lessons from primary sidebar (#1333)

### DIFF
--- a/e2e/tests/sidebar-no-lessons.spec.ts
+++ b/e2e/tests/sidebar-no-lessons.spec.ts
@@ -28,8 +28,8 @@ test('sidebar hides Lessons but /lessons route still renders', async ({ browser 
 
     await page.goto('/lessons')
     await expect(page).toHaveURL(/\/lessons$/, { timeout: NAV_TIMEOUT })
-    await expect(page.locator('body')).toBeVisible({ timeout: UI_TIMEOUT })
-    expect(page.url()).toContain('/lessons')
+    await expect(page.getByRole('heading', { level: 1, name: 'Lessons' })).toBeVisible({ timeout: UI_TIMEOUT })
+    await expect(page.getByTestId('new-lesson-btn')).toBeVisible({ timeout: UI_TIMEOUT })
   } finally {
     await context.close()
   }

--- a/e2e/tests/sidebar-no-lessons.spec.ts
+++ b/e2e/tests/sidebar-no-lessons.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test'
+import { createMockAuthContext } from '../helpers/auth-helper'
+import { setupMockTeacher } from '../helpers/mock-teacher-helper'
+import { NAV_TIMEOUT, UI_TIMEOUT } from '../helpers/timeouts'
+
+test.beforeAll(async ({ browser }) => {
+  const ctx = await createMockAuthContext(browser)
+  const page = await ctx.newPage()
+  await setupMockTeacher(page)
+  await page.close()
+  await ctx.close()
+})
+
+test('sidebar hides Lessons but /lessons route still renders', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    await page.goto('/')
+    await expect(page.locator('h1')).toHaveText('Dashboard', { timeout: NAV_TIMEOUT })
+
+    const sidebar = page.locator('aside').first()
+    const navLinks = sidebar.locator('a')
+    const labels = (await navLinks.allTextContents()).map(s => s.trim())
+
+    expect(labels).not.toContain('Lessons')
+    expect(labels).toEqual(['Dashboard', 'Students', 'Sessions', 'Courses', 'Settings'])
+
+    await page.goto('/lessons')
+    await expect(page).toHaveURL(/\/lessons$/, { timeout: NAV_TIMEOUT })
+    await expect(page.locator('body')).toBeVisible({ timeout: UI_TIMEOUT })
+    expect(page.url()).toContain('/lessons')
+  } finally {
+    await context.close()
+  }
+})

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -102,11 +102,11 @@ describe('AppShell', () => {
     expect(allDashboardLinks.length).toBeGreaterThanOrEqual(2)
   })
 
-  it('renders nav items in correct order: Dashboard, Students, Sessions, Courses, Lessons, then Settings separated at bottom', () => {
+  it('renders nav items in correct order: Dashboard, Students, Sessions, Courses, then Settings separated at bottom', () => {
     renderShell()
     const links = document.querySelector('aside')?.querySelectorAll('a')
     const labels = Array.from(links ?? []).map(a => a.textContent?.trim())
-    expect(labels).toEqual(['Dashboard', 'Students', 'Sessions', 'Courses', 'Lessons', 'Settings'])
+    expect(labels).toEqual(['Dashboard', 'Students', 'Sessions', 'Courses', 'Settings'])
   })
 
   it('Settings link is outside the main nav element', () => {
@@ -164,7 +164,7 @@ describe('AppShell', () => {
 
   it('sidebar renders the same nav items regardless of route', () => {
     const routes = ['/', '/sessions', '/settings']
-    const expectedLabels = ['Dashboard', 'Students', 'Sessions', 'Courses', 'Lessons', 'Settings']
+    const expectedLabels = ['Dashboard', 'Students', 'Sessions', 'Courses', 'Settings']
 
     for (const route of routes) {
       const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, type ElementType } from 'react'
 import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth0 } from '@auth0/auth0-react'
 import { useQuery } from '@tanstack/react-query'
-import { LayoutDashboard, Users, CalendarDays, BookOpen, GraduationCap, Settings, LogOut, Menu, Sparkles, X } from 'lucide-react'
+import { LayoutDashboard, Users, CalendarDays, GraduationCap, Settings, LogOut, Menu, Sparkles, X } from 'lucide-react'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { cn } from '@/lib/utils'
 import AtelierLogo from '@/components/AtelierLogo'
@@ -19,7 +19,6 @@ const mainNavItems = [
   { to: '/students', label: 'Students', icon: Users },
   { to: '/sessions', label: 'Sessions', icon: CalendarDays },
   { to: '/courses', label: 'Courses', icon: GraduationCap },
-  { to: '/lessons', label: 'Lessons', icon: BookOpen },
 ]
 
 const SESSION_EDIT_RE = /^\/students\/[^/]+\/sessions\/[^/]+\/edit$/

--- a/plan/ui-review-skipped.md
+++ b/plan/ui-review-skipped.md
@@ -10,3 +10,4 @@ The sprint-close procedure (Stage 1) audits this log and clears it after each sp
 |-------|------|----|-------------------------------------------|
 | #1257 | 2026-05-13 | pending | Added `.docx` to OCR_ACCEPTED constant in RedaccionesTab.tsx (1 line, single file, attribute value only, no components/state/layout change) |
 | #1290 | 2026-05-16 | pending | Import swap only (axios.isAxiosError -> re-exported isAxiosError from apiClient.ts); zero JSX/styling changes, OCR error banner unchanged |
+| #1333 | 2026-05-23 | pending | Removed one nav item + unused icon import from AppShell.tsx (2 lines net deletion), updated 2 test assertions. No styling, no new elements, no logic, no state changes. Verified live on e2e stack: sidebar shows Dashboard/Students/Sessions/Courses/Settings, /lessons route still renders. |


### PR DESCRIPTION
## Summary

- Removes the Lessons entry from the primary sidebar in `AppShell.tsx` (and drops the now-unused `BookOpen` import). Routes, `LessonEditor`, lesson generation API, prompts, and DB tables all stay intact.
- Pilot user Jordi has 0 lessons across 6 months of production usage. The vision was reframed (83178d98) to deprioritize lesson generation; the sidebar entry was dead weight.
- Direct URL navigation to `/lessons` and `/lessons/:id` continues to work.

## Why

Closes #1333. Issue body pre-classified this as eligible for the trivial-frontend exemption; logged in `plan/ui-review-skipped.md`.

## Changes

- `frontend/src/components/AppShell.tsx`: remove `{ to: '/lessons', label: 'Lessons', icon: BookOpen }` from `mainNavItems`; drop `BookOpen` import.
- `frontend/src/components/AppShell.test.tsx`: update two nav-order assertions and one test title.
- `e2e/tests/sidebar-no-lessons.spec.ts`: new spec locking in the "silent hide" contract (sidebar excludes Lessons, `/lessons` still renders).
- `plan/ui-review-skipped.md`: logged trivial-frontend exemption.

## Test plan

- [x] Unit tests pass (`AppShell.test.tsx`, 47/47)
- [x] Full frontend suite passes (1775/1775)
- [x] `dotnet build` / `dotnet test` / `bicep build` / `npm lint` / `npm build` all PASS
- [x] Live e2e verification on the visual stack: sidebar shows `Dashboard / Students / Sessions / Courses / Settings`; `/lessons` still renders
- [x] qa-verify: PASS
- [x] architecture-reviewer: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed the Lessons navigation item from the main sidebar.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->