### PR TITLE
feat(corrections): show original scan alongside extracted text (#1314)

### DIFF
--- a/frontend/src/components/student/RedaccionesTab.test.tsx
+++ b/frontend/src/components/student/RedaccionesTab.test.tsx
@@ -62,6 +62,9 @@ function wrapper(ui: React.ReactElement) {
 describe('RedaccionesTab', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // URL.createObjectURL / revokeObjectURL are not implemented in jsdom
+    URL.createObjectURL = vi.fn(() => 'blob:http://localhost/mock-preview')
+    URL.revokeObjectURL = vi.fn()
   })
 
   it('renders empty state with CTA when no corrections', async () => {
@@ -466,6 +469,176 @@ describe('RedaccionesTab', () => {
     resolveOcr({ text: 'Texto extraído.', blobUrl: 'https://blob.example.com/source.jpg', incomplete: false })
     await waitFor(() => {
       expect(screen.getByTestId('correction-drawer-save')).not.toBeDisabled()
+    })
+  })
+
+  // Scan preview tests
+  it('image upload shows scan preview immediately before OCR resolves', async () => {
+    vi.mocked(correctionsApi.listCorrections).mockResolvedValue([])
+    vi.mocked(correctionsApi.uploadForExtractText).mockReturnValue(new Promise(() => {}))
+    wrapper(<RedaccionesTab studentId={STUDENT_ID} />)
+
+    fireEvent.click(await screen.findByTestId('redacciones-empty-cta'))
+    const input = await screen.findByTestId('correction-drawer-file-input')
+
+    const jpgFile = new File(['data'], 'scan.jpg', { type: 'image/jpeg' })
+    Object.defineProperty(input, 'files', { value: [jpgFile], writable: false })
+    fireEvent.change(input)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('correction-drawer-scan-preview')).toBeInTheDocument()
+    })
+    expect(URL.createObjectURL).toHaveBeenCalledWith(jpgFile)
+    // img element (not iframe) for image type
+    expect(screen.getByTestId('correction-drawer-scan-preview').tagName).toBe('IMG')
+  })
+
+  it('PDF upload shows iframe scan preview immediately', async () => {
+    vi.mocked(correctionsApi.listCorrections).mockResolvedValue([])
+    vi.mocked(correctionsApi.uploadForExtractText).mockReturnValue(new Promise(() => {}))
+    wrapper(<RedaccionesTab studentId={STUDENT_ID} />)
+
+    fireEvent.click(await screen.findByTestId('redacciones-empty-cta'))
+    const input = await screen.findByTestId('correction-drawer-file-input')
+
+    const pdfFile = new File(['data'], 'exam.pdf', { type: 'application/pdf' })
+    Object.defineProperty(input, 'files', { value: [pdfFile], writable: false })
+    fireEvent.change(input)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('correction-drawer-scan-preview')).toBeInTheDocument()
+    })
+    // iframe element for PDF type
+    expect(screen.getByTestId('correction-drawer-scan-preview').tagName).toBe('IFRAME')
+  })
+
+  it('DOCX upload does NOT show scan preview', async () => {
+    vi.mocked(correctionsApi.listCorrections).mockResolvedValue([])
+    vi.mocked(correctionsApi.uploadForExtractText).mockReturnValue(new Promise(() => {}))
+    wrapper(<RedaccionesTab studentId={STUDENT_ID} />)
+
+    fireEvent.click(await screen.findByTestId('redacciones-empty-cta'))
+    const input = await screen.findByTestId('correction-drawer-file-input')
+
+    const docxFile = new File(['data'], 'essay.docx', { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' })
+    Object.defineProperty(input, 'files', { value: [docxFile], writable: false })
+    fireEvent.change(input)
+
+    // Give React a tick to process
+    await waitFor(() => {
+      expect(correctionsApi.uploadForExtractText).toHaveBeenCalled()
+    })
+    expect(screen.queryByTestId('correction-drawer-scan-preview')).not.toBeInTheDocument()
+    expect(URL.createObjectURL).not.toHaveBeenCalled()
+  })
+
+  it('OCR error keeps scan preview visible for manual editing', async () => {
+    vi.mocked(correctionsApi.listCorrections).mockResolvedValue([])
+    vi.mocked(correctionsApi.uploadForExtractText).mockRejectedValue(new Error('network error'))
+    wrapper(<RedaccionesTab studentId={STUDENT_ID} />)
+
+    fireEvent.click(await screen.findByTestId('redacciones-empty-cta'))
+    const input = await screen.findByTestId('correction-drawer-file-input')
+
+    const jpgFile = new File(['data'], 'scan.jpg', { type: 'image/jpeg' })
+    Object.defineProperty(input, 'files', { value: [jpgFile], writable: false })
+    fireEvent.change(input)
+
+    // Wait for error to appear
+    await screen.findByTestId('correction-drawer-ocr-error')
+
+    // Preview must still be present
+    expect(screen.getByTestId('correction-drawer-scan-preview')).toBeInTheDocument()
+  })
+
+  it('drawer panel gets wide class when preview is present', async () => {
+    vi.mocked(correctionsApi.listCorrections).mockResolvedValue([])
+    vi.mocked(correctionsApi.uploadForExtractText).mockReturnValue(new Promise(() => {}))
+    wrapper(<RedaccionesTab studentId={STUDENT_ID} />)
+
+    fireEvent.click(await screen.findByTestId('redacciones-empty-cta'))
+    const panelBefore = screen.getByTestId('correction-drawer-panel')
+    expect(panelBefore.className).toContain('sm:w-[520px]')
+
+    const input = screen.getByTestId('correction-drawer-file-input')
+    const jpgFile = new File(['data'], 'scan.jpg', { type: 'image/jpeg' })
+    Object.defineProperty(input, 'files', { value: [jpgFile], writable: false })
+    fireEvent.change(input)
+
+    await waitFor(() => {
+      const panelAfter = screen.getByTestId('correction-drawer-panel')
+      expect(panelAfter.className).toContain('sm:w-[90vw]')
+    })
+  })
+
+  it('object URL is revoked when drawer closes', async () => {
+    vi.mocked(correctionsApi.listCorrections).mockResolvedValue([])
+    vi.mocked(correctionsApi.uploadForExtractText).mockReturnValue(new Promise(() => {}))
+    wrapper(<RedaccionesTab studentId={STUDENT_ID} />)
+
+    fireEvent.click(await screen.findByTestId('redacciones-empty-cta'))
+    const input = await screen.findByTestId('correction-drawer-file-input')
+
+    const jpgFile = new File(['data'], 'scan.jpg', { type: 'image/jpeg' })
+    Object.defineProperty(input, 'files', { value: [jpgFile], writable: false })
+    fireEvent.change(input)
+
+    await screen.findByTestId('correction-drawer-scan-preview')
+
+    fireEvent.click(screen.getByTestId('correction-drawer-cancel'))
+
+    // After unmount the effect cleanup should have been called
+    await waitFor(() => {
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:http://localhost/mock-preview')
+    })
+  })
+
+  it('HEIC upload after valid image clears the stale preview', async () => {
+    vi.mocked(correctionsApi.listCorrections).mockResolvedValue([])
+    vi.mocked(correctionsApi.uploadForExtractText).mockReturnValue(new Promise(() => {}))
+    wrapper(<RedaccionesTab studentId={STUDENT_ID} />)
+
+    fireEvent.click(await screen.findByTestId('redacciones-empty-cta'))
+    const input = await screen.findByTestId('correction-drawer-file-input')
+
+    // First: valid JPG -- preview should appear
+    const jpgFile = new File(['data'], 'scan.jpg', { type: 'image/jpeg' })
+    Object.defineProperty(input, 'files', { value: [jpgFile], writable: false, configurable: true })
+    fireEvent.change(input)
+    await screen.findByTestId('correction-drawer-scan-preview')
+
+    // Second: HEIC -- preview should be cleared, error shown
+    const heicFile = new File(['data'], 'photo.heic', { type: 'image/heic' })
+    Object.defineProperty(input, 'files', { value: [heicFile], writable: false, configurable: true })
+    fireEvent.change(input)
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('correction-drawer-scan-preview')).not.toBeInTheDocument()
+    })
+    expect(screen.getByTestId('correction-drawer-ocr-error')).toBeInTheDocument()
+  })
+
+  it('DOCX upload after valid image clears the stale preview', async () => {
+    vi.mocked(correctionsApi.listCorrections).mockResolvedValue([])
+    vi.mocked(correctionsApi.uploadForExtractText).mockReturnValue(new Promise(() => {}))
+    wrapper(<RedaccionesTab studentId={STUDENT_ID} />)
+
+    fireEvent.click(await screen.findByTestId('redacciones-empty-cta'))
+    const input = await screen.findByTestId('correction-drawer-file-input')
+
+    // First: valid JPG -- preview should appear
+    const jpgFile = new File(['data'], 'scan.jpg', { type: 'image/jpeg' })
+    Object.defineProperty(input, 'files', { value: [jpgFile], writable: false, configurable: true })
+    fireEvent.change(input)
+    await screen.findByTestId('correction-drawer-scan-preview')
+
+    // Second: DOCX -- preview should be cleared
+    const docxFile = new File(['data'], 'essay.docx', { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' })
+    Object.defineProperty(input, 'files', { value: [docxFile], writable: false, configurable: true })
+    fireEvent.change(input)
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('correction-drawer-scan-preview')).not.toBeInTheDocument()
     })
   })
 

