### PR TITLE
fix(assistant): apply duration and topicTags proposals to session (#1404)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/ReflectionMapperTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/ReflectionMapperTests.cs
@@ -15,7 +15,9 @@ public class ReflectionMapperTests
         string? whatWasCovered = null,
         string? homeworkAssigned = null,
         string? nextSessionTopics = null,
-        List<SuggestedDifficultyDto>? suggestedDifficulties = null)
+        List<SuggestedDifficultyDto>? suggestedDifficulties = null,
+        int? durationMinutes = null,
+        List<TopicTagDto>? topicTags = null)
     {
         return new ExtractedReflectionDto(
             WhatWasCovered: whatWasCovered is null ? null : new ExtractedTextFieldDto(whatWasCovered, ExtractionMode.Replace),
@@ -27,12 +29,12 @@ public class ReflectionMapperTests
             SuggestedDifficulties: suggestedDifficulties ?? [],
             RawExtractionJson: null,
             SessionTitle: sessionTitle,
-            TopicTags: [],
+            TopicTags: topicTags ?? [],
             PreviousHomeworkStatus: null,
             TeachingTodos: [],
             TeacherFollowups: [],
             LevelReassessment: null,
-            DurationMinutes: null,
+            DurationMinutes: durationMinutes,
             IsCancelled: null,
             DifficultiesWorkedOn: [],
             SessionStartTime: null,
@@ -196,6 +198,67 @@ public class ReflectionMapperTests
             SessionFields: [new SessionFieldEntry("title", "Title", false)]);
 
         var proposals = ReflectionMapper.ToSessionFieldProposals(dto, currentSession, config).ToList();
+
+        Assert.Empty(proposals);
+    }
+
+    [Fact]
+    public void ToSessionFieldProposals_EmitsDurationProposal_WhenExtracted()
+    {
+        var dto = MakeDto(durationMinutes: 50);
+        var config = new ProposalFieldsConfig(
+            StudentFields: [],
+            SkillLevelFields: [],
+            SessionFields: [new SessionFieldEntry("duration", "Duration (minutes)", false)]);
+
+        var proposals = ReflectionMapper.ToSessionFieldProposals(dto, null, config).ToList();
+
+        Assert.Single(proposals);
+        Assert.Equal("duration", proposals[0].Field);
+        Assert.Equal("50", proposals[0].NewValue);
+    }
+
+    [Fact]
+    public void ToSessionFieldProposals_SkipsDurationProposal_WhenNotExtracted()
+    {
+        var dto = MakeDto(durationMinutes: null);
+        var config = new ProposalFieldsConfig(
+            StudentFields: [],
+            SkillLevelFields: [],
+            SessionFields: [new SessionFieldEntry("duration", "Duration (minutes)", false)]);
+
+        var proposals = ReflectionMapper.ToSessionFieldProposals(dto, null, config).ToList();
+
+        Assert.Empty(proposals);
+    }
+
+    [Fact]
+    public void ToSessionFieldProposals_EmitsTopicTagsProposal_WhenExtracted()
+    {
+        var tags = new List<TopicTagDto> { new("comida", "vocabulary"), new("llevarse bien/mal", "grammar") };
+        var dto = MakeDto(topicTags: tags);
+        var config = new ProposalFieldsConfig(
+            StudentFields: [],
+            SkillLevelFields: [],
+            SessionFields: [new SessionFieldEntry("topicTags", "Topic Tags", false)]);
+
+        var proposals = ReflectionMapper.ToSessionFieldProposals(dto, null, config).ToList();
+
+        Assert.Single(proposals);
+        Assert.Equal("topicTags", proposals[0].Field);
+        Assert.Contains("comida", proposals[0].NewValue);
+    }
+
+    [Fact]
+    public void ToSessionFieldProposals_SkipsTopicTagsProposal_WhenEmpty()
+    {
+        var dto = MakeDto(topicTags: []);
+        var config = new ProposalFieldsConfig(
+            StudentFields: [],
+            SkillLevelFields: [],
+            SessionFields: [new SessionFieldEntry("topicTags", "Topic Tags", false)]);
+
+        var proposals = ReflectionMapper.ToSessionFieldProposals(dto, null, config).ToList();
 
         Assert.Empty(proposals);
     }

--- a/backend/LangTeach.Api/Controllers/GroupSessionLogsController.cs
+++ b/backend/LangTeach.Api/Controllers/GroupSessionLogsController.cs
@@ -120,6 +120,8 @@ public class GroupSessionLogsController : ControllerBase
         if (patch.GeneralNotes is not null) request.GeneralNotes = patch.GeneralNotes;
         if (patch.HomeworkAssigned is not null) request.HomeworkAssigned = patch.HomeworkAssigned;
         if (patch.NextSessionTopics is not null) request.NextSessionTopics = patch.NextSessionTopics;
