### PR TITLE
fix(corrections): keep paragraph-break C finding for B1+ students in level filter (#1368)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionLevelFilterTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/RedaccionCorrectionLevelFilterTests.cs
@@ -506,6 +506,70 @@ public class RedaccionCorrectionLevelFilterTests : IDisposable
         req.SystemPrompt.Should().Contain("intentional effort", "soften trigger must reference intentional effort by the student");
     }
 
+    [Theory]
+    [InlineData("B1")]
+    [InlineData("B2")]
+    [InlineData("C1")]
+    [InlineData("C2")]
+    public async Task LevelFilter_ParagraphBreakCTag_KeptForB1PlusStudentEvenWhenFilterSaysRemove(string cefr)
+    {
+        // Arrange: student at B1+, paragraph-break C tag (correctedForm="¶").
+        // The filter incorrectly says "remove" -- the structural guard must override it (#1368).
+        var text = "Me gusta el verano porque hace calor y podemos ir a la playa. Pero hay un problema grave en el mundo. El cambio climático afecta a todos.";
+        var student = _db.Students.First(s => s.Id == _studentId);
+        student.CefrLevel = cefr;
+        _db.SaveChanges();
+
+        var id = SeedCorrection(text, CorrectionStatus.Entregada);
+        var spanStart = text.IndexOf("Pero hay un problema", StringComparison.Ordinal);
+        var spanEnd = spanStart + "Pero hay un problema".Length;
+
+        _claude.EnqueueResponse(Pass1Json(text, new[]
+        {
+            ("C", spanStart, spanEnd, "Pero hay un problema", "Aquí debería empezar un párrafo nuevo.", "¶"),
+        }));
+        _claude.EnqueueResponse(FilterJson(new[] { (0, "remove", "") }));
+
+        await _sut.CorregirAsync(_teacherId, _studentId, id);
+        SetStatusToCorrigiendo(id);
+        await RunExecutionAsync(id);
+        using var check = new AppDbContext(_dbOptions);
+        var row = check.Corrections.Include(c => c.Tags).First(c => c.Id == id);
+
+        row.Tags.Should().HaveCount(1, $"paragraph-break C tag must be kept for {cefr} student even when filter says remove");
+        row.Tags.First().Category.Should().Be("C");
+        row.Tags.First().CorrectedForm.Should().Be("¶");
+        row.Tags.First().FilterStatus.Should().Be(CorrectionTagFilterStatus.Kept);
+    }
+
+    [Fact]
+    public async Task LevelFilter_ParagraphBreakCTag_StillRemovedForBelowFloorStudent()
+    {
+        // A2 is below the B1 floor for paragraph-break C tags.
+        // If the filter says "remove", the tag must remain teacher-only (no floor bypass).
+        var text = "Me gusta el verano porque hace calor. Pero hay un problema grave en el mundo. El cambio climático afecta a todos.";
+        // Default student is A2 (seeded in constructor).
+        var id = SeedCorrection(text, CorrectionStatus.Entregada);
+        var spanStart = text.IndexOf("Pero hay un problema", StringComparison.Ordinal);
+        var spanEnd = spanStart + "Pero hay un problema".Length;
+
+        _claude.EnqueueResponse(Pass1Json(text, new[]
+        {
+            ("C", spanStart, spanEnd, "Pero hay un problema", "Aquí debería empezar un párrafo nuevo.", "¶"),
+        }));
+        _claude.EnqueueResponse(FilterJson(new[] { (0, "remove", "") }));
+
+        await _sut.CorregirAsync(_teacherId, _studentId, id);
+        SetStatusToCorrigiendo(id);
+        await RunExecutionAsync(id);
+        using var check = new AppDbContext(_dbOptions);
+        var row = check.Corrections.Include(c => c.Tags).First(c => c.Id == id);
+
+        row.Tags.Where(t => t.FilterStatus == CorrectionTagFilterStatus.Kept)
+            .Should().BeEmpty("A2 is below the B1 paragraph-break floor; tag must stay teacher-only");
+        row.Tags.Should().ContainSingle(t => t.FilterStatus == CorrectionTagFilterStatus.Removed && t.Category == "C");
+    }
+
     // ─── Helpers ────────────────────────────────────────────────────────────────
 
     private void SeedStudent(string cefrLevel = "A2")