--- a/frontend/src/components/student/RedaccionesTab.tsx
+++ b/frontend/src/components/student/RedaccionesTab.tsx
@@ -345,6 +345,7 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved, onCorregirError
     if (HEIC_EXTENSIONS.some((ext) => lower.endsWith(ext))) {
       setLocalPreviewUrl(null)
       setPreviewType(null)
+      setBlobUrl(null)
       setOcrError('El formato HEIC no es compatible. Usa JPG, PNG, WEBP o PDF.')
       setOcrState('error')
       return

--- a/frontend/src/components/student/RedaccionesTab.tsx
+++ b/frontend/src/components/student/RedaccionesTab.tsx
@@ -310,6 +310,8 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved, onCorregirError
   const [ocrError, setOcrError] = useState<string | null>(null)
   const [ocrErrorCode, setOcrErrorCode] = useState<string | null>(null)
   const [blobUrl, setBlobUrl] = useState<string | null>(null)
+  const [localPreviewUrl, setLocalPreviewUrl] = useState<string | null>(null)
+  const [previewType, setPreviewType] = useState<'image' | 'pdf' | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const detailQuery = useQuery({
@@ -330,14 +332,36 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved, onCorregirError
     }
   }, [isEdit, detail, hydrated])
 
+  // Revoke the object URL when it changes or when the drawer unmounts
+  useEffect(() => {
+    return () => {
+      if (localPreviewUrl) URL.revokeObjectURL(localPreviewUrl)
+    }
+  }, [localPreviewUrl])
+
   async function handleFileUpload(file: File) {
     setOcrErrorCode(null)
     const lower = file.name.toLowerCase()
     if (HEIC_EXTENSIONS.some((ext) => lower.endsWith(ext))) {
+      setLocalPreviewUrl(null)
+      setPreviewType(null)
       setOcrError('El formato HEIC no es compatible. Usa JPG, PNG, WEBP o PDF.')
       setOcrState('error')
       return
     }
+
+    // Create a local object URL immediately for non-DOCX files so the scan is
+    // visible before OCR completes (and stays visible even on extraction error).
+    if (!lower.endsWith('.docx')) {
+      const newUrl = URL.createObjectURL(file)
+      setLocalPreviewUrl(newUrl)
+      setPreviewType(lower.endsWith('.pdf') ? 'pdf' : 'image')
+    } else {
+      // DOCX has no visual preview; clear any previous scan from a prior upload.
+      setLocalPreviewUrl(null)
+      setPreviewType(null)
+    }
+
     setOcrState('loading')
     setOcrError(null)
     setBlobUrl(null)
@@ -357,6 +381,8 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved, onCorregirError
       }
       setOcrErrorCode(backendCode)
       setOcrError(backendMessage ?? 'No se pudo extraer el texto. Inténtalo de nuevo o escríbelo manualmente.')
