### PR TITLE
fix(groups): enable Atelier FAB on group routes, wire group anchor to assistant (#1398)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/AssistantTargetResolverTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/AssistantTargetResolverTests.cs
@@ -192,5 +192,24 @@ public class AssistantTargetResolverTests : IDisposable
         result.Target.RawMention.Should().Be("be uno punto uno");
     }
 
+    [Fact]
+    public async Task ResolveByIdAsync_KnownGroup_ReturnsConfidentWithGroupNameAndLevel()
+    {
+        var id = AddGroup("B1 Intensivo", "B1");
+        var result = await _sut.ResolveByIdAsync(id, _teacherId);
+        result.Should().NotBeNull();
+        result!.IsConfident.Should().BeTrue();
+        result.Target.ResolvedId.Should().Be(id);
+        result.ResolvedGroupName.Should().Be("B1 Intensivo");
+        result.ResolvedCefrLevel.Should().Be("B1");
+    }
+
+    [Fact]
+    public async Task ResolveByIdAsync_UnknownId_ReturnsNull()
+    {
+        var result = await _sut.ResolveByIdAsync(Guid.NewGuid(), _teacherId);
+        result.Should().BeNull();
+    }
+
     public void Dispose() => _db.Dispose();
 }

--- a/backend/LangTeach.Api/Controllers/AssistantController.cs
+++ b/backend/LangTeach.Api/Controllers/AssistantController.cs
@@ -21,6 +21,7 @@ public class AssistantController : ControllerBase
     private readonly IPedagogyConfigService _pedagogy;
     private readonly IAssistantFeedbackService _feedbackService;
     private readonly IAssistantTargetResolver _targetResolver;
+    private readonly IGroupService _groupService;
     private readonly ILogger<AssistantController> _logger;
 
     public AssistantController(
@@ -32,6 +33,7 @@ public class AssistantController : ControllerBase
         IPedagogyConfigService pedagogy,
         IAssistantFeedbackService feedbackService,
         IAssistantTargetResolver targetResolver,
+        IGroupService groupService,
         ILogger<AssistantController> logger)
     {
         _studentService = studentService;
@@ -42,6 +44,7 @@ public class AssistantController : ControllerBase
         _pedagogy = pedagogy;
         _feedbackService = feedbackService;
         _targetResolver = targetResolver;
+        _groupService = groupService;
         _logger = logger;
     }
 
@@ -194,6 +197,21 @@ public class AssistantController : ControllerBase
             {
                 hasAdminIntent = true;
                 adminMemberName = extractedStudentName;
+            }
+        }
+
+        // If the request carries a GroupId anchor (FAB opened from a group route) and the
+        // transcript did not produce a group mention, pin the resolved target to that group.
+        if (resolvedTarget is null && request.GroupId.HasValue)
+        {
+            var anchorGroup = await _groupService.GetByIdAsync(teacherId, request.GroupId.Value, ct);
+            if (anchorGroup is not null)
+            {
+                resolvedTarget = new ResolvedTarget(
+                    IsConfident: true,
+                    Target: new ProposedTarget("group", anchorGroup.Name, anchorGroup.Id, [], true),
+                    ResolvedGroupName: anchorGroup.Name,
+                    ResolvedCefrLevel: anchorGroup.CefrLevel);
             }
         }
 

--- a/backend/LangTeach.Api/Controllers/AssistantController.cs
+++ b/backend/LangTeach.Api/Controllers/AssistantController.cs
@@ -21,7 +21,6 @@ public class AssistantController : ControllerBase
     private readonly IPedagogyConfigService _pedagogy;
     private readonly IAssistantFeedbackService _feedbackService;
     private readonly IAssistantTargetResolver _targetResolver;
-    private readonly IGroupService _groupService;
     private readonly ILogger<AssistantController> _logger;
 
     public AssistantController(
@@ -33,7 +32,6 @@ public class AssistantController : ControllerBase
         IPedagogyConfigService pedagogy,
         IAssistantFeedbackService feedbackService,
         IAssistantTargetResolver targetResolver,
-        IGroupService groupService,
         ILogger<AssistantController> logger)
     {
         _studentService = studentService;
@@ -44,7 +42,6 @@ public class AssistantController : ControllerBase
         _pedagogy = pedagogy;
         _feedbackService = feedbackService;
         _targetResolver = targetResolver;
-        _groupService = groupService;
         _logger = logger;
     }
 
@@ -203,17 +200,7 @@ public class AssistantController : ControllerBase
         // If the request carries a GroupId anchor (FAB opened from a group route) and the
         // transcript did not produce a group mention, pin the resolved target to that group.
         if (resolvedTarget is null && request.GroupId.HasValue)
