### PR TITLE
polish(groups): UI polish from Vera close review (#1370)

### DIFF
--- a/frontend/src/components/group/GroupOverviewTab.tsx
+++ b/frontend/src/components/group/GroupOverviewTab.tsx
@@ -112,15 +112,18 @@ export function GroupOverviewTab({
   onViewAllMembers,
   onViewAllSessions,
 }: Props) {
+  // Overview is a summary, not a full listing: the Members and Sessions tabs own the complete lists.
   const members = group.members ?? []
-  const displayMembers = members.slice(0, 8)
-  const showMembersViewAll = members.length > 8
+  const displayMembers = members.slice(0, 3)
+  const showMembersViewAll = members.length > 3
 
   const pastSessions = sessions
     .filter(s => !s.isCancelled && s.sessionDate && new Date(s.sessionDate) <= new Date())
     .sort((a, b) => new Date(b.sessionDate!).getTime() - new Date(a.sessionDate!).getTime())
   const lastSession = pastSessions[0] ?? null
-  const recentSessions = pastSessions.slice(1, 6)
+  // Last Session card already highlights index 0; the strip summarises the next few.
+  const recentSessions = pastSessions.slice(1, 4)
+  const showSessionsViewAll = pastSessions.length > 4
 
   return (
     <div className="space-y-6">
@@ -211,7 +214,7 @@ export function GroupOverviewTab({
         <div data-testid="session-history-strip">
           <div className="flex items-center justify-between mb-3">
             <h3 className="text-sm font-bold text-[#1A1B22]">Session History</h3>
-            {pastSessions.length > 6 && (
+            {showSessionsViewAll && (
               <button
                 type="button"
                 onClick={onViewAllSessions}

--- a/frontend/src/components/session/SessionHistoryTab.test.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.test.tsx
@@ -239,6 +239,21 @@ describe('SessionHistoryTab', () => {
     expect(screen.getByTestId('group-session-pill')).toBeInTheDocument()
   })
 
+  it('renders the session-type filter as a pill-toggle group matching the status pills, not a dropdown', async () => {
+    vi.mocked(sessionLogsApi.listSessionsIncludingGroups).mockResolvedValue([SESSION_BASE])
+    wrapper()
+    await screen.findByTestId('session-entry')
+
+    const typeFilter = screen.getByTestId('session-type-filter')
+    expect(typeFilter).toBeInTheDocument()
+    // Default option is "All types" (not a bare "All" that would duplicate the status filter)
+    expect(screen.getByTestId('session-type-filter-all')).toHaveTextContent('All types')
+    expect(screen.getByTestId('session-type-filter-1-to-1')).toHaveTextContent('1-to-1')
+    expect(screen.getByTestId('session-type-filter-groups')).toHaveTextContent('Groups')
+    // Old Radix Select dropdown is gone
+    expect(typeFilter.querySelector('[role="combobox"]')).toBeNull()
+  })
+
   it('shows topic tag chips with category colors in expanded view', async () => {
     const session = {
       ...SESSION_BASE,

--- a/frontend/src/components/session/SessionHistoryTab.tsx
+++ b/frontend/src/components/session/SessionHistoryTab.tsx
@@ -27,7 +27,6 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { SavedIndicator } from '@/components/ui/SavedIndicator'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
   AlertDialog,
   AlertDialogContent,
@@ -776,6 +775,13 @@ export function SessionHistoryTab({ studentId, sessionTypeFilter = 'all', onSess
     { key: 'draft', label: 'Draft' },
   ]
 
+  // "All types" (not bare "All") avoids a confusing second "All" next to the status pills.
+  const typeButtons: { key: SessionTypeFilter; label: string }[] = [
+    { key: 'all', label: 'All types' },
+    { key: '1-to-1', label: '1-to-1' },
+    { key: 'groups', label: 'Groups' },
+  ]
+
   return (
     <div className="space-y-5 pt-2">
       {/* Header stat */}
@@ -924,26 +930,26 @@ export function SessionHistoryTab({ studentId, sessionTypeFilter = 'all', onSess
           </Popover>
         )}
 
-        {/* Session-type filter */}
-        <Select
-          value={sessionTypeFilter}
-          onValueChange={(v) => {
-            onSessionTypeFilterChange?.(v as SessionTypeFilter)
-            setVisibleCount(PAGE_SIZE)
-          }}
-        >
-          <SelectTrigger
-            className="w-36 bg-white border-0 ring-1 ring-[#C7C4D8]/30 rounded-xl text-sm"
-            data-testid="session-type-filter"
-          >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All</SelectItem>
-            <SelectItem value="1-to-1">1-to-1</SelectItem>
-            <SelectItem value="groups">Groups</SelectItem>
-          </SelectContent>
-        </Select>
+        {/* Session-type filter -- same pill-toggle paradigm as the status filter */}
+        <div className="flex bg-[#F4F2FD] p-1 rounded-xl" data-testid="session-type-filter">
+          {typeButtons.map(({ key, label }) => (
+            <button
+              key={key}
+              onClick={() => {
+                onSessionTypeFilterChange?.(key)
+                setVisibleCount(PAGE_SIZE)
+              }}
+              className={`px-3 py-1.5 text-xs font-bold rounded-lg transition-colors ${
+                sessionTypeFilter === key
+                  ? 'bg-white text-[#3525CD] shadow-sm'
+                  : 'text-zinc-500 hover:text-[#3525CD]'
+              }`}
+              data-testid={`session-type-filter-${key}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Session feed */}

--- a/frontend/src/components/student/StudentDetailHeader.test.tsx
+++ b/frontend/src/components/student/StudentDetailHeader.test.tsx
@@ -233,7 +233,7 @@ describe('StudentDetailHeader', () => {
     expect(screen.queryAllByTestId('group-affiliation-pill')).toHaveLength(0)
   })
 
-  it('renders group affiliation pills for each group', () => {
+  it('renders group affiliation pills, dropping the level only when the name already implies it', () => {
     render(
       <MemoryRouter>
         <StudentDetailHeader
@@ -241,15 +241,20 @@ describe('StudentDetailHeader', () => {
           nextSession={null}
           sessionFrequency={null}
           groups={[
+            // Name already references the level -> trailing " - B1" is dropped as redundant.
             { id: 'g1', name: 'B1 Conversacion', cefrLevel: 'B1' },
+            // No level -> name only.
             { id: 'g2', name: 'Exam Prep', cefrLevel: null },
+            // Name does not reference the level -> level is appended.
+            { id: 'g3', name: 'Lunes', cefrLevel: 'B2' },
           ]}
         />
       </MemoryRouter>
     )
     const pills = screen.getAllByTestId('group-affiliation-pill')
-    expect(pills).toHaveLength(2)
-    expect(pills[0]).toHaveTextContent('B1 Conversacion - B1')
-    expect(pills[1]).toHaveTextContent('Exam Prep')
+    expect(pills).toHaveLength(3)
+    expect(pills[0]).toHaveTextContent(/^B1 Conversacion$/)
+    expect(pills[1]).toHaveTextContent(/^Exam Prep$/)
+    expect(pills[2]).toHaveTextContent(/^Lunes - B2$/)
   })
 })

--- a/frontend/src/components/student/StudentDetailHeader.tsx
+++ b/frontend/src/components/student/StudentDetailHeader.tsx
@@ -11,6 +11,14 @@ import { cn } from '@/lib/utils'
 import { CefrBadge } from '@/components/dashboard/CefrBadge'
 import { getObjectiveUrgency, getDaysRemaining, formatDaysRemaining } from '@/lib/objectiveUrgency'
 
+// Append the group's CEFR level only when the group name doesn't already reference it,
+// so "Lunes B1" stays "Lunes B1" instead of becoming "Lunes B1 - B1".
+function groupPillLabel(name: string, cefrLevel: string | null | undefined): string {
+  if (!cefrLevel) return name
+  const alreadyMentioned = new RegExp(`\\b${cefrLevel}\\b`, 'i').test(name)
+  return alreadyMentioned ? name : `${name} - ${cefrLevel}`
+}
+
 function buildIdentitySubtitle(student: Student): string {
   const segments: string[] = []
   if (student.languages.nativeLanguages.length > 0) {
@@ -168,7 +176,7 @@ export function StudentDetailHeader({ student, nextSession, sessionFrequency, on
                   data-testid="group-affiliation-pill"
                   className="inline-flex items-center rounded-md px-2 py-0.5 text-[0.6875rem] font-medium bg-[#EDE9FE] text-[#5B21B6] hover:bg-[#DDD6FE] transition-colors"
                 >
-                  {group.name}{group.cefrLevel ? ` - ${group.cefrLevel}` : ''}
+                  {groupPillLabel(group.name, group.cefrLevel)}
                 </Link>
               ))}
               <TeachingChannelPicker

--- a/frontend/src/pages/GroupForm.test.tsx
+++ b/frontend/src/pages/GroupForm.test.tsx
@@ -89,6 +89,12 @@ describe('GroupForm - create mode', () => {
     expect(screen.getByTestId('member-search-input')).toBeInTheDocument()
   })
 
+  it('shows a placeholder for the CEFR control instead of a lowercase "none" default', () => {
+    renderCreate()
+    expect(screen.getByText('Select level…')).toBeInTheDocument()
+    expect(screen.queryByText('none')).not.toBeInTheDocument()
+  })
+
   it('shows validation error when saving with empty name', async () => {
     renderCreate()
     fireEvent.click(screen.getByTestId('save-button'))

--- a/frontend/src/pages/GroupForm.tsx
+++ b/frontend/src/pages/GroupForm.tsx
@@ -374,11 +374,11 @@ function GroupFormBody({ group }: { group?: Group }) {
                 CEFR Level
               </Label>
               <Select
-                value={cefrLevel || 'none'}
+                value={cefrLevel || undefined}
                 onValueChange={(v) => setCefrLevel(v == null || v === 'none' ? '' : v)}
               >
                 <SelectTrigger id="group-cefr" data-testid="group-cefr-select">
-                  <SelectValue placeholder="Select level (optional)" />
+                  <SelectValue placeholder="Select level…" />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="none">

--- a/frontend/src/pages/GroupLogSession.tsx
+++ b/frontend/src/pages/GroupLogSession.tsx
@@ -22,6 +22,8 @@ import { CefrBadge } from '@/components/dashboard/CefrBadge'
 import { TopicTagsInput } from '@/components/session/TopicTagsInput'
 import { AudioRecorder } from '@/components/audio/AudioRecorder'
 import { GroupAvatarCluster } from '@/components/GroupAvatarCluster'
+import { getAvatarColor } from '@/lib/avatarColor'
+import { cn } from '@/lib/utils'
 import { COMPETENCY_OPTIONS } from '@/lib/studentOptions'
 import { suggestTopicTags } from '@/lib/suggestTopicTags'
 import { formatDate as formatDateUtil, relativeTime, todayLocalDateStr } from '@/utils/formatDate'
@@ -478,7 +480,10 @@ export default function GroupLogSession() {
                 {members.map(m => (
                   <div key={m.id} className="flex items-center gap-2">
                     <div
-                      className="flex items-center justify-center rounded-full text-white text-[0.6rem] font-bold shrink-0 lt-gradient-primary"
+                      className={cn(
+                        'flex items-center justify-center rounded-full text-[0.6rem] font-bold shrink-0',
+                        getAvatarColor(m.id),
+                      )}
                       style={{ width: 24, height: 24 }}
                       aria-hidden
                     >

--- a/frontend/src/pages/Groups.test.tsx
+++ b/frontend/src/pages/Groups.test.tsx
@@ -80,6 +80,23 @@ describe('Groups page', () => {
     expect(screen.getAllByTestId('group-avatar-cluster')).toHaveLength(2)
   })
 
+  it('does not render an empty SIGNALS column header', async () => {
+    vi.mocked(groupsApi.getGroups).mockResolvedValue({
+      items: [makeGroup()],
+      totalCount: 1,
+      page: 1,
+      pageSize: 100,
+    })
+
+    renderPage()
+
+    await waitFor(() => expect(screen.getByText('B1.1 Tuesdays')).toBeInTheDocument())
+    expect(screen.queryByText('SIGNALS')).not.toBeInTheDocument()
+    // Real headers still present
+    expect(screen.getByText('CEFR LEVEL')).toBeInTheDocument()
+    expect(screen.getByText('NEXT SESSION')).toBeInTheDocument()
+  })
+
   it('filters by CEFR pill', async () => {
     vi.mocked(groupsApi.getGroups).mockResolvedValue({
       items: [makeGroup(), makeGroup({ id: 'g2', name: 'A2.1 Mondays', cefrLevel: 'A2' })],

--- a/frontend/src/pages/Groups.tsx
+++ b/frontend/src/pages/Groups.tsx
@@ -17,7 +17,8 @@ const CEFR_FILTER_OPTIONS = ['All', ...CEFR_LEVELS] as const
 const PAGE_SIZE = 12
 
 const COL_CLASSES = 'grid-cols-[minmax(140px,2fr)_80px_minmax(180px,1.5fr)_110px_130px_1fr]'
-const TABLE_HEADERS = ['NAME', 'CEFR LEVEL', 'MEMBERS', 'LAST SESSION', 'NEXT SESSION', 'SIGNALS'] as const
+// Last column header is intentionally blank: it sits over the row-chevron cell, which carries no label.
+const TABLE_HEADERS = ['NAME', 'CEFR LEVEL', 'MEMBERS', 'LAST SESSION', 'NEXT SESSION', ''] as const
 
 export default function Groups() {
   const navigate = useNavigate()


### PR DESCRIPTION
Closes #1370.

Six discrete frontend polish items from the Vera UX review during the Groups sprint close. Frontend-only; no API/DTO/entity changes.

## Changes
1. **Groups list** (`Groups.tsx`): dropped the empty `SIGNALS` column header (it sat over the row-chevron cell with no content). Grid columns unchanged; the last header is now a blank string.
2. **Log-session member disclosure** (`GroupLogSession.tsx`): avatars now use the stable per-entity pastel palette via `getAvatarColor(m.id)` instead of a flat indigo gradient, matching the cluster/list/detail and member chips.
3. **Group detail Overview** (`GroupOverviewTab.tsx`): now a summary, not a full listing. Members capped at top 3 with a "View all" link to the Members tab; the Last Session card stays and the Session History strip is capped at top 3 with "View all" to the Sessions tab. Avoids duplicating the dedicated tabs and scaling badly for large groups.
4. **Student Sessions tab** (`SessionHistoryTab.tsx`): the session-type filter is now a pill-toggle group styled identically to the status filter (one visual paradigm). Default labelled "All types" to avoid a confusing second bare "All". The old shadcn `Select` dropdown was removed.
5. **Create/edit group CEFR control** (`GroupForm.tsx`): shows a "Select level…" placeholder when no level is chosen, instead of defaulting to the lowercase `none` sentinel value. The `none` item is kept so edit-mode users can clear back to no level.
6. **Student hero group pill** (`StudentDetailHeader.tsx`): drops the trailing CEFR level when the group name already references it (`Lunes B1 - B1` becomes `Lunes B1`); keeps it when the name does not imply the level (`Lunes - B2`).

## What MUST NOT happen
No regression to the no-line rule, badge shapes, or cross-page consistency with the Students screens. Verified: avatars use the shared `getAvatarColor`, badges unchanged.

## Tests
- `Groups.test.tsx`: asserts no empty SIGNALS header while real headers remain.
- `SessionHistoryTab.test.tsx`: asserts the session-type filter renders as a pill-toggle group (All types / 1-to-1 / Groups), not a Select.
- `GroupForm.test.tsx`: asserts the "Select level…" placeholder is present and lowercase "none" is absent.
- `StudentDetailHeader.test.tsx`: asserts the level is dropped when the name implies it, kept otherwise.
- Items 2 and 3 are visual; covered by the live Verify + UI review rather than isolated unit tests (those components require disproportionate provider/audio mocking).

## Verification
**Live Verify (e2e stack, all 6 items):** created group "Lunes B1" (B1) with members + walked every screen. All 6 confirmed: no SIGNALS header (page-text), per-entity disclosure avatars, Overview top-3 + "View all", session-type pills matching the status pills, "Select level…" placeholder, hero pill "Lunes B1" (level dropped).

**UI review:** PASS on all 6 after a clean `--no-cache` rebuild (HEAD a561efd2). An initial review-ui run reported items 1 and 3 as NEEDS WORK; this was a stale-build false negative (its first stack session was built before these commits, then a mid-run stack restart rebuilt with the fixes, so observations were conflated). The committed `Groups.tsx` has no "SIGNALS" string and no responsive logic, so it cannot render that header at any width; the re-review with a guaranteed-current build confirmed PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session-type filter redesigned with pill/toggle buttons for improved usability.
  * Avatar colors now dynamically assigned per member.

* **Improvements**
  * Streamlined member previews and session history display to show fewer items.
  * Fixed duplicate level text in group affiliation labels.
  * Enhanced placeholder text in CEFR level field for clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->