--- a/backend/LangTeach.Api/Services/IPedagogyConfigService.cs
+++ b/backend/LangTeach.Api/Services/IPedagogyConfigService.cs
@@ -216,6 +216,12 @@ public interface IPedagogyConfigService
     string? GetNextLevel(string cefrLevel);
 
     /// <summary>
+    /// Returns true if <paramref name="level"/> is at or above <paramref name="floor"/> in the CEFR order.
+    /// Returns false if either value is unrecognised.
+    /// </summary>
+    bool IsAtOrAboveLevel(string level, string floor);
+
+    /// <summary>
     /// Returns the list of always-keep grammar topics loaded from always-keep-grammar-rules.json.
     /// G tags matching these topics pass through the level filter unconditionally.
     /// </summary>

--- a/backend/LangTeach.Api/Services/PedagogyConfigService.cs
+++ b/backend/LangTeach.Api/Services/PedagogyConfigService.cs
@@ -639,7 +639,7 @@ public class PedagogyConfigService : IPedagogyConfigService
 
         // Drift anchor for the paragraph-break floor guard in RedaccionCorrectionService (#1368).
         // If either constant drifts from the config prose, the service will fail fast at startup.
-        var cohesionCategory = f.Categories.First(c => c.Code == "C");
+        var cohesionCategory = f.Categories.First(c => string.Equals(c.Code, "C", StringComparison.OrdinalIgnoreCase));
         var cohesionText = cohesionCategory.Description + string.Join(" ", cohesionCategory.SubTypes ?? []);
         if (!cohesionText.Contains("¶", StringComparison.Ordinal))
             throw new InvalidOperationException(

--- a/backend/LangTeach.Api/Services/PedagogyConfigService.cs
+++ b/backend/LangTeach.Api/Services/PedagogyConfigService.cs
@@ -518,6 +518,13 @@ public class PedagogyConfigService : IPedagogyConfigService
         return idx >= 0 && idx < CefrOrder.Length - 1 ? CefrOrder[idx + 1] : null;
     }
 
+    public bool IsAtOrAboveLevel(string level, string floor)
+    {
+        var levelIdx = Array.IndexOf(CefrOrder, NormalizeLevel(level));
+        var floorIdx = Array.IndexOf(CefrOrder, NormalizeLevel(floor));
+        return levelIdx >= 0 && floorIdx >= 0 && levelIdx >= floorIdx;
+    }
+
     public IReadOnlyList<AlwaysKeepGrammarTopic> GetAlwaysKeepTopics() =>
         _alwaysKeepRules.AlwaysKeepTopics;
 
@@ -629,6 +636,17 @@ public class PedagogyConfigService : IPedagogyConfigService
                 throw new InvalidOperationException(
                     $"PedagogyConfigService: correction-categories.json category '{cat.Code}' has an example with a blank Text, Note, or Label.");
         }
+
+        // Drift anchor for the paragraph-break floor guard in RedaccionCorrectionService (#1368).
+        // If either constant drifts from the config prose, the service will fail fast at startup.
+        var cohesionCategory = f.Categories.First(c => c.Code == "C");
+        var cohesionText = cohesionCategory.Description + string.Join(" ", cohesionCategory.SubTypes ?? []);
+        if (!cohesionText.Contains("¶", StringComparison.Ordinal))
+            throw new InvalidOperationException(
+                "PedagogyConfigService: correction-categories.json C category must define the paragraph-break marker (¶).");
+        if (!cohesionText.Contains("B1", StringComparison.OrdinalIgnoreCase))
+            throw new InvalidOperationException(
+                "PedagogyConfigService: correction-categories.json C category must define the paragraph-break floor (B1).");
 
         if (f.CriticalRules.Any(r => string.IsNullOrWhiteSpace(r.Topic) || string.IsNullOrWhiteSpace(r.Preamble)))
             throw new InvalidOperationException("PedagogyConfigService: correction-categories.json has a criticalRule with a blank Topic or Preamble.");