-        {
-            var anchorGroup = await _groupService.GetByIdAsync(teacherId, request.GroupId.Value, ct);
-            if (anchorGroup is not null)
-            {
-                resolvedTarget = new ResolvedTarget(
-                    IsConfident: true,
-                    Target: new ProposedTarget("group", anchorGroup.Name, anchorGroup.Id, [], true),
-                    ResolvedGroupName: anchorGroup.Name,
-                    ResolvedCefrLevel: anchorGroup.CefrLevel);
-            }
-        }
+            resolvedTarget = await _targetResolver.ResolveByIdAsync(request.GroupId.Value, teacherId, ct);
 
         proposals.AddRange(ReflectionMapper.ToSessionFieldProposals(
             reflectionExtraction, session, _pedagogy.ProposalFields,

--- a/backend/LangTeach.Api/DTOs/AssistantDtos.cs
+++ b/backend/LangTeach.Api/DTOs/AssistantDtos.cs
@@ -12,6 +12,7 @@ public class AssistantProposeRequest
     public Guid? StudentId { get; set; }
     public Guid? SessionLogId { get; set; }
     public Guid? VoiceNoteId { get; set; }
+    public Guid? GroupId { get; set; }
 }
 
 public class AssistantFeedbackRequest

--- a/backend/LangTeach.Api/Services/AssistantTargetResolver.cs
+++ b/backend/LangTeach.Api/Services/AssistantTargetResolver.cs
@@ -22,6 +22,13 @@ public class AssistantTargetResolver : IAssistantTargetResolver
         _groupService = groupService;
     }
 
+    public async Task<ResolvedTarget?> ResolveByIdAsync(Guid groupId, Guid teacherId, CancellationToken ct = default)
+    {
+        var group = await _groupService.GetByIdAsync(teacherId, groupId, ct);
+        if (group is null) return null;
+        return Confident(new GroupForResolutionDto(group.Id, group.Name, group.Aliases ?? [], group.CefrLevel), group.Name, []);
+    }
+
     public async Task<ResolvedTarget> ResolveAsync(string rawMention, Guid teacherId, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(rawMention))

