### PR TITLE
feat(corrections): flag missing paragraph breaks under C category (#1350)

### DIFF
--- a/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs
@@ -224,6 +224,18 @@ public class RedaccionCorrectionPromptBuilderTests
         req.SystemPrompt.Should().Contain("logically ordered", "C must include logical ordering as a discourse-level error");
     }
 
+    [Fact]
+    public void Build_SystemPromptContainsParagraphBreakSubtype()
+    {
+        // Issue #1350: C must cover paragraph-break errors (B1+) so the model can flag
+        // a wall of text that should be split into paragraphs per the EOI rubric.
+        var req = _builder.BuildWithTool(MakeCtx()).Request;
+
+        req.SystemPrompt.Should().Contain("Paragraph-break", "C must include paragraph-break as a B1+ subtype");
+        req.SystemPrompt.Should().Contain("B1 and above", "paragraph-break gating must be explicit in the subtype");
+        req.SystemPrompt.Should().Contain("¶", "correctedForm for paragraph-break must be the pilcrow symbol");
+    }
+
     private static RedaccionCorrectionPromptContext MakeCtx() =>
         new("Texto.", null, Array.Empty<string>(), null);
 }

--- a/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs
@@ -239,12 +239,13 @@ public class RedaccionCorrectionPromptBuilderTests
     [Fact]
     public void Build_SystemPromptContainsParagraphBreakOverflagGuard()
     {
-        // Issue #1350: the anti-pattern rule must prevent the model from flagging A1 texts,
-        // short texts, and already-paragraphed texts -- primary defence against over-flagging.
+        // Issue #1350: the anti-pattern rule must prevent the model from flagging A1 texts
+        // and already-paragraphed texts. Sentence-count threshold is stated in the subtype.
         var req = _builder.BuildWithTool(MakeCtx()).Request;
 
-        req.SystemPrompt.Should().Contain("4 sentences or fewer", "paragraph-break anti-pattern must include the sentence-count guard");
+        req.SystemPrompt.Should().Contain("5 or more sentences", "paragraph-break subtype must include the sentence-count threshold");
         req.SystemPrompt.Should().Contain("reasonably paragraphed", "paragraph-break anti-pattern must forbid flagging already-paragraphed texts");
+        req.SystemPrompt.Should().Contain("position marker", "paragraph-break span exception to minimum-span rule must be explicit");
     }
 
     private static RedaccionCorrectionPromptContext MakeCtx() =>

--- a/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs
+++ b/backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs
@@ -236,6 +236,17 @@ public class RedaccionCorrectionPromptBuilderTests
         req.SystemPrompt.Should().Contain("¶", "correctedForm for paragraph-break must be the pilcrow symbol");
     }
 
+    [Fact]
+    public void Build_SystemPromptContainsParagraphBreakOverflagGuard()
+    {
+        // Issue #1350: the anti-pattern rule must prevent the model from flagging A1 texts,
+        // short texts, and already-paragraphed texts -- primary defence against over-flagging.
+        var req = _builder.BuildWithTool(MakeCtx()).Request;
+
+        req.SystemPrompt.Should().Contain("4 sentences or fewer", "paragraph-break anti-pattern must include the sentence-count guard");
+        req.SystemPrompt.Should().Contain("reasonably paragraphed", "paragraph-break anti-pattern must forbid flagging already-paragraphed texts");
+    }
+
     private static RedaccionCorrectionPromptContext MakeCtx() =>
         new("Texto.", null, Array.Empty<string>(), null);
 }

