### PR TITLE
fix(groups/corrections): sprint-close UI defects (#1369)

### DIFF
--- a/frontend/src/components/GroupAvatarCluster.test.tsx
+++ b/frontend/src/components/GroupAvatarCluster.test.tsx
@@ -33,6 +33,12 @@ describe('GroupAvatarCluster', () => {
     expect(screen.getByRole('img', { name: /5 members: Person 0, Person 1, Person 2/i })).toBeInTheDocument()
   })
 
+  it('handles short preview array in grid overflow mode (preview shorter than maxVisible-1)', () => {
+    render(<GroupAvatarCluster size="lg" members={makeMembers(2)} totalCount={5} />)
+    expect(screen.getAllByTestId('group-avatar-tile')).toHaveLength(2)
+    expect(screen.getByTestId('group-avatar-overflow')).toHaveTextContent('+3')
+  })
+
   it('renders 4 tiles and no overflow for size=lg when count = 4', () => {
     render(<GroupAvatarCluster size="lg" members={makeMembers(4)} totalCount={4} />)
     expect(screen.getAllByTestId('group-avatar-tile')).toHaveLength(4)

--- a/frontend/src/components/GroupAvatarCluster.test.tsx
+++ b/frontend/src/components/GroupAvatarCluster.test.tsx
@@ -23,7 +23,14 @@ describe('GroupAvatarCluster', () => {
   it('renders 2x2 grid for size=lg with overflow on the 4th slot when count > 4', () => {
     render(<GroupAvatarCluster size="lg" members={makeMembers(5)} totalCount={10} />)
     expect(screen.getAllByTestId('group-avatar-tile')).toHaveLength(3)
-    expect(screen.getByTestId('group-avatar-overflow')).toHaveTextContent('+6')
+    expect(screen.getByTestId('group-avatar-overflow')).toHaveTextContent('+7')
+  })
+
+  it('shows correct overflow for a 5-member group (real-world case: 3 tiles + "+2")', () => {
+    render(<GroupAvatarCluster size="lg" members={makeMembers(5)} totalCount={5} />)
+    expect(screen.getAllByTestId('group-avatar-tile')).toHaveLength(3)
+    expect(screen.getByTestId('group-avatar-overflow')).toHaveTextContent('+2')
+    expect(screen.getByRole('img', { name: /5 members: Person 0, Person 1, Person 2/i })).toBeInTheDocument()
   })
 
   it('renders 4 tiles and no overflow for size=lg when count = 4', () => {

--- a/frontend/src/components/GroupAvatarCluster.tsx
+++ b/frontend/src/components/GroupAvatarCluster.tsx
@@ -29,15 +29,16 @@ export function GroupAvatarCluster({
 }: GroupAvatarClusterProps) {
   const isGrid = size === 'lg'
   const maxVisible = isGrid ? 4 : 3
-  const visible = members.slice(0, maxVisible)
-  const overflow = totalCount - maxVisible
+  // In grid mode the overflow tile occupies slot 3, so only maxVisible-1 member tiles are shown.
+  const showsOverflow = totalCount > maxVisible
+  const tilesShown = isGrid && showsOverflow ? maxVisible - 1 : Math.min(members.length, maxVisible)
+  const overflow = totalCount - tilesShown
+  const visible = members.slice(0, tilesShown)
   const tileCls = TILE_CLASS[size]
   const ariaNames = visible.map(m => m.name).join(', ')
   const ariaLabel = `${totalCount} member${totalCount === 1 ? '' : 's'}${ariaNames ? `: ${ariaNames}` : ''}`
 
   if (isGrid) {
-    const slots = [...visible]
-    while (slots.length < 4 && slots.length < totalCount) slots.push(null as unknown as GroupAvatarMember)
     return (
       <div
         role="img"

--- a/frontend/src/components/GroupAvatarCluster.tsx
+++ b/frontend/src/components/GroupAvatarCluster.tsx
@@ -31,7 +31,7 @@ export function GroupAvatarCluster({
   const maxVisible = isGrid ? 4 : 3
   // In grid mode the overflow tile occupies slot 3, so only maxVisible-1 member tiles are shown.
   const showsOverflow = totalCount > maxVisible
-  const tilesShown = isGrid && showsOverflow ? maxVisible - 1 : Math.min(members.length, maxVisible)
+  const tilesShown = isGrid && showsOverflow ? Math.min(members.length, maxVisible - 1) : Math.min(members.length, maxVisible)
   const overflow = totalCount - tilesShown
   const visible = members.slice(0, tilesShown)
   const tileCls = TILE_CLASS[size]

--- a/frontend/src/components/student/StudentOverviewTab.test.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.test.tsx
@@ -397,3 +397,40 @@ describe('StudentOverviewTab - rotating empty-state prompts', () => {
     expect(screen.queryByTestId('ideas-rotating-prompt')).not.toBeInTheDocument()
   })
 })
+
+describe('StudentOverviewTab - allSessions includes group sessions', () => {
+  const GROUP_SESSION: SessionLog = {
+    ...MOCK_SESSION,
+    id: 'group-sess-1',
+    targetType: 'group' as const,
+    groupId: 'grp-1',
+    targetName: 'B1 Group',
+    title: 'Group Conversation Class',
+    sessionDate: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+  }
+
+  it('shows empty state when sessions=[](1-to-1 only) and allSessions not passed', () => {
+    renderOverview(BASE_STUDENT, [])
+    expect(screen.getByTestId('last-session-empty')).toBeInTheDocument()
+  })
+
+  it('shows LastSessionCard for group session when allSessions provided and sessions is empty', () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={qc}>
+        <TooltipProvider>
+          <MemoryRouter>
+            <StudentOverviewTab
+              student={BASE_STUDENT}
+              sessions={[]}
+              allSessions={[GROUP_SESSION]}
+              onStudentChange={() => {}}
+            />
+          </MemoryRouter>
+        </TooltipProvider>
+      </QueryClientProvider>
+    )
+    expect(screen.getByTestId('last-session-card')).toBeInTheDocument()
+    expect(screen.getByTestId('last-session-title')).toHaveTextContent('Group Conversation Class')
+  })
+})

--- a/frontend/src/components/student/StudentOverviewTab.tsx
+++ b/frontend/src/components/student/StudentOverviewTab.tsx
@@ -20,6 +20,8 @@ import { rotatingPrompt } from '@/utils/rotatingPrompt'
 interface Props {
   student: Student
   sessions?: SessionLog[]
+  /** All sessions including group sessions. When provided, used for LastSessionCard and recent-sessions strip. */
+  allSessions?: SessionLog[]
   followups?: TeacherFollowup[]
   onFollowupChange?: () => void
   onStudentChange: () => void
@@ -422,6 +424,7 @@ function TeachingNotesPanel({
 export function StudentOverviewTab({
   student,
   sessions = [],
+  allSessions,
   followups = [],
   onFollowupChange,
   onStudentChange,
@@ -433,7 +436,8 @@ export function StudentOverviewTab({
   const pendingFollowupsCount = followups.filter(f => f.status === 'pending').length
   const pendingTodosCount = student.profile.teachingTodos.filter(t => t.status === 'pending').length
   const firstName = student.name.split(' ')[0]
-  const lastSession = pickLastSession(sessions)
+  const mergedSessions = allSessions ?? sessions
+  const lastSession = pickLastSession(mergedSessions)
 
   const FOLLOWUP_PROMPTS = [
     `Anything you promised ${firstName} for next class?`,
@@ -512,7 +516,7 @@ export function StudentOverviewTab({
 
       {/* Compact Session History -- skip the top entry when LastSessionCard is showing it */}
       {lastSession !== null && (
-        <RecentSessions sessions={sessions} onViewAll={onViewAllSessions} skipFirst studentId={student.id} />
+        <RecentSessions sessions={mergedSessions} onViewAll={onViewAllSessions} skipFirst studentId={student.id} />
       )}
 
       {/* Teacher's Working Memory */}

--- a/frontend/src/pages/RedaccionDetail.tsx
+++ b/frontend/src/pages/RedaccionDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { ArrowLeft, Download, Loader2, RefreshCw, ThumbsDown, ThumbsUp } from 'lucide-react'
+import { ArrowLeft, Download, Lock, Loader2, RefreshCw, ThumbsDown, ThumbsUp } from 'lucide-react'
 import {
   corregirCorrection,
   downloadCorrectionDocx,
@@ -159,8 +159,8 @@ export default function RedaccionDetail() {
             </Button>
           )}
           {isCorregida && hasAboveLevel && (
-            <Button variant="outline" size="sm" onClick={() => onDownload('teacher')}>
-              <Download className="mr-2 h-4 w-4" />
+            <Button variant="secondary" size="sm" onClick={() => onDownload('teacher')}>
+              <Lock className="mr-2 h-4 w-4" />
               Versión completa
             </Button>
           )}

--- a/frontend/src/pages/StudentDetail.test.tsx
+++ b/frontend/src/pages/StudentDetail.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../api/students', () => ({
 
 vi.mock('../api/sessionLogs', () => ({
   listSessions: vi.fn().mockResolvedValue([]),
+  listSessionsIncludingGroups: vi.fn().mockResolvedValue([]),
   createSession: vi.fn(),
   serializeTopicTags: vi.fn(() => '[]'),
   parseTopicTags: vi.fn(() => []),

--- a/frontend/src/pages/StudentDetail.tsx
+++ b/frontend/src/pages/StudentDetail.tsx
@@ -7,7 +7,7 @@ import { listCorrections } from '@/api/corrections'
 import { logger } from '../lib/logger'
 import { newId } from '@/lib/newId'
 import { getFollowups } from '@/api/followups'
-import { listSessions } from '@/api/sessionLogs'
+import { listSessions, listSessionsIncludingGroups } from '@/api/sessionLogs'
 import { getStudentGroups } from '@/api/groups'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -56,6 +56,12 @@ export default function StudentDetail() {
   const { data: sessions = [] } = useQuery({
     queryKey: ['sessions', id],
     queryFn: () => listSessions(id!),
+    enabled: !!id,
+  })
+
+  const { data: allSessions = [] } = useQuery({
+    queryKey: ['sessions-all', id],
+    queryFn: () => listSessionsIncludingGroups(id!),
     enabled: !!id,
   })
 
@@ -372,6 +378,7 @@ export default function StudentDetail() {
         <StudentOverviewTab
           student={student}
           sessions={sessions}
+          allSessions={allSessions}
           followups={followups}
           onFollowupChange={onFollowupChange}
           onStudentChange={onStudentChange}

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -5,6 +5,7 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 ## Open
 
 - *#1362 (arch, future-reuse, low): quota-429 client handling (detect status, extract resetsAt, format date) is now inline in two places (useGenerate hook + RedaccionDetail onError). If a third 429 call site appears, extract a shared `parseQuotaError` util. Not a current violation (two call sites, different abstraction layers).*
+- *#1369 (arch, convention, low): RedaccionDetail uses `variant="secondary"` for the teacher-only "Versión completa" button to visually differentiate it from the student-facing `variant="outline"` button. No existing restricted-action button pattern in the codebase. If a design system spec for restricted/teacher actions is established, this should adopt that pattern.*
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes three correctness/safety bugs found during Groups sprint-close walkthroughs.

- **GroupAvatarCluster overflow miscount**: In `lg`/grid mode, the overflow tile occupies slot 3, leaving only 3 member tiles visible. The previous formula (`totalCount - maxVisible`) gave "+1" for a 5-member group; the corrected formula (`totalCount - tilesShown` where `tilesShown = maxVisible - 1` when overflow exists) gives "+2". Aria-label name count now matches visible tiles.
- **Identical download buttons**: "Versión completa" (full teacher diagnostic) changed from `variant="outline"` + Download icon to `variant="secondary"` + Lock icon, making the student-facing default visually distinct from the teacher-only version.
- **Overview "Last Session" card ignores group sessions**: `StudentDetail` now fetches `listSessionsIncludingGroups` (same endpoint/key as the Sessions tab) and passes it as `allSessions` to `StudentOverviewTab`, which uses it for `pickLastSession` and the recent-sessions strip.

## Verify notes

- Bug 1 (avatar overflow) and Bug 3 (Overview last session): verified on live e2e stack -- "+2" confirmed for 5-member group, group session title confirmed in LastSessionCard.
- Bug 2 (download buttons): requires a real AI-generated correction with above-level errors to show both buttons simultaneously. Code change verified by inspection (variant + icon changed). The e2e seed data does not trigger `hasAboveLevel=true`.

## Test plan

- [ ] Unit tests: `GroupAvatarCluster.test.tsx` (updated "+7" assertion + new 5-member "+2" test), `StudentOverviewTab.test.tsx` (new group-session last-session test), `StudentDetail.test.tsx` (added `listSessionsIncludingGroups` mock)
- [ ] Build verify: PASS (all 110 frontend tests pass, dotnet build/tests pass)
- [ ] Live e2e: Avatar overflow "+2" and Overview last session confirmed
- [ ] UI review: PASS (17 visual tests passed, no layout issues)
- [ ] Architecture review: PASS WITH NOTES (note logged to code-review-backlog.md)

Closes #1369

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Group sessions are now visible within the student overview tab.

* **Bug Fixes**
  * Corrected overflow member count calculations in group avatar clusters.

* **Style**
  * Updated the teacher download button with new icon styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->