--- a/backend/LangTeach.Api/Services/IAssistantTargetResolver.cs
+++ b/backend/LangTeach.Api/Services/IAssistantTargetResolver.cs
@@ -7,4 +7,5 @@ public record ResolvedTarget(bool IsConfident, ProposedTarget Target, string? Re
 public interface IAssistantTargetResolver
 {
     Task<ResolvedTarget> ResolveAsync(string rawMention, Guid teacherId, CancellationToken ct = default);
+    Task<ResolvedTarget?> ResolveByIdAsync(Guid groupId, Guid teacherId, CancellationToken ct = default);
 }

--- a/frontend/src/api/assistant.ts
+++ b/frontend/src/api/assistant.ts
@@ -61,12 +61,14 @@ export async function proposeAssistant(
   studentId?: string,
   sessionId?: string,
   voiceNoteId?: string,
+  groupId?: string | null,
 ): Promise<ProposeResponse> {
   const res = await apiClient.post<ProposeResponse>('/api/assistant/propose', {
     text,
     studentId: studentId ?? null,
     sessionLogId: sessionId ?? null,
     voiceNoteId: voiceNoteId ?? null,
+    groupId: groupId ?? null,
   })
   return res.data
 }

--- a/frontend/src/components/AppShell.test.tsx
+++ b/frontend/src/components/AppShell.test.tsx
@@ -456,8 +456,8 @@ describe('AppShell', () => {
   })
 
   describe('launcher enabled/disabled by route', () => {
-    const disabledRoutes = ['/', '/courses', '/courses/abc', '/lessons', '/lessons/abc', '/lessons/abc/study', '/sessions', '/settings']
-    const enabledRoutes = ['/students', '/students/123', '/students/123/edit', '/students/123/log-session', '/students/123/sessions/456/edit']
+    const disabledRoutes = ['/', '/courses', '/courses/abc', '/lessons', '/lessons/abc', '/lessons/abc/study', '/sessions', '/settings', '/groups/new']
+    const enabledRoutes = ['/students', '/students/123', '/students/123/edit', '/students/123/log-session', '/students/123/sessions/456/edit', '/groups', '/groups/abc', '/groups/abc/log-session']
 
     for (const route of disabledRoutes) {
       it(`launcher is disabled on ${route}`, () => {

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -111,6 +111,7 @@ function SidebarContent({ user, initials, logout, location }: {
 
 const STUDENT_ID_RE = /^\/students\/([^/]+)/
 const SESSION_ID_RE = /^\/students\/[^/]+\/sessions\/([^/]+)/
+const GROUP_ID_RE = /^\/groups\/([^/]+)/
 
 function extractStudentId(pathname: string): string | null {
   const match = pathname.match(STUDENT_ID_RE)
@@ -123,11 +124,20 @@ function extractSessionId(pathname: string): string | null {
   return match ? match[1] : null
 }
 
+function extractGroupId(pathname: string): string | null {
+  const match = pathname.match(GROUP_ID_RE)
+  if (!match) return null
+  return match[1] === 'new' ? null : match[1]
+}
+
 // Returns true only when the route has a concrete entity anchor.
-// `/students` is explicitly OR'd because STUDENT_ID_RE requires a segment
-// after "students" and does not match the list route itself.
+// `/students` and `/groups` are explicitly OR'd because their ID regexes
+// require a segment after the noun and do not match the list routes themselves.
 function isAtelierEnabled(pathname: string): boolean {
-  return pathname === '/students' || extractStudentId(pathname) !== null
+  return (
+    pathname === '/students' || extractStudentId(pathname) !== null ||
+    pathname === '/groups' || extractGroupId(pathname) !== null
+  )
 }
 
 export default function AppShell() {
@@ -138,6 +148,7 @@ export default function AppShell() {
 
   const studentId = extractStudentId(location.pathname)
   const sessionId = extractSessionId(location.pathname)
+  const groupId = extractGroupId(location.pathname)
   const atelierEnabled = isAtelierEnabled(location.pathname)
   const assistantOpen = userWantsOpen && atelierEnabled
 
@@ -159,7 +170,7 @@ export default function AppShell() {
     }
   }, [studentId, navigate])
 
-  const assistant = useAtelierAssistant(studentId, effectiveSessionId, handleAfterSessionApply)
+  const assistant = useAtelierAssistant(studentId, effectiveSessionId, handleAfterSessionApply, groupId)
 
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => {
@@ -241,7 +252,7 @@ export default function AppShell() {
             <TooltipContent side="bottom">
               {atelierEnabled
                 ? (assistantOpen ? 'Close Assistant' : 'Open Assistant')
-                : 'Open a student or session to use the assistant'}
+                : 'Open a student, session, or group to use the assistant'}
             </TooltipContent>
           </Tooltip>
           <Avatar className="h-8 w-8">
@@ -328,6 +339,7 @@ export default function AppShell() {
         onEditPayload={assistant.onEditPayload}
         studentId={studentId}
         sessionId={effectiveSessionId}
+        groupId={groupId}
         onSelectSession={setPickerSessionId}
       />
     </div>

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -315,7 +315,7 @@ export default function AppShell() {
         <TooltipContent side="left">
           {atelierEnabled
             ? <>Open Assistant <kbd data-slot="kbd">⌘K</kbd></>
-            : 'Open a student or session to use the assistant'}
+            : 'Open a student, session, or group to use the assistant'}
         </TooltipContent>
       </Tooltip>
 

--- a/frontend/src/components/AtelierAssistantPanel.tsx
+++ b/frontend/src/components/AtelierAssistantPanel.tsx
@@ -52,6 +52,7 @@ interface Props {
   onEditPayload?: (id: string, payload: import('@/api/assistant').NewStudentData | import('@/api/assistant').NewSessionData | Record<string, unknown>) => void
   studentId?: string | null
   sessionId?: string | null
+  groupId?: string | null
   onSelectSession?: (sessionId: string) => void
 }
 

--- a/frontend/src/hooks/useAtelierAssistant.test.ts
+++ b/frontend/src/hooks/useAtelierAssistant.test.ts
@@ -82,7 +82,7 @@ describe('useAtelierAssistant', () => {
     const { result } = renderHook(() => useAtelierAssistant('student-1', 'session-1'), { wrapper: makeWrapper() })
     act(() => { result.current.submit('Some text') })
     await act(async () => { await vi.runAllTimersAsync() })
-    expect(mockPropose).toHaveBeenCalledWith('Some text', 'student-1', 'session-1')
+    expect(mockPropose).toHaveBeenCalledWith('Some text', 'student-1', 'session-1', undefined, undefined)
   })
 
   it('apply: routes student proposal to applyStudentProposal', async () => {

--- a/frontend/src/hooks/useAtelierAssistant.ts
+++ b/frontend/src/hooks/useAtelierAssistant.ts
@@ -48,6 +48,7 @@ export function useAtelierAssistant(
   studentId: string | null,
   sessionId: string | null,
   onAfterSessionApply?: (sessionId: string) => void,
+  groupId?: string | null,
 ): AtelierAssistantState & AtelierAssistantActions {
   const queryClient = useQueryClient()
   const [transcription, setTranscription] = useState<string | null>(null)
@@ -89,6 +90,8 @@ export function useAtelierAssistant(
         text,
         studentId ?? undefined,
         sessionId ?? undefined,
+        undefined,
+        groupId,
       )
       if (generationRef.current !== gen) return
       extractedSessionDateRef.current = extractedSessionDate ?? null
@@ -130,7 +133,7 @@ export function useAtelierAssistant(
     } finally {
       if (generationRef.current === gen) setProcessing(false)
     }
-  }, [studentId, sessionId])
+  }, [studentId, sessionId, groupId])
 
   const apply = useCallback(async (id: string) => {
     if (applyingIdsRef.current.has(id)) return

--- a/plan/code-review-backlog.md
+++ b/plan/code-review-backlog.md
@@ -4,6 +4,7 @@ Unfixed notes from code review (review agent) runs. When reviewing this backlog,
 
 ## Open
 
+- *#1398 (arch, convention, low): `useAtelierAssistant` hook signature has `groupId` as 4th param (after `onAfterSessionApply`) instead of grouped with other entity anchors before the callback. Breaks the (studentId, sessionId, onAfterSessionApply) positional convention. Correcting it requires updating ~30 test call sites. Address when another entity anchor is added or a hook API cleanup sprint occurs.*
 - *#1362 (arch, future-reuse, low): quota-429 client handling (detect status, extract resetsAt, format date) is now inline in two places (useGenerate hook + RedaccionDetail onError). If a third 429 call site appears, extract a shared `parseQuotaError` util. Not a current violation (two call sites, different abstraction layers).*
 - *#1369 (arch, convention, low): RedaccionDetail uses `variant="secondary"` for the teacher-only "Versión completa" button to visually differentiate it from the student-facing `variant="outline"` button. No existing restricted-action button pattern in the codebase. If a design system spec for restricted/teacher actions is established, this should adopt that pattern.*
 - *#1385 (arch, intentional scope): StudentDetailHeader still hand-rolls the same floating-card layout and badge markup that EntityDetailHeader/StatusBadge introduce. Student migration is explicitly out of scope -- tracked in #1386.*

--- a/plan/observed-issues.md
+++ b/plan/observed-issues.md
@@ -4,6 +4,7 @@ Out-of-scope observations logged by agents during implementation. Each row is so
 
 | Source issue | Date | Severity | Observation |
 |---|---|---|---|
+| #1398 | 2026-05-31 | low | AssistantTargetResolver.TryNormalizeSpoken emits CEFR subforms like "B1.1" which violate project rule (only A1/A2/B1/B2/C1/C2 valid, no dot notation). Pre-existing, out of scope. |
 | #1362 | 2026-05-25 | medium | DemoSeeder.SeedTeacherFollowupsAsync throws SQL FK constraint error 547 (DemoSeeder.cs:978) during visual-stack startup on sprint/groups, which aborts EnsureAnaVisualCorrectionAsync so no demo corrections get seeded. Non-fatal (API still starts healthy) but blocks the correction-detail visual spec and review-ui Corregida screenshots. Pre-existing, unrelated to this PR. |
 
 ---


### PR DESCRIPTION
## Summary

- Extend `isAtelierEnabled()` in `AppShell.tsx` to cover `/groups` (list) and `/groups/:id` (detail + nested) routes, mirroring the existing student ID pattern with `GROUP_ID_RE` / `extractGroupId()`
- Update disabled-state tooltip from "Open a student or session to use the assistant" to "Open a student, session, or group to use the assistant" (both mobile and desktop)
- Thread `groupId` from the URL route through `useAtelierAssistant` and `proposeAssistant` to the backend, so the assistant receives the group as its anchor when the FAB is opened from a group route
- Backend: add `GroupId` to `AssistantProposeRequest`; add `ResolveByIdAsync` to `IAssistantTargetResolver` so the controller delegates group-by-ID lookups to the resolver layer (not inline); use it to pin a confident `ResolvedTarget` when `GroupId` is set and the transcript has no explicit group mention
- Add 2 unit tests for `ResolveByIdAsync`; update AppShell and `useAtelierAssistant` tests to cover group routes

## Verify results

All 5 verify steps passed against live e2e stack:
1. `/groups` list -- FAB enabled (full indigo)
2. `/groups/:id` -- FAB enabled
3. FAB opened from `/groups/:id`, transcript submitted, proposals returned with group-anchored session picker
4. `/dashboard` -- FAB disabled (regression preserved)
5. `/students/:id` -- FAB enabled (no regression)

## Test plan

- [ ] Navigate to `/groups` -- FAB should be full color (not greyed out)
- [ ] Navigate to any `/groups/:id` -- FAB should be full color
- [ ] Hover disabled FAB on `/dashboard` -- tooltip reads "Open a student, session, or group to use the assistant"
- [ ] Open FAB from `/groups/:id`, type a session note -- proposals come back and session picker shows "+ New session"
- [ ] Navigate to `/students/:id` -- FAB still enabled (no regression)

Fixes #1398

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Atelier Assistant is now available on group pages, allowing teachers to access AI assistance within group contexts.
  * Assistant can now accept a group identifier to provide contextually relevant proposals for group-based activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->