### PR TITLE
polish(groups): converge group detail content width with student detail (#1375)

### DIFF
--- a/frontend/src/components/group/GroupDetailHeader.tsx
+++ b/frontend/src/components/group/GroupDetailHeader.tsx
@@ -24,70 +24,68 @@ export function GroupDetailHeader({ group, sessionFrequency }: GroupDetailHeader
 
   return (
     <div className="bg-white border-b border-zinc-100 px-6 py-5">
-      <div className="max-w-6xl mx-auto">
-        <Link
-          to="/groups"
-          className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-700 mb-4"
-          data-testid="back-to-groups"
-        >
-          <ArrowLeft className="h-3.5 w-3.5" />
-          Groups
-        </Link>
+      <Link
+        to="/groups"
+        className="inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-zinc-700 mb-4"
+        data-testid="back-to-groups"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+        Groups
+      </Link>
 
-        <div className="flex items-start gap-5">
-          <GroupAvatarCluster
-            size="lg"
-            members={memberPreview}
-            totalCount={group.memberCount}
-            className="shrink-0"
-          />
+      <div className="flex items-start gap-5">
+        <GroupAvatarCluster
+          size="lg"
+          members={memberPreview}
+          totalCount={group.memberCount}
+          className="shrink-0"
+        />
 
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 flex-wrap">
-              <h1 className="text-2xl font-bold font-manrope text-[#1A1B22] truncate" data-testid="group-name">
-                {group.name}
-              </h1>
-              {group.cefrLevel && (
-                <CefrBadge level={group.cefrLevel}  />
-              )}
-            </div>
-
-            <p className="text-sm text-zinc-500 mt-0.5" data-testid="group-subtitle">
-              {buildSubtitle(group)}
-            </p>
-
-            <div className="flex items-center gap-2 mt-1.5 flex-wrap">
-              {group.isActive && (
-                <span className="inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-[0.6875rem] font-bold uppercase tracking-wider text-emerald-700" data-testid="active-pill">
-                  Active
-                </span>
-              )}
-              {sessionFrequency && (
-                <span className="text-xs text-zinc-400" data-testid="cadence-text">
-                  {sessionFrequency}
-                </span>
-              )}
-            </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h1 className="text-2xl font-bold font-manrope text-[#1A1B22] truncate" data-testid="group-name">
+              {group.name}
+            </h1>
+            {group.cefrLevel && (
+              <CefrBadge level={group.cefrLevel}  />
+            )}
           </div>
 
-          <div className="flex items-center gap-2 shrink-0">
-            <Link
-              to={`/groups/${group.id}/edit`}
-              className={cn(buttonVariants({ variant: 'outline' }), 'gap-1.5')}
-              data-testid="edit-group-btn"
-            >
-              <Pencil className="h-3.5 w-3.5" />
-              Edit Group
-            </Link>
-            <Link
-              to={`/groups/${group.id}/log-session`}
-              className={cn(buttonVariants({ variant: 'default' }), 'gap-1.5')}
-              data-testid="log-session-btn"
-            >
-              <NotebookPen className="h-3.5 w-3.5" />
-              Log Session
-            </Link>
+          <p className="text-sm text-zinc-500 mt-0.5" data-testid="group-subtitle">
+            {buildSubtitle(group)}
+          </p>
+
+          <div className="flex items-center gap-2 mt-1.5 flex-wrap">
+            {group.isActive && (
+              <span className="inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-[0.6875rem] font-bold uppercase tracking-wider text-emerald-700" data-testid="active-pill">
+                Active
+              </span>
+            )}
+            {sessionFrequency && (
+              <span className="text-xs text-zinc-400" data-testid="cadence-text">
+                {sessionFrequency}
+              </span>
+            )}
           </div>
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          <Link
+            to={`/groups/${group.id}/edit`}
+            className={cn(buttonVariants({ variant: 'outline' }), 'gap-1.5')}
+            data-testid="edit-group-btn"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+            Edit Group
+          </Link>
+          <Link
+            to={`/groups/${group.id}/log-session`}
+            className={cn(buttonVariants({ variant: 'default' }), 'gap-1.5')}
+            data-testid="log-session-btn"
+          >
+            <NotebookPen className="h-3.5 w-3.5" />
+            Log Session
+          </Link>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/GroupDetail.tsx
+++ b/frontend/src/pages/GroupDetail.tsx
@@ -87,8 +87,8 @@ export default function GroupDetail() {
       <GroupDetailHeader group={group} sessionFrequency={sessionFrequency} />
 
       {/* Tabs row */}
-      <div className="bg-white border-b border-zinc-100 px-6">
-        <div className="max-w-6xl mx-auto flex gap-0">
+      <div className="bg-white border-b border-zinc-100">
+        <div className="flex gap-0">
           {TABS.map(tab => (
             <button
               key={tab}
@@ -108,7 +108,7 @@ export default function GroupDetail() {
       </div>
 
       {/* Tab content */}
-      <div className="max-w-6xl mx-auto px-6 py-6">
+      <div className="py-6">
         {activeTab === 'overview' && (
           <GroupOverviewTab
             group={group}


### PR DESCRIPTION
Closes #1375

## Problem
`GroupDetail` capped its content at `max-w-6xl mx-auto` (~1152px) and centered it, producing fat empty side gutters on wide windows. `StudentDetail` has no cap and fills the AppShell `<main>` content area, so the two sibling detail screens read at different widths.

## Fix
- Removed the three `max-w-6xl mx-auto` caps (`GroupDetailHeader`, `GroupDetail` tabs row, `GroupDetail` tab content).
- Removed the extra band `px-6` from the tabs band and the tab-content wrapper so the tabs, card grid, and dark "Teacher's Working Memory" band sit flush at the content-area edge, identical to `StudentDetail`.
- The header band keeps its `px-6` so hero content aligns with the student header card's content inset.
- Unwrapped the now-redundant inner `<div>` in `GroupDetailHeader` to match `StudentDetailHeader`'s structure (per architecture review).

The full-bleed-band-vs-floating-card scaffold difference between the two screens is intentionally preserved; only content width converges (per the issue's "What MUST NOT happen").

## Verification
Live e2e stack, 1700px viewport, measured bounding boxes:

| Element | Group | Student |
|---|---|---|
| Dark band | 280–1676 | 280–1676 |
| Card grid | 280–1676 | 280–1676 |
| First tab (left) | 280 | 280 |
| Hero name (left) | 406 | 408 |

Members and Sessions tabs verified to render flush at the same left edge (content sits at the content-box edge with AppShell `main`'s ~24px gutter; no viewport-edge bleed).

- `task-build-verify`: PASS (bicep/dotnet build+test, npm lint/build/test; 1825 frontend unit tests pass)
- qa-verify: PASS · architecture-reviewer: PASS WITH NOTES (both notes addressed) · review-ui: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
- Adjusted the group detail page layout to display full-width content instead of centered containers, providing a more spacious presentation of group information and tabs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robert-Freire/langTeachSaaS/pull/1377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->