### PR TITLE
test(groups): visual specs for group detail + log-session screens (#1355)

### DIFF
--- a/e2e/tests/visual/group-detail.visual.spec.ts
+++ b/e2e/tests/visual/group-detail.visual.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test'
+import { createMockAuthContext } from '../../helpers/auth-helper'
+import { setupMockTeacher } from '../../helpers/mock-teacher-helper'
+import { NAV_TIMEOUT, UI_TIMEOUT } from '../../helpers/timeouts'
+import * as fs from 'fs'
+
+const API_BASE = process.env.VITE_API_BASE_URL ?? 'http://localhost:5178'
+const AUTH_HEADER = { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' }
+
+let groupId = ''
+
+test.beforeAll(async ({ browser }) => {
+  const ctx = await createMockAuthContext(browser)
+  const page = await ctx.newPage()
+  await setupMockTeacher(page)
+
+  // Seed a group with a member so the detail tabs have content to render
+  const studentRes = await page.request.post(`${API_BASE}/api/students`, {
+    headers: AUTH_HEADER,
+    data: { name: 'Visual Student', learningLanguage: 'Spanish', cefrLevel: 'B1', interests: [], learningGoals: [], weaknesses: [], difficulties: [] },
+  })
+  const student = await studentRes.json()
+
+  const groupRes = await page.request.post(`${API_BASE}/api/groups`, {
+    headers: AUTH_HEADER,
+    data: { name: 'Visual Review Group', cefrLevel: 'B1', description: 'A sample group for visual review.', isActive: true },
+  })
+  const group = await groupRes.json()
+  groupId = group.id
+
+  await page.request.post(`${API_BASE}/api/groups/${groupId}/members`, {
+    headers: AUTH_HEADER,
+    data: { studentId: student.id },
+  })
+
+  await page.close()
+  await ctx.close()
+})
+
+test('@visual group detail tabs', async ({ browser }) => {
+  fs.mkdirSync('screenshots', { recursive: true })
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  const consoleErrors: string[] = []
+  page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()) })
+
+  await page.goto(`/groups/${groupId}`)
+  await expect(page.getByTestId('group-detail-page')).toBeVisible({ timeout: NAV_TIMEOUT })
+
+  // Overview tab (default): hero spine + group-scoped Teacher's Working Memory card
+  await expect(page.getByTestId('tab-overview')).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.screenshot({ path: 'screenshots/group-detail-overview.png', fullPage: true })
+
+  // Members tab: roster of seeded member
+  await page.getByTestId('tab-members').click()
+  await expect(page.getByTestId('tab-members')).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.screenshot({ path: 'screenshots/group-detail-members.png', fullPage: true })
+
+  // Sessions tab: group session history
+  await page.getByTestId('tab-sessions').click()
+  await expect(page.getByTestId('tab-sessions')).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.screenshot({ path: 'screenshots/group-detail-sessions.png', fullPage: true })
+
+  expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)
+  await context.close()
+})

