### PR TITLE
fix(infra): reconcile OpenAI/Whisper + Computer Vision Bicep with live resources

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -7,6 +7,9 @@ param location string = resourceGroup().location
 @description('Azure region for the OpenAI account. Whisper is not available in every region (e.g. not in northeurope), so it is pinned independently of the resource group location.')
 param openaiLocation string = 'swedencentral'
 
+@description('Azure region for the Computer Vision account, pinned independently of the resource group location to match the live resource.')
+param visionLocation string = 'uksouth'
+
 @description('SQL Server administrator login')
 param sqlAdminUser string
 
@@ -52,7 +55,7 @@ var acrName = 'crlangteach${env}'
 // Azure OpenAI resource name
 var openaiName = 'langteach-openai-${env}'
 // Azure Computer Vision resource name
-var computerVisionName = 'vision-langteach-${env}'
+var computerVisionName = 'langteach-vision-${env}'
 
 // ── Modules ───────────────────────────────────────────────────────────────────
 
@@ -137,7 +140,7 @@ module computerVision 'modules/computer-vision.bicep' = {
   name: 'computervision'
   params: {
     name: computerVisionName
-    location: location
+    location: visionLocation
     keyVaultName: keyVaultName
     appPrincipalId: containerApp.outputs.principalId
   }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -4,6 +4,9 @@ param env string
 @description('Azure region for all resources')
 param location string = resourceGroup().location
 
+@description('Azure region for the OpenAI account. Whisper is not available in every region (e.g. not in northeurope), so it is pinned independently of the resource group location.')
+param openaiLocation string = 'swedencentral'
+
 @description('SQL Server administrator login')
 param sqlAdminUser string
 
@@ -47,7 +50,7 @@ var keyVaultName  = 'kv-lt-${env}-${take(uniqueString(resourceGroup().id), 6)}'
 // ACR names: 5-50 chars, alphanumeric only, globally unique
 var acrName = 'crlangteach${env}'
 // Azure OpenAI resource name
-var openaiName = 'oai-langteach-${env}'
+var openaiName = 'langteach-openai-${env}'
 // Azure Computer Vision resource name
 var computerVisionName = 'vision-langteach-${env}'
 
@@ -123,7 +126,7 @@ module openai 'modules/openai.bicep' = {
   name: 'openai'
   params: {
     name: openaiName
-    location: location
+    location: openaiLocation
     keyVaultName: keyVaultName
     appPrincipalId: containerApp.outputs.principalId
   }

--- a/infra/modules/openai.bicep
+++ b/infra/modules/openai.bicep
@@ -20,7 +20,7 @@ resource openai 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
 resource whisperDeployment 'Microsoft.CognitiveServices/accounts/deployments@2023-05-01' = {
   parent: openai
   name: 'whisper'
-  sku: { name: 'Standard', capacity: 1 }
+  sku: { name: 'Standard', capacity: 3 }
   properties: {
     model: {
       format: 'OpenAI'


### PR DESCRIPTION
## Why

Two Cognitive Services accounts had drifted between Bicep and the live resource group, so `infra/deploy.sh` did not manage the real resources and a future deploy would fork broken duplicates. One drift already caused a production outage (Whisper); the other (Vision) would fail silently.

### 1. OpenAI / Whisper (voice-note transcription) — caused a live outage

Teachers saw **"Upload failed. Please try again."** Blob upload succeeded; the inline **Whisper** call returned **401**, failing the whole request. Root cause: the Whisper KV secrets pointed at a stray Foundry resource (`rfre-mov8xdcp-switzerlandnorth`) that was **never in code** and got deleted during a cleanup.

| | Bicep declared | Live |
|---|---|---|
| Account name | `oai-langteach-dev` | `langteach-openai-dev` |
| Region | northeurope (RG) | swedencentral |

northeurope doesn't offer Whisper, so the Bicep could never have provisioned it.

**Fixed live already (prod working):** created `whisper` (v001, Standard cap 3) on `langteach-openai-dev`, repointed `AzureOpenAIWhisper--{Endpoint,ApiKey,DeploymentName}`, restarted `app-langteach-api-dev`. Verified transcription → HTTP 200, no 401s since.

### 2. Computer Vision (redacciones OCR)

Used by `POST /api/corrections/extract-text` (`AzureVisionTextExtractor`, keys `AzureAIVision--Endpoint/Key`) to OCR uploaded student compositions. A misconfigured account **fails silently** (`OCR_FORMAT_UNSUPPORTED`), so the drift is worth fixing pre-emptively.

| | Bicep declared | Live |
|---|---|---|
| Account name | `vision-langteach-dev` | `langteach-vision-dev` |
| Region | northeurope (RG) | uksouth |
| Secret names | `AzureAIVision--Endpoint/Key` | ✅ match |

## Changes

- `openaiName`: `oai-langteach-${env}` → `langteach-openai-${env}`
- `computerVisionName`: `vision-langteach-${env}` → `langteach-vision-${env}`
- New `openaiLocation` (default `swedencentral`) and `visionLocation` (default `uksouth`) params, pinning each account's region independently of the RG's `northeurope`
- Whisper deployment capacity `1` → `3` to match live

## Safety

Idempotent against the live resources — names, regions, the whisper deployment, and all KV secret values already match what the Bicep now produces. **Before applying, run `az deployment group what-if` with `LANGTEACH_SQL_PASSWORD` set** to confirm no unexpected changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)