### PR TITLE
fix(assistant): preserve Spanish characters in topic tags proposals (#1407)

### DIFF
--- a/backend/LangTeach.Api.Tests/Services/ReflectionMapperTests.cs
+++ b/backend/LangTeach.Api.Tests/Services/ReflectionMapperTests.cs
@@ -250,6 +250,24 @@ public class ReflectionMapperTests
     }
 
     [Fact]
+    public void ToSessionFieldProposals_TopicTagsProposal_PreservesAccentedCharacters()
+    {
+        var tags = new List<TopicTagDto> { new("pretérito perfecto", "Grammar"), new("conversación", null) };
+        var dto = MakeDto(topicTags: tags);
+        var config = new ProposalFieldsConfig(
+            StudentFields: [],
+            SkillLevelFields: [],
+            SessionFields: [new SessionFieldEntry("topicTags", "Topic Tags", false)]);
+
+        var proposals = ReflectionMapper.ToSessionFieldProposals(dto, null, config).ToList();
+
+        Assert.Single(proposals);
+        Assert.DoesNotContain("\\u00", proposals[0].NewValue);
+        Assert.Contains("pretérito perfecto", proposals[0].NewValue);
+        Assert.Contains("conversación", proposals[0].NewValue);
+    }
+
+    [Fact]
     public void ToSessionFieldProposals_SkipsTopicTagsProposal_WhenEmpty()
     {
         var dto = MakeDto(topicTags: []);

--- a/backend/LangTeach.Api/Services/ReflectionMapper.cs
+++ b/backend/LangTeach.Api/Services/ReflectionMapper.cs
@@ -1,3 +1,4 @@
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using LangTeach.Api.AI;
 using LangTeach.Api.DTOs;
@@ -6,7 +7,11 @@ namespace LangTeach.Api.Services;
 
 internal static class ReflectionMapper
 {
-    private static readonly JsonSerializerOptions CamelCaseOpts = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+    private static readonly JsonSerializerOptions CamelCaseOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
 
     internal static CreateSessionLogRequest ToSessionLogRequest(ExtractedReflectionDto extracted, string rawNotes)
     {

--- a/e2e/tests/verify-1407-topic-tags-unicode.spec.ts
+++ b/e2e/tests/verify-1407-topic-tags-unicode.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test'
+import { createMockAuthContext } from '../helpers/auth-helper'
+import { setupMockTeacher } from '../helpers/mock-teacher-helper'
+import { NAV_TIMEOUT, UI_TIMEOUT, AI_STREAM_TIMEOUT } from '../helpers/timeouts'
+
+test.beforeAll(async ({ browser }) => {
+  const ctx = await createMockAuthContext(browser)
+  const page = await ctx.newPage()
+  await setupMockTeacher(page)
+  await page.close()
+  await ctx.close()
+})
+
+// Issue #1407 — Topic tags proposal must not show unicode escapes
+// When the assistant extracts topic tags with Spanish accented characters,
+// the proposal card must display them literally (e.g. pretérito perfecto),
+// not as unicode escape sequences (e.g. pretérito).
+
+test('assistant: topic tags proposal with accented characters shows literal chars, not unicode escapes', async ({ browser }) => {
+  const context = await createMockAuthContext(browser)
+  const page = await context.newPage()
+
+  try {
+    await page.goto('/')
+    await expect(page.locator('h1')).toHaveText('Dashboard', { timeout: NAV_TIMEOUT })
+
+    // Navigate to a student page so the assistant button is enabled
+    const studentLink = page.getByRole('link', { name: /Petra Seed/i }).first()
+    await expect(studentLink).toBeVisible({ timeout: UI_TIMEOUT })
+    await studentLink.click()
+    await expect(page.locator('h1')).toContainText('Petra', { timeout: NAV_TIMEOUT })
+
+    // Open the assistant panel
+    const fabBtn = page.getByTestId('open-assistant-btn')
+    await expect(fabBtn).toBeVisible({ timeout: UI_TIMEOUT })
+    await fabBtn.click()
+
+    const panel = page.getByTestId('assistant-panel')
+    await expect(panel).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // Send a transcription that forces accented topic tags
+    const input = panel.getByTestId('assistant-input')
+    await input.fill('en la sesion de hoy a las 16:00 hemos hablado de la universidad y de su infancia hemos trabajado el preterito perfecto')
+    await panel.getByTestId('assistant-send-btn').click()
+
+    // Wait for proposals to appear
+    await expect(page.getByTestId(/^proposal-card-/).first()).toBeVisible({ timeout: AI_STREAM_TIMEOUT })
+
+    // Find the topicTags proposal card and check its text content
+    const proposalCards = page.getByTestId(/^proposal-card-/)
+    const count = await proposalCards.count()
+
+    let topicTagsText = ''
+    for (let i = 0; i < count; i++) {
+      const card = proposalCards.nth(i)
+      const cardText = await card.innerText()
+      if (cardText.includes('TOPIC TAGS') || cardText.includes('Topic Tags')) {
+        topicTagsText = cardText
+        break
+      }
+    }
+
+    if (topicTagsText) {
+      // Must not contain unicode escape sequences
+      expect(topicTagsText).not.toContain('\\u00')
+      expect(topicTagsText).not.toContain('\\u00e9')
+      expect(topicTagsText).not.toContain('\\u00f3')
+    }
+    // Whether or not topicTags appeared (AI may vary), no unicode escapes must be present anywhere
+    const panelText = await panel.innerText()
+    expect(panelText).not.toContain('\\u00')
+  } finally {
+    await page.close().catch(() => {})
+    await context.close().catch(() => {})
+  }
+})

--- a/e2e/tests/verify-1407-topic-tags-unicode.spec.ts
+++ b/e2e/tests/verify-1407-topic-tags-unicode.spec.ts
@@ -60,15 +60,10 @@ test('assistant: topic tags proposal with accented characters shows literal char
       }
     }
 
-    if (topicTagsText) {
-      // Must not contain unicode escape sequences
-      expect(topicTagsText).not.toContain('\\u00')
-      expect(topicTagsText).not.toContain('\\u00e9')
-      expect(topicTagsText).not.toContain('\\u00f3')
-    }
-    // Whether or not topicTags appeared (AI may vary), no unicode escapes must be present anywhere
-    const panelText = await panel.innerText()
-    expect(panelText).not.toContain('\\u00')
+    expect(topicTagsText).not.toBe('')
+    expect(topicTagsText).not.toContain('\\u00')
+    expect(topicTagsText).not.toContain('\\u00e9')
+    expect(topicTagsText).not.toContain('\\u00f3')
   } finally {
     await page.close().catch(() => {})
     await context.close().catch(() => {})


### PR DESCRIPTION
## Summary

- `System.Text.Json` escapes all non-ASCII characters by default (`é` → `é`). `ReflectionMapper.CamelCaseOpts` did not override the encoder, so topic tag names with Spanish accented characters were serialized as unicode escapes and rendered verbatim in the proposal card.
- Added `Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping` to `CamelCaseOpts` so characters like `é`, `ó`, `ñ` are written literally.
- Added a unit test asserting `DoesNotContain("\\u00", ...)` using accented tag names (`pretérito perfecto`, `conversación`).
- Added an e2e test that sends a transcription with accented topics and asserts no unicode escape sequences appear in the proposal panel.

Closes #1407

## Reviews

| Reviewer | Verdict | Action |
|---|---|---|
| architecture-reviewer | PASS WITH NOTES | Note: other `CamelCaseOpts` instances in `SessionLogService`/`AssistantController` use ASCII-only data today, no immediate risk. Filed as observation. |
| qa-verify | PASS (after fixes) | Added unit test + live e2e verify; both pass. |

## Test plan

- [x] `dotnet test` passes (19 ReflectionMapper tests, including new accented-chars test)
- [x] `npm test` passes (115 passed)
- [x] E2e live verify: sent transcription `hemos trabajado el preterito perfecto` to assistant on Petra Seed B1 student page; proposal panel showed no unicode escape sequences. Test passes in 1.4s.

## Observed issues (out of scope)

- `SessionLogService.CamelCaseOptions` and `AssistantController.camelCaseOpts` also lack `UnsafeRelaxedJsonEscaping`, but both serialize ASCII-only data today. Worth centralizing into `AppJsonOptions` in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Corrected display of accented characters in topic tag proposals so they render as literal text (e.g., Spanish accents) rather than Unicode escape sequences.

## Tests
- Added a backend unit test and a Playwright end-to-end test to verify accented topic-tag text is preserved and shown correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->