### PR TITLE
feat(groups/ui): extract PillTabs component, fix group tab strip pattern (#1394)

### DIFF
--- a/frontend/src/components/common/PillTabs.test.tsx
+++ b/frontend/src/components/common/PillTabs.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { PillTabs } from './PillTabs'
+
+const tabs = [
+  { key: 'overview', label: 'Overview' },
+  { key: 'members', label: 'Members' },
+  { key: 'sessions', label: 'Sessions', badge: true },
+]
+
+describe('PillTabs', () => {
+  it('renders all tabs', () => {
+    render(<PillTabs tabs={tabs} activeTab="overview" onTabChange={vi.fn()} />)
+    expect(screen.getByTestId('tab-overview')).toBeInTheDocument()
+    expect(screen.getByTestId('tab-members')).toBeInTheDocument()
+    expect(screen.getByTestId('tab-sessions')).toBeInTheDocument()
+  })
+
+  it('applies bg-white to the selected tab', () => {
+    render(<PillTabs tabs={tabs} activeTab="members" onTabChange={vi.fn()} />)
+    expect(screen.getByTestId('tab-members').className).toContain('bg-white')
+    expect(screen.getByTestId('tab-overview').className).not.toContain('bg-white')
+  })
+
+  it('applies box-shadow inline style to selected tab only', () => {
+    render(<PillTabs tabs={tabs} activeTab="overview" onTabChange={vi.fn()} />)
+    expect(screen.getByTestId('tab-overview')).toHaveStyle({ boxShadow: '0 1px 3px rgba(26, 27, 34, 0.08)' })
+    expect(screen.getByTestId('tab-members')).not.toHaveStyle({ boxShadow: '0 1px 3px rgba(26, 27, 34, 0.08)' })
+  })
+
+  it('calls onTabChange with the clicked tab key', async () => {
+    const onTabChange = vi.fn()
+    render(<PillTabs tabs={tabs} activeTab="overview" onTabChange={onTabChange} />)
+    await userEvent.click(screen.getByTestId('tab-members'))
+    expect(onTabChange).toHaveBeenCalledWith('members')
+  })
+
+  it('renders the badge dot when badge is true', () => {
+    render(<PillTabs tabs={tabs} activeTab="overview" onTabChange={vi.fn()} />)
+    const sessionBtn = screen.getByTestId('tab-sessions')
+    expect(sessionBtn.querySelector('.bg-amber-500')).toBeInTheDocument()
+  })
+
+  it('does not render a badge dot when badge is false', () => {
+    render(<PillTabs tabs={tabs} activeTab="overview" onTabChange={vi.fn()} />)
+    const overviewBtn = screen.getByTestId('tab-overview')
+    expect(overviewBtn.querySelector('.bg-amber-500')).toBeNull()
+  })
+})

--- a/frontend/src/components/common/PillTabs.tsx
+++ b/frontend/src/components/common/PillTabs.tsx
@@ -1,4 +1,4 @@
-interface PillTab {
+export interface PillTab {
   key: string
   label: string
   badge?: boolean
@@ -8,11 +8,12 @@ interface PillTabsProps {
   tabs: PillTab[]
   activeTab: string
   onTabChange: (key: string) => void
+  'data-testid'?: string
 }
 
-export function PillTabs({ tabs, activeTab, onTabChange }: PillTabsProps) {
+export function PillTabs({ tabs, activeTab, onTabChange, 'data-testid': testId }: PillTabsProps) {
   return (
-    <div className="flex gap-1 overflow-x-auto scrollbar-none" role="tablist">
+    <div className="flex gap-1 overflow-x-auto scrollbar-none" role="tablist" data-testid={testId}>
       {tabs.map(tab => (
         <button
           key={tab.key}

--- a/frontend/src/components/common/PillTabs.tsx
+++ b/frontend/src/components/common/PillTabs.tsx
@@ -1,0 +1,41 @@
+interface PillTab {
+  key: string
+  label: string
+  badge?: boolean
+}
+
+interface PillTabsProps {
+  tabs: PillTab[]
+  activeTab: string
+  onTabChange: (key: string) => void
+}
+
+export function PillTabs({ tabs, activeTab, onTabChange }: PillTabsProps) {
+  return (
+    <div className="flex gap-1 overflow-x-auto scrollbar-none" role="tablist">
+      {tabs.map(tab => (
+        <button
+          key={tab.key}
+          type="button"
+          role="tab"
+          aria-selected={activeTab === tab.key}
+          onClick={() => onTabChange(tab.key)}
+          data-testid={`tab-${tab.key}`}
+          className={`shrink-0 px-3 py-2 sm:px-5 sm:py-2.5 text-sm font-medium rounded-lg transition-colors ${
+            activeTab === tab.key
+              ? 'text-indigo-700 bg-white'
+              : 'text-zinc-500 hover:text-zinc-700 hover:bg-[#F4F2FD]'
+          }`}
+          style={activeTab === tab.key ? { boxShadow: '0 1px 3px rgba(26, 27, 34, 0.08)' } : undefined}
+        >
+          <span className="relative">
+            {tab.label}
+            {tab.badge && (
+              <span className="absolute -top-1 -right-2 h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse" />
+            )}
+          </span>
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/pages/GroupDetail.tsx
+++ b/frontend/src/pages/GroupDetail.tsx
@@ -8,6 +8,7 @@ import { GroupOverviewTab } from '@/components/group/GroupOverviewTab'
 import { GroupMembersTab } from '@/components/group/GroupMembersTab'
 import { GroupSessionsTab } from '@/components/group/GroupSessionsTab'
 import { calcSessionFrequency } from '@/utils/sessionFrequency'
+import { PillTabs } from '@/components/common/PillTabs'
 
 const TABS = ['overview', 'members', 'sessions'] as const
 type Tab = typeof TABS[number]
@@ -83,32 +84,20 @@ export default function GroupDetail() {
   const members = group.members ?? []
 
   return (
-    <div className="min-h-screen bg-[#F7F6FC]" data-testid="group-detail-page">
+    <div className="min-h-screen bg-[#F4F2FD]" data-testid="group-detail-page">
       <GroupDetailHeader group={group} sessionFrequency={sessionFrequency} />
 
-      {/* Tabs row */}
-      <div className="bg-white border-b border-zinc-100">
-        <div className="flex gap-0">
-          {TABS.map(tab => (
-            <button
-              key={tab}
-              type="button"
-              onClick={() => setTab(tab)}
-              className={`px-5 py-3.5 text-sm font-semibold border-b-2 transition-colors ${
-                activeTab === tab
-                  ? 'border-indigo-600 text-indigo-700'
-                  : 'border-transparent text-zinc-500 hover:text-zinc-700'
-              }`}
-              data-testid={`tab-${tab}`}
-            >
-              {TAB_LABELS[tab]}
-            </button>
-          ))}
-        </div>
+      {/* Tab bar */}
+      <div className="mt-4">
+        <PillTabs
+          tabs={TABS.map(t => ({ key: t, label: TAB_LABELS[t] }))}
+          activeTab={activeTab}
+          onTabChange={tab => setTab(tab as Tab)}
+        />
       </div>
 
       {/* Tab content */}
-      <div className="py-6">
+      <div className="py-4">
         {activeTab === 'overview' && (
           <GroupOverviewTab
             group={group}


### PR DESCRIPTION
## Summary

- Extracts the pill-on-tint tab strip pattern into a shared `PillTabs` component at `frontend/src/components/common/PillTabs.tsx`, following the same `common/` convention as `EntityDetailHeader`
- Replaces `GroupDetail`'s drifted underline-on-white tab strip (two lines: divider + underline) with `PillTabs`
- Fixes the one-off page tint: `bg-[#F7F6FC]` -> `bg-[#F4F2FD]` (canonical app tint, already used by AppShell / Dashboard / Students)
- `StudentDetail` tab strip is NOT migrated this sprint (that belongs in the consistency sweep, #1387)

## Test plan

- [ ] `PillTabs.test.tsx`: 6 unit tests covering selected/unselected rendering, box-shadow, badge dot, onTabChange callback
- [ ] Live e2e verify: opened `/groups/:id` and `/students/:id` side by side -- tab strips visually identical (white pill, no lines, lavender tint)
- [ ] Confirmed `#F7F6FC` absent from `frontend/src/` via grep
- [ ] `npm build` passes (2 pre-existing `sonner` TS failures unrelated to this PR)

## Reviewers

| Reviewer | Finding | Action |
|---|---|---|
| review-plan | Add unit tests for PillTabs; clarify TABS+TAB_LABELS mapping | Fixed in plan |
| architecture-reviewer | Export PillTab interface; add data-testid prop (EntityDetailHeader convention) | Fixed |
| architecture-reviewer | Layout wrapper padding note (flush alignment) | Dismissed -- AppShell p-4/p-6 provides horizontal breathing room; verified visually |
| qa-verify | No test guard for StudentDetail not importing PillTabs; no page-bg class test | Accepted gap -- StudentDetail unchanged confirmed via code diff + live verify |
| review-ui | PASS (code review; Docker stack built from main, not worktree) | n/a |

Closes #1394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new horizontally scrollable tab navigation component with animated badge indicators for better user experience and visual organization.

* **Tests**
  * Added comprehensive test suite for the tab navigation component covering selection behavior, styling, badge rendering, and user interactions.

* **Style**
  * Updated tab layout styling and adjusted spacing for improved visual consistency and refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->