### PR TITLE
fix(groups): delete action compact text-link + right rail overflow fix (#1389)

### DIFF
--- a/frontend/src/pages/GroupForm.tsx
+++ b/frontend/src/pages/GroupForm.tsx
@@ -539,7 +539,7 @@ function GroupFormBody({ group }: { group?: Group }) {
           </Button>
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_280px] gap-6 items-start">
+        <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_280px] gap-6 items-start overflow-x-hidden">
           {/* Main column */}
           <div className="space-y-6">
             <Card className="rounded-2xl border-0 bg-white shadow-[0_12px_40px_rgba(26,27,34,0.06)]">
@@ -837,19 +837,20 @@ function GroupFormBody({ group }: { group?: Group }) {
               />
             </div>
 
-            {/* Danger zone */}
-            <div className="pt-2" data-testid="danger-zone">
-              <Button
-                type="button"
-                variant="ghost"
-                className="text-red-600 hover:text-red-700 hover:bg-red-50 text-sm w-full justify-start"
-                onClick={() => setShowDeleteDialog(true)}
-                data-testid="delete-group-button"
-              >
-                Delete group
-              </Button>
-            </div>
           </div>
+        </div>
+
+        {/* Danger zone */}
+        <div className="pt-8 space-y-2" data-testid="danger-zone">
+          <Button
+            type="button"
+            variant="ghost"
+            className="text-red-500 hover:text-red-700 hover:bg-red-50 text-sm px-0"
+            onClick={() => setShowDeleteDialog(true)}
+            data-testid="delete-group-button"
+          >
+            Delete group
+          </Button>
         </div>
 
         <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>


### PR DESCRIPTION
Fixes #1389.

## Summary

- Move "Delete group" out of the 280px right rail into a full-width danger zone below the grid, matching the Edit Student pattern (`StudentForm.tsx:1439`)
- Change button styling from `w-full justify-start text-red-600` to `px-0 text-red-500` so it renders as a compact quiet text link, not a full-width band
- Add `overflow-x-hidden` to the two-column grid container to prevent the right rail from bleeding past the viewport at the lg breakpoint

## Verify

Tested live against the e2e stack at localhost:5174:
1. Edit Group at ~1024px -- rail (Members, Teaching Ideas, Pending Followups) fully visible, no horizontal scroll or clipping
2. "Delete group" appears as a compact red text link at the bottom of the page, below the grid
3. Side-by-side with Edit Student confirms matching danger zone treatment

## Reviewers

| Reviewer | Finding | Action |
|---|---|---|
| qa-verify | PASS WITH GAPS (no unit test for button class/position regression) | Accepted -- styling-only, e2e selector `data-testid` intact |
| code-review | PASS | -- |
| architecture-reviewer | PASS -- byte-for-byte match to StudentForm pattern | -- |
| review-ui | PASS (code inspection; live verify done manually against worktree stack) | -- |

🤖 Generated with [Claude Code](https://claude.com/claude-code)