--- a/data/pedagogy/correction-categories.json
+++ b/data/pedagogy/correction-categories.json
@@ -6,7 +6,8 @@
       "description": "cohesion or discourse-organization error (includes connector misuse, paragraph structure, logical sequencing).",
       "subTypes": [
         "Connector-level: missing connector, wrong connector, missing temporal marker, repetitive linking structure.",
-        "Discourse-level (most significant at B2 and above): paragraph lacks a clear main idea (no topic sentence), ideas within a paragraph are not logically ordered."
+        "Discourse-level (most significant at B2 and above): paragraph lacks a clear main idea (no topic sentence), ideas within a paragraph are not logically ordered.",
+        "Paragraph-break (B1 and above only): the text clearly shifts main topic or idea but contains no paragraph break, and the absence would cost marks in an EOI written-expression rubric. Only flag when ALL of these hold: (a) the student text has 5 or more sentences, (b) there is an unambiguous change in main idea or topic -- not merely a new example or a supporting detail, (c) the shift is sustained for at least two sentences. spannedText = the first 5-10 words of the sentence that should open the new paragraph (choose a span that is unique in the text; use contextBefore to disambiguate if needed). correctedForm = \"¶\". Explanation in Spanish, e.g. \"Aquí debería empezar un párrafo nuevo: cambias de idea principal.\""
       ],
       "examples": [
         {
@@ -22,6 +23,11 @@
         {
           "text": "Hay muchos plásticos en el océano. El reciclaje es costoso. Por eso debemos reciclar más.",
           "note": "the paragraph lists facts before stating the main claim, leaving the reader uncertain what point is being made",
+          "label": "C"
+        },
+        {
+          "text": "Me gusta el verano porque hace calor y podemos ir a la playa con mi familia. Siempre vamos a la costa y comemos paella juntos. Es una tradición que me encanta mucho. Pero hay un problema muy grave en el mundo hoy en día. El cambio climático afecta a todos los países y debemos actuar urgentemente. Los científicos dicen que necesitamos reducir las emisiones.",
+          "note": "two distinct ideas (summer holidays, climate change) run together without a paragraph break; at B1+ this would lose marks in an EOI rubric; spannedText = first words of the climate-change sentence, correctedForm = \"¶\"",
           "label": "C"
         }
       ]
@@ -114,6 +120,7 @@
     "A wrong preposition is G, NEVER L.",
     "A literal translation from the student's L1 is L, NEVER G.",
     "A missing or wrong connector is C, NEVER G.",
-    "An ambiguous pronoun or noun-phrase reference where the word is grammatically correct but the referent is unclear is C, NEVER G."
+    "An ambiguous pronoun or noun-phrase reference where the word is grammatically correct but the referent is unclear is C, NEVER G.",
+    "Do NOT flag paragraph breaks at A1 level, for texts of 4 sentences or fewer, or when the text is already reasonably paragraphed. Do NOT flag a paragraph break for stylistic preference or slightly dense structure -- only flag when there is a clear, unambiguous thematic shift that would lose EOI marks."
   ]
 }

--- a/data/pedagogy/correction-categories.json
+++ b/data/pedagogy/correction-categories.json
@@ -27,7 +27,7 @@
         },
         {
           "text": "Me gusta el verano porque hace calor y podemos ir a la playa con mi familia. Siempre vamos a la costa y comemos paella juntos. Es una tradición que me encanta mucho. Pero hay un problema muy grave en el mundo hoy en día. El cambio climático afecta a todos los países y debemos actuar urgentemente. Los científicos dicen que necesitamos reducir las emisiones.",
-          "note": "two distinct ideas (summer holidays, climate change) run together without a paragraph break; at B1+ this would lose marks in an EOI rubric; spannedText = first words of the climate-change sentence, correctedForm = \"¶\"",
+          "note": "two distinct ideas (summer holidays, climate change) run together without a paragraph break; at B1+ this would lose marks in an EOI rubric; spannedText = \"Pero hay un problema\" (first words of the sentence opening the climate-change topic), correctedForm = \"¶\". Note: \"Pero\" here is also a potential connector-level C issue (abrupt topic change with a contrastive connector rather than a topic-introducing phrase); the paragraph-break tag and any connector-level tag are independent findings, not redundant.",
           "label": "C"
         }
       ]
@@ -121,6 +121,6 @@
     "A literal translation from the student's L1 is L, NEVER G.",
     "A missing or wrong connector is C, NEVER G.",
     "An ambiguous pronoun or noun-phrase reference where the word is grammatically correct but the referent is unclear is C, NEVER G.",
-    "Do NOT flag paragraph breaks at A1 level, or when the text is already reasonably paragraphed. Do NOT flag a paragraph break for stylistic preference or slightly dense structure -- only flag when there is a clear, unambiguous thematic shift that would lose EOI marks. (Sentence-count threshold is defined in the Paragraph-break subtype above.)"
+    "Do NOT flag paragraph breaks below B1 (i.e. not at A1 or A2), or when the text is already reasonably paragraphed. Do NOT flag a paragraph break for stylistic preference or slightly dense structure -- only flag when there is a clear, unambiguous thematic shift that would lose EOI marks. (Sentence-count threshold is defined in the Paragraph-break subtype above.)"
   ]
 }