--- a/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
+++ b/backend/LangTeach.Api/Services/RedaccionCorrectionService.cs
@@ -511,6 +511,19 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
                     });
                     break;
                 case "remove":
+                    // Floored-category guard (#1368): if the finding's category has a minimum CEFR
+                    // floor and the student is at or above that floor, the tag is in scope and must
+                    // not be removed regardless of the filter's decision.
+                    // Paragraph-break C findings (correctedForm == "¶") have a B1 floor;
+                    // the filter incorrectly classifies them by tag type rather than checking the floor.
+                    if (IsParagraphBreakAtFloor(tag, cefr, pedagogy))
+                    {
+                        logger.LogDebug(
+                            "Level filter overridden: paragraph-break C tag kept for {Cefr} student (floor B1). CorrectionId={CorrectionId}",
+                            cefr, correctionId);
+                        result.Add(tag);
+                        break;
+                    }
                     // Above the student's level. No longer discarded: persisted with the
                     // original category/explanation/correctedForm so the teacher can see it
                     // in the all-errors view, but excluded from the student default (#1351).
@@ -642,6 +655,17 @@ public class RedaccionCorrectionService : IRedaccionCorrectionService
     }
 
     private static readonly ConcurrentDictionary<string, Regex> _keywordRegexCache = new();
+
+    // Paragraph-break C tags use correctedForm == "¶" as their structural marker (#1350).
+    // They have a B1 floor: only generated for B1-and-above students, so the filter must not
+    // remove them for a student who is at or above that floor (#1368).
+    private const string ParagraphBreakFloor = "B1";
+    private const string ParagraphBreakCorrectedForm = "¶";
+
+    private static bool IsParagraphBreakAtFloor(RedaccionCorrectionTagDto tag, string studentCefr, IPedagogyConfigService pedagogy) =>
+        tag.Category == CorrectionTagCategory.Cohesion
+        && tag.CorrectedForm == ParagraphBreakCorrectedForm
+        && pedagogy.IsAtOrAboveLevel(studentCefr, ParagraphBreakFloor);
 
     private static bool IsAlwaysKeepGTag(RedaccionCorrectionTagDto tag, IReadOnlyList<AlwaysKeepGrammarTopic> topics)
     {


### PR DESCRIPTION
## Summary
- The level filter incorrectly removed in-scope B1 cohesion (paragraph-break) findings from the student view. The AI filter classified the finding by tag type (C = cohesion) rather than checking whether the student's level meets the B1 floor that #1350 set.
- Added a structural floor guard in `ApplyLevelFilterAsync`: paragraph-break C tags (identified by `correctedForm == "¶"`) are never removed when the student is at or above B1. Analogous to the existing O-tag and ser/estar G-tag guards.
- Added `IsAtOrAboveLevel` to `IPedagogyConfigService` + startup validation that anchors the floor/marker constants to `correction-categories.json` so drift fails fast at startup.

## What was NOT changed
- Pass 1 trigger rubric (`correction-categories.json`) -- untouched
- Teacher/student split mechanism (#1351) -- untouched; removed tags still persist as "removed" for the teacher-only all-errors view

## Test plan
- [x] 5 new unit tests: B1/B2/C1/C2 students with paragraph-break C + filter "remove" -> kept; A2 student + filter "remove" -> still removed
- [x] 1565 dotnet tests pass, 1818 frontend tests pass
- [x] Live verify: B1 student correction ran end-to-end with no tags incorrectly removed
- [x] QA verify: PASS WITH GAPS (docx rendering path not integration-tested, but FilterStatus correctness fully covered)
- [x] Architecture review: PASS
- [x] Sophy pre-implementation: addressed (added startup drift anchor)

Closes #1368

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of paragraph markers in student correction feedback for intermediate and advanced learners, ensuring consistent behavior across proficiency levels.

* **Tests**
  * Added comprehensive unit tests verifying proper treatment of paragraph markers across different student proficiency levels and scenarios.

* **Chores**
  * Enhanced startup validation of correction category settings to enforce consistency requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->