### PR TITLE
feat(#1349): correction explanations always written in Spanish

### DIFF
--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -131,6 +131,7 @@ public class RedaccionCorrectionPromptBuilder
 When you have identified all errors, call the submit_correction_tags tool with schemaVersion=1 and the complete tags array.
 
 "explanation" and "correctedForm" are always non-empty for every tag.
+"explanation" MUST be written in Spanish (regardless of the student's L1 or CEFR level). It is a metalinguistic teaching note for the teacher, not a student-facing text; use standard pedagogical Spanish.
 
 OFFSETS (read carefully — accented characters cause silent errors if you count positions):
 - startIndex and endIndex are Unicode character offsets into the student text between the markers (0-based, end-exclusive).
@@ -204,7 +205,7 @@ OFFSETS (read carefully — accented characters cause silent errors if you count
 
         var adj = _pedagogy.GetL1Adjustments(l1);
         var sb = new StringBuilder();
-        sb.AppendLine($"L1 INTERFERENCE: the student's native language is {l1}. When you flag a (L) error, prefer explanations that point to the L1 source if applicable.");
+        sb.AppendLine($"L1 INTERFERENCE: the student's native language is {l1}. When you flag a (L) error, prefer explanations (in Spanish) that point to the L1 source if applicable.");
         if (adj is not null)
         {
             if (adj.IncreaseEmphasis.Length > 0)

--- a/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
+++ b/backend/LangTeach.Api/AI/RedaccionCorrectionPromptBuilder.cs
@@ -205,7 +205,7 @@ OFFSETS (read carefully — accented characters cause silent errors if you count
 
         var adj = _pedagogy.GetL1Adjustments(l1);
         var sb = new StringBuilder();
-        sb.AppendLine($"L1 INTERFERENCE: the student's native language is {l1}. When you flag a (L) error, prefer explanations (in Spanish) that point to the L1 source if applicable.");
+        sb.AppendLine($"L1 INTERFERENCE: the student's native language is {l1}. When you flag a (L) error, prefer explanations that reference the L1 source if applicable.");
         if (adj is not null)
         {
             if (adj.IncreaseEmphasis.Length > 0)


### PR DESCRIPTION
## Summary

- Adds one explicit instruction to the Pass 1 output contract (`OutputContract` in `RedaccionCorrectionPromptBuilder.cs`): `explanation` MUST be written in Spanish regardless of student L1 or CEFR level.
- Tightens the L1 interference block wording from "point to the L1 source" to "reference the L1 source" to remove the ambiguity that a model could read it as permission to write part of the explanation in the student's native language.
- No branching logic; no schema, migration, API, or frontend changes.

## Verify

Live-verified on the e2e visual stack with a realistic B1 redacción (Ana Seed, ~150 words, 4 errors tagged). All 4 explanation fields came back in Spanish. Category codes, correctedForm, and offsets unchanged.

## Reviewer findings

| Reviewer | Finding | Action |
|---|---|---|
| qa-verify | All criteria met; no unit test for prompt string content | Accepted: area:ai changes are verified via live stack per procedure |
| code-review | Minor: L1 block "(in Spanish)" parenthetical uses weaker "prefer" vs MUST in OutputContract | Fixed: removed the "(in Spanish)" parenthetical from the L1 block |
| architecture-reviewer | PASS WITH NOTES: same minor phrasing note | Fixed: removed redundant parenthetical |
| Sophy | APPROVE | No action |
| prompt-health-reviewer | "point to the L1 source" could be read as language attribution; suggest "reference the L1 source" | Fixed: wording updated |

Closes #1349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced writing correction feedback by ensuring all explanations are consistently presented in Spanish
  * Refined how first language references are handled in correction feedback for more flexible and contextually appropriate guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->