+        if (patch.Duration is not null) request.Duration = patch.Duration;
+        if (patch.TopicTags is not null) request.TopicTags = patch.TopicTags;
 
         try
         {

--- a/backend/LangTeach.Api/Controllers/SessionLogsController.cs
+++ b/backend/LangTeach.Api/Controllers/SessionLogsController.cs
@@ -147,6 +147,8 @@ public class SessionLogsController : ControllerBase
         if (patch.GeneralNotes is not null) request.GeneralNotes = patch.GeneralNotes;
         if (patch.HomeworkAssigned is not null) request.HomeworkAssigned = patch.HomeworkAssigned;
         if (patch.NextSessionTopics is not null) request.NextSessionTopics = patch.NextSessionTopics;
+        if (patch.Duration is not null) request.Duration = patch.Duration;
+        if (patch.TopicTags is not null) request.TopicTags = patch.TopicTags;
 
         try
         {

--- a/backend/LangTeach.Api/DTOs/AssistantDtos.cs
+++ b/backend/LangTeach.Api/DTOs/AssistantDtos.cs
@@ -115,6 +115,7 @@ public class PatchSessionRequest
     [MaxLength(2000)]
     public string? NextSessionTopics { get; set; }
 
+    [Range(1, 1440)]
     public int? Duration { get; set; }
 
     [MaxLength(2000)]

--- a/backend/LangTeach.Api/DTOs/AssistantDtos.cs
+++ b/backend/LangTeach.Api/DTOs/AssistantDtos.cs
@@ -114,4 +114,9 @@ public class PatchSessionRequest
 
     [MaxLength(2000)]
     public string? NextSessionTopics { get; set; }
+
+    public int? Duration { get; set; }
+
+    [MaxLength(2000)]
+    public string? TopicTags { get; set; }
 }

--- a/backend/LangTeach.Api/Services/PedagogyConfigService.cs
+++ b/backend/LangTeach.Api/Services/PedagogyConfigService.cs
@@ -542,7 +542,7 @@ public class PedagogyConfigService : IPedagogyConfigService
     // session proposal field requires updating BOTH this set AND proposal-fields.json
     // sessionFields[]. Drift is caught at startup by ValidateProposalFields.
     internal static readonly HashSet<string> ExpectedSessionProposalFieldKeys = new(StringComparer.Ordinal)
-        { "title", "actualContent", "generalNotes", "homeworkAssigned", "nextSessionTopics" };
+        { "title", "actualContent", "generalNotes", "homeworkAssigned", "nextSessionTopics", "duration", "topicTags" };
 
     internal static void ValidateProposalFields(ProposalFieldsConfig f)
     {

--- a/backend/LangTeach.Api/Services/ReflectionMapper.cs
+++ b/backend/LangTeach.Api/Services/ReflectionMapper.cs
@@ -36,6 +36,10 @@ internal static class ReflectionMapper
         bool hasAdminIntent = false,
         string? adminMemberName = null)
     {
+        var extractedTopicTags = extracted.TopicTags.Count > 0
+            ? JsonSerializer.Serialize(extracted.TopicTags, CamelCaseOpts)
+            : null;
+
         var fieldValues = new Dictionary<string, (string? current, string? extracted)>
         {
             ["title"] = (current?.Title, NormalizeSessionTitle(extracted.SessionTitle)),
@@ -43,6 +47,8 @@ internal static class ReflectionMapper
             ["generalNotes"] = (current?.GeneralNotes, extracted.AreasToImprove?.Value),
             ["homeworkAssigned"] = (current?.HomeworkAssigned, extracted.HomeworkAssigned?.Value),
             ["nextSessionTopics"] = (current?.NextSessionTopics, extracted.NextSessionTopics?.Value),
+            ["duration"] = (current?.Duration?.ToString(), extracted.DurationMinutes?.ToString()),
+            ["topicTags"] = (current?.TopicTags, extractedTopicTags),
         };
 
         foreach (var f in config.SessionFields)

--- a/data/assistant/proposal-fields.json
+++ b/data/assistant/proposal-fields.json
@@ -15,6 +15,8 @@
     { "field": "actualContent", "label": "What Was Covered", "multiline": true },
     { "field": "generalNotes", "label": "Areas to Improve", "multiline": true },
     { "field": "homeworkAssigned", "label": "Homework Assigned", "multiline": true },
-    { "field": "nextSessionTopics", "label": "Next Session Topics", "multiline": true }
+    { "field": "nextSessionTopics", "label": "Next Session Topics", "multiline": true },
+    { "field": "duration", "label": "Duration (minutes)", "multiline": false },
+    { "field": "topicTags", "label": "Topic Tags", "multiline": false }
   ]
 }