--- a/data/pedagogy/correction-categories.json
+++ b/data/pedagogy/correction-categories.json
@@ -7,7 +7,7 @@
       "subTypes": [
         "Connector-level: missing connector, wrong connector, missing temporal marker, repetitive linking structure.",
         "Discourse-level (most significant at B2 and above): paragraph lacks a clear main idea (no topic sentence), ideas within a paragraph are not logically ordered.",
-        "Paragraph-break (B1 and above only): the text clearly shifts main topic or idea but contains no paragraph break, and the absence would cost marks in an EOI written-expression rubric. Only flag when ALL of these hold: (a) the student text has 5 or more sentences, (b) there is an unambiguous change in main idea or topic -- not merely a new example or a supporting detail, (c) the shift is sustained for at least two sentences. spannedText = the first 5-10 words of the sentence that should open the new paragraph (choose a span that is unique in the text; use contextBefore to disambiguate if needed). correctedForm = \"¶\". Explanation in Spanish, e.g. \"Aquí debería empezar un párrafo nuevo: cambias de idea principal.\""
+        "Paragraph-break (B1 and above only): the text clearly shifts main topic or idea but contains no paragraph break, and the absence would cost marks in an EOI written-expression rubric. Only flag when ALL of these hold: (a) the student text has 5 or more sentences, (b) there is an unambiguous change in main idea or topic -- not merely a new example or a supporting detail, (c) the shift is sustained for at least two sentences. SPAN MECHANICS (exception to the minimum-span rule): a paragraph break is a position marker, not a word error -- there is no erroneous substring to replace. Instead, spannedText = the first 5-10 words of the sentence that should open the new paragraph; this identifies the insertion point, not an error. correctedForm = \"¶\". Explanation in Spanish, e.g. \"Aquí debería empezar un párrafo nuevo: cambias de idea principal.\""
       ],
       "examples": [
         {
@@ -121,6 +121,6 @@
     "A literal translation from the student's L1 is L, NEVER G.",
     "A missing or wrong connector is C, NEVER G.",
     "An ambiguous pronoun or noun-phrase reference where the word is grammatically correct but the referent is unclear is C, NEVER G.",
-    "Do NOT flag paragraph breaks at A1 level, for texts of 4 sentences or fewer, or when the text is already reasonably paragraphed. Do NOT flag a paragraph break for stylistic preference or slightly dense structure -- only flag when there is a clear, unambiguous thematic shift that would lose EOI marks."
+    "Do NOT flag paragraph breaks at A1 level, or when the text is already reasonably paragraphed. Do NOT flag a paragraph break for stylistic preference or slightly dense structure -- only flag when there is a clear, unambiguous thematic shift that would lose EOI marks. (Sentence-count threshold is defined in the Paragraph-break subtype above.)"
   ]
 }


### PR DESCRIPTION
## Summary

- Adds "Paragraph-break" as a new subtype of the C (Cohesión y Coherencia) correction category, gated at B1 and above
- The AI now flags single-block texts with a clear, sustained topic shift that would lose marks in an EOI rubric, using `correctedForm="¶"` to mark the insertion point
- No schema changes, no backend code changes, no renderer changes -- purely a prompt data change embedded in the pedagogy config

## What changed

`data/pedagogy/correction-categories.json`:
- New C subtype: Paragraph-break (B1+), with triggering conditions (5+ sentences, unambiguous topic shift sustained 2+ sentences), span mechanics exception (position marker, not word error), and correctedForm guidance
- New example: 6-sentence wall-of-text covering two distinct topics with no paragraph break; clarifies that the paragraph-break tag and any connector-level tag are independent findings
- New anti-pattern rule: do not flag below B1 (A1 or A2), do not flag well-paragraphed texts, do not flag for stylistic preference only

`backend/LangTeach.Api.Tests/AI/RedaccionCorrectionPromptBuilderTests.cs`:
- Two new pinning tests: one asserting the Paragraph-break subtype and ¶ symbol appear in the rendered system prompt; one asserting the over-flag guard wording (sentence-count threshold, "reasonably paragraphed", position-marker exception) appears

## Live verify results

- **Wall-of-text B1** (9 sentences, summer-holiday topic then work-life topic, no paragraph break): 1 C tag returned, `spannedText="Actualmente tr"`, `correctedForm="¶"`, explanation in Spanish: "Aquí debería empezar un párrafo nuevo: cambias de idea principal (de las vacaciones de verano a tu vida laboral actual), y el cambio se mantiene durante varias frases."
- **Same text with actual paragraph break** (`\n\n` between topics): 0 tags

## Review findings addressed

| Reviewer | Finding | Action |
|---|---|---|
| qa-verify | No unit test for over-flag anti-pattern guard | Fixed: added `Build_SystemPromptContainsParagraphBreakOverflagGuard` |
| Sophy | Multi-word spannedText contradicts minimum-span rule without explicit exception | Fixed: added "SPAN MECHANICS (exception to the minimum-span rule)" note in subtype |
| Sophy | Sentence-count threshold duplicated in subtype and anti-pattern rule | Fixed: removed from anti-pattern, added cross-reference |
| Isaac | Anti-pattern said "A1" but was ambiguous about A2 | Fixed: now says "below B1 (i.e. not at A1 or A2)" |
| Isaac | Example spannedText vague ("first words") | Fixed: now says spannedText = "Pero hay un problema" |
| Isaac | "Pero" in example could seem redundant with connector-level C | Fixed: note clarifies the two findings are independent |
| architecture-reviewer | PASS | No action needed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)