### PR TITLE
feat(infra): automated CI audit for appsettings.json key wiring (#1284)

### DIFF
--- a/.github/workflows/config-audit.yml
+++ b/.github/workflows/config-audit.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install dependencies
-        run: pip install pyyaml
+        run: pip install pyyaml==6.0.2
 
       - name: Run config wiring audit
         run: python3 scripts/audit-config-wiring.py

--- a/.github/workflows/config-audit.yml
+++ b/.github/workflows/config-audit.yml
@@ -1,0 +1,37 @@
+name: Config wiring audit
+
+on:
+  pull_request:
+  push:
+    branches: [main, 'sprint/*']
+    paths:
+      - 'backend/LangTeach.Api/appsettings*.json'
+      - 'infra/required-secrets.json'
+      - 'infra/optional-secrets.json'
+      - 'infra/key-policy.json'
+      - 'docker-compose.qa.yml'
+      - 'docker-compose.e2e.yml'
+      - '.env.qa.example'
+      - '.env.e2e.example'
+      - 'scripts/audit-config-wiring.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Audit config key wiring
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Run config wiring audit
+        run: python3 scripts/audit-config-wiring.py

--- a/.github/workflows/config-audit.yml
+++ b/.github/workflows/config-audit.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a20  # v5.3.0
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/config-audit.yml
+++ b/.github/workflows/config-audit.yml
@@ -24,14 +24,16 @@ jobs:
     name: Audit config key wiring
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
-          python-version: '3.x'
+          persist-credentials: false
+
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a20  # v5.3.0
+        with:
+          python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install pyyaml==6.0.2
+        run: pip install pyyaml==6.0.3
 
       - name: Run config wiring audit
         run: python3 scripts/audit-config-wiring.py

--- a/infra/key-policy.json
+++ b/infra/key-policy.json
@@ -1,0 +1,19 @@
+{
+  "_readme": "Explicit key classification overrides for audit-config-wiring.py. Values: SECRET | CONFIG | INTERNAL. Add entries here when the heuristic misclassifies a key rather than modifying the script.",
+  "keys": {
+    "Logging:LogLevel:Default": "INTERNAL",
+    "Logging:LogLevel:Microsoft.AspNetCore": "INTERNAL",
+    "AllowedHosts": "INTERNAL",
+    "AzureSpeech:Language": "CONFIG",
+    "AzureSpeech:Region": "SECRET",
+    "AzureOpenAIWhisper:Language": "CONFIG",
+    "Transcription:Provider": "CONFIG",
+    "Ocr:MaxBytes": "CONFIG",
+    "Ocr:MinExtractedChars": "CONFIG",
+    "Ocr:AcceptedContentTypes": "CONFIG",
+    "Ocr:PdfClaudeMaxFileBytes": "CONFIG",
+    "GenerationLimits:FreeTierMonthlyLimit": "CONFIG",
+    "GenerationLimits:ProTierMonthlyLimit": "CONFIG",
+    "Claude:BaseUrl": "CONFIG"
+  }
+}

--- a/infra/optional-secrets.json
+++ b/infra/optional-secrets.json
@@ -1,5 +1,23 @@
 {
-  "_readme": "SECRET keys that are legitimately absent from required-secrets.json because they are provider-gated or genuinely optional. The CI audit will not flag these as missing from required-secrets.json. They must still appear in the docker-compose env blocks and env example files.",
+  "_readme": "Two lists: optionalSecrets (keys absent from required-secrets.json because provider-gated) and envOnlySecrets (keys NOT declared in appsettings.json, set purely via env var). The CI audit uses envOnlySecrets to suppress false positives in the reverse-direction check.",
+  "envOnlySecrets": [
+    {
+      "key": "ConnectionStrings:Default",
+      "reason": "Set via docker-compose environment variable only; not declared in appsettings.json. ASP.NET Core binds it directly from the env var ConnectionStrings__Default."
+    },
+    {
+      "key": "Auth0:Domain",
+      "reason": "Set via docker-compose environment variable only; not declared in appsettings.json."
+    },
+    {
+      "key": "Auth0:Audience",
+      "reason": "Set via docker-compose environment variable only; not declared in appsettings.json."
+    },
+    {
+      "key": "AzureBlobStorage:ConnectionString",
+      "reason": "Set via docker-compose environment variable only; not declared in appsettings.json."
+    }
+  ],
   "optionalSecrets": [
     {
       "key": "AzureSpeech:ApiKey",

--- a/infra/optional-secrets.json
+++ b/infra/optional-secrets.json
@@ -1,0 +1,25 @@
+{
+  "_readme": "SECRET keys that are legitimately absent from required-secrets.json because they are provider-gated or genuinely optional. The CI audit will not flag these as missing from required-secrets.json. They must still appear in the docker-compose env blocks and env example files.",
+  "optionalSecrets": [
+    {
+      "key": "AzureSpeech:ApiKey",
+      "reason": "Provider-gated: only required when Transcription:Provider=AzureSpeech. Mutually exclusive with AzureOpenAIWhisper:* set. Both sets appear in required-secrets.json so operators know which to provision."
+    },
+    {
+      "key": "AzureSpeech:Region",
+      "reason": "Provider-gated: only required when Transcription:Provider=AzureSpeech."
+    },
+    {
+      "key": "AzureOpenAIWhisper:ApiKey",
+      "reason": "Provider-gated: only required when Transcription:Provider=AzureOpenAIWhisper (default). Mutually exclusive with AzureSpeech:* set."
+    },
+    {
+      "key": "AzureOpenAIWhisper:Endpoint",
+      "reason": "Provider-gated: only required when Transcription:Provider=AzureOpenAIWhisper."
+    },
+    {
+      "key": "AzureOpenAIWhisper:DeploymentName",
+      "reason": "Provider-gated: only required when Transcription:Provider=AzureOpenAIWhisper."
+    }
+  ]
+}

--- a/scripts/audit-config-wiring.py
+++ b/scripts/audit-config-wiring.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+Audit that every SECRET key in appsettings.json is wired in:
+  - infra/required-secrets.json (or infra/optional-secrets.json)
+  - docker-compose.qa.yml and docker-compose.e2e.yml api service environment block
+  - .env.qa.example and .env.e2e.example
+
+Also checks the reverse: every entry in required-secrets.json must exist somewhere
+in appsettings*.json or a docker-compose api environment block (catches stale entries).
+
+Classification order:
+  1. Explicit entry in infra/key-policy.json
+  2. Heuristic: empty string default + secret suffix pattern -> SECRET
+  3. Heuristic: non-empty default -> CONFIG
+  4. Default: CONFIG
+
+Run from repo root. Exit 0 = clean. Exit 1 = wiring gaps found.
+"""
+
+import json
+import re
+import sys
+import glob
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+
+APPSETTINGS = REPO_ROOT / "backend/LangTeach.Api/appsettings.json"
+REQUIRED_SECRETS = REPO_ROOT / "infra/required-secrets.json"
+OPTIONAL_SECRETS = REPO_ROOT / "infra/optional-secrets.json"
+KEY_POLICY = REPO_ROOT / "infra/key-policy.json"
+COMPOSE_QA = REPO_ROOT / "docker-compose.qa.yml"
+COMPOSE_E2E = REPO_ROOT / "docker-compose.e2e.yml"
+ENV_QA_EXAMPLE = REPO_ROOT / ".env.qa.example"
+ENV_E2E_EXAMPLE = REPO_ROOT / ".env.e2e.example"
+
+SECRET_SUFFIXES = {
+    "apikey", "key", "token", "connectionstring", "password",
+    "secret", "endpoint", "deploymentname",
+}
+
+
+def flatten_json(obj, prefix=""):
+    """Flatten nested dict to colon-separated keys. Arrays are kept as single CONFIG entry."""
+    items = {}
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            full_key = f"{prefix}:{k}" if prefix else k
+            if isinstance(v, (dict, list)):
+                if isinstance(v, list):
+                    items[full_key] = v
+                else:
+                    items.update(flatten_json(v, full_key))
+            else:
+                items[full_key] = v
+    return items
+
+
+def classify(key, value, policy):
+    if key in policy:
+        return policy[key]
+
+    if isinstance(value, list):
+        return "CONFIG"
+
+    value_str = str(value) if value is not None else ""
+
+    if not value_str:
+        suffix = key.split(":")[-1].lower()
+        if any(suffix.endswith(s) for s in SECRET_SUFFIXES):
+            return "SECRET"
+
+    return "CONFIG"
+
+
+def load_compose_api_env(compose_path):
+    """Return the api service environment block as a dict {key: value_string}."""
+    with open(compose_path) as f:
+        doc = yaml.safe_load(f)
+    services = doc.get("services", {})
+    api = services.get("api", {})
+    env = api.get("environment", {})
+    if isinstance(env, list):
+        result = {}
+        for item in env:
+            k, _, v = item.partition("=")
+            result[k.strip()] = v.strip()
+        return result
+    return {str(k): str(v) for k, v in env.items()}
+
+
+def extract_env_var(value_str):
+    """Extract the env var name from a compose value like '${SOME_VAR}'. Returns None if not a simple ref."""
+    m = re.fullmatch(r'\$\{([A-Z0-9_]+)\}', value_str.strip())
+    return m.group(1) if m else None
+
+
+def load_env_example_vars(path):
+    """Return set of declared variable names from an env example file."""
+    vars_ = set()
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                name = line.split("=", 1)[0].strip()
+                if name:
+                    vars_.add(name)
+    return vars_
+
+
+def key_to_double_underscore(key):
+    return key.replace(":", "__")
+
+
+def key_to_double_dash(key):
+    return key.replace(":", "--")
+
+
+def double_dash_to_colon(key):
+    return key.replace("--", ":")
+
+
+def double_dash_to_double_underscore(key):
+    return key.replace("--", "__")
+
+
+def collect_appsettings_keys():
+    """Return set of all colon-notation keys across all appsettings*.json files."""
+    keys = set()
+    for path in glob.glob(str(REPO_ROOT / "backend/LangTeach.Api/appsettings*.json")):
+        with open(path) as f:
+            obj = json.load(f)
+        keys.update(flatten_json(obj).keys())
+    return keys
+
+
+def main():
+    with open(APPSETTINGS) as f:
+        appsettings = json.load(f)
+    flat = flatten_json(appsettings)
+
+    with open(KEY_POLICY) as f:
+        policy_raw = json.load(f)
+    policy = {k: v for k, v in policy_raw.get("keys", {}).items()}
+
+    with open(REQUIRED_SECRETS) as f:
+        req_secrets_data = json.load(f)
+    required_set = set(req_secrets_data.get("requiredSecrets", []))
+
+    optional_set = set()
+    if OPTIONAL_SECRETS.exists():
+        with open(OPTIONAL_SECRETS) as f:
+            opt_data = json.load(f)
+        optional_set = {e["key"] for e in opt_data.get("optionalSecrets", [])}
+
+    qa_env = load_compose_api_env(COMPOSE_QA)
+    e2e_env = load_compose_api_env(COMPOSE_E2E)
+
+    qa_example_vars = load_env_example_vars(ENV_QA_EXAMPLE)
+    e2e_example_vars = load_env_example_vars(ENV_E2E_EXAMPLE)
+
+    # Forward check: each SECRET key must be wired everywhere
+    forward_failures = []
+
+    for key, value in flat.items():
+        classification = classify(key, value, policy)
+        if classification != "SECRET":
+            continue
+
+        double_dash_key = key_to_double_dash(key)
+        double_under_key = key_to_double_underscore(key)
+
+        in_required = double_dash_key in required_set
+        in_optional = key in optional_set
+        secrets_ok = in_required or in_optional
+
+        qa_compose_ok = double_under_key in qa_env
+        e2e_compose_ok = double_under_key in e2e_env
+
+        # For env-example check: find the env var name from the compose entry
+        # If compose value is not a simple ${VAR} reference, skip the env-example check
+        # (e.g. ConnectionStrings__Default uses a hardcoded string with embedded vars)
+        qa_env_var = extract_env_var(qa_env.get(double_under_key, ""))
+        e2e_env_var = extract_env_var(e2e_env.get(double_under_key, ""))
+
+        if not qa_compose_ok or not e2e_compose_ok:
+            # Can't check env example when compose entry is missing
+            env_example_status = "N/A"
+            env_example_ok = True
+        elif qa_env_var and e2e_env_var:
+            qa_example_ok = qa_env_var in qa_example_vars
+            e2e_example_ok = e2e_env_var in e2e_example_vars
+            env_example_ok = qa_example_ok and e2e_example_ok
+            env_example_status = "OK" if env_example_ok else "MISSING"
+        elif qa_env_var:
+            env_example_ok = qa_env_var in qa_example_vars
+            env_example_status = "OK" if env_example_ok else "MISSING"
+        elif e2e_env_var:
+            env_example_ok = e2e_env_var in e2e_example_vars
+            env_example_status = "OK" if env_example_ok else "MISSING"
+        else:
+            # Compose values are hardcoded literals (not ${VAR} refs) - skip env-example check
+            env_example_ok = True
+            env_example_status = "N/A"
+
+        if not (secrets_ok and qa_compose_ok and e2e_compose_ok and env_example_ok):
+            forward_failures.append({
+                "key": key,
+                "required_secrets": "OK" if secrets_ok else "MISSING",
+                "qa_compose": "OK" if qa_compose_ok else "MISSING",
+                "e2e_compose": "OK" if e2e_compose_ok else "MISSING",
+                "env_example": env_example_status,
+            })
+
+    # Reverse check: every required-secrets entry must exist in appsettings or a compose block
+    all_appsettings_keys = collect_appsettings_keys()
+    all_compose_env_keys = set(qa_env.keys()) | set(e2e_env.keys())
+
+    reverse_failures = []
+    for secret in required_set:
+        colon_key = double_dash_to_colon(secret)
+        double_under = double_dash_to_double_underscore(secret)
+        in_appsettings = colon_key in all_appsettings_keys
+        in_compose = double_under in all_compose_env_keys
+        if not (in_appsettings or in_compose):
+            reverse_failures.append(secret)
+
+    # Report
+    failed = False
+
+    if forward_failures:
+        failed = True
+        print("appsettings.json declared SECRET keys not fully wired:\n")
+        header = f"| {'Key':<40} | {'required-secrets':<16} | {'qa compose':<10} | {'e2e compose':<11} | {'env example':<11} |"
+        sep = f"|{'-'*42}|{'-'*18}|{'-'*12}|{'-'*13}|{'-'*13}|"
+        print(header)
+        print(sep)
+        for f_ in forward_failures:
+            print(
+                f"| {f_['key']:<40} | {f_['required_secrets']:<16} | {f_['qa_compose']:<10} | {f_['e2e_compose']:<11} | {f_['env_example']:<11} |"
+            )
+        print()
+        print("Add the missing entries, or add a justified exception in infra/optional-secrets.json.")
+        print()
+
+    if reverse_failures:
+        failed = True
+        print("required-secrets.json entries not found in appsettings.json or docker-compose api environment blocks:")
+        print("(These may be stale entries left over after a config key was removed.)")
+        print()
+        for s in reverse_failures:
+            print(f"  - {s}")
+        print()
+        print("Remove the stale entries from infra/required-secrets.json, or re-add the key to appsettings.json.")
+        print()
+
+    if not failed:
+        print("Config wiring audit passed: all SECRET keys are fully wired.")
+
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit-config-wiring.py
+++ b/scripts/audit-config-wiring.py
@@ -65,7 +65,8 @@ def classify(key, value, policy):
     if isinstance(value, list):
         return "CONFIG"
 
-    value_str = str(value) if value is not None else ""
+    # Treat None and empty string as "no default" - potential secret
+    value_str = "" if (value is None or value == "") else str(value)
 
     if not value_str:
         suffix = key.split(":")[-1].lower()
@@ -92,8 +93,9 @@ def load_compose_api_env(compose_path):
 
 
 def extract_env_var(value_str):
-    """Extract the env var name from a compose value like '${SOME_VAR}'. Returns None if not a simple ref."""
-    m = re.fullmatch(r'\$\{([A-Z0-9_]+)\}', value_str.strip())
+    """Extract env var name from a compose value like '${SOME_VAR}' or '${SOME_VAR:-default}'.
+    Returns None if the value is not a ${...} reference (e.g. a hardcoded literal string)."""
+    m = re.fullmatch(r'\$\{([A-Za-z0-9_]+)(?::[+-]?[^}]*)?\}', value_str.strip())
     return m.group(1) if m else None
 
 
@@ -129,7 +131,10 @@ def double_dash_to_double_underscore(key):
 def collect_appsettings_keys():
     """Return set of all colon-notation keys across all appsettings*.json files."""
     keys = set()
-    for path in glob.glob(str(REPO_ROOT / "backend/LangTeach.Api/appsettings*.json")):
+    paths = glob.glob(str(REPO_ROOT / "backend/LangTeach.Api/appsettings*.json"))
+    if not paths:
+        raise FileNotFoundError(f"No appsettings*.json found under {REPO_ROOT}/backend/LangTeach.Api/")
+    for path in paths:
         with open(path) as f:
             obj = json.load(f)
         keys.update(flatten_json(obj).keys())
@@ -229,6 +234,17 @@ def main():
         if not (in_appsettings or in_env_only):
             reverse_failures.append(secret)
 
+    # Also check for stale entries in optional-secrets.json
+    stale_optional = []
+    for key in optional_set:
+        # optionalSecrets keys should still be declared in appsettings.json
+        if key not in all_appsettings_keys:
+            stale_optional.append(f"{key} (optionalSecrets entry no longer in appsettings.json)")
+    for key in env_only_set:
+        # envOnlySecrets keys should still be in required-secrets.json (using double-dash separator)
+        if key_to_double_dash(key) not in required_set:
+            stale_optional.append(f"{key} (envOnlySecrets entry not in required-secrets.json)")
+
     # Report
     failed = False
 
@@ -258,6 +274,15 @@ def main():
             print(f"  - {s}")
         print()
         print("Remove the stale entries from infra/required-secrets.json, or re-add the key to appsettings.json.")
+        print()
+
+    if stale_optional:
+        failed = True
+        print("infra/optional-secrets.json contains stale entries:")
+        for s in stale_optional:
+            print(f"  - {s}")
+        print()
+        print("Remove entries that no longer correspond to keys in appsettings.json or required-secrets.json.")
         print()
 
     if not failed:

--- a/scripts/audit-config-wiring.py
+++ b/scripts/audit-config-wiring.py
@@ -150,10 +150,12 @@ def main():
     required_set = set(req_secrets_data.get("requiredSecrets", []))
 
     optional_set = set()
+    env_only_set = set()
     if OPTIONAL_SECRETS.exists():
         with open(OPTIONAL_SECRETS) as f:
             opt_data = json.load(f)
         optional_set = {e["key"] for e in opt_data.get("optionalSecrets", [])}
+        env_only_set = {e["key"] for e in opt_data.get("envOnlySecrets", [])}
 
     qa_env = load_compose_api_env(COMPOSE_QA)
     e2e_env = load_compose_api_env(COMPOSE_E2E)
@@ -214,17 +216,17 @@ def main():
                 "env_example": env_example_status,
             })
 
-    # Reverse check: every required-secrets entry must exist in appsettings or a compose block
+    # Reverse check: every required-secrets entry must exist in appsettings.json.
+    # Keys in envOnlySecrets are exempt (set via env var without an appsettings declaration).
+    # This catches stale entries when a config key is removed from appsettings.
     all_appsettings_keys = collect_appsettings_keys()
-    all_compose_env_keys = set(qa_env.keys()) | set(e2e_env.keys())
 
     reverse_failures = []
     for secret in required_set:
         colon_key = double_dash_to_colon(secret)
-        double_under = double_dash_to_double_underscore(secret)
         in_appsettings = colon_key in all_appsettings_keys
-        in_compose = double_under in all_compose_env_keys
-        if not (in_appsettings or in_compose):
+        in_env_only = colon_key in env_only_set
+        if not (in_appsettings or in_env_only):
             reverse_failures.append(secret)
 
     # Report
@@ -247,8 +249,10 @@ def main():
 
     if reverse_failures:
         failed = True
-        print("required-secrets.json entries not found in appsettings.json or docker-compose api environment blocks:")
-        print("(These may be stale entries left over after a config key was removed.)")
+        print("required-secrets.json entries not found in appsettings.json:")
+        print("(These may be stale entries left over after a config key was removed."
+              " If the key is set purely via env var with no appsettings declaration,"
+              " add it to the envOnlySecrets list in infra/optional-secrets.json.)")
         print()
         for s in reverse_failures:
             print(f"  - {s}")


### PR DESCRIPTION
## Summary

- Adds `scripts/audit-config-wiring.py`: a Python CI script that fails with a clear table when a SECRET key in `appsettings.json` is missing from `infra/required-secrets.json`, either docker-compose api environment block, or either env example file.
- Adds reverse-direction check: entries in `required-secrets.json` that no longer appear in `appsettings*.json` are flagged as stale.
- Adds `infra/key-policy.json`: data-driven classification overrides (SECRET/CONFIG/INTERNAL) so new keys can be explicitly classified without touching the script.
- Adds `infra/optional-secrets.json`: two lists — `optionalSecrets` (provider-gated secrets like AzureSpeech vs AzureOpenAIWhisper) and `envOnlySecrets` (keys set purely via env var, not declared in appsettings, like ConnectionStrings and Auth0).
- Adds `.github/workflows/config-audit.yml`: runs the audit on every PR.

## Verification

All four scenarios from the issue verified locally:
1. Clean run against current codebase: `python3 scripts/audit-config-wiring.py` exits 0.
2. New unwired key (`Stripe:ApiKey`) added to appsettings without wiring: exits 1 with table showing all four columns as MISSING.
3. Fully wired key added: exits 0.
4. Key removed from appsettings but left in required-secrets.json (`Telegram:BotToken`): exits 1 with stale-entry message.

## Reviewer findings

| Reviewer | Finding | Action |
|---|---|---|
| qa-verify | Scenario 4 not met: reverse check accepted compose presence as sufficient | Fixed: tightened reverse check to appsettings-only + envOnlySecrets list |
| code-review | `extract_env_var` didn't handle `${VAR:-default}` syntax | Fixed: widened regex |
| code-review | JSON null defaults not classified as SECRET | Fixed: treat None same as empty string |
| code-review | No guard if `appsettings*.json` glob matches nothing | Fixed: FileNotFoundError raised |
| code-review | Stale entries in optional-secrets.json undetected | Fixed: added reverse check for both optional and envOnly lists |
| code-review | pyyaml not pinned in CI | Fixed: pinned to 6.0.2 |
| code-review | `AzureSpeech:Region` classification inconsistent | Kept as SECRET (it IS wired in all places and must be to function; region names are low-sensitivity but the wiring contract is what matters) |

Closes #1284

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Added automated configuration audit workflow that validates secrets and configuration consistency across backend settings, infrastructure definitions, and deployment files. The audit runs on pull requests and pushes to main and release branches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->