--- a/frontend/src/api/assistant.ts
+++ b/frontend/src/api/assistant.ts
@@ -117,8 +117,13 @@ export async function applySessionProposal(
   field: string,
   value: string,
 ): Promise<void> {
-  // field is one of: title, actualContent, generalNotes, homeworkAssigned, nextSessionTopics — matches PatchSessionRequest
-  await apiClient.patch(`/api/students/${studentId}/sessions/${sessionId}`, { [field]: value })
+  let patchValue: string | number = value
+  if (field === 'duration') {
+    const parsed = parseInt(value, 10)
+    if (isNaN(parsed)) return
+    patchValue = parsed
+  }
+  await apiClient.patch(`/api/students/${studentId}/sessions/${sessionId}`, { [field]: patchValue })
 }
 
 export async function applyGroupSessionProposal(
@@ -127,7 +132,13 @@ export async function applyGroupSessionProposal(
   field: string,
   value: string,
 ): Promise<void> {
-  await apiClient.patch(`/api/groups/${groupId}/sessions/${sessionId}`, { [field]: value })
+  let patchValue: string | number = value
+  if (field === 'duration') {
+    const parsed = parseInt(value, 10)
+    if (isNaN(parsed)) return
+    patchValue = parsed
+  }
+  await apiClient.patch(`/api/groups/${groupId}/sessions/${sessionId}`, { [field]: patchValue })
 }
 
 export async function applyTodoProposal(

--- a/frontend/src/api/assistant.ts
+++ b/frontend/src/api/assistant.ts
@@ -119,8 +119,10 @@ export async function applySessionProposal(
 ): Promise<void> {
   let patchValue: string | number = value
   if (field === 'duration') {
-    const parsed = parseInt(value, 10)
-    if (isNaN(parsed)) return
+    const parsed = Number(value)
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 1440) {
+      throw new Error(`Invalid duration proposal value: ${value}`)
+    }
     patchValue = parsed
   }
   await apiClient.patch(`/api/students/${studentId}/sessions/${sessionId}`, { [field]: patchValue })
@@ -134,8 +136,10 @@ export async function applyGroupSessionProposal(
 ): Promise<void> {
   let patchValue: string | number = value
   if (field === 'duration') {
-    const parsed = parseInt(value, 10)
-    if (isNaN(parsed)) return
+    const parsed = Number(value)
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 1440) {
+      throw new Error(`Invalid duration proposal value: ${value}`)
+    }
     patchValue = parsed
   }
   await apiClient.patch(`/api/groups/${groupId}/sessions/${sessionId}`, { [field]: patchValue })


### PR DESCRIPTION
## Summary

- `ReflectionMapper.ToSessionFieldProposals` was silently dropping `DurationMinutes` and `TopicTags` — these were extracted by the AI but never turned into proposals
- `PatchSession` (student + group controllers) only handled 5 text fields; the two new fields are now wired through the full pipeline
- Frontend coerces `duration` string proposal value to `int` with a NaN guard before PATCHing

## Changes

| File | Change |
|---|---|
| `ReflectionMapper.cs` | Add `duration` and `topicTags` to `fieldValues` dict |
| `AssistantDtos.cs` | Add `Duration` (int?) and `TopicTags` (string?, MaxLength 2000) to `PatchSessionRequest` |
| `SessionLogsController.cs` | Apply both fields in student PatchSession handler |
| `GroupSessionLogsController.cs` | Apply both fields in group PatchSession handler |
| `proposal-fields.json` | Add `duration` and `topicTags` entries to sessionFields |
| `PedagogyConfigService.cs` | Add both keys to `ExpectedSessionProposalFieldKeys` (startup drift guard) |
| `assistant.ts` | Duration string→int coercion with NaN guard in both student and group apply functions |
| `ReflectionMapperTests.cs` | 4 new unit tests: proposal emitted/skipped for duration and topicTags |

## Out of Scope

- `MentionedDifficultyPairs` — no clean mapping in `ExtractedReflectionDto` (only `DifficultiesWorkedOn` as `List<string>`, no Competency/Subcategory)
- `nextSessionTopics` PATCH drop (latent pre-existing bug) — tracked in #1405

## Test Plan

- [x] `dotnet test` — 115 passed (4 new mapper tests)
- [x] `npm test` — all passed
- [x] Live verify: `topicTags` proposal generated by `/api/assistant/propose`, PATCH applies `topicTags` and `duration` correctly against e2e stack
- [x] qa-verify: PASS

Closes #1404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions can now be updated with duration (minutes) and topic tags through API endpoints
  * Session proposal system now generates suggestions for duration and topic tags fields
  * Users can apply duration and topic tag proposals to session records

* **Tests**
  * Added comprehensive test coverage for duration and topic tags proposal handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->