--- a/e2e/tests/visual/group-detail.visual.spec.ts
+++ b/e2e/tests/visual/group-detail.visual.spec.ts
@@ -14,24 +14,29 @@ test.beforeAll(async ({ browser }) => {
   const page = await ctx.newPage()
   await setupMockTeacher(page)
 
-  // Seed a group with a member so the detail tabs have content to render
+  // Seed a group with a member so the detail tabs have content to render.
+  // Assert each seed call succeeds; a silent seed failure would otherwise
+  // cascade into misleading screenshots.
   const studentRes = await page.request.post(`${API_BASE}/api/students`, {
     headers: AUTH_HEADER,
     data: { name: 'Visual Student', learningLanguage: 'Spanish', cefrLevel: 'B1', interests: [], learningGoals: [], weaknesses: [], difficulties: [] },
   })
+  expect(studentRes.ok(), 'student seed failed').toBeTruthy()
   const student = await studentRes.json()
 
   const groupRes = await page.request.post(`${API_BASE}/api/groups`, {
     headers: AUTH_HEADER,
     data: { name: 'Visual Review Group', cefrLevel: 'B1', description: 'A sample group for visual review.', isActive: true },
   })
+  expect(groupRes.ok(), 'group seed failed').toBeTruthy()
   const group = await groupRes.json()
   groupId = group.id
 
-  await page.request.post(`${API_BASE}/api/groups/${groupId}/members`, {
+  const memberRes = await page.request.post(`${API_BASE}/api/groups/${groupId}/members`, {
     headers: AUTH_HEADER,
     data: { studentId: student.id },
   })
+  expect(memberRes.ok(), 'group-member seed failed').toBeTruthy()
 
   await page.close()
   await ctx.close()
@@ -47,18 +52,20 @@ test('@visual group detail tabs', async ({ browser }) => {
   await page.goto(`/groups/${groupId}`)
   await expect(page.getByTestId('group-detail-page')).toBeVisible({ timeout: NAV_TIMEOUT })
 
-  // Overview tab (default): hero spine + group-scoped Teacher's Working Memory card
-  await expect(page.getByTestId('tab-overview')).toBeVisible({ timeout: UI_TIMEOUT })
+  // Overview tab (default): assert overview content rendered, not just the tab button.
+  await expect(page.getByTestId('group-profile-card')).toBeVisible({ timeout: UI_TIMEOUT })
   await page.screenshot({ path: 'screenshots/group-detail-overview.png', fullPage: true })
 
-  // Members tab: roster of seeded member
+  // Members tab: assert the members panel actually rendered (proves the tab switched).
   await page.getByTestId('tab-members').click()
-  await expect(page.getByTestId('tab-members')).toBeVisible({ timeout: UI_TIMEOUT })
+  await expect(page.getByTestId('group-members-tab')).toBeVisible({ timeout: UI_TIMEOUT })
   await page.screenshot({ path: 'screenshots/group-detail-members.png', fullPage: true })
 
-  // Sessions tab: group session history
+  // Sessions tab: assert the sessions panel (or its empty state) rendered.
   await page.getByTestId('tab-sessions').click()
-  await expect(page.getByTestId('tab-sessions')).toBeVisible({ timeout: UI_TIMEOUT })
+  await expect(
+    page.getByTestId('group-sessions-tab').or(page.getByTestId('sessions-empty-state')),
+  ).toBeVisible({ timeout: UI_TIMEOUT })
   await page.screenshot({ path: 'screenshots/group-detail-sessions.png', fullPage: true })
 
   expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)

--- a/e2e/tests/visual/group-log-session.visual.spec.ts
+++ b/e2e/tests/visual/group-log-session.visual.spec.ts
@@ -14,24 +14,29 @@ test.beforeAll(async ({ browser }) => {
   const page = await ctx.newPage()
   await setupMockTeacher(page)
 
-  // Seed a group with a member so the left-rail identity + members disclosure render
+  // Seed a group with a member so the left-rail identity + members disclosure
+  // render. Assert each seed call succeeds; a silent seed failure would
+  // otherwise cascade into misleading screenshots.
   const studentRes = await page.request.post(`${API_BASE}/api/students`, {
     headers: AUTH_HEADER,
     data: { name: 'Visual Student', learningLanguage: 'Spanish', cefrLevel: 'B1', interests: [], learningGoals: [], weaknesses: [], difficulties: [] },
   })
+  expect(studentRes.ok(), 'student seed failed').toBeTruthy()
   const student = await studentRes.json()
 
   const groupRes = await page.request.post(`${API_BASE}/api/groups`, {
     headers: AUTH_HEADER,
     data: { name: 'Visual Review Group', cefrLevel: 'B1', description: 'A sample group for visual review.', isActive: true },
   })
+  expect(groupRes.ok(), 'group seed failed').toBeTruthy()
   const group = await groupRes.json()
   groupId = group.id
 
-  await page.request.post(`${API_BASE}/api/groups/${groupId}/members`, {
+  const memberRes = await page.request.post(`${API_BASE}/api/groups/${groupId}/members`, {
     headers: AUTH_HEADER,
     data: { studentId: student.id },
   })
+  expect(memberRes.ok(), 'group-member seed failed').toBeTruthy()
 
   await page.close()
   await ctx.close()
@@ -48,9 +53,12 @@ test('@visual group log session form', async ({ browser }) => {
   await expect(page.getByTestId('group-log-session-page')).toBeVisible({ timeout: NAV_TIMEOUT })
   await expect(page.getByTestId('group-log-session-left-panel')).toBeVisible({ timeout: UI_TIMEOUT })
 
-  // Group variant suppresses the editable Previous-Homework tri-state toggle:
-  // it surfaces as a read-only marker, never the interactive control.
-  await expect(page.getByTestId('prev-homework-readonly')).toBeVisible({ timeout: UI_TIMEOUT })
+  // The core group requirement: the editable Previous-Homework tri-state toggle
+  // (data-testid="prev-homework-status" in the 1-to-1 form) must NEVER appear in the
+  // group variant. Homework status is per-student, not a group-level concept. A fresh
+  // group with no prior session shows the "first session" rail instead.
+  await expect(page.getByTestId('first-session-empty')).toBeVisible({ timeout: UI_TIMEOUT })
+  await expect(page.getByTestId('prev-homework-status')).toHaveCount(0)
   await page.screenshot({ path: 'screenshots/group-log-session.png', fullPage: true })
 
   // Expand the members disclosure in the group-identity rail

--- a/e2e/tests/visual/group-log-session.visual.spec.ts
+++ b/e2e/tests/visual/group-log-session.visual.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test'
+import { createMockAuthContext } from '../../helpers/auth-helper'
+import { setupMockTeacher } from '../../helpers/mock-teacher-helper'
+import { NAV_TIMEOUT, UI_TIMEOUT } from '../../helpers/timeouts'
+import * as fs from 'fs'
+
+const API_BASE = process.env.VITE_API_BASE_URL ?? 'http://localhost:5178'
+const AUTH_HEADER = { Authorization: 'Bearer test-token', 'Content-Type': 'application/json' }
+
+let groupId = ''
+
+test.beforeAll(async ({ browser }) => {
+  const ctx = await createMockAuthContext(browser)
+  const page = await ctx.newPage()
+  await setupMockTeacher(page)
+
+  // Seed a group with a member so the left-rail identity + members disclosure render
+  const studentRes = await page.request.post(`${API_BASE}/api/students`, {
+    headers: AUTH_HEADER,
+    data: { name: 'Visual Student', learningLanguage: 'Spanish', cefrLevel: 'B1', interests: [], learningGoals: [], weaknesses: [], difficulties: [] },
+  })
+  const student = await studentRes.json()
+
+  const groupRes = await page.request.post(`${API_BASE}/api/groups`, {
+    headers: AUTH_HEADER,
+    data: { name: 'Visual Review Group', cefrLevel: 'B1', description: 'A sample group for visual review.', isActive: true },
+  })
+  const group = await groupRes.json()
+  groupId = group.id
+
+  await page.request.post(`${API_BASE}/api/groups/${groupId}/members`, {
+    headers: AUTH_HEADER,
+    data: { studentId: student.id },
+  })
+
+  await page.close()
+  await ctx.close()
+})
+
+test('@visual group log session form', async ({ browser }) => {
+  fs.mkdirSync('screenshots', { recursive: true })
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+  const consoleErrors: string[] = []
+  page.on('console', msg => { if (msg.type() === 'error') consoleErrors.push(msg.text()) })
+
+  await page.goto(`/groups/${groupId}/log-session`)
+  await expect(page.getByTestId('group-log-session-page')).toBeVisible({ timeout: NAV_TIMEOUT })
+  await expect(page.getByTestId('group-log-session-left-panel')).toBeVisible({ timeout: UI_TIMEOUT })
+
+  // Group variant suppresses the editable Previous-Homework tri-state toggle:
+  // it surfaces as a read-only marker, never the interactive control.
+  await expect(page.getByTestId('prev-homework-readonly')).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.screenshot({ path: 'screenshots/group-log-session.png', fullPage: true })
+
+  // Expand the members disclosure in the group-identity rail
+  await page.getByTestId('members-disclosure-toggle').click()
+  await expect(page.getByTestId('members-disclosure-list')).toBeVisible({ timeout: UI_TIMEOUT })
+  await page.screenshot({ path: 'screenshots/group-log-session-members.png', fullPage: true })
+
+  expect(consoleErrors.filter(e => !e.includes('favicon'))).toHaveLength(0)
+  await context.close()
+})


### PR DESCRIPTION
## What

Adds the two missing Playwright visual specs that were blocking the end-of-sprint `review-ui-sprint` gate for the Groups sprint:

- `e2e/tests/visual/group-detail.visual.spec.ts` — `/groups/:id`, screenshots Overview / Members / Sessions tabs
- `e2e/tests/visual/group-log-session.visual.spec.ts` — `/groups/:id/log-session`, asserts the group-identity left rail + members disclosure, and that the editable Previous-Homework tri-state toggle (`prev-homework-status`) is **absent** in the group variant (homework status is per-student, not group-level)

Routes `/groups/:id` and `/groups/:id/log-session` (merged in #1329, #1330) had no visual-spec coverage, so the Playwright stack could not screenshot the sprint's two marquee screens.

## Verification

Both specs pass green against the live visual stack:
```
2 passed (3.4s)
```
(Run with `DB_PORT=1435` per docker-compose.visual.yml port mapping.)

Test-only change — no production code touched. Full per-task build-verify and the per-task review agents were not run as they are N/A for an additive e2e-spec change; CI validates the e2e TypeScript build.

## Note

During verification of these specs, the visual stack seed surfaced a separate P1 regression filed as **#1356** (CK_TeacherFollowups_Scope XOR constraint breaks teacher-level followups). That is fixed in its own PR.

Closes #1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added visual regression tests for group detail page functionality
  * Added visual regression tests for group log session form

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->