+      // localPreviewUrl is intentionally kept so the teacher can see the scan
+      // while typing the correction text manually after a failed extraction.
     }
   }
 
@@ -445,6 +471,7 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved, onCorregirError
 
   const detailLoading = isEdit && detailQuery.isLoading
   const detailError = isEdit && detailQuery.isError
+  const hasPreview = localPreviewUrl !== null
 
   return (
     <div className="fixed inset-0 z-50 flex justify-end" data-testid="correction-drawer">
@@ -454,7 +481,7 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved, onCorregirError
         data-testid="correction-drawer-backdrop"
       />
       <div
-        className="relative flex flex-col w-full sm:w-[520px] h-full overflow-hidden bg-white"
+        className={`relative flex flex-col ${hasPreview ? 'w-full sm:w-[90vw] max-w-[1400px]' : 'w-full sm:w-[520px]'} h-full overflow-hidden bg-white transition-all duration-300`}
         data-testid="correction-drawer-panel"
       >
         <div className="flex items-center justify-between px-6 py-4 bg-zinc-50/60">
@@ -472,133 +499,158 @@ function CorrectionDrawer({ studentId, editId, onClose, onSaved, onCorregirError
           </button>
         </div>
 
-        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
-          {detailLoading && (
-            <div className="space-y-3" data-testid="correction-drawer-loading">
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-9 w-full" />
-              <Skeleton className="h-4 w-32" />
-              <Skeleton className="h-20 w-full" />
+        <div className="flex-1 overflow-hidden flex flex-col sm:flex-row">
+          {hasPreview && (
+            <div
+              className="h-52 sm:h-auto sm:w-1/2 flex-shrink-0 bg-[#F4F2FD] overflow-auto"
+              data-testid="correction-drawer-scan-panel"
+            >
+              {previewType === 'pdf' ? (
+                <iframe
+                  src={localPreviewUrl}
+                  className="w-full h-full"
+                  title="Documento original"
+                  data-testid="correction-drawer-scan-preview"
+                />
+              ) : (
+                <img
+                  src={localPreviewUrl}
+                  alt="Documento original"
+                  className="w-full h-full object-contain"
+                  data-testid="correction-drawer-scan-preview"
+                />
+              )}
             </div>
           )}
 
-          {detailError && (
-            <div className="text-sm text-red-600">No se pudo cargar la redacción.</div>
-          )}
-
-          {!detailLoading && !detailError && (
-            <>
-              <div className="space-y-1.5">
-                <label
-                  htmlFor="redaccion-title"
-                  className="text-[10px] font-bold tracking-widest uppercase text-gray-400"
-                >
-                  Título
-                </label>
-                <Input
-                  id="redaccion-title"
-                  autoFocus
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value.slice(0, TITLE_MAX))}
-                  placeholder="p. ej. Carta a un extraterrestre"
-                  data-testid="correction-drawer-title"
-                />
+          <div className={`overflow-y-auto px-6 py-4 space-y-4 ${hasPreview ? 'sm:w-1/2 flex-1' : 'flex-1'}`}>
+            {detailLoading && (
+              <div className="space-y-3" data-testid="correction-drawer-loading">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-9 w-full" />
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-20 w-full" />
               </div>
+            )}
 
-              <div className="space-y-1.5">
-                <label
-                  htmlFor="redaccion-prompt"
-                  className="text-[10px] font-bold tracking-widest uppercase text-gray-400"
-                >
-                  Consigna (opcional)
-                </label>
-                <Textarea
-                  id="redaccion-prompt"
-                  value={prompt}
-                  onChange={(e) => setPrompt(e.target.value.slice(0, PROMPT_MAX))}
-                  placeholder="Notas sobre el ejercicio"
-                  rows={3}
-                  className="resize-none"
-                  data-testid="correction-drawer-prompt"
-                />
-              </div>
+            {detailError && (
+              <div className="text-sm text-red-600">No se pudo cargar la redacción.</div>
+            )}
 
-              <div className="space-y-1.5">
-                <div className="flex items-center justify-between">
+            {!detailLoading && !detailError && (
+              <>
+                <div className="space-y-1.5">
                   <label
-                    htmlFor="redaccion-text"
+                    htmlFor="redaccion-title"
                     className="text-[10px] font-bold tracking-widest uppercase text-gray-400"
                   >
-                    Texto del alumno (opcional)
+                    Título
                   </label>
+                  <Input
+                    id="redaccion-title"
+                    autoFocus
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value.slice(0, TITLE_MAX))}
+                    placeholder="p. ej. Carta a un extraterrestre"
+                    data-testid="correction-drawer-title"
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label
+                    htmlFor="redaccion-prompt"
+                    className="text-[10px] font-bold tracking-widest uppercase text-gray-400"
+                  >
+                    Consigna (opcional)
+                  </label>
+                  <Textarea
+                    id="redaccion-prompt"
+                    value={prompt}
+                    onChange={(e) => setPrompt(e.target.value.slice(0, PROMPT_MAX))}
+                    placeholder="Notas sobre el ejercicio"
+                    rows={3}
+                    className="resize-none"
+                    data-testid="correction-drawer-prompt"
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between">
+                    <label
+                      htmlFor="redaccion-text"
+                      className="text-[10px] font-bold tracking-widest uppercase text-gray-400"
+                    >
+                      Texto del alumno (opcional)
+                    </label>
+                    {!studentTextLocked && (
+                      <>
+                        <input
+                          ref={fileInputRef}
+                          type="file"
+                          accept={OCR_ACCEPTED}
+                          className="sr-only"
+                          data-testid="correction-drawer-file-input"
+                          onChange={(e) => {
+                            const file = e.target.files?.[0]
+                            if (file) void handleFileUpload(file)
+                            e.target.value = ''
+                          }}
+                        />
+                        <button
+                          type="button"
+                          onClick={() => fileInputRef.current?.click()}
+                          disabled={ocrState === 'loading'}
+                          className="flex items-center gap-1 text-[10px] font-semibold tracking-wide text-indigo-600 hover:text-indigo-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                          title="Subir archivo: foto, PDF o documento Word"
+                          data-testid="correction-drawer-upload-btn"
+                        >
+                          {ocrState === 'loading'
+                            ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            : <FileUp className="h-3.5 w-3.5" />}
+                          Subir archivo
+                        </button>
+                      </>
+                    )}
+                  </div>
                   {!studentTextLocked && (
-                    <>
-                      <input
-                        ref={fileInputRef}
-                        type="file"
-                        accept={OCR_ACCEPTED}
-                        className="sr-only"
-                        data-testid="correction-drawer-file-input"
-                        onChange={(e) => {
-                          const file = e.target.files?.[0]
-                          if (file) void handleFileUpload(file)
-                          e.target.value = ''
-                        }}
-                      />
-                      <button
-                        type="button"
-                        onClick={() => fileInputRef.current?.click()}
-                        disabled={ocrState === 'loading'}
-                        className="flex items-center gap-1 text-[10px] font-semibold tracking-wide text-indigo-600 hover:text-indigo-800 disabled:opacity-50 disabled:cursor-not-allowed"
-                        title="Subir archivo: foto, PDF o documento Word"
-                        data-testid="correction-drawer-upload-btn"
-                      >
-                        {ocrState === 'loading'
-                          ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                          : <FileUp className="h-3.5 w-3.5" />}
-                        Subir archivo
-                      </button>
-                    </>
+                    <p className="text-[10px] text-zinc-400" data-testid="correction-drawer-upload-hint">
+                      Acepta imagen (JPG, PNG, WEBP), PDF y Word (.docx)
+                    </p>
+                  )}
+                  <Textarea
+                    id="redaccion-text"
+                    value={ocrState === 'loading' ? '' : text}
+                    onChange={(e) => setText(e.target.value.slice(0, TEXT_MAX))}
+                    placeholder={ocrState === 'loading' ? 'Extrayendo texto...' : 'Pega el texto del alumno aquí'}
+                    rows={10}
+                    className="resize-y max-h-[50vh] min-h-[12rem]"
+                    disabled={studentTextLocked || ocrState === 'loading'}
+                    data-testid="correction-drawer-text"
+                  />
+                  {ocrState === 'warn' && (
+                    <p className="text-xs text-amber-600" data-testid="correction-drawer-ocr-warn">
+                      El texto extraído parece incompleto. Puedes editarlo antes de corregir.
+                    </p>
+                  )}
+                  {ocrState === 'error' && ocrError && (
+                    <p className="text-xs text-red-600" data-testid="correction-drawer-ocr-error" data-error-code={ocrErrorCode ?? undefined}>
+                      {ocrError}
+                    </p>
+                  )}
+                  <p className="text-xs text-zinc-500">
+                    {studentTextLocked
+                      ? 'El texto no se puede modificar una vez generada la corrección.'
+                      : 'Si ya tienes el texto del alumno, pégalo aquí o sube una foto, PDF o documento Word. Lo puedes añadir más tarde.'}
+                  </p>
+                  {textLockedError && (
+                    <p className="text-xs text-red-600" data-testid="correction-drawer-text-error">
+                      {textLockedError}
+                    </p>
                   )}
                 </div>
-                {!studentTextLocked && (
-                  <p className="text-[10px] text-zinc-400" data-testid="correction-drawer-upload-hint">
-                    Acepta imagen (JPG, PNG, WEBP), PDF y Word (.docx)
-                  </p>
-                )}
-                <Textarea
-                  id="redaccion-text"
-                  value={ocrState === 'loading' ? '' : text}
-                  onChange={(e) => setText(e.target.value.slice(0, TEXT_MAX))}
-                  placeholder={ocrState === 'loading' ? 'Extrayendo texto...' : 'Pega el texto del alumno aquí'}
-                  rows={10}
-                  className="resize-y max-h-[50vh] min-h-[12rem]"
-                  disabled={studentTextLocked || ocrState === 'loading'}
-                  data-testid="correction-drawer-text"
-                />
-                {ocrState === 'warn' && (
-                  <p className="text-xs text-amber-600" data-testid="correction-drawer-ocr-warn">
-                    El texto extraído parece incompleto. Puedes editarlo antes de corregir.
-                  </p>
-                )}
-                {ocrState === 'error' && ocrError && (
-                  <p className="text-xs text-red-600" data-testid="correction-drawer-ocr-error" data-error-code={ocrErrorCode ?? undefined}>
-                    {ocrError}
-                  </p>
-                )}
-                <p className="text-xs text-zinc-500">
-                  {studentTextLocked
-                    ? 'El texto no se puede modificar una vez generada la corrección.'
-                    : 'Si ya tienes el texto del alumno, pégalo aquí o sube una foto, PDF o documento Word. Lo puedes añadir más tarde.'}
-                </p>
-                {textLockedError && (
-                  <p className="text-xs text-red-600" data-testid="correction-drawer-text-error">
-                    {textLockedError}
-                  </p>
-                )}
-              </div>
-            </>
-          )}
+              </>
+            )}
+          </div>
         </div>
 
         <div className="flex flex-col gap-2 px-6 py-4 bg-zinc-50/60">


### PR DESCRIPTION
## Summary

- When a teacher uploads a scanned JPG/PNG/WEBP/PDF, the CorrectionDrawer expands from 520px to 90vw and shows the original document on the left with the editable OCR text on the right
- The scan appears instantly via `URL.createObjectURL` before the OCR API call returns, so the teacher has a visual reference during extraction
- PDF files render in a native `<iframe>` (browser handles multi-page scroll + zoom); images render with `<img>` + `object-fit: contain`
- DOCX uploads and pasted text stay in the single-column narrow layout (no scan to show)
- On OCR error the scan stays visible so the teacher can still type manually while comparing
- HEIC or DOCX uploaded after a valid image clears the stale preview
- Object URLs are revoked on drawer close/unmount (no memory leak)

## Design decisions (resolved with Vera before implementation)

- Progressive expansion (narrow → wide on file select) avoids a jarring layout jump for DOCX/paste flows
- `surface-container-low` (#F4F2FD) left panel with no divider line (compliant with Academic Atelier no-line rule)
- No custom zoom controls: PDFs in iframe get browser zoom natively; images use `object-fit: contain` with scroll

## Test plan

- [ ] Build verify: PASS (bicep, dotnet build, dotnet test, npm lint, npm build, npm test 110/110)
- [ ] Unit tests: 35 pass (6 new tests: img/PDF/DOCX/error/wide-class/revoke)
- [ ] Verify: unit tests cover all behaviors; full Playwright e2e blocked by CORS (dev server vs e2e API) and pre-change container -- DOCX behavior confirmed on e2e stack
- [ ] qa-verify: ran (found pre-existing issue with wrong issue scope; unit tests confirm all AC)
- [ ] Code review: PASS WITH NOTES -- two stale-preview edge cases (HEIC-after-image, DOCX-after-image) fixed and covered by tests
- [ ] review-ui: ALMOST -- two-column expanded state not visually confirmed (e2e container pre-change); narrow drawer and empty state comply with Academic Atelier DS

## Out-of-scope observations

- Pre-existing: CorrectionDrawer footer Ghost+Primary pairing violates DS §5 (logged to observed-issues)
- Pre-existing: Manrope Display-LG font not rendering in e2e stack for Redacciones empty state (logged to observed-issues)
- New pattern: `surface-container-low` as image viewer panel bg flagged to ui-review-backlog for Vera to document

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local file preview in the correction drawer—images and PDFs display immediately upon upload, while DOCX files skip preview.
  * Preview remains visible if OCR extraction fails, allowing manual editing.
  * Drawer layout adjusts to accommodate preview alongside form fields.
  * Preview properly clears when uploading a different file or closing the drawer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->