### PR TITLE
fix(groups): relax CK_TeacherFollowups_Scope from XOR to at-most-one (#1356)

### DIFF
--- a/backend/LangTeach.Api/Data/AppDbContext.cs
+++ b/backend/LangTeach.Api/Data/AppDbContext.cs
@@ -388,9 +388,13 @@ public class AppDbContext : DbContext
             e.HasIndex(f => new { f.TeacherId, f.StudentId });
             e.HasIndex(f => new { f.TeacherId, f.StudentId, f.Kind });
             e.HasIndex(f => new { f.GroupId, f.Status }).HasFilter("[GroupId] IS NOT NULL");
+            // At-most-one scope: a followup may be scoped to a student, a group, or
+            // neither (teacher-level agenda items). Both at once is rejected. This mirrors
+            // TeacherFollowupService.CreateAsync, which only forbids the both-set case.
+            // (Previously XOR, which wrongly forbade teacher-level followups -- see #1356.)
             e.ToTable(t => t.HasCheckConstraint(
                 "CK_TeacherFollowups_Scope",
-                "([StudentId] IS NULL) <> ([GroupId] IS NULL)"));
+                "[StudentId] IS NULL OR [GroupId] IS NULL"));
             e.Property(f => f.Text).HasMaxLength(500).IsRequired();
             e.Property(f => f.Status).HasDefaultValue("pending");
             e.Property(f => f.Kind).HasMaxLength(20).HasDefaultValue(TeacherFollowupKinds.Operational).IsRequired();

--- a/backend/LangTeach.Api/Migrations/20260524200808_FixTeacherFollowupScopeAtMostOne.Designer.cs
+++ b/backend/LangTeach.Api/Migrations/20260524200808_FixTeacherFollowupScopeAtMostOne.Designer.cs
@@ -4,6 +4,7 @@ using LangTeach.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LangTeach.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260524200808_FixTeacherFollowupScopeAtMostOne")]
+    partial class FixTeacherFollowupScopeAtMostOne
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/LangTeach.Api/Migrations/20260524200808_FixTeacherFollowupScopeAtMostOne.cs
+++ b/backend/LangTeach.Api/Migrations/20260524200808_FixTeacherFollowupScopeAtMostOne.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LangTeach.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixTeacherFollowupScopeAtMostOne : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_TeacherFollowups_Scope",
+                table: "TeacherFollowups");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_TeacherFollowups_Scope",
+                table: "TeacherFollowups",
+                sql: "[StudentId] IS NULL OR [GroupId] IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_TeacherFollowups_Scope",
+                table: "TeacherFollowups");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_TeacherFollowups_Scope",
+                table: "TeacherFollowups",
+                sql: "([StudentId] IS NULL) <> ([GroupId] IS NULL)");
+        }
+    }
+}

--- a/backend/LangTeach.Api/Migrations/20260524200808_FixTeacherFollowupScopeAtMostOne.cs
+++ b/backend/LangTeach.Api/Migrations/20260524200808_FixTeacherFollowupScopeAtMostOne.cs
@@ -27,6 +27,11 @@ namespace LangTeach.Api.Migrations
                 name: "CK_TeacherFollowups_Scope",
                 table: "TeacherFollowups");
 
+            // Reverting to XOR re-forbids teacher-level (unscoped) followups. If any rows
+            // with both StudentId and GroupId NULL exist, this AddCheckConstraint fails
+            // (SQL 547) by design: an "exactly-one" invariant cannot be restored once
+            // "neither" rows legitimately exist. Roll back only against data predating such
+            // rows. See #1356.
             migrationBuilder.AddCheckConstraint(
                 name: "CK_TeacherFollowups_Scope",
                 table: "TeacherFollowups",


### PR DESCRIPTION
## Problem

#1330 tightened `CK_TeacherFollowups_Scope` to **XOR** (`([StudentId] IS NULL) <> ([GroupId] IS NULL)`), requiring exactly one of StudentId/GroupId. This forbids **teacher-level (unscoped) followups** — the dashboard agenda items that predate Groups (StudentId NULL **and** GroupId NULL).

The model (`StudentId?`, `GroupId?` both nullable) and `TeacherFollowupService.CreateAsync` (rejects only the *both-set* case, permits *neither*) both intend at-most-one. The DB constraint contradicted them.

### Impact (all reproduced live)
- `POST /api/teacher-followups` with no student/group → **HTTP 500 / SQL 547**.
- The visual/demo seed aborted on its 4 teacher-level followups, cascading so the correction fixture never seeded (this was the root cause of the correction-detail visual spec failing during sprint-close UI review).
- The `ADD CONSTRAINT` migration would **fail on any prod DB that already holds unscoped followups**, blocking deploy.

## Fix

New migration `20260524200808_FixTeacherFollowupScopeAtMostOne` relaxes the constraint to **at-most-one** (`[StudentId] IS NULL OR [GroupId] IS NULL`), matching the service layer exactly. Up drops + re-adds; Down restores XOR. `AppDbContext.cs` (+ explanatory comment) and the snapshot updated. `CK_SessionLogs_Target` intentionally remains XOR (a session must have exactly one target).

## Verification (live, against the e2e visual stack)

| Case | Result |
|---|---|
| unscoped create | 201 |
| both-set | 400 (service guard) |
| student-scoped | 201 |
| group-scoped | 201 |
| visual seed | completes ("4 entries" + correction fixture seeded) |
| correction-detail.visual.spec.ts | 1 passed |

Build-verify: backend bicep/build/test PASS; frontend build + 1817 tests pass (initial npm failure was a missing `sonner` dep — a worktree-setup artifact, not this backend-only change).

### Regression guard note
The project's backend tests use EF **InMemory**, which does not enforce check constraints, so a unit test cannot catch XOR reintroduction (existing InMemory tests already create unscoped followups and passed *with* the bug). The guards are: the visual seed now exercises unscoped followups (integration-level, fails fast on re-regression) and the inline comment in `AppDbContext.cs` warning against re-tightening.

## Reviews
qa-verify PASS WITH GAPS (no automated constraint test — see note above), code review PASS, architecture PASS, Sophy APPROVE.

Closes #1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed teacher followup scope validation to allow unscoped followups, enabling teachers to create follow-up tasks not tied to specific students or groups for greater organizational flexibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->